### PR TITLE
Исправление ошибок сборки под JDK 24.

### DIFF
--- a/mcp/.mvn/jvm.config
+++ b/mcp/.mvn/jvm.config
@@ -1,0 +1,3 @@
+-Djdk.xml.maxGeneralEntitySizeLimit=0
+-Djdk.xml.totalEntitySizeLimit=0
+


### PR DESCRIPTION
В JDK 24 ввели лимиты на размер одного entity (MaxEntitySizeLimit) и общий размер сущностей(TotalEntitySizeLimit). 
При превышении лимитов оно падает с соответствующими ошибками: 
JAXP00010004: The accumulated size of entities is "100,001" that exceeded the "100,000" limit set by "jaxp.properties". JAXP00010003: The length of entity "[xml]" is "100,001" that exceeds the "100,000" limit set by "jdk.xml.maxGeneralEntitySizeLimit". 

Детали здесь: https://github.com/google/google-java-format/pull/1212.  Там же и workaround: 
создать в корне проекта файл .mvn/jvm.config и положить туда 
-Djdk.xml.maxGeneralEntitySizeLimit=0 
-Djdk.xml.totalEntitySizeLimit=0

После применения данного фикса проект нормально собирается под jdk25 через mvn clean install