### PR TITLE
fix: capture form screenshot via PrintWindow(PW_RENDERFULLCONTENT)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/EditorScreenshotHelper.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/EditorScreenshotHelper.java
@@ -452,7 +452,7 @@ public final class EditorScreenshotHelper
                 }
 
                 // Read all shell pixels
-                byte[] bmi = buildBitmapInfoHeader(shellW, -shellH, (short)32);
+                byte[] bmi = Win32BitmapUtils.buildBitmapInfoHeader(shellW, -shellH, (short)32);
                 byte[] pixels = new byte[shellW * shellH * 4];
                 int scanLines = (int)mGetDIBits.invoke(null, memDC, hBitmap, 0, shellH, pixels, bmi, 0);
                 if (scanLines <= 0)
@@ -513,31 +513,6 @@ public final class EditorScreenshotHelper
         }
     }
 
-    /**
-     * Builds a BITMAPINFOHEADER byte array (40 bytes, little-endian) for use with GetDIBits.
-     *
-     * @param width     bitmap width
-     * @param height    bitmap height (negative = top-down DIB)
-     * @param bitCount  bits per pixel (e.g. 32)
-     * @return 40-byte BITMAPINFOHEADER
-     */
-    static byte[] buildBitmapInfoHeader(int width, int height, short bitCount)
-    {
-        java.nio.ByteBuffer buf = java.nio.ByteBuffer.allocate(40)
-            .order(java.nio.ByteOrder.LITTLE_ENDIAN);
-        buf.putInt(40);        // biSize
-        buf.putInt(width);     // biWidth
-        buf.putInt(height);    // biHeight (negative = top-down)
-        buf.putShort((short)1); // biPlanes
-        buf.putShort(bitCount); // biBitCount
-        buf.putInt(0);         // biCompression = BI_RGB
-        buf.putInt(0);         // biSizeImage
-        buf.putInt(0);         // biXPelsPerMeter
-        buf.putInt(0);         // biYPelsPerMeter
-        buf.putInt(0);         // biClrUsed
-        buf.putInt(0);         // biClrImportant
-        return buf.array();
-    }
 
     /**
      * Refreshes the WYSIWYG viewer and waits for it to complete.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/Win32BitmapUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/Win32BitmapUtils.java
@@ -1,0 +1,46 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Pure-Java Win32 bitmap utilities. No SWT or OSGi dependencies — safe to test standalone.
+ */
+final class Win32BitmapUtils
+{
+    private Win32BitmapUtils()
+    {
+        // Utility class
+    }
+
+    /**
+     * Builds a BITMAPINFOHEADER byte array (40 bytes, little-endian) for use with GetDIBits.
+     *
+     * @param width    bitmap width in pixels
+     * @param height   bitmap height (negative = top-down DIB)
+     * @param bitCount bits per pixel (e.g. 32)
+     * @return 40-byte BITMAPINFOHEADER
+     */
+    static byte[] buildBitmapInfoHeader(int width, int height, short bitCount)
+    {
+        ByteBuffer buf = ByteBuffer.allocate(40).order(ByteOrder.LITTLE_ENDIAN);
+        buf.putInt(40);         // biSize
+        buf.putInt(width);      // biWidth
+        buf.putInt(height);     // biHeight (negative = top-down)
+        buf.putShort((short)1); // biPlanes
+        buf.putShort(bitCount); // biBitCount
+        buf.putInt(0);          // biCompression = BI_RGB
+        buf.putInt(0);          // biSizeImage
+        buf.putInt(0);          // biXPelsPerMeter
+        buf.putInt(0);          // biYPelsPerMeter
+        buf.putInt(0);          // biClrUsed
+        buf.putInt(0);          // biClrImportant
+        return buf.array();
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/EditorScreenshotHelperTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/EditorScreenshotHelperTest.java
@@ -14,7 +14,7 @@ import java.nio.ByteOrder;
 import org.junit.Test;
 
 /**
- * Tests for {@link EditorScreenshotHelper}.
+ * Tests for {@link Win32BitmapUtils}.
  * Covers pure-Java logic that does not require SWT or a running EDT instance.
  */
 public class EditorScreenshotHelperTest
@@ -24,14 +24,14 @@ public class EditorScreenshotHelperTest
     @Test
     public void testBitmapInfoHeaderSize()
     {
-        byte[] bmi = EditorScreenshotHelper.buildBitmapInfoHeader(100, -200, (short)32);
+        byte[] bmi = Win32BitmapUtils.buildBitmapInfoHeader(100, -200, (short)32);
         assertEquals("BITMAPINFOHEADER must be exactly 40 bytes", 40, bmi.length);
     }
 
     @Test
     public void testBitmapInfoHeaderBiSize()
     {
-        byte[] bmi = EditorScreenshotHelper.buildBitmapInfoHeader(1, -1, (short)32);
+        byte[] bmi = Win32BitmapUtils.buildBitmapInfoHeader(1, -1, (short)32);
         ByteBuffer buf = ByteBuffer.wrap(bmi).order(ByteOrder.LITTLE_ENDIAN);
         int biSize = buf.getInt(0);
         assertEquals("biSize must be 40", 40, biSize);
@@ -40,7 +40,7 @@ public class EditorScreenshotHelperTest
     @Test
     public void testBitmapInfoHeaderWidth()
     {
-        byte[] bmi = EditorScreenshotHelper.buildBitmapInfoHeader(1280, -720, (short)32);
+        byte[] bmi = Win32BitmapUtils.buildBitmapInfoHeader(1280, -720, (short)32);
         ByteBuffer buf = ByteBuffer.wrap(bmi).order(ByteOrder.LITTLE_ENDIAN);
         int biWidth = buf.getInt(4);
         assertEquals("biWidth must match", 1280, biWidth);
@@ -50,7 +50,7 @@ public class EditorScreenshotHelperTest
     public void testBitmapInfoHeaderNegativeHeight()
     {
         // Negative height = top-down DIB (required for correct pixel order from GetDIBits)
-        byte[] bmi = EditorScreenshotHelper.buildBitmapInfoHeader(100, -720, (short)32);
+        byte[] bmi = Win32BitmapUtils.buildBitmapInfoHeader(100, -720, (short)32);
         ByteBuffer buf = ByteBuffer.wrap(bmi).order(ByteOrder.LITTLE_ENDIAN);
         int biHeight = buf.getInt(8);
         assertEquals("biHeight must be negative for top-down DIB", -720, biHeight);
@@ -59,7 +59,7 @@ public class EditorScreenshotHelperTest
     @Test
     public void testBitmapInfoHeaderPlanes()
     {
-        byte[] bmi = EditorScreenshotHelper.buildBitmapInfoHeader(1, -1, (short)32);
+        byte[] bmi = Win32BitmapUtils.buildBitmapInfoHeader(1, -1, (short)32);
         ByteBuffer buf = ByteBuffer.wrap(bmi).order(ByteOrder.LITTLE_ENDIAN);
         short biPlanes = buf.getShort(12);
         assertEquals("biPlanes must be 1", 1, biPlanes);
@@ -68,7 +68,7 @@ public class EditorScreenshotHelperTest
     @Test
     public void testBitmapInfoHeaderBitCount()
     {
-        byte[] bmi = EditorScreenshotHelper.buildBitmapInfoHeader(1, -1, (short)32);
+        byte[] bmi = Win32BitmapUtils.buildBitmapInfoHeader(1, -1, (short)32);
         ByteBuffer buf = ByteBuffer.wrap(bmi).order(ByteOrder.LITTLE_ENDIAN);
         short biBitCount = buf.getShort(14);
         assertEquals("biBitCount must be 32", 32, biBitCount);
@@ -77,7 +77,7 @@ public class EditorScreenshotHelperTest
     @Test
     public void testBitmapInfoHeaderCompressionIsRgb()
     {
-        byte[] bmi = EditorScreenshotHelper.buildBitmapInfoHeader(1, -1, (short)32);
+        byte[] bmi = Win32BitmapUtils.buildBitmapInfoHeader(1, -1, (short)32);
         ByteBuffer buf = ByteBuffer.wrap(bmi).order(ByteOrder.LITTLE_ENDIAN);
         int biCompression = buf.getInt(16);
         assertEquals("biCompression must be BI_RGB (0)", 0, biCompression);
@@ -86,7 +86,7 @@ public class EditorScreenshotHelperTest
     @Test
     public void testBitmapInfoHeaderRemainingFieldsAreZero()
     {
-        byte[] bmi = EditorScreenshotHelper.buildBitmapInfoHeader(100, -100, (short)32);
+        byte[] bmi = Win32BitmapUtils.buildBitmapInfoHeader(100, -100, (short)32);
         ByteBuffer buf = ByteBuffer.wrap(bmi).order(ByteOrder.LITTLE_ENDIAN);
         // biSizeImage, biXPelsPerMeter, biYPelsPerMeter, biClrUsed, biClrImportant
         assertEquals(0, buf.getInt(20));


### PR DESCRIPTION
## Problem

`get_form_screenshot` returns a black image on Windows when EDT is minimized or behind other windows.

**Root cause:** The fallback `Control.print(gc)` uses GDI `BitBlt` which cannot capture Direct3D surfaces used by the 1C native form renderer. The primary method `getFormImageData()` requires `-DnativeFormBufferedLayoutRender=true` in `1cedt.ini`, but that flag makes the WYSIWYG panel appear black in the EDT UI — so neither approach works without tradeoffs.

## Fix

Add `captureViaPrintWindow()` as the primary fallback before `Control.print()`.

**How it works:**
- `PrintWindow(PW_RENDERFULLCONTENT)` captures window content via DWM composition, including Direct3D layers — works even when EDT is **minimized or occluded**
- `PW_RENDERFULLCONTENT` only works on **top-level windows**, so we capture the EDT shell (not the child WYSIWYG control), then crop to the control's screen bounds
- All Win32 calls go through **reflection** (`Class.forName("org.eclipse.swt.internal.win32.OS")`), so the plugin **compiles and runs unchanged on Linux/macOS** — on non-Windows, `ClassNotFoundException` is caught and the method returns `null`, falling through to the existing `Control.print()` fallback

## Tests

Added `EditorScreenshotHelperTest` covering `buildBitmapInfoHeader()` (made package-private):
- Correct size (40 bytes)
- All BITMAPINFOHEADER fields: `biSize`, `biWidth`, negative `biHeight` (top-down DIB), `biPlanes`, `biBitCount`, `biCompression=BI_RGB`, zeroed remaining fields

## Tested on

- Windows 10, EDT 2025.2.0, EDT minimized ✅
- No changes to Linux/macOS codepath

🤖 Generated with [Claude Code](https://claude.com/claude-code)