### PR TITLE
Connection stability, bilingual FQN support

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,13 +825,27 @@ groups:
 ## Version History
 
 <details>
-<summary><strong>1.24.6</strong> - Symbol info tool and GoToDefinition in tools list</summary>
+<summary><strong>1.24.6</strong> - Symbol info tool, connection stability, bilingual FQN support</summary>
 
 - **New**: `get_symbol_info` tool — get type/hover information about a symbol at a BSL code position
   - Returns inferred types, method signatures, and documentation (same as EDT hover tooltip)
   - Multi-level approach: editor hover → EObject analysis → EMF fallback
   - Pre-validates position to avoid returning contextual info for whitespace/comments
   - Useful for understanding variable types in dynamically-typed BSL code
+- **Improved**: Connection stability — reduced "socket connection was closed unexpectedly" errors
+  - Split into two thread pools: main pool (8 threads, queue 200) for POST/DELETE requests and dedicated SSE pool (max 10) for long-lived event streams — prevents SSE connections from starving request processing
+  - Two-level overload protection: admission control (threshold 50) returns HTTP 503 + `Retry-After` instantly; bounded queue (200) acts as memory safety net
+  - SSE pool returns HTTP 503 when connection limit (10) is exceeded
+  - Reduced SSE heartbeat interval from 15s to 5s to prevent proxy/client timeouts
+  - Added HTTP server timeout configuration (idle: 300s, request/response: 600s)
+  - Added `Connection: keep-alive` header to JSON responses
+  - Improved error handling with graceful recovery on client disconnection
+- **Improved**: `get_project_errors` tool — full bilingual FQN support
+  - Accepts both English and Russian metadata type names (e.g. 'Document.SalesOrder' or 'Документ.ПродажаТоваров')
+  - Automatically matches markers regardless of configuration language
+- **Improved**: `revalidate_objects` tool — Russian metadata type names support
+  - FQN normalization via `MetadataTypeUtils.normalizeFqn()` before BM API calls
+
 </details>
 
 <details>

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtilsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtilsTest.java
@@ -387,4 +387,96 @@ public class MetadataTypeUtilsTest
             }
         }
     }
+
+    // ========== getAllFqnVariants ==========
+
+    @Test
+    public void testGetAllFqnVariantsRussianInput()
+    {
+        // Russian FQN should produce original (lowercased) + English variant
+        Set<String> variants = MetadataTypeUtils.getAllFqnVariants(
+            "\u0414\u043E\u043A\u0443\u043C\u0435\u043D\u0442.\u0420\u0430\u0441\u0445\u043E\u0434\u044B"); // Документ.Расходы
+        assertTrue("Should contain original lowercased",
+            variants.contains("\u0434\u043E\u043A\u0443\u043C\u0435\u043D\u0442.\u0440\u0430\u0441\u0445\u043E\u0434\u044B")); // документ.расходы
+        assertTrue("Should contain English variant",
+            variants.contains("document.\u0440\u0430\u0441\u0445\u043E\u0434\u044B")); // document.расходы
+    }
+
+    @Test
+    public void testGetAllFqnVariantsEnglishInput()
+    {
+        // English FQN should produce original (lowercased) + Russian variant
+        Set<String> variants = MetadataTypeUtils.getAllFqnVariants("Document.SalesOrder");
+        assertTrue("Should contain original lowercased",
+            variants.contains("document.salesorder"));
+        assertTrue("Should contain Russian variant",
+            variants.contains("\u0434\u043E\u043A\u0443\u043C\u0435\u043D\u0442.salesorder")); // документ.salesorder
+    }
+
+    @Test
+    public void testGetAllFqnVariantsPluralInput()
+    {
+        // Plural English should also work
+        Set<String> variants = MetadataTypeUtils.getAllFqnVariants("Catalogs.Products");
+        assertTrue("Should contain original lowercased",
+            variants.contains("catalogs.products"));
+        assertTrue("Should contain English singular variant",
+            variants.contains("catalog.products"));
+        assertTrue("Should contain Russian variant",
+            variants.contains("\u0441\u043F\u0440\u0430\u0432\u043E\u0447\u043D\u0438\u043A.products")); // справочник.products
+    }
+
+    @Test
+    public void testGetAllFqnVariantsMixedCase()
+    {
+        // Mixed case input should be lowercased
+        Set<String> variants = MetadataTypeUtils.getAllFqnVariants("DOCUMENT.SalesOrder");
+        assertTrue(variants.contains("document.salesorder"));
+        assertTrue(variants.contains("\u0434\u043E\u043A\u0443\u043C\u0435\u043D\u0442.salesorder")); // документ.salesorder
+    }
+
+    @Test
+    public void testGetAllFqnVariantsUnknownType()
+    {
+        // Unknown type — should return only original lowercased
+        Set<String> variants = MetadataTypeUtils.getAllFqnVariants("UnknownType.Name");
+        assertEquals(1, variants.size());
+        assertTrue(variants.contains("unknowntype.name"));
+    }
+
+    @Test
+    public void testGetAllFqnVariantsNoDot()
+    {
+        // No dot — single variant
+        Set<String> variants = MetadataTypeUtils.getAllFqnVariants("MethodName");
+        assertEquals(1, variants.size());
+        assertTrue(variants.contains("methodname"));
+    }
+
+    @Test
+    public void testGetAllFqnVariantsNullEmpty()
+    {
+        assertTrue(MetadataTypeUtils.getAllFqnVariants(null).isEmpty());
+        assertTrue(MetadataTypeUtils.getAllFqnVariants("").isEmpty());
+    }
+
+    @Test
+    public void testGetAllFqnVariantsNoDuplicates()
+    {
+        // English singular input: original == English variant, so set should deduplicate
+        Set<String> variants = MetadataTypeUtils.getAllFqnVariants("Document.Test");
+        // Should have exactly 2: "document.test" and "документ.test"
+        assertEquals(2, variants.size());
+    }
+
+    @Test
+    public void testGetAllFqnVariantsAllLowercase()
+    {
+        // All returned variants must be lowercase
+        Set<String> variants = MetadataTypeUtils.getAllFqnVariants("Catalog.MyObject");
+        for (String v : variants)
+        {
+            assertEquals("Variant should be lowercase: " + v, v.toLowerCase(), v);
+        }
+    }
 }


### PR DESCRIPTION
- **Improved**: Connection stability — reduced "socket connection was closed unexpectedly" errors
  - Split into two thread pools: main pool (8 threads, queue 200) for POST/DELETE requests and dedicated SSE pool (max 10) for long-lived event streams — prevents SSE connections from starving request processing
  - Two-level overload protection: admission control (threshold 50) returns HTTP 503 + `Retry-After` instantly; bounded queue (200) acts as memory safety net
  - SSE pool returns HTTP 503 when connection limit (10) is exceeded
  - Reduced SSE heartbeat interval from 15s to 5s to prevent proxy/client timeouts
  - Added HTTP server timeout configuration (idle: 300s, request/response: 600s)
  - Added `Connection: keep-alive` header to JSON responses
  - Improved error handling with graceful recovery on client disconnection
- **Improved**: `get_project_errors` tool — full bilingual FQN support
  - Accepts both English and Russian metadata type names (e.g. 'Document.SalesOrder' or 'Документ.ПродажаТоваров')
  - Automatically matches markers regardless of configuration language
- **Improved**: `revalidate_objects` tool — Russian metadata type names support
  - FQN normalization via `MetadataTypeUtils.normalizeFqn()` before BM API calls
  
  FIx: #53 #48 