### PR TITLE
BSL Module Analysis: 6 tools for reading and analyzing BSL source code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,15 @@
-/mcp/bundles/com.ditrix.edt.mcp.server/target
+# Maven build output
+**/target/
+
+# Temp files
 nulq
 nul
-/source
 log.log
+
+# Build script backup
+*.target.bak
+
+# Claude Code local settings (may contain personal paths)
+.claude/settings.json
+
+/source

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,120 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+EDT MCP Server — Eclipse RCP plugin for 1C:EDT that implements the Model Context Protocol (MCP), enabling AI assistants to interact with EDT workspaces. Java 17, OSGi architecture, ~5K LOC.
+
+- **Plugin ID:** `com.ditrix.edt.mcp.server`
+- **Version:** 1.20.1-SNAPSHOT
+- **Target platform:** EDT 2025.2 (Ruby)
+- **License:** EPL 2.0
+
+## Critical Rules
+
+- **DO NOT BUILD YOURSELF, ASK THE EXPERT!** The build requires EDT SDK and Tycho — do not run `mvn` commands without user approval.
+- **ALL CODE AND INTERFACE MUST BE IN ENGLISH.**
+- Before committing, verify `git diff --cached` contains no private data (real project names, paths, IPs, keys).
+
+## Build System
+
+Maven + Tycho 4.0.5 (Eclipse plugin builder). Multi-module structure:
+
+```
+mcp/
+├── bom/         — Bill of Materials, parent POM with build plugin versions
+├── bundles/     — Main plugin bundle (com.ditrix.edt.mcp.server)
+├── features/    — Eclipse feature for installation
+├── targets/     — Target platform definition (EDT 2025.2)
+└── repositories/ — P2 update site output
+```
+
+Build: `build.cmd [EDT_INSTALL_DIR]` — auto-detects EDT, injects Directory location into target, runs Maven, restores target. Requires Maven 3.9+ and JDK 17 in PATH.
+
+Build output: `mcp/repositories/com.ditrix.edt.mcp.server.repository/target/repository/` (P2 update site) and `.zip` archive.
+
+No test suite in the repository. Manual testing via EDT workspace.
+
+## Architecture
+
+### Core Server
+
+- **Activator** (`server/Activator.java`) — OSGi entry point. Initializes 11 EDT service trackers, creates `McpServer` singleton.
+- **McpServer** (`server/McpServer.java`) — Embedded HTTP server (`com.sun.net.httpserver`), 4-thread pool. Endpoints: `POST /mcp` (JSON-RPC), `GET /mcp` (info), `GET /health`. Registers all tools, tracks active tool execution, supports user interrupt signals.
+- **McpServerStartup** (`server/McpServerStartup.java`) — `IStartup` hook for auto-start on EDT launch.
+- **McpProtocolHandler** (`protocol/McpProtocolHandler.java`) — MCP JSON-RPC 2.0 processor. Handles `initialize`, `tools/list`, `tools/call`. Supports Streamable HTTP transport with SSE.
+
+### Tool System
+
+- **IMcpTool** (`tools/IMcpTool.java`) — Interface all tools implement: `getName()`, `getDescription()`, `getInputSchema()`, `execute(params)`, `getResponseType()`.
+- **McpToolRegistry** (`tools/McpToolRegistry.java`) — Thread-safe singleton (ConcurrentHashMap). Tools register/unregister at runtime.
+- **26 tool implementations** in `tools/impl/` — each tool is a separate class. Response types: TEXT, JSON, or MARKDOWN. Includes 6 BSL module analysis tools (read_module_source, get_module_structure, list_modules, search_in_code, read_method_source, get_method_call_hierarchy).
+
+### Major Features
+
+- **Tags** (`tags/`) — Persistent metadata tagging stored in `.settings/metadata-tags.yaml`. TagService, UI dialogs, keyboard shortcuts (Ctrl+Alt+1-0), Navigator decorator, refactoring sync.
+- **Groups** (`groups/`) — Custom folder hierarchy in Navigator per metadata collection. Stored in `.settings/groups.yaml`. IGroupService interface with internal impl, content/label providers, Navigator filter.
+- **User Signals** (`UserSignal.java`, `ui/`) — Status bar with real-time tool execution info. Users can send cancel/retry/background/expert/custom signals to interrupt MCP calls.
+
+### Key Utilities
+
+- **ProjectStateChecker** (`utils/`) — Validates project is open and validation complete before tool execution.
+- **LifecycleWaiter** (`utils/`) — Waits for validation completion and project context availability.
+- **MarkdownUtils** (`utils/`) — Markdown table escaping for tool responses.
+- **BslModuleUtils** (`utils/`) — BSL module operations: file resolution, FQN-to-path mapping, source reading with line ranges, Xtext AST loading, method extraction (signatures, pragmas, regions), project-wide BSL file scanning.
+- **Metadata formatters** (`tools/metadata/`) — Format metadata object details for tool responses.
+
+### Preferences
+
+Stored in Eclipse preference store. Constants in `preferences/PreferenceConstants.java`:
+- Server port (default 8765), auto-start, check descriptions folder path, plain text mode (Cursor compatibility), default/max result limits.
+
+### Bundled Libraries
+
+Located in `bundles/com.ditrix.edt.mcp.server/lib/`:
+- `snakeyaml-2.2.jar` — YAML parsing for tags/groups storage
+- `jsoup-1.17.2.jar` — HTML processing for documentation
+- `copy-down-1.1.jar` — HTML to Markdown conversion
+
+## Source Layout
+
+All Java source is under `mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/`:
+
+| Package | Purpose |
+|---------|---------|
+| `(root)` | Activator, McpServer, UserSignal, ActiveToolCall |
+| `tools/` | IMcpTool, McpToolRegistry |
+| `tools/impl/` | 26 tool implementations |
+| `tools/metadata/` | Metadata formatting helpers |
+| `protocol/` | McpProtocolHandler, constants, JSON schema builder |
+| `protocol/jsonrpc/` | JSON-RPC request/response models |
+| `preferences/` | Preference page, initializer, constants |
+| `tags/` | Tag management service, storage, models |
+| `groups/` | Group service, content providers, filter |
+| `groups/handlers/` | Navigator group command handlers |
+| `groups/ui/` | Group editing dialogs |
+| `handlers/` | Navigator toolbar handlers (expand/collapse) |
+| `ui/` | Status bar contribution, user signal dialogs |
+| `utils/` | Markdown, project state, lifecycle, build utilities |
+
+## Adding a New MCP Tool
+
+1. Create a class implementing `IMcpTool` in `tools/impl/`.
+2. Implement `getName()`, `getDescription()`, `getInputSchema()`, `execute()`.
+3. Override `getResponseType()` if not MARKDOWN (default).
+4. Register in `McpServer.registerTools()` via `toolRegistry.register(new YourTool())`.
+
+## Check Descriptions
+
+The `checks/` directory at repository root contains 100+ markdown files documenting EDT validation checks (e.g., `bsl-variable-name-invalid.md`). These are served by the `get_check_description` tool.
+
+## Client Connection
+
+Default server URL: `http://localhost:8765/mcp`
+
+MCP config files for different clients:
+- VS Code: `.vscode/mcp.json` (type: `sse`)
+- Claude Code: `.claude.json` (type: `http`)
+- Cursor: `.cursor/mcp.json`
+- Claude Desktop: `claude_desktop_config.json`

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,60 @@
+@echo off
+setlocal enabledelayedexpansion
+
+rem EDT MCP Server Plugin build script
+rem Usage: build.cmd [EDT_INSTALL_DIR]
+rem Example: build.cmd "C:\Program Files\1C\1CE\components\1c-edt-2025.1.5+34-x86_64"
+rem
+rem If EDT_INSTALL_DIR is not passed, the script tries to auto-detect it.
+
+set "TARGET_FILE=%~dp0mcp\targets\default\default.target"
+set "BACKUP_FILE=%~dp0mcp\targets\default\default.target.bak"
+set "EDT_DIR=%~1"
+
+rem Auto-detect EDT if not specified
+if "%EDT_DIR%"=="" (
+    for /d %%d in ("C:\Program Files\1C\1CE\components\1c-edt-*") do (
+        set "EDT_DIR=%%d"
+    )
+)
+
+if "%EDT_DIR%"=="" (
+    echo ERROR: EDT installation not found.
+    echo Usage: build.cmd "C:\path\to\1c-edt-directory"
+    exit /b 1
+)
+
+if not exist "%EDT_DIR%\plugins" (
+    echo ERROR: Invalid EDT directory: %EDT_DIR%
+    echo The directory must contain a "plugins" subdirectory.
+    exit /b 1
+)
+
+echo Using EDT: %EDT_DIR%
+
+rem Backup original target
+copy /y "%TARGET_FILE%" "%BACKUP_FILE%" >nul
+
+rem Insert Directory location before </locations>
+powershell -Command "(Get-Content '%TARGET_FILE%' -Raw) -replace '</locations>', ('<!-- EDT Runtime (auto-added by build script) -->' + [Environment]::NewLine + '<location path=\"%EDT_DIR%\" type=\"Directory\"/>' + [Environment]::NewLine + [Environment]::NewLine + '</locations>') | Set-Content '%TARGET_FILE%' -NoNewline"
+
+echo Building...
+cd /d "%~dp0mcp"
+call mvn clean verify
+set "BUILD_RESULT=%ERRORLEVEL%"
+
+rem Restore original target
+copy /y "%BACKUP_FILE%" "%TARGET_FILE%" >nul
+del "%BACKUP_FILE%" >nul 2>&1
+
+if %BUILD_RESULT%==0 (
+    echo.
+    echo BUILD SUCCESS
+    echo P2 repository: mcp\repositories\com.ditrix.edt.mcp.server.repository\target\repository\
+    echo ZIP archive:    mcp\repositories\com.ditrix.edt.mcp.server.repository\target\*.zip
+) else (
+    echo.
+    echo BUILD FAILED
+)
+
+exit /b %BUILD_RESULT%

--- a/mcp/bom/pom.xml
+++ b/mcp/bom/pom.xml
@@ -51,7 +51,7 @@
               <artifact>
                 <groupId>com.ditrix.edt.mcp</groupId>
                 <artifactId>default</artifactId>
-                <version>1.0.0-SNAPSHOT</version>
+                <version>1.20.1-SNAPSHOT</version>
               </artifact>
             </target>
             <dependency-resolution>

--- a/mcp/bundles/com.ditrix.edt.mcp.server/META-INF/MANIFEST.MF
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/META-INF/MANIFEST.MF
@@ -62,4 +62,6 @@ Import-Package: com._1c.g5.v8.bm.common.collections,
  org.eclipse.emf.ecore.util,
  org.eclipse.ltk.core.refactoring,
  org.eclipse.ui.navigator,
+ org.eclipse.xtext.nodemodel,
+ org.eclipse.xtext.nodemodel.util,
  org.eclipse.xtext.resource

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/McpServer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/McpServer.java
@@ -35,6 +35,12 @@ import com.ditrix.edt.mcp.server.tools.impl.GetTasksTool;
 import com.ditrix.edt.mcp.server.tools.impl.ListProjectsTool;
 import com.ditrix.edt.mcp.server.tools.impl.CleanProjectTool;
 import com.ditrix.edt.mcp.server.tools.impl.RevalidateObjectsTool;
+import com.ditrix.edt.mcp.server.tools.impl.GetMethodCallHierarchyTool;
+import com.ditrix.edt.mcp.server.tools.impl.GetModuleStructureTool;
+import com.ditrix.edt.mcp.server.tools.impl.ListModulesTool;
+import com.ditrix.edt.mcp.server.tools.impl.ReadMethodSourceTool;
+import com.ditrix.edt.mcp.server.tools.impl.ReadModuleSourceTool;
+import com.ditrix.edt.mcp.server.tools.impl.SearchInCodeTool;
 import com.ditrix.edt.mcp.server.tools.impl.UpdateDatabaseTool;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
@@ -136,6 +142,14 @@ public class McpServer
         registry.register(new GetApplicationsTool());
         registry.register(new UpdateDatabaseTool());
         registry.register(new DebugLaunchTool());
+
+        // BSL module analysis tools
+        registry.register(new ReadModuleSourceTool());
+        registry.register(new GetModuleStructureTool());
+        registry.register(new ListModulesTool());
+        registry.register(new SearchInCodeTool());
+        registry.register(new ReadMethodSourceTool());
+        registry.register(new GetMethodCallHierarchyTool());
         
         Activator.logInfo("Registered " + registry.getToolCount() + " MCP tools"); //$NON-NLS-1$ //$NON-NLS-2$
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
@@ -1,0 +1,444 @@
+/**
+ * Copyright (c) 2025 DitriX
+ */
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.resource.IReferenceDescription;
+import org.eclipse.xtext.resource.IResourceServiceProvider;
+import org.eclipse.xtext.resource.XtextResourceFactory;
+import org.eclipse.xtext.ui.editor.findrefs.IReferenceFinder;
+
+import com._1c.g5.v8.dt.bsl.model.Method;
+import com._1c.g5.v8.dt.bsl.model.Module;
+import com.ditrix.edt.mcp.server.Activator;
+import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
+import com.ditrix.edt.mcp.server.protocol.JsonUtils;
+import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.BslModuleUtils;
+import com.ditrix.edt.mcp.server.utils.BslModuleUtils.MethodInfo;
+
+/**
+ * Tool to find all callers of a specific procedure/function through EDT's semantic
+ * BM index. Not a text search - uses the real call graph through the AST.
+ */
+@SuppressWarnings("restriction")
+public class GetMethodCallHierarchyTool implements IMcpTool
+{
+    public static final String NAME = "get_method_call_hierarchy"; //$NON-NLS-1$
+
+    /** URI for getting BSL resource service provider */
+    private static final URI BSL_URI = URI.createURI("/nopr/module.bsl"); //$NON-NLS-1$
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Find all callers of a specific procedure/function using EDT's semantic BM index. " + //$NON-NLS-1$
+               "This is NOT a text search - it uses the real call graph through the AST. " + //$NON-NLS-1$
+               "Returns module paths, calling method names, and line numbers for each call site."; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getInputSchema()
+    {
+        return JsonSchemaBuilder.object()
+            .stringProperty("projectName", //$NON-NLS-1$
+                "EDT project name (required)", true) //$NON-NLS-1$
+            .stringProperty("modulePath", //$NON-NLS-1$
+                "Path to BSL file relative to project's src folder " + //$NON-NLS-1$
+                "(e.g. 'CommonModules/MyModule/Module.bsl')", true) //$NON-NLS-1$
+            .stringProperty("methodName", //$NON-NLS-1$
+                "Name of the procedure or function to find callers for (case-insensitive)", true) //$NON-NLS-1$
+            .integerProperty("limit", //$NON-NLS-1$
+                "Maximum number of results. Default: 100") //$NON-NLS-1$
+            .build();
+    }
+
+    @Override
+    public ResponseType getResponseType()
+    {
+        return ResponseType.MARKDOWN;
+    }
+
+    @Override
+    public String getResultFileName(Map<String, String> params)
+    {
+        String methodName = JsonUtils.extractStringArgument(params, "methodName"); //$NON-NLS-1$
+        if (methodName != null && !methodName.isEmpty())
+        {
+            return "callers-" + methodName.toLowerCase() + ".md"; //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return "call-hierarchy.md"; //$NON-NLS-1$
+    }
+
+    @Override
+    public String execute(Map<String, String> params)
+    {
+        String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
+        String modulePath = JsonUtils.extractStringArgument(params, "modulePath"); //$NON-NLS-1$
+        String methodName = JsonUtils.extractStringArgument(params, "methodName"); //$NON-NLS-1$
+        String limitStr = JsonUtils.extractStringArgument(params, "limit"); //$NON-NLS-1$
+
+        if (projectName == null || projectName.isEmpty())
+        {
+            return "Error: projectName is required"; //$NON-NLS-1$
+        }
+        if (modulePath == null || modulePath.isEmpty())
+        {
+            return "Error: modulePath is required"; //$NON-NLS-1$
+        }
+        if (methodName == null || methodName.isEmpty())
+        {
+            return "Error: methodName is required"; //$NON-NLS-1$
+        }
+
+        int limit = 100;
+        if (limitStr != null && !limitStr.isEmpty())
+        {
+            try
+            {
+                limit = Math.min((int) Double.parseDouble(limitStr), 500);
+            }
+            catch (NumberFormatException e)
+            {
+                // Use default
+            }
+        }
+
+        // Execute on UI thread (IReferenceFinder may need UI thread context)
+        AtomicReference<String> resultRef = new AtomicReference<>();
+        final int maxResults = limit;
+
+        Display display = PlatformUI.getWorkbench().getDisplay();
+        display.syncExec(() -> {
+            try
+            {
+                String result = findCallersInternal(projectName, modulePath, methodName, maxResults);
+                resultRef.set(result);
+            }
+            catch (Exception e)
+            {
+                Activator.logError("Error finding call hierarchy", e); //$NON-NLS-1$
+                resultRef.set("Error: " + e.getMessage()); //$NON-NLS-1$
+            }
+        });
+
+        return resultRef.get();
+    }
+
+    /**
+     * Internal implementation that finds all callers.
+     */
+    private String findCallersInternal(String projectName, String modulePath,
+        String methodName, int limit)
+    {
+        IProject project = BslModuleUtils.resolveProject(projectName);
+        if (project == null)
+        {
+            return "Error: Project not found: " + projectName; //$NON-NLS-1$
+        }
+
+        IFile file = BslModuleUtils.resolveModuleFile(project, modulePath);
+        if (file == null)
+        {
+            return "Error: Module not found: " + modulePath; //$NON-NLS-1$
+        }
+
+        // Load BSL module AST
+        Module module = BslModuleUtils.loadBslModule(file);
+        if (module == null)
+        {
+            return "Error: Failed to load BSL module AST for: " + modulePath; //$NON-NLS-1$
+        }
+
+        // Find the target method
+        List<MethodInfo> methods = BslModuleUtils.extractMethods(module);
+        MethodInfo targetMethodInfo = null;
+        Method targetMethod = null;
+
+        int methodIndex = 0;
+        for (Method m : module.allMethods())
+        {
+            if (m.getName().equalsIgnoreCase(methodName))
+            {
+                targetMethod = m;
+                // Find corresponding MethodInfo
+                for (MethodInfo mi : methods)
+                {
+                    if (mi.name.equalsIgnoreCase(methodName))
+                    {
+                        targetMethodInfo = mi;
+                        break;
+                    }
+                }
+                break;
+            }
+            methodIndex++;
+        }
+
+        if (targetMethod == null || targetMethodInfo == null)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Error: Method '").append(methodName) //$NON-NLS-1$
+                .append("' not found in ").append(modulePath).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+
+            if (!methods.isEmpty())
+            {
+                sb.append("**Available methods:**\n"); //$NON-NLS-1$
+                for (MethodInfo m : methods)
+                {
+                    sb.append("- ").append(m.name).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+                }
+            }
+            return sb.toString();
+        }
+
+        // Get IReferenceFinder
+        IResourceServiceProvider rsp =
+            IResourceServiceProvider.Registry.INSTANCE.getResourceServiceProvider(BSL_URI);
+        if (rsp == null)
+        {
+            return "Error: BSL resource service provider not available"; //$NON-NLS-1$
+        }
+
+        IReferenceFinder finder = rsp.get(IReferenceFinder.class);
+        if (finder == null)
+        {
+            return "Error: Reference finder not available"; //$NON-NLS-1$
+        }
+
+        // Get URI of the target method
+        URI targetUri = EcoreUtil.getURI(targetMethod);
+        List<URI> targetURIs = new ArrayList<>();
+        targetURIs.add(targetUri);
+
+        // Collect references
+        List<CallerInfo> callers = new ArrayList<>();
+        final int maxCallers = limit;
+
+        try
+        {
+            finder.findAllReferences(targetURIs, null, refDesc -> {
+                if (callers.size() >= maxCallers)
+                {
+                    return;
+                }
+                processReferenceDescription(refDesc, callers);
+            }, new NullProgressMonitor());
+        }
+        catch (Exception e)
+        {
+            Activator.logError("Error finding references for method", e); //$NON-NLS-1$
+            return "Error finding references: " + e.getMessage(); //$NON-NLS-1$
+        }
+
+        // Format output
+        return formatOutput(modulePath, targetMethodInfo, callers, limit);
+    }
+
+    /**
+     * Processes a single reference description.
+     */
+    private void processReferenceDescription(IReferenceDescription refDesc,
+        List<CallerInfo> callers)
+    {
+        URI sourceUri = refDesc.getSourceEObjectUri();
+        if (sourceUri == null)
+        {
+            return;
+        }
+
+        // Extract module path from URI
+        String callerModulePath = extractModulePath(sourceUri.path());
+
+        // Extract line number
+        int line = extractLineNumber(sourceUri);
+
+        callers.add(new CallerInfo(callerModulePath, line));
+    }
+
+    /**
+     * Extracts module path from URI path.
+     * Follows the same pattern as FindReferencesTool.extractModulePath().
+     */
+    private String extractModulePath(String path)
+    {
+        if (path == null)
+        {
+            return "Unknown module"; //$NON-NLS-1$
+        }
+
+        int srcIdx = path.indexOf("/src/"); //$NON-NLS-1$
+        if (srcIdx >= 0)
+        {
+            return path.substring(srcIdx + 5);
+        }
+
+        // Return last segments
+        String[] parts = path.split("/"); //$NON-NLS-1$
+        if (parts.length >= 3)
+        {
+            return parts[parts.length - 3] + "/" + parts[parts.length - 2] //$NON-NLS-1$
+                + "/" + parts[parts.length - 1]; //$NON-NLS-1$
+        }
+
+        return path;
+    }
+
+    /**
+     * Extracts line number from sourceEObjectUri by loading the EObject
+     * and using NodeModelUtils.
+     * Follows the same pattern as FindReferencesTool.extractLineNumberFromSourceUri().
+     */
+    private int extractLineNumber(URI sourceUri)
+    {
+        if (sourceUri == null)
+        {
+            return 0;
+        }
+
+        try
+        {
+            ResourceSet resourceSet = new ResourceSetImpl();
+
+            // Configure resource factory
+            IResourceServiceProvider rsp =
+                IResourceServiceProvider.Registry.INSTANCE.getResourceServiceProvider(sourceUri);
+            if (rsp != null)
+            {
+                XtextResourceFactory factory = rsp.get(XtextResourceFactory.class);
+                if (factory != null)
+                {
+                    resourceSet.getResourceFactoryRegistry()
+                        .getExtensionToFactoryMap().put("bsl", factory); //$NON-NLS-1$
+                }
+            }
+
+            URI resourceUri = sourceUri.trimFragment();
+            Resource resource = resourceSet.getResource(resourceUri, true);
+
+            if (resource != null && sourceUri.fragment() != null)
+            {
+                EObject eObject = resource.getEObject(sourceUri.fragment());
+                if (eObject != null)
+                {
+                    INode node = NodeModelUtils.findActualNodeFor(eObject);
+                    if (node != null)
+                    {
+                        return node.getStartLine();
+                    }
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Activator.logError("Error extracting line number from URI: " + sourceUri, e); //$NON-NLS-1$
+        }
+
+        return 0;
+    }
+
+    /**
+     * Formats the output as markdown.
+     */
+    private String formatOutput(String modulePath, MethodInfo targetMethod,
+        List<CallerInfo> callers, int limit)
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("## Call Hierarchy: ").append(targetMethod.name).append(" (callers)\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("**Module:** ").append(modulePath).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("**Method:** ").append(targetMethod.signature).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("**Callers found:** ").append(callers.size()); //$NON-NLS-1$
+        if (callers.size() >= limit)
+        {
+            sb.append(" (limit reached)"); //$NON-NLS-1$
+        }
+        sb.append("\n\n"); //$NON-NLS-1$
+
+        if (callers.isEmpty())
+        {
+            sb.append("No callers found.\n"); //$NON-NLS-1$
+            return sb.toString();
+        }
+
+        // Group by module
+        Map<String, List<Integer>> callersByModule = new TreeMap<>();
+        for (CallerInfo caller : callers)
+        {
+            callersByModule.computeIfAbsent(caller.modulePath, k -> new ArrayList<>())
+                .add(caller.line);
+        }
+
+        // Output grouped by module
+        sb.append("| # | Module | Lines |\n"); //$NON-NLS-1$
+        sb.append("|---|--------|-------|\n"); //$NON-NLS-1$
+
+        int index = 1;
+        for (Map.Entry<String, List<Integer>> entry : callersByModule.entrySet())
+        {
+            String callerModule = entry.getKey();
+            List<Integer> lines = entry.getValue();
+            lines.sort(Integer::compareTo);
+
+            // Format lines
+            StringBuilder linesStr = new StringBuilder();
+            for (int i = 0; i < lines.size(); i++)
+            {
+                if (i > 0)
+                {
+                    linesStr.append(", "); //$NON-NLS-1$
+                }
+                linesStr.append(lines.get(i));
+            }
+
+            sb.append("| ").append(index); //$NON-NLS-1$
+            sb.append(" | ").append(callerModule); //$NON-NLS-1$
+            sb.append(" | ").append(linesStr); //$NON-NLS-1$
+            sb.append(" |\n"); //$NON-NLS-1$
+
+            index++;
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Holds information about a caller.
+     */
+    private static class CallerInfo
+    {
+        final String modulePath;
+        final int line;
+
+        CallerInfo(String modulePath, int line)
+        {
+            this.modulePath = modulePath;
+            this.line = line;
+        }
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetModuleStructureTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetModuleStructureTool.java
@@ -1,0 +1,292 @@
+/**
+ * Copyright (c) 2025 DitriX
+ */
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+
+import com._1c.g5.v8.dt.bsl.model.Module;
+import com._1c.g5.v8.dt.bsl.model.Preprocessor;
+import com._1c.g5.v8.dt.bsl.model.RegionPreprocessor;
+import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
+import com.ditrix.edt.mcp.server.protocol.JsonUtils;
+import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.BslModuleUtils;
+import com.ditrix.edt.mcp.server.utils.BslModuleUtils.MethodInfo;
+
+/**
+ * Tool to get module structure: all procedures/functions with signatures,
+ * line numbers, regions, execution context, and Export flags.
+ */
+@SuppressWarnings("restriction")
+public class GetModuleStructureTool implements IMcpTool
+{
+    public static final String NAME = "get_module_structure"; //$NON-NLS-1$
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Get BSL module structure: all procedures/functions with their signatures, " + //$NON-NLS-1$
+               "line numbers, #Region names, execution context (&AtServer, &AtClient, etc.), " + //$NON-NLS-1$
+               "and Export flags. Useful for understanding module layout without reading the full source."; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getInputSchema()
+    {
+        return JsonSchemaBuilder.object()
+            .stringProperty("projectName", //$NON-NLS-1$
+                "EDT project name (required)", true) //$NON-NLS-1$
+            .stringProperty("modulePath", //$NON-NLS-1$
+                "Path to BSL file relative to project's src folder " + //$NON-NLS-1$
+                "(e.g. 'CommonModules/MyModule/Module.bsl', " + //$NON-NLS-1$
+                "'Documents/SalesOrder/Ext/ObjectModule.bsl')", true) //$NON-NLS-1$
+            .build();
+    }
+
+    @Override
+    public ResponseType getResponseType()
+    {
+        return ResponseType.MARKDOWN;
+    }
+
+    @Override
+    public String getResultFileName(Map<String, String> params)
+    {
+        String modulePath = JsonUtils.extractStringArgument(params, "modulePath"); //$NON-NLS-1$
+        if (modulePath != null && !modulePath.isEmpty())
+        {
+            String safeName = modulePath.replace("/", "-").replace("\\", "-") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+                .replace(".bsl", "").toLowerCase(); //$NON-NLS-1$ //$NON-NLS-2$
+            return "structure-" + safeName + ".md"; //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return "module-structure.md"; //$NON-NLS-1$
+    }
+
+    @Override
+    public String execute(Map<String, String> params)
+    {
+        String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
+        String modulePath = JsonUtils.extractStringArgument(params, "modulePath"); //$NON-NLS-1$
+
+        if (projectName == null || projectName.isEmpty())
+        {
+            return "Error: projectName is required"; //$NON-NLS-1$
+        }
+        if (modulePath == null || modulePath.isEmpty())
+        {
+            return "Error: modulePath is required"; //$NON-NLS-1$
+        }
+
+        IProject project = BslModuleUtils.resolveProject(projectName);
+        if (project == null)
+        {
+            return "Error: Project not found: " + projectName; //$NON-NLS-1$
+        }
+
+        IFile file = BslModuleUtils.resolveModuleFile(project, modulePath);
+        if (file == null)
+        {
+            return "Error: Module not found: " + modulePath; //$NON-NLS-1$
+        }
+
+        // Count total lines
+        int totalLines = BslModuleUtils.countLines(file);
+
+        // Load BSL module AST
+        Module module = BslModuleUtils.loadBslModule(file);
+        if (module == null)
+        {
+            return "Error: Failed to load BSL module AST for: " + modulePath; //$NON-NLS-1$
+        }
+
+        // Extract methods
+        List<MethodInfo> methods = BslModuleUtils.extractMethods(module);
+
+        // Extract regions
+        List<RegionInfo> regions = extractRegions(module);
+
+        // Format output
+        return formatOutput(modulePath, totalLines, methods, regions);
+    }
+
+    /**
+     * Extracts region information from the module AST.
+     */
+    private List<RegionInfo> extractRegions(Module module)
+    {
+        List<RegionInfo> regions = new ArrayList<>();
+
+        EList<Preprocessor> preprocessors = module.getPreprocessors();
+        if (preprocessors != null)
+        {
+            for (Preprocessor preprocessor : preprocessors)
+            {
+                collectRegions(preprocessor, regions);
+            }
+        }
+
+        // Also check module body for regions
+        for (EObject child : module.eContents())
+        {
+            if (child instanceof RegionPreprocessor)
+            {
+                addRegionInfo((RegionPreprocessor) child, regions);
+            }
+        }
+
+        regions.sort(Comparator.comparingInt(r -> r.startLine));
+        return regions;
+    }
+
+    /**
+     * Recursively collects region preprocessors.
+     */
+    private void collectRegions(Preprocessor preprocessor, List<RegionInfo> regions)
+    {
+        if (preprocessor instanceof RegionPreprocessor)
+        {
+            addRegionInfo((RegionPreprocessor) preprocessor, regions);
+        }
+    }
+
+    /**
+     * Adds a region's info to the list.
+     */
+    private void addRegionInfo(RegionPreprocessor region, List<RegionInfo> regions)
+    {
+        String name = region.getName();
+        if (name == null || name.isEmpty())
+        {
+            return;
+        }
+
+        // Check for duplicates
+        for (RegionInfo existing : regions)
+        {
+            if (name.equals(existing.name))
+            {
+                return;
+            }
+        }
+
+        INode node = NodeModelUtils.findActualNodeFor(region);
+        int startLine = node != null ? node.getStartLine() : 0;
+        int endLine = node != null ? node.getEndLine() : 0;
+
+        regions.add(new RegionInfo(name, startLine, endLine));
+    }
+
+    /**
+     * Formats the output as markdown.
+     */
+    private String formatOutput(String modulePath, int totalLines,
+        List<MethodInfo> methods, List<RegionInfo> regions)
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("## Module Structure: ").append(modulePath).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("**Total lines:** ").append(totalLines >= 0 ? totalLines : "?"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append(" | **Methods:** ").append(methods.size()); //$NON-NLS-1$
+        sb.append(" | **Regions:** ").append(regions.size()); //$NON-NLS-1$
+        sb.append("\n\n"); //$NON-NLS-1$
+
+        // Methods table
+        if (!methods.isEmpty())
+        {
+            sb.append("### Methods\n\n"); //$NON-NLS-1$
+            sb.append("| # | Name | Type | Export | Context | Lines | Region |\n"); //$NON-NLS-1$
+            sb.append("|---|------|------|--------|---------|-------|--------|\n"); //$NON-NLS-1$
+
+            int index = 1;
+            for (MethodInfo method : methods)
+            {
+                String type = method.isFunction ? "Function" : "Procedure"; //$NON-NLS-1$ //$NON-NLS-2$
+                String export = method.isExport ? "Yes" : "-"; //$NON-NLS-1$ //$NON-NLS-2$
+                String context = method.pragmas != null && !method.pragmas.isEmpty()
+                    ? method.pragmas : "-"; //$NON-NLS-1$
+                String lines = method.startLine + "-" + method.endLine; //$NON-NLS-1$
+                String region = method.regionName != null ? method.regionName : "-"; //$NON-NLS-1$
+
+                sb.append("| ").append(index); //$NON-NLS-1$
+                sb.append(" | ").append(method.name); //$NON-NLS-1$
+                sb.append(" | ").append(type); //$NON-NLS-1$
+                sb.append(" | ").append(export); //$NON-NLS-1$
+                sb.append(" | ").append(context); //$NON-NLS-1$
+                sb.append(" | ").append(lines); //$NON-NLS-1$
+                sb.append(" | ").append(region); //$NON-NLS-1$
+                sb.append(" |\n"); //$NON-NLS-1$
+
+                index++;
+            }
+        }
+        else
+        {
+            sb.append("No methods found in this module.\n"); //$NON-NLS-1$
+        }
+
+        // Regions table
+        if (!regions.isEmpty())
+        {
+            sb.append("\n### Regions\n\n"); //$NON-NLS-1$
+            sb.append("| Region | Lines |\n"); //$NON-NLS-1$
+            sb.append("|--------|-------|\n"); //$NON-NLS-1$
+
+            for (RegionInfo region : regions)
+            {
+                sb.append("| ").append(region.name); //$NON-NLS-1$
+                sb.append(" | ").append(region.startLine).append("-").append(region.endLine); //$NON-NLS-1$ //$NON-NLS-2$
+                sb.append(" |\n"); //$NON-NLS-1$
+            }
+        }
+
+        // Signatures section
+        if (!methods.isEmpty())
+        {
+            sb.append("\n### Signatures\n\n"); //$NON-NLS-1$
+            for (MethodInfo method : methods)
+            {
+                if (method.pragmas != null && !method.pragmas.isEmpty())
+                {
+                    sb.append(method.pragmas).append("\n"); //$NON-NLS-1$
+                }
+                sb.append(method.signature).append("\n\n"); //$NON-NLS-1$
+            }
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Holds region information.
+     */
+    private static class RegionInfo
+    {
+        final String name;
+        final int startLine;
+        final int endLine;
+
+        RegionInfo(String name, int startLine, int endLine)
+        {
+            this.name = name;
+            this.startLine = startLine;
+            this.endLine = endLine;
+        }
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListModulesTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListModulesTool.java
@@ -1,0 +1,238 @@
+/**
+ * Copyright (c) 2025 DitriX
+ */
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+
+import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
+import com.ditrix.edt.mcp.server.protocol.JsonUtils;
+import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.BslModuleUtils;
+import com.ditrix.edt.mcp.server.utils.BslModuleUtils.ModuleInfo;
+import com.ditrix.edt.mcp.server.utils.BslModuleUtils.ModulePathInfo;
+
+/**
+ * Tool to list all BSL modules of a specific metadata object or the entire project.
+ */
+public class ListModulesTool implements IMcpTool
+{
+    public static final String NAME = "list_modules"; //$NON-NLS-1$
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "List all BSL modules of a specific metadata object or the entire project. " + //$NON-NLS-1$
+               "When objectFqn is provided, lists modules of that object (ObjectModule, ManagerModule, FormModules, etc.). " + //$NON-NLS-1$
+               "Without objectFqn, scans the entire project with optional metadataType filter."; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getInputSchema()
+    {
+        return JsonSchemaBuilder.object()
+            .stringProperty("projectName", //$NON-NLS-1$
+                "EDT project name (required)", true) //$NON-NLS-1$
+            .stringProperty("objectFqn", //$NON-NLS-1$
+                "Fully qualified name of a specific object (e.g. 'Document.SalesOrder', " + //$NON-NLS-1$
+                "'CommonModule.ServerModule'). If omitted, lists all modules in the project.") //$NON-NLS-1$
+            .stringProperty("metadataType", //$NON-NLS-1$
+                "Filter by metadata type when listing all modules (e.g. 'Documents', " + //$NON-NLS-1$
+                "'CommonModules', 'Catalogs'). Only used when objectFqn is omitted.") //$NON-NLS-1$
+            .integerProperty("limit", //$NON-NLS-1$
+                "Maximum number of results. Default: 200") //$NON-NLS-1$
+            .build();
+    }
+
+    @Override
+    public ResponseType getResponseType()
+    {
+        return ResponseType.MARKDOWN;
+    }
+
+    @Override
+    public String getResultFileName(Map<String, String> params)
+    {
+        String objectFqn = JsonUtils.extractStringArgument(params, "objectFqn"); //$NON-NLS-1$
+        if (objectFqn != null && !objectFqn.isEmpty())
+        {
+            String safeName = objectFqn.replace(".", "-").toLowerCase(); //$NON-NLS-1$ //$NON-NLS-2$
+            return "modules-" + safeName + ".md"; //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return "modules-list.md"; //$NON-NLS-1$
+    }
+
+    @Override
+    public String execute(Map<String, String> params)
+    {
+        String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
+        String objectFqn = JsonUtils.extractStringArgument(params, "objectFqn"); //$NON-NLS-1$
+        String metadataType = JsonUtils.extractStringArgument(params, "metadataType"); //$NON-NLS-1$
+        String limitStr = JsonUtils.extractStringArgument(params, "limit"); //$NON-NLS-1$
+
+        if (projectName == null || projectName.isEmpty())
+        {
+            return "Error: projectName is required"; //$NON-NLS-1$
+        }
+
+        int limit = 200;
+        if (limitStr != null && !limitStr.isEmpty())
+        {
+            try
+            {
+                limit = Math.min((int) Double.parseDouble(limitStr), 1000);
+            }
+            catch (NumberFormatException e)
+            {
+                // Use default
+            }
+        }
+
+        IProject project = BslModuleUtils.resolveProject(projectName);
+        if (project == null)
+        {
+            return "Error: Project not found: " + projectName; //$NON-NLS-1$
+        }
+
+        if (objectFqn != null && !objectFqn.isEmpty())
+        {
+            return listObjectModules(project, projectName, objectFqn);
+        }
+        else
+        {
+            return listProjectModules(project, projectName, metadataType, limit);
+        }
+    }
+
+    /**
+     * Lists modules of a specific metadata object.
+     */
+    private String listObjectModules(IProject project, String projectName, String objectFqn)
+    {
+        List<ModuleInfo> modules = BslModuleUtils.findObjectModules(project, objectFqn);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("## BSL Modules: ").append(objectFqn).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("**Project:** ").append(projectName).append(" | "); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("**Modules found:** ").append(modules.size()).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        if (modules.isEmpty())
+        {
+            sb.append("No BSL modules found for this object.\n"); //$NON-NLS-1$
+            return sb.toString();
+        }
+
+        sb.append("| Module Type | Path | Lines |\n"); //$NON-NLS-1$
+        sb.append("|-------------|------|-------|\n"); //$NON-NLS-1$
+
+        for (ModuleInfo module : modules)
+        {
+            String displayType = module.type.displayName;
+            if (module.formName != null)
+            {
+                displayType = "FormModule (" + module.formName + ")"; //$NON-NLS-1$ //$NON-NLS-2$
+            }
+
+            int lines = countModuleLines(project, module.relativePath);
+
+            sb.append("| ").append(displayType); //$NON-NLS-1$
+            sb.append(" | ").append(module.relativePath); //$NON-NLS-1$
+            sb.append(" | ").append(lines >= 0 ? lines : "?"); //$NON-NLS-1$ //$NON-NLS-2$
+            sb.append(" |\n"); //$NON-NLS-1$
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Lists all modules in the project, optionally filtered by metadata type.
+     */
+    private String listProjectModules(IProject project, String projectName,
+        String metadataType, int limit)
+    {
+        List<IFile> bslFiles;
+        if (metadataType != null && !metadataType.isEmpty())
+        {
+            bslFiles = BslModuleUtils.findBslFilesByType(project, metadataType);
+        }
+        else
+        {
+            bslFiles = BslModuleUtils.findAllBslFiles(project);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("## BSL Modules: ").append(projectName).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        if (metadataType != null && !metadataType.isEmpty())
+        {
+            sb.append("**Filter:** ").append(metadataType).append(" | "); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+
+        int total = bslFiles.size();
+        int shown = Math.min(total, limit);
+        sb.append("**Total:** ").append(total).append(" modules"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (shown < total)
+        {
+            sb.append(" (showing ").append(shown).append(")"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        sb.append("\n\n"); //$NON-NLS-1$
+
+        if (bslFiles.isEmpty())
+        {
+            sb.append("No BSL modules found.\n"); //$NON-NLS-1$
+            return sb.toString();
+        }
+
+        sb.append("| Module Path | Module Type | Owner | Lines |\n"); //$NON-NLS-1$
+        sb.append("|-------------|-------------|-------|-------|\n"); //$NON-NLS-1$
+
+        int count = 0;
+        for (IFile file : bslFiles)
+        {
+            if (count >= limit)
+            {
+                break;
+            }
+
+            String relativePath = BslModuleUtils.getRelativeModulePath(project, file);
+            ModulePathInfo pathInfo = BslModuleUtils.parseModulePath(relativePath);
+
+            String moduleType = pathInfo != null ? pathInfo.moduleType.displayName : "Unknown"; //$NON-NLS-1$
+            String ownerFqn = pathInfo != null ? pathInfo.ownerFqn : "Unknown"; //$NON-NLS-1$
+            int lines = BslModuleUtils.countLines(file);
+
+            sb.append("| ").append(relativePath); //$NON-NLS-1$
+            sb.append(" | ").append(moduleType); //$NON-NLS-1$
+            sb.append(" | ").append(ownerFqn); //$NON-NLS-1$
+            sb.append(" | ").append(lines >= 0 ? lines : "?"); //$NON-NLS-1$ //$NON-NLS-2$
+            sb.append(" |\n"); //$NON-NLS-1$
+
+            count++;
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Counts lines in a module by its relative path.
+     */
+    private int countModuleLines(IProject project, String modulePath)
+    {
+        IFile file = BslModuleUtils.resolveModuleFile(project, modulePath);
+        if (file == null)
+        {
+            return -1;
+        }
+        return BslModuleUtils.countLines(file);
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadMethodSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadMethodSourceTool.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2025 DitriX
+ */
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+
+import com._1c.g5.v8.dt.bsl.model.Module;
+import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
+import com.ditrix.edt.mcp.server.protocol.JsonUtils;
+import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.BslModuleUtils;
+import com.ditrix.edt.mcp.server.utils.BslModuleUtils.MethodInfo;
+
+/**
+ * Tool to extract a specific procedure/function source code from a BSL module.
+ * Instead of reading 60,000 lines, reads only the needed 50 lines of a specific method.
+ */
+@SuppressWarnings("restriction")
+public class ReadMethodSourceTool implements IMcpTool
+{
+    public static final String NAME = "read_method_source"; //$NON-NLS-1$
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Extract a specific procedure or function source code from a BSL module. " + //$NON-NLS-1$
+               "Instead of reading the entire module (which can be tens of thousands of lines), " + //$NON-NLS-1$
+               "reads only the specific method by name."; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getInputSchema()
+    {
+        return JsonSchemaBuilder.object()
+            .stringProperty("projectName", //$NON-NLS-1$
+                "EDT project name (required)", true) //$NON-NLS-1$
+            .stringProperty("modulePath", //$NON-NLS-1$
+                "Path to BSL file relative to project's src folder " + //$NON-NLS-1$
+                "(e.g. 'CommonModules/MyModule/Module.bsl')", true) //$NON-NLS-1$
+            .stringProperty("methodName", //$NON-NLS-1$
+                "Name of the procedure or function to extract (case-insensitive)", true) //$NON-NLS-1$
+            .build();
+    }
+
+    @Override
+    public ResponseType getResponseType()
+    {
+        return ResponseType.MARKDOWN;
+    }
+
+    @Override
+    public String getResultFileName(Map<String, String> params)
+    {
+        String methodName = JsonUtils.extractStringArgument(params, "methodName"); //$NON-NLS-1$
+        if (methodName != null && !methodName.isEmpty())
+        {
+            return "method-" + methodName.toLowerCase() + ".md"; //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return "method-source.md"; //$NON-NLS-1$
+    }
+
+    @Override
+    public String execute(Map<String, String> params)
+    {
+        String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
+        String modulePath = JsonUtils.extractStringArgument(params, "modulePath"); //$NON-NLS-1$
+        String methodName = JsonUtils.extractStringArgument(params, "methodName"); //$NON-NLS-1$
+
+        if (projectName == null || projectName.isEmpty())
+        {
+            return "Error: projectName is required"; //$NON-NLS-1$
+        }
+        if (modulePath == null || modulePath.isEmpty())
+        {
+            return "Error: modulePath is required"; //$NON-NLS-1$
+        }
+        if (methodName == null || methodName.isEmpty())
+        {
+            return "Error: methodName is required"; //$NON-NLS-1$
+        }
+
+        IProject project = BslModuleUtils.resolveProject(projectName);
+        if (project == null)
+        {
+            return "Error: Project not found: " + projectName; //$NON-NLS-1$
+        }
+
+        IFile file = BslModuleUtils.resolveModuleFile(project, modulePath);
+        if (file == null)
+        {
+            return "Error: Module not found: " + modulePath; //$NON-NLS-1$
+        }
+
+        // Load BSL module AST
+        Module module = BslModuleUtils.loadBslModule(file);
+        if (module == null)
+        {
+            return "Error: Failed to load BSL module AST for: " + modulePath; //$NON-NLS-1$
+        }
+
+        // Extract all methods
+        List<MethodInfo> methods = BslModuleUtils.extractMethods(module);
+
+        // Find method by name (case-insensitive)
+        MethodInfo targetMethod = null;
+        for (MethodInfo method : methods)
+        {
+            if (method.name.equalsIgnoreCase(methodName))
+            {
+                targetMethod = method;
+                break;
+            }
+        }
+
+        if (targetMethod == null)
+        {
+            // Method not found - provide list of available methods
+            StringBuilder sb = new StringBuilder();
+            sb.append("Error: Method '").append(methodName) //$NON-NLS-1$
+                .append("' not found in ").append(modulePath).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+
+            if (!methods.isEmpty())
+            {
+                sb.append("**Available methods:**\n"); //$NON-NLS-1$
+                for (MethodInfo m : methods)
+                {
+                    sb.append("- ").append(m.name); //$NON-NLS-1$
+                    sb.append(" (").append(m.isFunction ? "Function" : "Procedure"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                    sb.append(", lines ").append(m.startLine).append("-").append(m.endLine); //$NON-NLS-1$ //$NON-NLS-2$
+                    sb.append(")\n"); //$NON-NLS-1$
+                }
+            }
+            else
+            {
+                sb.append("The module contains no methods.\n"); //$NON-NLS-1$
+            }
+
+            return sb.toString();
+        }
+
+        // Read the method source
+        String content = BslModuleUtils.readFileContent(file,
+            targetMethod.startLine, targetMethod.endLine);
+        if (content == null)
+        {
+            return "Error: Failed to read method source"; //$NON-NLS-1$
+        }
+
+        // Format output
+        StringBuilder sb = new StringBuilder();
+        sb.append("## Method: ").append(targetMethod.name).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        sb.append("**Module:** ").append(modulePath).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("**Type:** ").append(targetMethod.isFunction ? "Function" : "Procedure"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        sb.append(" | **Export:** ").append(targetMethod.isExport ? "Yes" : "No"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+        if (targetMethod.pragmas != null && !targetMethod.pragmas.isEmpty())
+        {
+            sb.append(" | **Context:** ").append(targetMethod.pragmas); //$NON-NLS-1$
+        }
+        if (targetMethod.regionName != null)
+        {
+            sb.append(" | **Region:** ").append(targetMethod.regionName); //$NON-NLS-1$
+        }
+
+        sb.append("\n"); //$NON-NLS-1$
+        sb.append("**Lines:** ").append(targetMethod.startLine) //$NON-NLS-1$
+            .append("-").append(targetMethod.endLine).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        sb.append("```bsl\n"); //$NON-NLS-1$
+        sb.append(content);
+        sb.append("```\n"); //$NON-NLS-1$
+
+        return sb.toString();
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) 2025 DitriX
+ */
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import java.util.Map;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+
+import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
+import com.ditrix.edt.mcp.server.protocol.JsonUtils;
+import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.BslModuleUtils;
+
+/**
+ * Tool to read BSL module source code (entire file or a specific line range).
+ * Returns source code with line numbers for easy reference.
+ */
+public class ReadModuleSourceTool implements IMcpTool
+{
+    public static final String NAME = "read_module_source"; //$NON-NLS-1$
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Read BSL module source code (entire file or specific line range). " + //$NON-NLS-1$
+               "Returns source code with line numbers. Use startLine/endLine to read " + //$NON-NLS-1$
+               "portions of large modules instead of loading the entire file."; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getInputSchema()
+    {
+        return JsonSchemaBuilder.object()
+            .stringProperty("projectName", //$NON-NLS-1$
+                "EDT project name (required)", true) //$NON-NLS-1$
+            .stringProperty("modulePath", //$NON-NLS-1$
+                "Path to BSL file relative to project's src folder " + //$NON-NLS-1$
+                "(e.g. 'CommonModules/MyModule/Module.bsl', " + //$NON-NLS-1$
+                "'Documents/SalesOrder/Ext/ObjectModule.bsl')", true) //$NON-NLS-1$
+            .integerProperty("startLine", //$NON-NLS-1$
+                "Start line number (1-based). If omitted, reads from the beginning") //$NON-NLS-1$
+            .integerProperty("endLine", //$NON-NLS-1$
+                "End line number (1-based, inclusive). If omitted, reads to the end") //$NON-NLS-1$
+            .build();
+    }
+
+    @Override
+    public ResponseType getResponseType()
+    {
+        return ResponseType.MARKDOWN;
+    }
+
+    @Override
+    public String getResultFileName(Map<String, String> params)
+    {
+        String modulePath = JsonUtils.extractStringArgument(params, "modulePath"); //$NON-NLS-1$
+        if (modulePath != null && !modulePath.isEmpty())
+        {
+            String safeName = modulePath.replace("/", "-").replace("\\", "-") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+                .replace(".bsl", "").toLowerCase(); //$NON-NLS-1$ //$NON-NLS-2$
+            return "source-" + safeName + ".md"; //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return "module-source.md"; //$NON-NLS-1$
+    }
+
+    @Override
+    public String execute(Map<String, String> params)
+    {
+        String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
+        String modulePath = JsonUtils.extractStringArgument(params, "modulePath"); //$NON-NLS-1$
+        String startLineStr = JsonUtils.extractStringArgument(params, "startLine"); //$NON-NLS-1$
+        String endLineStr = JsonUtils.extractStringArgument(params, "endLine"); //$NON-NLS-1$
+
+        // Validate required parameters
+        if (projectName == null || projectName.isEmpty())
+        {
+            return "Error: projectName is required"; //$NON-NLS-1$
+        }
+        if (modulePath == null || modulePath.isEmpty())
+        {
+            return "Error: modulePath is required"; //$NON-NLS-1$
+        }
+
+        int startLine = parseIntParam(startLineStr, 0);
+        int endLine = parseIntParam(endLineStr, 0);
+
+        // Resolve project and file
+        IProject project = BslModuleUtils.resolveProject(projectName);
+        if (project == null)
+        {
+            return "Error: Project not found: " + projectName; //$NON-NLS-1$
+        }
+
+        IFile file = BslModuleUtils.resolveModuleFile(project, modulePath);
+        if (file == null)
+        {
+            return "Error: Module not found: " + modulePath; //$NON-NLS-1$
+        }
+
+        // Count total lines
+        int totalLines = BslModuleUtils.countLines(file);
+        if (totalLines < 0)
+        {
+            return "Error: Failed to read file"; //$NON-NLS-1$
+        }
+
+        // Read content
+        String content = BslModuleUtils.readFileContent(file, startLine, endLine);
+        if (content == null)
+        {
+            return "Error: Failed to read file content"; //$NON-NLS-1$
+        }
+
+        // Format output
+        StringBuilder sb = new StringBuilder();
+        sb.append("## ").append(modulePath).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("**Total lines:** ").append(totalLines); //$NON-NLS-1$
+
+        if (startLine > 0 || endLine > 0)
+        {
+            int effectiveStart = Math.max(startLine, 1);
+            int effectiveEnd = endLine > 0 ? Math.min(endLine, totalLines) : totalLines;
+            sb.append(" | **Showing:** lines ").append(effectiveStart) //$NON-NLS-1$
+                .append("-").append(effectiveEnd); //$NON-NLS-1$
+        }
+        sb.append("\n\n"); //$NON-NLS-1$
+
+        sb.append("```bsl\n"); //$NON-NLS-1$
+        sb.append(content);
+        sb.append("```\n"); //$NON-NLS-1$
+
+        return sb.toString();
+    }
+
+    /**
+     * Parses an integer parameter string, handling both integer and double formats.
+     */
+    private int parseIntParam(String value, int defaultValue)
+    {
+        if (value == null || value.isEmpty())
+        {
+            return defaultValue;
+        }
+        try
+        {
+            return (int) Double.parseDouble(value);
+        }
+        catch (NumberFormatException e)
+        {
+            return defaultValue;
+        }
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SearchInCodeTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SearchInCodeTool.java
@@ -1,0 +1,384 @@
+/**
+ * Copyright (c) 2025 DitriX
+ */
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+
+import com.ditrix.edt.mcp.server.Activator;
+import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
+import com.ditrix.edt.mcp.server.protocol.JsonUtils;
+import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.BslModuleUtils;
+
+/**
+ * Tool for full-text search across all BSL code in the configuration.
+ * Supports plain text, regex, case-sensitivity, whole-word matching, and context lines.
+ */
+public class SearchInCodeTool implements IMcpTool
+{
+    public static final String NAME = "search_in_code"; //$NON-NLS-1$
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Full-text search across all BSL code modules in the configuration. " + //$NON-NLS-1$
+               "Supports plain text and regex patterns, case-sensitivity, whole-word matching, " + //$NON-NLS-1$
+               "and context lines around each match. Can be restricted to specific modules or metadata types."; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getInputSchema()
+    {
+        return JsonSchemaBuilder.object()
+            .stringProperty("projectName", //$NON-NLS-1$
+                "EDT project name (required)", true) //$NON-NLS-1$
+            .stringProperty("query", //$NON-NLS-1$
+                "Search text or regex pattern (required)", true) //$NON-NLS-1$
+            .booleanProperty("caseSensitive", //$NON-NLS-1$
+                "Case-sensitive search. Default: false") //$NON-NLS-1$
+            .booleanProperty("wholeWord", //$NON-NLS-1$
+                "Match whole words only. Default: false") //$NON-NLS-1$
+            .booleanProperty("regex", //$NON-NLS-1$
+                "Treat query as regular expression. Default: false") //$NON-NLS-1$
+            .integerProperty("contextLines", //$NON-NLS-1$
+                "Number of surrounding lines to include with each match. Default: 2") //$NON-NLS-1$
+            .integerProperty("limit", //$NON-NLS-1$
+                "Maximum number of matches to return. Default: 50") //$NON-NLS-1$
+            .stringProperty("modulePath", //$NON-NLS-1$
+                "Restrict search to a specific module path " + //$NON-NLS-1$
+                "(e.g. 'CommonModules/MyModule/Module.bsl')") //$NON-NLS-1$
+            .stringProperty("metadataType", //$NON-NLS-1$
+                "Restrict search to modules of this metadata type " + //$NON-NLS-1$
+                "(e.g. 'Documents', 'CommonModules')") //$NON-NLS-1$
+            .build();
+    }
+
+    @Override
+    public ResponseType getResponseType()
+    {
+        return ResponseType.MARKDOWN;
+    }
+
+    @Override
+    public String getResultFileName(Map<String, String> params)
+    {
+        String query = JsonUtils.extractStringArgument(params, "query"); //$NON-NLS-1$
+        if (query != null && !query.isEmpty())
+        {
+            String safeName = query.replaceAll("[^a-zA-Z0-9]", "-").toLowerCase(); //$NON-NLS-1$ //$NON-NLS-2$
+            if (safeName.length() > 30)
+            {
+                safeName = safeName.substring(0, 30);
+            }
+            return "search-" + safeName + ".md"; //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return "search-results.md"; //$NON-NLS-1$
+    }
+
+    @Override
+    public String execute(Map<String, String> params)
+    {
+        String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
+        String query = JsonUtils.extractStringArgument(params, "query"); //$NON-NLS-1$
+        String caseSensitiveStr = JsonUtils.extractStringArgument(params, "caseSensitive"); //$NON-NLS-1$
+        String wholeWordStr = JsonUtils.extractStringArgument(params, "wholeWord"); //$NON-NLS-1$
+        String regexStr = JsonUtils.extractStringArgument(params, "regex"); //$NON-NLS-1$
+        String contextLinesStr = JsonUtils.extractStringArgument(params, "contextLines"); //$NON-NLS-1$
+        String limitStr = JsonUtils.extractStringArgument(params, "limit"); //$NON-NLS-1$
+        String modulePath = JsonUtils.extractStringArgument(params, "modulePath"); //$NON-NLS-1$
+        String metadataType = JsonUtils.extractStringArgument(params, "metadataType"); //$NON-NLS-1$
+
+        if (projectName == null || projectName.isEmpty())
+        {
+            return "Error: projectName is required"; //$NON-NLS-1$
+        }
+        if (query == null || query.isEmpty())
+        {
+            return "Error: query is required"; //$NON-NLS-1$
+        }
+
+        boolean caseSensitive = "true".equalsIgnoreCase(caseSensitiveStr); //$NON-NLS-1$
+        boolean wholeWord = "true".equalsIgnoreCase(wholeWordStr); //$NON-NLS-1$
+        boolean useRegex = "true".equalsIgnoreCase(regexStr); //$NON-NLS-1$
+
+        int contextLines = 2;
+        if (contextLinesStr != null && !contextLinesStr.isEmpty())
+        {
+            try
+            {
+                contextLines = Math.min((int) Double.parseDouble(contextLinesStr), 10);
+            }
+            catch (NumberFormatException e)
+            {
+                // Use default
+            }
+        }
+
+        int limit = 50;
+        if (limitStr != null && !limitStr.isEmpty())
+        {
+            try
+            {
+                limit = Math.min((int) Double.parseDouble(limitStr), 500);
+            }
+            catch (NumberFormatException e)
+            {
+                // Use default
+            }
+        }
+
+        IProject project = BslModuleUtils.resolveProject(projectName);
+        if (project == null)
+        {
+            return "Error: Project not found: " + projectName; //$NON-NLS-1$
+        }
+
+        // Compile search pattern
+        Pattern searchPattern;
+        try
+        {
+            searchPattern = compilePattern(query, caseSensitive, wholeWord, useRegex);
+        }
+        catch (Exception e)
+        {
+            return "Error: Invalid regex pattern: " + e.getMessage(); //$NON-NLS-1$
+        }
+
+        // Get files to search
+        List<IFile> filesToSearch;
+        if (modulePath != null && !modulePath.isEmpty())
+        {
+            // Single file search
+            IFile file = BslModuleUtils.resolveModuleFile(project, modulePath);
+            if (file == null)
+            {
+                return "Error: Module not found: " + modulePath; //$NON-NLS-1$
+            }
+            filesToSearch = List.of(file);
+        }
+        else if (metadataType != null && !metadataType.isEmpty())
+        {
+            filesToSearch = BslModuleUtils.findBslFilesByType(project, metadataType);
+        }
+        else
+        {
+            filesToSearch = BslModuleUtils.findAllBslFiles(project);
+        }
+
+        // Search
+        Map<String, List<SearchMatch>> resultsByFile = new LinkedHashMap<>();
+        int totalMatches = 0;
+
+        for (IFile file : filesToSearch)
+        {
+            if (totalMatches >= limit)
+            {
+                break;
+            }
+
+            List<SearchMatch> matches = searchInFile(file, searchPattern, contextLines,
+                limit - totalMatches);
+            if (!matches.isEmpty())
+            {
+                String relPath = BslModuleUtils.getRelativeModulePath(project, file);
+                resultsByFile.put(relPath, matches);
+                totalMatches += matches.size();
+            }
+        }
+
+        // Format output
+        return formatOutput(query, projectName, caseSensitive, wholeWord, useRegex,
+            resultsByFile, totalMatches, limit, filesToSearch.size());
+    }
+
+    /**
+     * Compiles the search pattern based on options.
+     */
+    private Pattern compilePattern(String query, boolean caseSensitive,
+        boolean wholeWord, boolean useRegex)
+    {
+        String pattern;
+        if (useRegex)
+        {
+            pattern = query;
+        }
+        else
+        {
+            pattern = Pattern.quote(query);
+        }
+
+        if (wholeWord)
+        {
+            pattern = "\\b" + pattern + "\\b"; //$NON-NLS-1$ //$NON-NLS-2$
+        }
+
+        int flags = caseSensitive ? 0 : Pattern.CASE_INSENSITIVE;
+        return Pattern.compile(pattern, flags);
+    }
+
+    /**
+     * Searches for matches in a single file.
+     */
+    private List<SearchMatch> searchInFile(IFile file, Pattern pattern,
+        int contextLines, int maxMatches)
+    {
+        List<SearchMatch> matches = new ArrayList<>();
+        List<String> allLines = new ArrayList<>();
+
+        // Read all lines
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(file.getContents(), file.getCharset())))
+        {
+            String line;
+            while ((line = reader.readLine()) != null)
+            {
+                allLines.add(line);
+            }
+        }
+        catch (Exception e)
+        {
+            Activator.logError("Error reading file for search", e); //$NON-NLS-1$
+            return matches;
+        }
+
+        // Search line by line
+        for (int i = 0; i < allLines.size(); i++)
+        {
+            if (matches.size() >= maxMatches)
+            {
+                break;
+            }
+
+            String line = allLines.get(i);
+            Matcher matcher = pattern.matcher(line);
+            if (matcher.find())
+            {
+                int lineNum = i + 1; // 1-based
+
+                // Extract context lines
+                int contextStart = Math.max(0, i - contextLines);
+                int contextEnd = Math.min(allLines.size() - 1, i + contextLines);
+
+                StringBuilder context = new StringBuilder();
+                for (int j = contextStart; j <= contextEnd; j++)
+                {
+                    int num = j + 1;
+                    String prefix = (j == i) ? ">" : " "; //$NON-NLS-1$ //$NON-NLS-2$
+                    context.append(String.format("%s%5d | %s%n", prefix, num, allLines.get(j))); //$NON-NLS-1$
+                }
+
+                matches.add(new SearchMatch(lineNum, line.trim(), context.toString()));
+            }
+        }
+
+        return matches;
+    }
+
+    /**
+     * Formats the search results as markdown.
+     */
+    private String formatOutput(String query, String projectName,
+        boolean caseSensitive, boolean wholeWord, boolean useRegex,
+        Map<String, List<SearchMatch>> resultsByFile,
+        int totalMatches, int limit, int filesSearched)
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("## Search Results: \"").append(escapeMarkdown(query)).append("\"\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("**Project:** ").append(projectName); //$NON-NLS-1$
+        sb.append(" | **Files searched:** ").append(filesSearched); //$NON-NLS-1$
+        sb.append(" | **Total matches:** ").append(totalMatches); //$NON-NLS-1$
+        if (totalMatches >= limit)
+        {
+            sb.append(" (limit reached)"); //$NON-NLS-1$
+        }
+        sb.append("\n"); //$NON-NLS-1$
+
+        // Options
+        List<String> options = new ArrayList<>();
+        if (caseSensitive) options.add("case-sensitive"); //$NON-NLS-1$
+        if (wholeWord) options.add("whole-word"); //$NON-NLS-1$
+        if (useRegex) options.add("regex"); //$NON-NLS-1$
+        if (!options.isEmpty())
+        {
+            sb.append("**Options:** ").append(String.join(", ", options)).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        }
+        sb.append("\n"); //$NON-NLS-1$
+
+        if (resultsByFile.isEmpty())
+        {
+            sb.append("No matches found.\n"); //$NON-NLS-1$
+            return sb.toString();
+        }
+
+        // Output by file
+        for (Map.Entry<String, List<SearchMatch>> entry : resultsByFile.entrySet())
+        {
+            String filePath = entry.getKey();
+            List<SearchMatch> matches = entry.getValue();
+
+            sb.append("### ").append(filePath).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+
+            for (SearchMatch match : matches)
+            {
+                sb.append("**Line ").append(match.lineNumber).append(":**\n"); //$NON-NLS-1$ //$NON-NLS-2$
+                sb.append("```bsl\n"); //$NON-NLS-1$
+                sb.append(match.context);
+                sb.append("```\n\n"); //$NON-NLS-1$
+            }
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Escapes markdown special characters in text.
+     */
+    private String escapeMarkdown(String text)
+    {
+        if (text == null)
+        {
+            return ""; //$NON-NLS-1$
+        }
+        return text.replace("\\", "\\\\") //$NON-NLS-1$ //$NON-NLS-2$
+            .replace("`", "\\`") //$NON-NLS-1$ //$NON-NLS-2$
+            .replace("*", "\\*") //$NON-NLS-1$ //$NON-NLS-2$
+            .replace("_", "\\_") //$NON-NLS-1$ //$NON-NLS-2$
+            .replace("[", "\\[") //$NON-NLS-1$ //$NON-NLS-2$
+            .replace("]", "\\]"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Holds a single search match result.
+     */
+    private static class SearchMatch
+    {
+        final int lineNumber;
+        final String matchLine;
+        final String context;
+
+        SearchMatch(int lineNumber, String matchLine, String context)
+        {
+            this.lineNumber = lineNumber;
+            this.matchLine = matchLine;
+            this.context = context;
+        }
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
@@ -1,0 +1,828 @@
+/**
+ * Copyright (c) 2025 DitriX
+ */
+package com.ditrix.edt.mcp.server.utils;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.resource.IResourceServiceProvider;
+import org.eclipse.xtext.resource.XtextResourceFactory;
+
+import com._1c.g5.v8.dt.bsl.model.FormalParam;
+import com._1c.g5.v8.dt.bsl.model.Function;
+import com._1c.g5.v8.dt.bsl.model.Method;
+import com._1c.g5.v8.dt.bsl.model.Module;
+import com._1c.g5.v8.dt.bsl.model.Pragma;
+import com._1c.g5.v8.dt.bsl.model.RegionPreprocessor;
+import com.ditrix.edt.mcp.server.Activator;
+
+/**
+ * Utility class for BSL module operations: file resolution, source reading,
+ * AST loading, method extraction, and project scanning.
+ */
+@SuppressWarnings("restriction")
+public final class BslModuleUtils
+{
+    private BslModuleUtils()
+    {
+        // utility class
+    }
+
+    /** URI for BSL resource service provider lookup */
+    private static final URI BSL_URI = URI.createURI("/nopr/module.bsl"); //$NON-NLS-1$
+
+    // ========== Module type mapping ==========
+
+    /** Maps metadata type singular (lowercase) to filesystem folder name */
+    private static final Map<String, String> TYPE_TO_FOLDER = new LinkedHashMap<>();
+
+    /** Reverse map: folder name (lowercase) to metadata type singular */
+    private static final Map<String, String> FOLDER_TO_TYPE = new LinkedHashMap<>();
+
+    static
+    {
+        TYPE_TO_FOLDER.put("commonmodule", "CommonModules"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("document", "Documents"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("catalog", "Catalogs"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("informationregister", "InformationRegisters"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("accumulationregister", "AccumulationRegisters"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("accountingregister", "AccountingRegisters"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("calculationregister", "CalculationRegisters"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("report", "Reports"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("dataprocessor", "DataProcessors"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("exchangeplan", "ExchangePlans"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("businessprocess", "BusinessProcesses"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("task", "Tasks"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("constant", "Constants"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("enum", "Enums"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("webservice", "WebServices"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("httpservice", "HTTPServices"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("chartofcharacteristictypes", "ChartsOfCharacteristicTypes"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("chartofaccounts", "ChartsOfAccounts"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("chartofcalculationtypes", "ChartsOfCalculationTypes"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("commandgroup", "CommandGroups"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("commoncommand", "CommonCommands"); //$NON-NLS-1$ //$NON-NLS-2$
+        TYPE_TO_FOLDER.put("commonform", "CommonForms"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        TYPE_TO_FOLDER.forEach((type, folder) -> FOLDER_TO_TYPE.put(folder.toLowerCase(), type));
+    }
+
+    /**
+     * Module type with its relative file path within the metadata object folder.
+     */
+    public enum ModuleType
+    {
+        /** CommonModule's only module (CommonModules/Name/Module.bsl) */
+        MODULE("Module.bsl", "Module"), //$NON-NLS-1$ //$NON-NLS-2$
+        /** Object module (Documents/Name/Ext/ObjectModule.bsl) */
+        OBJECT_MODULE("Ext/ObjectModule.bsl", "ObjectModule"), //$NON-NLS-1$ //$NON-NLS-2$
+        /** Manager module (Documents/Name/Ext/ManagerModule.bsl) */
+        MANAGER_MODULE("Ext/ManagerModule.bsl", "ManagerModule"), //$NON-NLS-1$ //$NON-NLS-2$
+        /** RecordSet module (InformationRegisters/Name/Ext/RecordSetModule.bsl) */
+        RECORDSET_MODULE("Ext/RecordSetModule.bsl", "RecordSetModule"), //$NON-NLS-1$ //$NON-NLS-2$
+        /** ValueManager module for constants (Constants/Name/Ext/ValueManagerModule.bsl) */
+        VALUE_MANAGER_MODULE("Ext/ValueManagerModule.bsl", "ValueManagerModule"), //$NON-NLS-1$ //$NON-NLS-2$
+        /** Command module (CommonCommands/Name/Ext/CommandModule.bsl) */
+        COMMAND_MODULE("Ext/CommandModule.bsl", "CommandModule"), //$NON-NLS-1$ //$NON-NLS-2$
+        /** Form module - path is dynamic: Forms/FormName/Ext/Form/Module.bsl */
+        FORM_MODULE(null, "FormModule"); //$NON-NLS-1$
+
+        /** Relative path from metadata object folder, null for dynamic paths */
+        public final String relativePath;
+        /** Display name */
+        public final String displayName;
+
+        ModuleType(String relativePath, String displayName)
+        {
+            this.relativePath = relativePath;
+            this.displayName = displayName;
+        }
+    }
+
+    // ========== Project & file resolution ==========
+
+    /**
+     * Resolves an IProject by name from the workspace.
+     *
+     * @param projectName the project name
+     * @return IProject or null if not found/closed
+     */
+    public static IProject resolveProject(String projectName)
+    {
+        IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+        if (project == null || !project.exists() || !project.isOpen())
+        {
+            return null;
+        }
+        return project;
+    }
+
+    /**
+     * Resolves a BSL module IFile from a path relative to src/.
+     *
+     * @param project the project
+     * @param modulePath path relative to src/ (e.g. "CommonModules/MyModule/Module.bsl")
+     * @return IFile or null if not found
+     */
+    public static IFile resolveModuleFile(IProject project, String modulePath)
+    {
+        IPath relativePath = new Path("src").append(modulePath); //$NON-NLS-1$
+        IFile file = project.getFile(relativePath);
+        return (file != null && file.exists()) ? file : null;
+    }
+
+    /**
+     * Gets the module path relative to src/ from an IFile.
+     *
+     * @param project the project
+     * @param file the BSL file
+     * @return path relative to src/
+     */
+    public static String getRelativeModulePath(IProject project, IFile file)
+    {
+        IPath srcPath = project.getFolder("src").getFullPath(); //$NON-NLS-1$
+        IPath filePath = file.getFullPath();
+        if (srcPath.isPrefixOf(filePath))
+        {
+            return filePath.makeRelativeTo(srcPath).toString();
+        }
+        return filePath.toString();
+    }
+
+    // ========== FQN <-> path mapping ==========
+
+    /**
+     * Gets the filesystem folder name for a metadata type.
+     *
+     * @param metadataType singular metadata type (e.g. "Document", "Catalog")
+     * @return folder name (e.g. "Documents", "Catalogs") or null if unknown
+     */
+    public static String getFolder(String metadataType)
+    {
+        if (metadataType == null)
+        {
+            return null;
+        }
+        return TYPE_TO_FOLDER.get(metadataType.toLowerCase());
+    }
+
+    /**
+     * Gets the metadata type from a filesystem folder name.
+     *
+     * @param folderName folder name (e.g. "Documents")
+     * @return singular metadata type (e.g. "document") or null if unknown
+     */
+    public static String getTypeFromFolder(String folderName)
+    {
+        if (folderName == null)
+        {
+            return null;
+        }
+        return FOLDER_TO_TYPE.get(folderName.toLowerCase());
+    }
+
+    /**
+     * Parses a module file path relative to src/ into metadata FQN and module type.
+     *
+     * @param modulePath e.g. "Documents/SalesOrder/Ext/ObjectModule.bsl"
+     * @return parsed info or null if path cannot be parsed
+     */
+    public static ModulePathInfo parseModulePath(String modulePath)
+    {
+        if (modulePath == null || modulePath.isEmpty())
+        {
+            return null;
+        }
+
+        String[] parts = modulePath.replace("\\", "/").split("/"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        if (parts.length < 2)
+        {
+            return null;
+        }
+
+        String folderName = parts[0];
+        String objectName = parts[1];
+        String metadataType = FOLDER_TO_TYPE.get(folderName.toLowerCase());
+
+        if (metadataType == null)
+        {
+            return null;
+        }
+
+        // Capitalize type for FQN (e.g. "document" -> "Document")
+        String capitalizedType = metadataType.substring(0, 1).toUpperCase() + metadataType.substring(1);
+        // Handle multi-word types properly
+        String fqnType = getFqnType(capitalizedType);
+        String ownerFqn = fqnType + "." + objectName; //$NON-NLS-1$
+
+        // Determine module type from path
+        ModuleType moduleType = determineModuleType(parts);
+        String formName = null;
+
+        if (moduleType == ModuleType.FORM_MODULE && parts.length >= 3)
+        {
+            formName = parts[2]; // Forms/<FormName>/...
+        }
+
+        return new ModulePathInfo(ownerFqn, moduleType, formName);
+    }
+
+    /**
+     * Converts internal type name to proper FQN format.
+     */
+    private static String getFqnType(String type)
+    {
+        // Map internal lowercase types to proper casing
+        switch (type.toLowerCase())
+        {
+            case "commonmodule":
+                return "CommonModule"; //$NON-NLS-1$
+            case "informationregister":
+                return "InformationRegister"; //$NON-NLS-1$
+            case "accumulationregister":
+                return "AccumulationRegister"; //$NON-NLS-1$
+            case "accountingregister":
+                return "AccountingRegister"; //$NON-NLS-1$
+            case "calculationregister":
+                return "CalculationRegister"; //$NON-NLS-1$
+            case "dataprocessor":
+                return "DataProcessor"; //$NON-NLS-1$
+            case "exchangeplan":
+                return "ExchangePlan"; //$NON-NLS-1$
+            case "businessprocess":
+                return "BusinessProcess"; //$NON-NLS-1$
+            case "chartofcharacteristictypes":
+                return "ChartOfCharacteristicTypes"; //$NON-NLS-1$
+            case "chartofaccounts":
+                return "ChartOfAccounts"; //$NON-NLS-1$
+            case "chartofcalculationtypes":
+                return "ChartOfCalculationTypes"; //$NON-NLS-1$
+            case "commoncommand":
+                return "CommonCommand"; //$NON-NLS-1$
+            case "commonform":
+                return "CommonForm"; //$NON-NLS-1$
+            case "commandgroup":
+                return "CommandGroup"; //$NON-NLS-1$
+            case "httpservice":
+                return "HTTPService"; //$NON-NLS-1$
+            case "webservice":
+                return "WebService"; //$NON-NLS-1$
+            case "valuemanagermodule":
+                return "ValueManagerModule"; //$NON-NLS-1$
+            default:
+                // For simple types, capitalize first letter
+                return type.substring(0, 1).toUpperCase() + type.substring(1);
+        }
+    }
+
+    /**
+     * Determines module type from path segments.
+     */
+    private static ModuleType determineModuleType(String[] parts)
+    {
+        // CommonModules/Name/Module.bsl
+        if (parts.length == 3 && "Module.bsl".equalsIgnoreCase(parts[2])) //$NON-NLS-1$
+        {
+            return ModuleType.MODULE;
+        }
+
+        // Check for Forms/FormName/Ext/Form/Module.bsl
+        if (parts.length >= 3 && "Forms".equalsIgnoreCase(parts[2])) //$NON-NLS-1$
+        {
+            return ModuleType.FORM_MODULE;
+        }
+
+        // Type/Name/Ext/XXXModule.bsl
+        if (parts.length >= 4 && "Ext".equalsIgnoreCase(parts[2])) //$NON-NLS-1$
+        {
+            String fileName = parts[3].toLowerCase();
+            if (fileName.equals("objectmodule.bsl")) return ModuleType.OBJECT_MODULE; //$NON-NLS-1$
+            if (fileName.equals("managermodule.bsl")) return ModuleType.MANAGER_MODULE; //$NON-NLS-1$
+            if (fileName.equals("recordsetmodule.bsl")) return ModuleType.RECORDSET_MODULE; //$NON-NLS-1$
+            if (fileName.equals("valuemanagermodule.bsl")) return ModuleType.VALUE_MANAGER_MODULE; //$NON-NLS-1$
+            if (fileName.equals("commandmodule.bsl")) return ModuleType.COMMAND_MODULE; //$NON-NLS-1$
+        }
+
+        // Nested Forms: Type/Name/Forms/FormName/Ext/Form/Module.bsl
+        if (parts.length >= 5 && "Forms".equalsIgnoreCase(parts[2])) //$NON-NLS-1$
+        {
+            return ModuleType.FORM_MODULE;
+        }
+
+        return ModuleType.MODULE; // fallback
+    }
+
+    // ========== File content reading ==========
+
+    /**
+     * Reads content of an IFile, optionally restricted to a line range.
+     * Returns text with line numbers prepended.
+     *
+     * @param file the IFile to read
+     * @param startLine 1-based start line (0 or negative = from beginning)
+     * @param endLine 1-based end line (0 or negative = to end)
+     * @return formatted text with line numbers, or null on error
+     */
+    public static String readFileContent(IFile file, int startLine, int endLine)
+    {
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(file.getContents(), file.getCharset())))
+        {
+            StringBuilder sb = new StringBuilder();
+            String line;
+            int lineNum = 0;
+
+            while ((line = reader.readLine()) != null)
+            {
+                lineNum++;
+                if (startLine > 0 && lineNum < startLine)
+                {
+                    continue;
+                }
+                if (endLine > 0 && lineNum > endLine)
+                {
+                    break;
+                }
+                sb.append(String.format("%5d | %s%n", lineNum, line)); //$NON-NLS-1$
+            }
+            return sb.toString();
+        }
+        catch (Exception e)
+        {
+            Activator.logError("Error reading file content", e); //$NON-NLS-1$
+            return null;
+        }
+    }
+
+    /**
+     * Counts lines in an IFile.
+     *
+     * @param file the file
+     * @return line count, or -1 on error
+     */
+    public static int countLines(IFile file)
+    {
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(file.getContents(), file.getCharset())))
+        {
+            int count = 0;
+            while (reader.readLine() != null)
+            {
+                count++;
+            }
+            return count;
+        }
+        catch (Exception e)
+        {
+            Activator.logError("Error counting lines", e); //$NON-NLS-1$
+            return -1;
+        }
+    }
+
+    // ========== BSL Xtext model loading ==========
+
+    /**
+     * Loads a BSL module's Xtext resource and returns the Module AST root.
+     * Uses the same resource loading pattern as FindReferencesTool.
+     *
+     * @param file the .bsl IFile
+     * @return the Module AST or null on failure
+     */
+    public static Module loadBslModule(IFile file)
+    {
+        try
+        {
+            URI fileUri = URI.createPlatformResourceURI(file.getFullPath().toString(), true);
+
+            ResourceSet resourceSet = new ResourceSetImpl();
+            IResourceServiceProvider rsp =
+                IResourceServiceProvider.Registry.INSTANCE.getResourceServiceProvider(BSL_URI);
+            if (rsp != null)
+            {
+                XtextResourceFactory factory = rsp.get(XtextResourceFactory.class);
+                if (factory != null)
+                {
+                    resourceSet.getResourceFactoryRegistry()
+                        .getExtensionToFactoryMap().put("bsl", factory); //$NON-NLS-1$
+                }
+            }
+
+            Resource resource = resourceSet.getResource(fileUri, true);
+            if (resource != null && !resource.getContents().isEmpty())
+            {
+                EObject root = resource.getContents().get(0);
+                if (root instanceof Module)
+                {
+                    return (Module) root;
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Activator.logError("Error loading BSL module: " + file.getFullPath(), e); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    // ========== Method extraction from AST ==========
+
+    /**
+     * Extracts all methods from a loaded BSL Module.
+     *
+     * @param module the BSL Module AST root
+     * @return list of MethodInfo, ordered by start line
+     */
+    public static List<MethodInfo> extractMethods(Module module)
+    {
+        List<MethodInfo> methods = new ArrayList<>();
+
+        EList<Method> allMethods = module.allMethods();
+        if (allMethods == null)
+        {
+            return methods;
+        }
+
+        for (Method method : allMethods)
+        {
+            String name = method.getName();
+            boolean isFunction = method instanceof Function;
+            boolean isExport = method.isExport();
+
+            // Get line numbers from Xtext node model
+            INode node = NodeModelUtils.findActualNodeFor(method);
+            int startLine = node != null ? node.getStartLine() : 0;
+            int endLine = node != null ? node.getEndLine() : 0;
+
+            // Build signature
+            String signature = buildMethodSignature(method, isFunction);
+
+            // Extract pragmas
+            String pragmas = extractPragmas(method);
+
+            // Find enclosing region
+            String regionName = findEnclosingRegion(method);
+
+            methods.add(new MethodInfo(name, isFunction, isExport,
+                startLine, endLine, signature, regionName, pragmas));
+        }
+
+        methods.sort(Comparator.comparingInt(m -> m.startLine));
+        return methods;
+    }
+
+    /**
+     * Builds the textual signature of a Method.
+     */
+    private static String buildMethodSignature(Method method, boolean isFunction)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append(isFunction ? "Function " : "Procedure "); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append(method.getName());
+        sb.append("("); //$NON-NLS-1$
+
+        EList<FormalParam> params = method.getFormalParams();
+        if (params != null)
+        {
+            for (int i = 0; i < params.size(); i++)
+            {
+                if (i > 0)
+                {
+                    sb.append(", "); //$NON-NLS-1$
+                }
+                FormalParam param = params.get(i);
+                if (param.isByValue())
+                {
+                    sb.append("Val "); //$NON-NLS-1$
+                }
+                sb.append(param.getName());
+                if (param.getDefaultValue() != null)
+                {
+                    sb.append(" = ..."); //$NON-NLS-1$
+                }
+            }
+        }
+
+        sb.append(")"); //$NON-NLS-1$
+        if (method.isExport())
+        {
+            sb.append(" Export"); //$NON-NLS-1$
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Extracts pragma annotations from a method.
+     */
+    private static String extractPragmas(Method method)
+    {
+        EList<Pragma> pragmas = method.getPragmas();
+        if (pragmas == null || pragmas.isEmpty())
+        {
+            return ""; //$NON-NLS-1$
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < pragmas.size(); i++)
+        {
+            if (i > 0)
+            {
+                sb.append(", "); //$NON-NLS-1$
+            }
+            Pragma pragma = pragmas.get(i);
+            String symbol = pragma.getSymbol();
+            if (symbol != null && !symbol.isEmpty())
+            {
+                sb.append("&").append(symbol); //$NON-NLS-1$
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Finds the enclosing #Region name for a method by walking up the AST.
+     */
+    private static String findEnclosingRegion(Method method)
+    {
+        EObject container = method.eContainer();
+        while (container != null)
+        {
+            if (container instanceof RegionPreprocessor)
+            {
+                return ((RegionPreprocessor) container).getName();
+            }
+            if (container instanceof Module)
+            {
+                break; // reached module root, no region
+            }
+            container = container.eContainer();
+        }
+        return null;
+    }
+
+    // ========== BSL file scanning ==========
+
+    /**
+     * Finds all .bsl files in a project's src/ directory.
+     *
+     * @param project the project
+     * @return list of IFile objects
+     */
+    public static List<IFile> findAllBslFiles(IProject project)
+    {
+        List<IFile> bslFiles = new ArrayList<>();
+        IFolder srcFolder = project.getFolder("src"); //$NON-NLS-1$
+        if (!srcFolder.exists())
+        {
+            return bslFiles;
+        }
+
+        try
+        {
+            srcFolder.accept(resource -> {
+                if (resource instanceof IFile
+                    && "bsl".equalsIgnoreCase(((IFile) resource).getFileExtension())) //$NON-NLS-1$
+                {
+                    bslFiles.add((IFile) resource);
+                }
+                return true;
+            });
+        }
+        catch (CoreException e)
+        {
+            Activator.logError("Error scanning BSL files", e); //$NON-NLS-1$
+        }
+        return bslFiles;
+    }
+
+    /**
+     * Finds all .bsl files filtered by metadata type folder.
+     *
+     * @param project the project
+     * @param metadataType metadata type filter (e.g. "Documents", "CommonModules")
+     * @return list of IFile objects
+     */
+    public static List<IFile> findBslFilesByType(IProject project, String metadataType)
+    {
+        List<IFile> bslFiles = new ArrayList<>();
+
+        // Try direct folder name first
+        IFolder typeFolder = project.getFolder("src/" + metadataType); //$NON-NLS-1$
+
+        // If not found, try mapping from type name
+        if (!typeFolder.exists())
+        {
+            String folderName = getFolder(metadataType);
+            if (folderName != null)
+            {
+                typeFolder = project.getFolder("src/" + folderName); //$NON-NLS-1$
+            }
+        }
+
+        if (!typeFolder.exists())
+        {
+            return bslFiles;
+        }
+
+        try
+        {
+            typeFolder.accept(resource -> {
+                if (resource instanceof IFile
+                    && "bsl".equalsIgnoreCase(((IFile) resource).getFileExtension())) //$NON-NLS-1$
+                {
+                    bslFiles.add((IFile) resource);
+                }
+                return true;
+            });
+        }
+        catch (CoreException e)
+        {
+            Activator.logError("Error scanning BSL files by type", e); //$NON-NLS-1$
+        }
+        return bslFiles;
+    }
+
+    /**
+     * Finds all .bsl module files for a specific metadata object.
+     *
+     * @param project the project
+     * @param objectFqn FQN like "Document.SalesOrder"
+     * @return list of ModuleInfo objects
+     */
+    public static List<ModuleInfo> findObjectModules(IProject project, String objectFqn)
+    {
+        List<ModuleInfo> modules = new ArrayList<>();
+
+        if (objectFqn == null || objectFqn.isEmpty())
+        {
+            return modules;
+        }
+
+        String[] parts = objectFqn.split("\\."); //$NON-NLS-1$
+        if (parts.length < 2)
+        {
+            return modules;
+        }
+
+        String mdType = parts[0];
+        String mdName = parts[1];
+
+        String folderName = getFolder(mdType);
+        if (folderName == null)
+        {
+            return modules;
+        }
+
+        String basePath = folderName + "/" + mdName; //$NON-NLS-1$
+        IFolder objectFolder = project.getFolder("src/" + basePath); //$NON-NLS-1$
+        if (!objectFolder.exists())
+        {
+            return modules;
+        }
+
+        // Check standard module files
+        checkAndAddModule(project, modules, basePath, ModuleType.MODULE, objectFqn);
+        checkAndAddModule(project, modules, basePath, ModuleType.OBJECT_MODULE, objectFqn);
+        checkAndAddModule(project, modules, basePath, ModuleType.MANAGER_MODULE, objectFqn);
+        checkAndAddModule(project, modules, basePath, ModuleType.RECORDSET_MODULE, objectFqn);
+        checkAndAddModule(project, modules, basePath, ModuleType.VALUE_MANAGER_MODULE, objectFqn);
+        checkAndAddModule(project, modules, basePath, ModuleType.COMMAND_MODULE, objectFqn);
+
+        // Scan for form modules: Forms/*/Ext/Form/Module.bsl
+        IFolder formsFolder = project.getFolder("src/" + basePath + "/Forms"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (formsFolder.exists())
+        {
+            try
+            {
+                IResource[] formFolders = formsFolder.members();
+                for (IResource formResource : formFolders)
+                {
+                    if (formResource instanceof IFolder)
+                    {
+                        String formName = formResource.getName();
+                        String formModulePath = basePath + "/Forms/" + formName + "/Ext/Form/Module.bsl"; //$NON-NLS-1$ //$NON-NLS-2$
+                        IFile formFile = resolveModuleFile(project, formModulePath);
+                        if (formFile != null)
+                        {
+                            modules.add(new ModuleInfo(ModuleType.FORM_MODULE, formModulePath,
+                                objectFqn, formName));
+                        }
+                    }
+                }
+            }
+            catch (CoreException e)
+            {
+                Activator.logError("Error scanning form modules", e); //$NON-NLS-1$
+            }
+        }
+
+        return modules;
+    }
+
+    /**
+     * Checks if a standard module file exists and adds it to the list.
+     */
+    private static void checkAndAddModule(IProject project, List<ModuleInfo> modules,
+        String basePath, ModuleType type, String ownerFqn)
+    {
+        if (type.relativePath == null)
+        {
+            return; // dynamic path (form modules handled separately)
+        }
+
+        String modulePath = basePath + "/" + type.relativePath; //$NON-NLS-1$
+        IFile file = resolveModuleFile(project, modulePath);
+        if (file != null)
+        {
+            modules.add(new ModuleInfo(type, modulePath, ownerFqn, null));
+        }
+    }
+
+    // ========== Data classes ==========
+
+    /**
+     * Holds metadata about a BSL module file.
+     */
+    public static class ModuleInfo
+    {
+        public final ModuleType type;
+        public final String relativePath;
+        public final String ownerFqn;
+        public final String formName;
+
+        public ModuleInfo(ModuleType type, String relativePath, String ownerFqn, String formName)
+        {
+            this.type = type;
+            this.relativePath = relativePath;
+            this.ownerFqn = ownerFqn;
+            this.formName = formName;
+        }
+    }
+
+    /**
+     * Result of parsing a module file path.
+     */
+    public static class ModulePathInfo
+    {
+        public final String ownerFqn;
+        public final ModuleType moduleType;
+        public final String formName;
+
+        public ModulePathInfo(String ownerFqn, ModuleType moduleType, String formName)
+        {
+            this.ownerFqn = ownerFqn;
+            this.moduleType = moduleType;
+            this.formName = formName;
+        }
+    }
+
+    /**
+     * Holds method metadata extracted from BSL AST.
+     */
+    public static class MethodInfo
+    {
+        public final String name;
+        public final boolean isFunction;
+        public final boolean isExport;
+        public final int startLine;
+        public final int endLine;
+        public final String signature;
+        public final String regionName;
+        public final String pragmas;
+
+        public MethodInfo(String name, boolean isFunction, boolean isExport,
+            int startLine, int endLine, String signature,
+            String regionName, String pragmas)
+        {
+            this.name = name;
+            this.isFunction = isFunction;
+            this.isExport = isExport;
+            this.startLine = startLine;
+            this.endLine = endLine;
+            this.signature = signature;
+            this.regionName = regionName;
+            this.pragmas = pragmas;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add 6 MCP tools for AI agents to read, search, and analyze BSL module source code:
  - `read_module_source` — read BSL file content with optional line ranges
  - `get_module_structure` — extract methods, signatures, regions from Xtext AST
  - `list_modules` — enumerate BSL modules per metadata object or project
  - `search_in_code` — full-text/regex search across all BSL modules
  - `read_method_source` — extract specific procedure/function by name
  - `get_method_call_hierarchy` — find callers/callees via BM cross-reference index
- Add shared `BslModuleUtils` utility (FQN mapping, Xtext AST loading, file scanning)
- Add `build.cmd` script for Maven/Tycho builds with auto-detected EDT installation
- Add `CLAUDE.md` for AI assistant onboarding
- Fix target artifact version mismatch in `bom/pom.xml` (1.0.0 -> 1.20.1)
- Update `.gitignore` for build artifacts and local settings

## Test plan

- [ ] Build plugin with `build.cmd` against EDT 2025.1+
- [ ] Install plugin into EDT, verify all 6 new tools appear in `tools/list`
- [ ] Test `read_module_source` on a BSL module with line range parameters
- [ ] Test `get_module_structure` returns methods, regions, and signatures
- [ ] Test `list_modules` for a configuration object and for entire project
- [ ] Test `search_in_code` with regex pattern across modules
- [ ] Test `read_method_source` extracts a single procedure by name
- [ ] Test `get_method_call_hierarchy` finds callers via BM index