### PR TITLE
docs: add Antigravity configuration example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,18 @@ Add to `claude_desktop_config.json`:
 }
 ```
 
+### Antigravity
+
+```json
+{
+    "mcpServers": {
+        "EDTMCPServer": {
+            "serverUrl": "http://localhost:8765/mcp"
+        }
+    }
+}
+```
+
 </details>
 
 ## Available Tools


### PR DESCRIPTION
Added a new configuration section for Antigravity in the README.
This includes the JSON structure for the `EDTMCPServer` with the local server URL.
