### PR TITLE
Add GitHub Actions workflows for build and release processes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      - name: Maven build
+        working-directory: mcp
+        run: mvn clean verify --batch-mode --no-transfer-progress
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(grep -oP 'Bundle-Version:\s*\K[\d.]+' mcp/bundles/com.ditrix.edt.mcp.server/META-INF/MANIFEST.MF)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Package archive
+        run: |
+          cd mcp/repositories/com.ditrix.edt.mcp.server.repository/target/repository
+          zip -r "$GITHUB_WORKSPACE/MCP-EDT.v${{ steps.version.outputs.version }}.zip" .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: MCP-EDT.v${{ steps.version.outputs.version }}
+          path: MCP-EDT.v*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      - name: Maven build
+        working-directory: mcp
+        run: mvn clean verify --batch-mode --no-transfer-progress
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(grep -oP 'Bundle-Version:\s*\K[\d.]+' mcp/bundles/com.ditrix.edt.mcp.server/META-INF/MANIFEST.MF)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Package archive
+        run: |
+          cd mcp/repositories/com.ditrix.edt.mcp.server.repository/target/repository
+          zip -r "$GITHUB_WORKSPACE/MCP-EDT.v${{ steps.version.outputs.version }}.zip" .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: MCP-EDT v${{ steps.version.outputs.version }}
+          files: MCP-EDT.v*.zip
+          generate_release_notes: true


### PR DESCRIPTION
Добавлена сборка плагина в Github Actions. Частично решен #23. Тесты надо делать отдельно.

Созданы файлы:

- `.github/workflows/build.yml` — сборка на каждый push/PR в master. Собирает проект и загружает zip как артефакт.
- `.github/workflows/release.yml` — при пуше тега v* собирает проект и создаёт GitHub Release и автоматически прикрепляются в Release.

## Как делать релиз

Шаг 1. Убедитесь, что версия в проекте актуальна (сейчас 1.22.1 в MANIFEST.MF, feature.xml, pom.xml).
Шаг 2. Создайте тег и запушьте его:

```
git tag v1.22.1
git push origin v1.22.1
```

Шаг 3. GitHub Actions автоматически:

- Соберёт проект Maven/Tycho
- Упакует p2-репозиторий в MCP-EDT.v1.22.1.zip
- Создаст GitHub Release с этим архивом и автосгенерированными release notes