### PR TITLE
Support Attach debug configurations in MCP debug tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ All 47 tools are organized into 8 semantic groups:
 | **Errors & Problems** | Error reporting, bookmarks, tasks | `get_problem_summary`, `get_project_errors`, `get_bookmarks`, `get_tasks` |
 | **Code Intelligence** | Content assist, documentation, metadata browsing | `get_content_assist`, `get_platform_documentation`, `get_metadata_objects`, `get_metadata_details`, `find_references` |
 | **Tags** | Tag management | `get_tags`, `get_objects_by_tags` |
-| **Applications & Testing** | App management, database updates, testing | `get_applications`, `update_database`, `debug_launch`, `run_yaxunit_tests` |
+| **Applications & Testing** | App management, database updates, testing | `get_applications`, `list_configurations`, `update_database`, `debug_launch`, `run_yaxunit_tests` |
 | **Debugging** | Breakpoints, stepping, variable inspection | `set_breakpoint`, `remove_breakpoint`, `list_breakpoints`, `wait_for_break`, `get_variables`, `step`, `resume`, `evaluate_expression`, `debug_yaxunit_tests`, `debug_status`, `start_profiling`, `get_profiling_results` |
 | **BSL Code** | Module browsing, code reading/writing, search | `read_module_source`, `write_module_source`, `get_module_structure`, `list_modules`, `search_in_code`, `read_method_source`, `get_method_call_hierarchy`, `go_to_definition`, `get_symbol_info`, `get_form_screenshot`, `validate_query` |
 | **Refactoring** | Metadata rename, delete, add attributes | `rename_metadata_object`, `delete_metadata_object`, `add_metadata_attribute` |
@@ -303,8 +303,9 @@ Add to `claude_desktop_config.json`:
 | `get_tags` | Get list of all tags defined in the project with descriptions and object counts |
 | `get_objects_by_tags` | Get metadata objects filtered by tags with tag descriptions and object FQNs |
 | `get_applications` | Get list of applications (infobases) for a project with update state |
-| `update_database` | Update database (infobase) with full or incremental update mode |
-| `debug_launch` | Launch application in debug mode (auto-updates database before launch) |
+| `list_configurations` | List EDT launch configurations (runtime-client + Attach) with current running / suspended state |
+| `update_database` | Update database (infobase) with full or incremental update mode — by `launchConfigurationName` or `projectName + applicationId` |
+| `debug_launch` | Launch application in debug mode — by `launchConfigurationName` (any type, incl. Attach to 1C:Enterprise Debug Server) or `projectName + applicationId` |
 | `run_yaxunit_tests` | Run YAXUnit tests for a project: launches 1C with `RunUnitTests`, parses JUnit XML, returns Markdown report |
 | `debug_yaxunit_tests` | Launch YAXUnit tests in DEBUG mode so breakpoints fire (autonomous LLM debug cycle) |
 | `set_breakpoint` | Set a 1C BSL line breakpoint (accepts EDT module path or absolute path) |
@@ -570,6 +571,18 @@ Add to `claude_desktop_config.json`:
 |-----------|----------|-------------|
 | `projectName` | Yes | EDT project name |
 
+#### List Configurations Tool
+
+**`list_configurations`** - List EDT launch configurations (runtime-client + Attach + other 1C types) with their current running state. Discovery step that precedes `debug_launch`, `run_yaxunit_tests`, `debug_yaxunit_tests` and `update_database`: once the MCP client knows the exact configuration name, it can target it by name without juggling `projectName + applicationId` pairs.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `type` | No | Filter: `attach` (RemoteRuntime + LocalRuntime), `client` (RuntimeClient), `all` (default — any 1C/EDT launch config) |
+| `projectName` | No | Project-name filter |
+
+**Returns:** per configuration — `name`, `type` (full type id), `attach` flag, `applicationId` (real or synthetic `attach:<name>`), `project`, `infobaseAlias`, `debugServerUrl`, `running`, `mode`, `suspended`.
+
 #### Update Database Tool
 
 **`update_database`** - Update database (infobase) configuration. Supports full and incremental update modes.
@@ -577,26 +590,30 @@ Add to `claude_desktop_config.json`:
 **Parameters:**
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `projectName` | Yes | EDT project name |
-| `applicationId` | Yes | Application ID from `get_applications` |
+| `launchConfigurationName` | No (preferred) | Exact EDT runtime-client launch configuration name (from `list_configurations`). When given, `projectName` and `applicationId` are derived from the config. |
+| `projectName` | If no name | EDT project name |
+| `applicationId` | If no name | Application ID from `get_applications` |
 | `fullUpdate` | No | If true - full reload, if false - incremental update (default: false) |
 | `autoRestructure` | No | Automatically apply restructurization if needed (default: true) |
 
 #### Debug Launch Tool
 
-**`debug_launch`** - Launch application in debug mode. Automatically updates database before launching and finds existing launch configuration.
+**`debug_launch`** - Start an EDT debug session. Works for both runtime-client configs (spawns `1cv8c`) and **Attach to 1C:Enterprise Debug Server** configs (attaches to a running `ragent`/`rphost`, required for debugging server-side code — HTTP services, server calls, scheduled and background jobs).
 
 **Parameters:**
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `projectName` | Yes | EDT project name |
-| `applicationId` | Yes | Application ID from `get_applications` |
-| `updateBeforeLaunch` | No | If true - update database before launching (default: true) |
+| `launchConfigurationName` | No (preferred) | Exact name of an EDT debug launch configuration (runtime client or Attach). Use this for Attach configs or to pick a specific client config by name. |
+| `projectName` | If no name | EDT project name |
+| `applicationId` | If no name | Application ID from `get_applications` (runtime-client launches only) |
+| `updateBeforeLaunch` | No | If true - update database before launching (default: true, ignored for Attach) |
 
 **Notes:**
-- Requires a launch configuration to be created in EDT first (Run → Run Configurations...)
-- If no configuration exists, returns list of available configurations
-- `updateBeforeLaunch=true` skips update if database is already up to date
+- Requires a launch configuration to be created in EDT first (Run → Run Configurations...).
+- For an Attach config, `debug_launch` returns `applicationId: "attach:<name>"` — a stable synthetic id used by `wait_for_break`, `resume`, `debug_status` and friends.
+- If the config is already running in debug mode, the tool short-circuits with `alreadyRunning: true` instead of spawning a duplicate launch.
+- If no configuration exists, returns list of available configurations (runtime client + attach) so the MCP client can discover what's on offer.
+- `updateBeforeLaunch=true` skips update if database is already up to date.
 
 #### Run YAXUnit Tests Tool
 
@@ -605,8 +622,9 @@ Add to `claude_desktop_config.json`:
 **Parameters:**
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `projectName` | Yes | EDT project name |
-| `applicationId` | Yes | Application ID from `get_applications` |
+| `launchConfigurationName` | No (preferred) | Exact EDT runtime-client launch configuration name (from `list_configurations`). When given, `projectName` and `applicationId` are derived from the config. |
+| `projectName` | If no name | EDT project name |
+| `applicationId` | If no name | Application ID from `get_applications` |
 | `extensions` | No | Comma-separated extension names to filter tests by extension |
 | `modules` | No | Comma-separated common-module names to run (e.g. `OM_tmrlGlovoCatalog`) |
 | `tests` | No | Comma-separated test names in `Module.Method` format |
@@ -616,6 +634,27 @@ Add to `claude_desktop_config.json`:
 - Requires a launch configuration in EDT for the project/application and the YAXUnit extension installed in the infobase.
 - The launch is **not** terminated when the polling window expires — call the tool again with identical arguments to keep waiting and fetch the result once 1C closes.
 - Reports are stored under `%TEMP%/edt-mcp-yaxunit/<sanitized-key>_<sha1>/` (`junit.xml` + `report.md` + `xUnitParams.json`). The directory name is derived from `projectName:applicationId:filterHash` — sanitized and suffixed with a SHA-1 hash to avoid collisions. A fresh `junit.xml` (younger than 5 minutes) is reused without restarting 1C.
+
+#### Server-Side Debugging (Attach to 1C:Enterprise Debug Server)
+
+The debug tools also drive **Attach** launch configurations (`com._1c.g5.v8.dt.debug.core.RemoteRuntime` / `LocalRuntime`), which is the only way to debug server-side BSL via MCP: HTTP services, server calls, scheduled jobs, background jobs, external connections running inside `rphost`.
+
+**Prerequisites on the 1C side:**
+- Cluster `ragent` launched with `-debug -http` (HTTP debugger, typical port `1550`).
+- For published infobases: debug flag enabled in the `.vrd` (Apache `wsap24.dll` or IIS).
+- In EDT, create a launch configuration of type *Attach to 1C:Enterprise Debug Server* with the infobase alias / UUID and the debug-server URL (e.g. `http://localhost:1550`).
+
+**Workflow:**
+
+1. `list_configurations({type: "attach"})` — discover available Attach configs and see which one is already running.
+2. `debug_launch({launchConfigurationName: "<name>"})` — attach to `rphost` (or short-circuit with `alreadyRunning: true` if the session is live). Returns `applicationId: "attach:<name>"`.
+3. `set_breakpoint` on the suspect HTTP-service handler / server procedure.
+4. Trigger the server-side call (e.g. `curl http://host/base/hs/your-endpoint`).
+5. `wait_for_break` — returns `threadId`, `frameRef`, suspended line.
+6. `evaluate_expression({frameRef, expression: "Request.QueryOptions[\"..\"]"})` — inspect request parameters, catalog refs, etc. (`get_variables` also works for most frames; use `evaluate_expression` as a fallback when the attach frame doesn't expose variables eagerly.)
+7. `step` / `resume` — finish the call; the HTTP request on the client returns.
+
+Attach launches register in the same snapshot / thread / frame registry as runtime-client launches — `debug_status` reports `applicationId`, `launchConfiguration`, `configurationType`, `attach: true`, `suspended`, `suspendedAt` and a `registered` flag.
 
 #### Debug Inspection Tools
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/McpServer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/McpServer.java
@@ -213,7 +213,7 @@ public class McpServer
         registry.register(new GetApplicationsTool());
         registry.register(new UpdateDatabaseTool());
         registry.register(new DebugLaunchTool());
-        registry.register(new ListDebugConfigurationsTool());
+        registry.register(new ListConfigurationsTool());
         registry.register(new RunYaxunitTestsTool());
 
         // Debug inspection tools (breakpoints + suspended state)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/McpServer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/McpServer.java
@@ -42,6 +42,7 @@ import com.ditrix.edt.mcp.server.tools.impl.GetProjectErrorsTool;
 import com.ditrix.edt.mcp.server.tools.impl.GetTagsTool;
 import com.ditrix.edt.mcp.server.tools.impl.GetObjectsByTagsTool;
 import com.ditrix.edt.mcp.server.tools.impl.GetTasksTool;
+import com.ditrix.edt.mcp.server.tools.impl.ListConfigurationsTool;
 import com.ditrix.edt.mcp.server.tools.impl.ListProjectsTool;
 import com.ditrix.edt.mcp.server.tools.impl.CleanProjectTool;
 import com.ditrix.edt.mcp.server.tools.impl.RevalidateObjectsTool;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/McpServer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/McpServer.java
@@ -213,6 +213,7 @@ public class McpServer
         registry.register(new GetApplicationsTool());
         registry.register(new UpdateDatabaseTool());
         registry.register(new DebugLaunchTool());
+        registry.register(new ListDebugConfigurationsTool());
         registry.register(new RunYaxunitTestsTool());
 
         // Debug inspection tools (breakpoints + suspended state)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolGroup.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolGroup.java
@@ -38,8 +38,8 @@ public enum ToolGroup
 
     APPLICATIONS("applications", "Applications & Testing", //$NON-NLS-1$ //$NON-NLS-2$
         "Application management, database update, launch, and testing", //$NON-NLS-1$
-        "get_applications", "update_database", "debug_launch", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        "list_debug_configurations", "run_yaxunit_tests"), //$NON-NLS-1$ //$NON-NLS-2$
+        "get_applications", "list_configurations", "update_database", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        "debug_launch", "run_yaxunit_tests"), //$NON-NLS-1$ //$NON-NLS-2$
 
     DEBUG("debug", "Debugging", //$NON-NLS-1$ //$NON-NLS-2$
         "Breakpoints, stepping, variables, expression evaluation, and profiling", //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolGroup.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolGroup.java
@@ -38,7 +38,8 @@ public enum ToolGroup
 
     APPLICATIONS("applications", "Applications & Testing", //$NON-NLS-1$ //$NON-NLS-2$
         "Application management, database update, launch, and testing", //$NON-NLS-1$
-        "get_applications", "update_database", "debug_launch", "run_yaxunit_tests"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        "get_applications", "update_database", "debug_launch", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        "list_debug_configurations", "run_yaxunit_tests"), //$NON-NLS-1$ //$NON-NLS-2$
 
     DEBUG("debug", "Debugging", //$NON-NLS-1$ //$NON-NLS-2$
         "Breakpoints, stepping, variables, expression evaluation, and profiling", //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
@@ -426,9 +426,15 @@ public class DebugLaunchTool implements IMcpTool
     }
 
     /**
-     * Launches the given configuration in debug mode on the UI thread when a
-     * Display is available, otherwise directly. Returns {@code null} on success,
-     * or an error message describing the failure.
+     * Launches the given configuration in debug mode.
+     *
+     * <p>Uses a direct {@code config.launch(DEBUG_MODE, null)} — not
+     * {@code DebugUITools.launch} — because the latter may open modal dialogs
+     * (save-prompt, perspective-switch, already-running-confirmation) that
+     * block the MCP worker thread indefinitely and eventually close the HTTP
+     * socket. {@code debug_yaxunit_tests} uses the same direct path.
+     *
+     * @return {@code null} on success, or an error message on failure.
      */
     private String performLaunch(ILaunchConfiguration config)
     {
@@ -440,7 +446,7 @@ public class DebugLaunchTool implements IMcpTool
             display.syncExec(() -> {
                 try
                 {
-                    org.eclipse.debug.ui.DebugUITools.launch(config, ILaunchManager.DEBUG_MODE);
+                    config.launch(ILaunchManager.DEBUG_MODE, null);
                     launchSuccess[0] = true;
                 }
                 catch (Exception e)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
@@ -26,6 +26,7 @@ import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
 import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.DebugSessionRegistry;
 import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
 import com.ditrix.edt.mcp.server.utils.ProjectStateChecker;
 import com.e1c.g5.dt.applications.ApplicationException;
@@ -157,6 +158,25 @@ public class DebugLaunchTool implements IMcpTool
             String configProject = LaunchConfigUtils.readAttribute(config,
                 LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
             String effectiveAppId = LaunchConfigUtils.getApplicationIdFor(config);
+
+            // If the config is already running in debug mode, don't re-launch.
+            if (effectiveAppId != null
+                && DebugSessionRegistry.findActiveTarget(effectiveAppId) != null)
+            {
+                ToolResult already = ToolResult.success()
+                    .put("launchConfiguration", config.getName()) //$NON-NLS-1$
+                    .put("configurationType", typeId) //$NON-NLS-1$
+                    .put("attach", isAttach) //$NON-NLS-1$
+                    .put("applicationId", effectiveAppId) //$NON-NLS-1$
+                    .put("alreadyRunning", true) //$NON-NLS-1$
+                    .put("mode", "debug") //$NON-NLS-1$ //$NON-NLS-2$
+                    .put("message", "Launch configuration is already running — skipped re-launch."); //$NON-NLS-1$ //$NON-NLS-2$
+                if (configProject != null && !configProject.isEmpty())
+                {
+                    already.put("project", configProject); //$NON-NLS-1$
+                }
+                return already.toJson();
+            }
 
             // For runtime-client configs, run the usual DB-update preflight.
             if (!isAttach && updateBeforeLaunch && configProject != null && !configProject.isEmpty())

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * MCP Server for EDT
  * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
  * Licensed under AGPL-3.0-or-later
@@ -40,78 +40,173 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 /**
- * Tool to launch EDT application in debug mode.
- * Finds launch configurations for the project/application and starts debugging.
+ * Tool to launch an EDT debug session.
+ *
+ * <p>Two modes:
+ * <ul>
+ *   <li>{@code launchConfigurationName} — start an existing EDT launch configuration
+ *       by its exact name. Works for both runtime-client configs (spawns 1cv8c) and
+ *       Attach configurations (attaches to {@code ragent}/{@code rphost} for
+ *       server-side code). Does not require {@code applicationId}.</li>
+ *   <li>{@code projectName} + {@code applicationId} — legacy path: searches the
+ *       runtime-client configs for a match and launches it.</li>
+ * </ul>
  */
 public class DebugLaunchTool implements IMcpTool
 {
     public static final String NAME = "debug_launch"; //$NON-NLS-1$
-    
+
     @Override
     public String getName()
     {
         return NAME;
     }
-    
+
     @Override
     public String getDescription()
     {
-        return "Launch EDT application in debug mode. " + //$NON-NLS-1$
-               "Finds existing launch configuration for the project/application and starts debugging. " + //$NON-NLS-1$
-               "Requires application ID from get_applications tool."; //$NON-NLS-1$
+        return "Start an EDT debug session. " //$NON-NLS-1$
+            + "Pass launchConfigurationName to run any existing EDT debug configuration by name " //$NON-NLS-1$
+            + "(runtime client OR 'Attach to 1C:Enterprise Debug Server' — required for debugging " //$NON-NLS-1$
+            + "server-side code: HTTP services, background jobs, scheduled jobs). " //$NON-NLS-1$
+            + "Otherwise pass projectName + applicationId to launch the matching runtime-client config."; //$NON-NLS-1$
     }
-    
+
     @Override
     public String getInputSchema()
     {
         return JsonSchemaBuilder.object()
-            .stringProperty("projectName", "EDT project name (required)", true) //$NON-NLS-1$ //$NON-NLS-2$
-            .stringProperty("applicationId", "Application ID from get_applications (required)", true) //$NON-NLS-1$ //$NON-NLS-2$
-            .booleanProperty("updateBeforeLaunch", "If true - update database before launching (default: true)") //$NON-NLS-1$ //$NON-NLS-2$
+            .stringProperty("projectName", //$NON-NLS-1$
+                "EDT project name (required unless launchConfigurationName is given)") //$NON-NLS-1$
+            .stringProperty("applicationId", //$NON-NLS-1$
+                "Application ID from get_applications (required for runtime-client launches)") //$NON-NLS-1$
+            .stringProperty("launchConfigurationName", //$NON-NLS-1$
+                "Exact name of an EDT debug launch configuration (runtime client or Attach). " //$NON-NLS-1$
+                    + "Use for Attach configurations or to pick a specific client config by name.") //$NON-NLS-1$
+            .booleanProperty("updateBeforeLaunch", //$NON-NLS-1$
+                "If true — update database before launching (default: true, ignored for Attach)") //$NON-NLS-1$
             .build();
     }
-    
+
     @Override
     public ResponseType getResponseType()
     {
         return ResponseType.JSON;
     }
-    
+
     @Override
     public String execute(Map<String, String> params)
     {
         String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
         String applicationId = JsonUtils.extractStringArgument(params, "applicationId"); //$NON-NLS-1$
+        String configName = JsonUtils.extractStringArgument(params, "launchConfigurationName"); //$NON-NLS-1$
         boolean updateBeforeLaunch = JsonUtils.extractBooleanArgument(params, "updateBeforeLaunch", true); //$NON-NLS-1$
-        
-        // Validate required parameters
+
+        // Mode 1: explicit config name — no project/application required.
+        if (configName != null && !configName.isEmpty())
+        {
+            return launchByConfigName(configName, updateBeforeLaunch);
+        }
+
+        // Mode 2: project + application (runtime-client only).
         if (projectName == null || projectName.isEmpty())
         {
-            return ToolResult.error("projectName is required").toJson(); //$NON-NLS-1$
+            return ToolResult.error("projectName is required (or pass launchConfigurationName)").toJson(); //$NON-NLS-1$
         }
-        
+
         if (applicationId == null || applicationId.isEmpty())
         {
-            return ToolResult.error("applicationId is required. Use get_applications to get application list.").toJson(); //$NON-NLS-1$
+            return ToolResult.error("applicationId is required. Use get_applications to get application list, " //$NON-NLS-1$
+                + "or pass launchConfigurationName to start a config by name (e.g. an Attach config).").toJson(); //$NON-NLS-1$
         }
-        
-        // Check if project is ready for operations
+
         String notReadyError = ProjectStateChecker.checkReadyOrError(projectName);
         if (notReadyError != null)
         {
             return ToolResult.error(notReadyError).toJson();
         }
-        
+
         return launchDebug(projectName, applicationId, updateBeforeLaunch);
     }
-    
+
     /**
-     * Launches the application in debug mode.
-     * 
-     * @param projectName name of the project
-     * @param applicationId ID of the application
-     * @param updateBeforeLaunch whether to update database before launching
-     * @return JSON string with result
+     * Launches a specific EDT debug configuration by name.
+     * Works for both runtime-client and Attach configuration types.
+     */
+    private String launchByConfigName(String configName, boolean updateBeforeLaunch)
+    {
+        try
+        {
+            ILaunchManager launchManager = LaunchConfigUtils.getLaunchManager();
+            if (launchManager == null)
+            {
+                return ToolResult.error("Launch manager is not available").toJson(); //$NON-NLS-1$
+            }
+
+            ILaunchConfiguration config = LaunchConfigUtils.findLaunchConfigByName(launchManager, configName);
+            if (config == null)
+            {
+                ToolResult err = ToolResult.error("Launch configuration not found: '" + configName //$NON-NLS-1$
+                    + "'. Create it in EDT first."); //$NON-NLS-1$
+                err.put("availableConfigurations", listAvailableConfigs(launchManager)); //$NON-NLS-1$
+                return err.toJson();
+            }
+
+            String typeId = LaunchConfigUtils.getConfigTypeId(config);
+            boolean isAttach = LaunchConfigUtils.isAttachConfigTypeId(typeId);
+            String configProject = LaunchConfigUtils.readAttribute(config,
+                LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+            String effectiveAppId = LaunchConfigUtils.getApplicationIdFor(config);
+
+            // For runtime-client configs, run the usual DB-update preflight.
+            if (!isAttach && updateBeforeLaunch && configProject != null && !configProject.isEmpty())
+            {
+                String notReady = ProjectStateChecker.checkReadyOrError(configProject);
+                if (notReady != null)
+                {
+                    return ToolResult.error(notReady).toJson();
+                }
+                String updateError = updateDatabaseIfNeeded(configProject, effectiveAppId);
+                if (updateError != null)
+                {
+                    return ToolResult.error(updateError).toJson();
+                }
+            }
+
+            String launchError = performLaunch(config);
+            if (launchError != null)
+            {
+                return ToolResult.error("Failed to launch debug session: " + launchError).toJson(); //$NON-NLS-1$
+            }
+
+            ToolResult result = ToolResult.success()
+                .put("launchConfiguration", config.getName()) //$NON-NLS-1$
+                .put("configurationType", typeId) //$NON-NLS-1$
+                .put("attach", isAttach) //$NON-NLS-1$
+                .put("mode", "debug") //$NON-NLS-1$ //$NON-NLS-2$
+                .put("message", isAttach //$NON-NLS-1$
+                    ? "Attach debug session started — use debug_status to inspect, " //$NON-NLS-1$
+                        + "wait_for_break to block until a breakpoint is hit." //$NON-NLS-1$
+                    : "Debug session started successfully"); //$NON-NLS-1$
+            if (configProject != null && !configProject.isEmpty())
+            {
+                result.put("project", configProject); //$NON-NLS-1$
+            }
+            if (effectiveAppId != null)
+            {
+                result.put("applicationId", effectiveAppId); //$NON-NLS-1$
+            }
+            return result.toJson();
+        }
+        catch (Exception e)
+        {
+            Activator.logError("Unexpected error during debug launch by name", e); //$NON-NLS-1$
+            return ToolResult.error("Unexpected error: " + e.getMessage()).toJson(); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Legacy path: launch a runtime-client config matched by project+application.
      */
     private String launchDebug(String projectName, String applicationId, boolean updateBeforeLaunch)
     {
@@ -119,22 +214,22 @@ public class DebugLaunchTool implements IMcpTool
         {
             IWorkspace workspace = ResourcesPlugin.getWorkspace();
             IProject project = workspace.getRoot().getProject(projectName);
-            
+
             if (project == null || !project.exists())
             {
                 return ToolResult.error("Project not found: " + projectName).toJson(); //$NON-NLS-1$
             }
-            
+
             if (!project.isOpen())
             {
                 return ToolResult.error("Project is closed: " + projectName).toJson(); //$NON-NLS-1$
             }
-            
+
             // Verify application exists and get its name
             IApplicationManager appManager = Activator.getDefault().getApplicationManager();
             String applicationName = applicationId; // Default to ID if can't get name
             IApplication application = null;
-            
+
             if (appManager != null)
             {
                 try
@@ -154,67 +249,24 @@ public class DebugLaunchTool implements IMcpTool
                     // Continue - we'll try to find launch config anyway
                 }
             }
-            
+
             // Update database before launch if requested
             if (updateBeforeLaunch && appManager != null && application != null)
             {
-                try
+                String updateError = updateDatabase(appManager, application);
+                if (updateError != null)
                 {
-                    ApplicationUpdateState updateState = appManager.getUpdateState(application);
-                    
-                    // Only update if needed
-                    if (updateState != ApplicationUpdateState.UPDATED && 
-                        updateState != ApplicationUpdateState.BEING_UPDATED)
-                    {
-                        Activator.logInfo("Updating database before launch: project=" + projectName + //$NON-NLS-1$
-                                ", application=" + applicationId); //$NON-NLS-1$
-                        
-                        // Create execution context with Shell
-                        ExecutionContext context = new ExecutionContext();
-                        Display display = Display.getDefault();
-                        if (display != null && !display.isDisposed())
-                        {
-                            final Shell[] shellHolder = new Shell[1];
-                            display.syncExec(() -> {
-                                shellHolder[0] = display.getActiveShell();
-                                if (shellHolder[0] == null)
-                                {
-                                    Shell[] shells = display.getShells();
-                                    if (shells.length > 0)
-                                    {
-                                        shellHolder[0] = shells[0];
-                                    }
-                                }
-                            });
-                            if (shellHolder[0] != null)
-                            {
-                                context.setProperty(ExecutionContext.ACTIVE_SHELL_NAME, shellHolder[0]);
-                            }
-                        }
-                        
-                        IProgressMonitor monitor = new NullProgressMonitor();
-                        ApplicationUpdateState stateAfter = appManager.update(application, 
-                                ApplicationUpdateType.INCREMENTAL, context, monitor);
-                        
-                        Activator.logInfo("Database update completed: stateAfter=" + stateAfter); //$NON-NLS-1$
-                    }
-                }
-                catch (ApplicationException e)
-                {
-                    Activator.logError("Error updating database before launch", e); //$NON-NLS-1$
-                    // Return error but allow user to retry with updateBeforeLaunch=false
-                    return ToolResult.error("Failed to update database before launch: " + e.getMessage() + //$NON-NLS-1$
-                            ". You can retry with updateBeforeLaunch=false to skip update.").toJson(); //$NON-NLS-1$
+                    return ToolResult.error(updateError).toJson();
                 }
             }
-            
+
             // Get launch manager
             ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
             if (launchManager == null)
             {
                 return ToolResult.error("Launch manager is not available").toJson(); //$NON-NLS-1$
             }
-            
+
             // Get launch configuration type
             ILaunchConfigurationType configType = launchManager
                     .getLaunchConfigurationType(LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID);
@@ -230,88 +282,201 @@ public class DebugLaunchTool implements IMcpTool
 
             if (matchingConfig == null)
             {
-                // Return list of available configurations for debugging
-                JsonArray availableConfigs = new JsonArray();
-                for (ILaunchConfiguration config : LaunchConfigUtils.getAllRuntimeClientConfigs(launchManager, configType))
-                {
-                    JsonObject configObj = new JsonObject();
-                    configObj.addProperty("name", config.getName()); //$NON-NLS-1$
-                    configObj.addProperty("project", LaunchConfigUtils.readAttribute(config, LaunchConfigUtils.ATTR_PROJECT_NAME, "")); //$NON-NLS-1$ //$NON-NLS-2$
-                    configObj.addProperty("applicationId", LaunchConfigUtils.readAttribute(config, LaunchConfigUtils.ATTR_APPLICATION_ID, "")); //$NON-NLS-1$ //$NON-NLS-2$
-                    availableConfigs.add(configObj);
-                }
-
-                ToolResult errorResult = ToolResult.error("No launch configuration found for project '" + projectName + //$NON-NLS-1$
-                        "' and application '" + applicationName + "' (" + applicationId + "). " + //$NON-NLS-1$ //$NON-NLS-2$
-                        "Create a launch configuration in EDT first."); //$NON-NLS-1$
-                errorResult.put("availableConfigurations", availableConfigs); //$NON-NLS-1$
+                ToolResult errorResult = ToolResult.error("No launch configuration found for project '" //$NON-NLS-1$
+                    + projectName + "' and application '" + applicationName + "' (" //$NON-NLS-1$ //$NON-NLS-2$
+                    + applicationId + "). Create a runtime-client launch configuration in EDT, " //$NON-NLS-1$
+                    + "or pass launchConfigurationName to start an Attach configuration."); //$NON-NLS-1$
+                errorResult.put("availableConfigurations", listAvailableConfigs(launchManager)); //$NON-NLS-1$
                 return errorResult.toJson();
             }
-            
-            // Launch in debug mode
-            final ILaunchConfiguration configToLaunch = matchingConfig;
-            final String configName = configToLaunch.getName();
-            
-            Activator.logInfo("Launching debug: config=" + configName +  //$NON-NLS-1$
-                    ", project=" + projectName +  //$NON-NLS-1$
-                    ", application=" + applicationId); //$NON-NLS-1$
-            
-            // Launch must be done on UI thread
-            final boolean[] launchSuccess = {false};
-            final String[] launchError = {null};
-            
-            Display display = Display.getDefault();
-            if (display != null && !display.isDisposed())
+
+            final String configName = matchingConfig.getName();
+            Activator.logInfo("Launching debug: config=" + configName //$NON-NLS-1$
+                + ", project=" + projectName //$NON-NLS-1$
+                + ", application=" + applicationId); //$NON-NLS-1$
+
+            String launchError = performLaunch(matchingConfig);
+            if (launchError != null)
             {
-                display.syncExec(() -> {
-                    try
-                    {
-                        // Use DebugUITools for proper debug launch
-                        org.eclipse.debug.ui.DebugUITools.launch(configToLaunch, ILaunchManager.DEBUG_MODE);
-                        launchSuccess[0] = true;
-                    }
-                    catch (Exception e)
-                    {
-                        Activator.logError("Error launching debug session", e); //$NON-NLS-1$
-                        launchError[0] = e.getMessage();
-                    }
-                });
+                return ToolResult.error("Failed to launch debug session: " + launchError).toJson(); //$NON-NLS-1$
             }
-            else
-            {
-                // Fallback - direct launch without UI
-                try
-                {
-                    configToLaunch.launch(ILaunchManager.DEBUG_MODE, null);
-                    launchSuccess[0] = true;
-                }
-                catch (CoreException e)
-                {
-                    Activator.logError("Error launching debug session", e); //$NON-NLS-1$
-                    launchError[0] = e.getMessage();
-                }
-            }
-            
-            if (launchSuccess[0])
-            {
-                return ToolResult.success()
-                    .put("project", projectName) //$NON-NLS-1$
-                    .put("applicationId", applicationId) //$NON-NLS-1$
-                    .put("launchConfiguration", configName) //$NON-NLS-1$
-                    .put("mode", "debug") //$NON-NLS-1$ //$NON-NLS-2$
-                    .put("message", "Debug session started successfully") //$NON-NLS-1$ //$NON-NLS-2$
-                    .toJson();
-            }
-            else
-            {
-                return ToolResult.error("Failed to launch debug session" + //$NON-NLS-1$
-                        (launchError[0] != null ? ": " + launchError[0] : "")).toJson(); //$NON-NLS-1$ //$NON-NLS-2$
-            }
+
+            return ToolResult.success()
+                .put("project", projectName) //$NON-NLS-1$
+                .put("applicationId", applicationId) //$NON-NLS-1$
+                .put("launchConfiguration", configName) //$NON-NLS-1$
+                .put("configurationType", LaunchConfigUtils.getConfigTypeId(matchingConfig)) //$NON-NLS-1$
+                .put("attach", false) //$NON-NLS-1$
+                .put("mode", "debug") //$NON-NLS-1$ //$NON-NLS-2$
+                .put("message", "Debug session started successfully") //$NON-NLS-1$ //$NON-NLS-2$
+                .toJson();
         }
         catch (Exception e)
         {
             Activator.logError("Unexpected error during debug launch", e); //$NON-NLS-1$
             return ToolResult.error("Unexpected error: " + e.getMessage()).toJson(); //$NON-NLS-1$
         }
+    }
+
+    /**
+     * Runs the EDT "update database before launch" step for a runtime-client launch.
+     * Returns {@code null} on success, or an error message describing the failure.
+     */
+    private String updateDatabaseIfNeeded(String projectName, String applicationId)
+    {
+        if (applicationId == null || applicationId.isEmpty()
+            || applicationId.startsWith(LaunchConfigUtils.ATTACH_APP_ID_PREFIX))
+        {
+            return null;
+        }
+        IWorkspace workspace = ResourcesPlugin.getWorkspace();
+        IProject project = workspace.getRoot().getProject(projectName);
+        if (project == null || !project.exists() || !project.isOpen())
+        {
+            return null;
+        }
+        IApplicationManager appManager = Activator.getDefault().getApplicationManager();
+        if (appManager == null)
+        {
+            return null;
+        }
+        try
+        {
+            Optional<IApplication> appOpt = appManager.getApplication(project, applicationId);
+            if (!appOpt.isPresent())
+            {
+                return null;
+            }
+            return updateDatabase(appManager, appOpt.get());
+        }
+        catch (ApplicationException e)
+        {
+            Activator.logError("Error resolving application for DB update", e); //$NON-NLS-1$
+            return null;
+        }
+    }
+
+    private String updateDatabase(IApplicationManager appManager, IApplication application)
+    {
+        try
+        {
+            ApplicationUpdateState updateState = appManager.getUpdateState(application);
+            if (updateState == ApplicationUpdateState.UPDATED
+                || updateState == ApplicationUpdateState.BEING_UPDATED)
+            {
+                return null;
+            }
+
+            Activator.logInfo("Updating database before launch: application=" + application.getId()); //$NON-NLS-1$
+
+            ExecutionContext context = new ExecutionContext();
+            Display display = Display.getDefault();
+            if (display != null && !display.isDisposed())
+            {
+                final Shell[] shellHolder = new Shell[1];
+                display.syncExec(() -> {
+                    shellHolder[0] = display.getActiveShell();
+                    if (shellHolder[0] == null)
+                    {
+                        Shell[] shells = display.getShells();
+                        if (shells.length > 0)
+                        {
+                            shellHolder[0] = shells[0];
+                        }
+                    }
+                });
+                if (shellHolder[0] != null)
+                {
+                    context.setProperty(ExecutionContext.ACTIVE_SHELL_NAME, shellHolder[0]);
+                }
+            }
+
+            IProgressMonitor monitor = new NullProgressMonitor();
+            ApplicationUpdateState stateAfter = appManager.update(application,
+                ApplicationUpdateType.INCREMENTAL, context, monitor);
+            Activator.logInfo("Database update completed: stateAfter=" + stateAfter); //$NON-NLS-1$
+            return null;
+        }
+        catch (ApplicationException e)
+        {
+            Activator.logError("Error updating database before launch", e); //$NON-NLS-1$
+            return "Failed to update database before launch: " + e.getMessage() //$NON-NLS-1$
+                + ". You can retry with updateBeforeLaunch=false to skip update."; //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Launches the given configuration in debug mode on the UI thread when a
+     * Display is available, otherwise directly. Returns {@code null} on success,
+     * or an error message describing the failure.
+     */
+    private String performLaunch(ILaunchConfiguration config)
+    {
+        final String[] launchError = {null};
+        final boolean[] launchSuccess = {false};
+        Display display = Display.getDefault();
+        if (display != null && !display.isDisposed())
+        {
+            display.syncExec(() -> {
+                try
+                {
+                    org.eclipse.debug.ui.DebugUITools.launch(config, ILaunchManager.DEBUG_MODE);
+                    launchSuccess[0] = true;
+                }
+                catch (Exception e)
+                {
+                    Activator.logError("Error launching debug session", e); //$NON-NLS-1$
+                    launchError[0] = e.getMessage();
+                }
+            });
+        }
+        else
+        {
+            try
+            {
+                config.launch(ILaunchManager.DEBUG_MODE, null);
+                launchSuccess[0] = true;
+            }
+            catch (CoreException e)
+            {
+                Activator.logError("Error launching debug session", e); //$NON-NLS-1$
+                launchError[0] = e.getMessage();
+            }
+        }
+        return launchSuccess[0] ? null : (launchError[0] != null ? launchError[0] : "unknown error"); //$NON-NLS-1$
+    }
+
+    /**
+     * Builds a diagnostic list of every debug-capable launch configuration known
+     * to EDT (runtime client + attach types), so the MCP client can discover
+     * what's available when a lookup fails.
+     */
+    private static JsonArray listAvailableConfigs(ILaunchManager launchManager)
+    {
+        JsonArray arr = new JsonArray();
+        for (ILaunchConfiguration cfg : LaunchConfigUtils.getAllDebugConfigs(launchManager))
+        {
+            JsonObject obj = new JsonObject();
+            obj.addProperty("name", cfg.getName()); //$NON-NLS-1$
+            String typeId = LaunchConfigUtils.getConfigTypeId(cfg);
+            obj.addProperty("type", typeId); //$NON-NLS-1$
+            obj.addProperty("attach", LaunchConfigUtils.isAttachConfigTypeId(typeId)); //$NON-NLS-1$
+            obj.addProperty("project", LaunchConfigUtils.readAttribute(cfg, //$NON-NLS-1$
+                LaunchConfigUtils.ATTR_PROJECT_NAME, "")); //$NON-NLS-1$
+            obj.addProperty("applicationId", LaunchConfigUtils.readAttribute(cfg, //$NON-NLS-1$
+                LaunchConfigUtils.ATTR_APPLICATION_ID, "")); //$NON-NLS-1$
+            String alias = LaunchConfigUtils.readAttribute(cfg, LaunchConfigUtils.ATTR_DEBUG_INFOBASE_ALIAS, ""); //$NON-NLS-1$
+            if (!alias.isEmpty())
+            {
+                obj.addProperty("infobaseAlias", alias); //$NON-NLS-1$
+            }
+            String url = LaunchConfigUtils.readAttribute(cfg, LaunchConfigUtils.ATTR_DEBUG_SERVER_URL, ""); //$NON-NLS-1$
+            if (!url.isEmpty())
+            {
+                obj.addProperty("debugServerUrl", url); //$NON-NLS-1$
+            }
+            arr.add(obj);
+        }
+        return arr;
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugStatusTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugStatusTool.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.model.IDebugTarget;
 import org.eclipse.debug.core.model.IStackFrame;
@@ -24,11 +25,14 @@ import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
 import com.ditrix.edt.mcp.server.utils.DebugSessionRegistry;
+import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
 
 /**
  * Reports active debug launches and their suspend state. If {@code applicationId}
  * is given the response is filtered to that one launch; otherwise all currently
- * tracked launches are returned.
+ * tracked launches are returned. Covers both runtime-client and Attach debug
+ * configurations (synthetic {@code attach:<configName>} ids are reported for
+ * attach launches that don't carry {@code ATTR_APPLICATION_ID}).
  */
 public class DebugStatusTool implements IMcpTool
 {
@@ -43,8 +47,9 @@ public class DebugStatusTool implements IMcpTool
     @Override
     public String getDescription()
     {
-        return "Report active debug launches: mode (debug/run), whether the target is " //$NON-NLS-1$
-            + "currently suspended, thread count, and the line of the top suspended frame. " //$NON-NLS-1$
+        return "Report active debug launches: applicationId (real or synthetic 'attach:<name>'), " //$NON-NLS-1$
+            + "launch configuration name/type, mode (debug/run), whether the target is currently " //$NON-NLS-1$
+            + "suspended, thread count, and the line of the top suspended frame. " //$NON-NLS-1$
             + "Optionally filter by applicationId."; //$NON-NLS-1$
     }
 
@@ -86,6 +91,11 @@ public class DebugStatusTool implements IMcpTool
                     continue;
                 }
                 String appId = DebugSessionRegistry.findApplicationIdFor(launch);
+                // Skip non-EDT launches entirely (e.g. Java apps, Ant tasks).
+                if (appId == null)
+                {
+                    continue;
+                }
                 if (filterAppId != null && !filterAppId.isEmpty() && !filterAppId.equals(appId))
                 {
                     continue;
@@ -95,6 +105,33 @@ public class DebugStatusTool implements IMcpTool
                 entry.put("applicationId", appId); //$NON-NLS-1$
                 entry.put("mode", launch.getLaunchMode()); //$NON-NLS-1$
                 entry.put("debug", ILaunchManager.DEBUG_MODE.equals(launch.getLaunchMode())); //$NON-NLS-1$
+
+                ILaunchConfiguration config = launch.getLaunchConfiguration();
+                if (config != null)
+                {
+                    entry.put("launchConfiguration", config.getName()); //$NON-NLS-1$
+                    String typeId = LaunchConfigUtils.getConfigTypeId(config);
+                    entry.put("configurationType", typeId); //$NON-NLS-1$
+                    entry.put("attach", LaunchConfigUtils.isAttachConfigTypeId(typeId)); //$NON-NLS-1$
+                    String project = LaunchConfigUtils.readAttribute(config,
+                        LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+                    if (!project.isEmpty())
+                    {
+                        entry.put("project", project); //$NON-NLS-1$
+                    }
+                    String alias = LaunchConfigUtils.readAttribute(config,
+                        LaunchConfigUtils.ATTR_DEBUG_INFOBASE_ALIAS, ""); //$NON-NLS-1$
+                    if (!alias.isEmpty())
+                    {
+                        entry.put("infobaseAlias", alias); //$NON-NLS-1$
+                    }
+                    String url = LaunchConfigUtils.readAttribute(config,
+                        LaunchConfigUtils.ATTR_DEBUG_SERVER_URL, ""); //$NON-NLS-1$
+                    if (!url.isEmpty())
+                    {
+                        entry.put("debugServerUrl", url); //$NON-NLS-1$
+                    }
+                }
 
                 IDebugTarget[] targets = launch.getDebugTargets();
                 int threadCount = 0;
@@ -136,6 +173,7 @@ public class DebugStatusTool implements IMcpTool
                 {
                     entry.put("suspendedAt", suspendedAt); //$NON-NLS-1$
                 }
+                entry.put("registered", DebugSessionRegistry.get().hasSnapshot(appId)); //$NON-NLS-1$
                 launches.add(entry);
             }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugYaxunitTestsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugYaxunitTestsTool.java
@@ -20,7 +20,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
 
@@ -81,8 +80,11 @@ public class DebugYaxunitTestsTool implements IMcpTool
     public String getInputSchema()
     {
         return JsonSchemaBuilder.object()
-            .stringProperty("projectName", "EDT project name (required)", true) //$NON-NLS-1$ //$NON-NLS-2$
-            .stringProperty("applicationId", "Application id from get_applications (required)", true) //$NON-NLS-1$ //$NON-NLS-2$
+            .stringProperty("launchConfigurationName", //$NON-NLS-1$
+                "Exact EDT runtime-client launch configuration name (preferred; from list_configurations)") //$NON-NLS-1$
+            .stringProperty("projectName", "EDT project name (required if launchConfigurationName is omitted)") //$NON-NLS-1$ //$NON-NLS-2$
+            .stringProperty("applicationId", //$NON-NLS-1$
+                "Application id from get_applications (required if launchConfigurationName is omitted)") //$NON-NLS-1$
             .stringProperty("extensions", "Comma-separated extension names to filter tests by extension") //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty("modules", "Comma-separated module names to filter tests") //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty("tests", "Comma-separated test names in Module.Method format (recommended: pin to one test)") //$NON-NLS-1$ //$NON-NLS-2$
@@ -98,29 +100,78 @@ public class DebugYaxunitTestsTool implements IMcpTool
     @Override
     public String execute(Map<String, String> params)
     {
+        String configName = JsonUtils.extractStringArgument(params, "launchConfigurationName"); //$NON-NLS-1$
         String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
         String applicationId = JsonUtils.extractStringArgument(params, "applicationId"); //$NON-NLS-1$
         String extensions = JsonUtils.extractStringArgument(params, "extensions"); //$NON-NLS-1$
         String modules = JsonUtils.extractStringArgument(params, "modules"); //$NON-NLS-1$
         String tests = JsonUtils.extractStringArgument(params, "tests"); //$NON-NLS-1$
 
-        if (projectName == null || projectName.isEmpty())
+        boolean hasName = configName != null && !configName.isEmpty();
+        if (!hasName)
         {
-            return ToolResult.error("projectName is required").toJson(); //$NON-NLS-1$
-        }
-        if (applicationId == null || applicationId.isEmpty())
-        {
-            return ToolResult.error("applicationId is required").toJson(); //$NON-NLS-1$
-        }
-
-        String notReady = ProjectStateChecker.checkReadyOrError(projectName);
-        if (notReady != null)
-        {
-            return ToolResult.error(notReady).toJson();
+            if (projectName == null || projectName.isEmpty())
+            {
+                return ToolResult.error("projectName is required (or pass launchConfigurationName)").toJson(); //$NON-NLS-1$
+            }
+            if (applicationId == null || applicationId.isEmpty())
+            {
+                return ToolResult.error("applicationId is required (or pass launchConfigurationName)").toJson(); //$NON-NLS-1$
+            }
         }
 
         try
         {
+            ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
+            if (launchManager == null)
+            {
+                return ToolResult.error("Launch manager is not available").toJson(); //$NON-NLS-1$
+            }
+
+            ILaunchConfiguration matchingConfig = LaunchConfigUtils.resolveLaunchConfig(
+                launchManager, configName, projectName, applicationId);
+            if (matchingConfig == null)
+            {
+                return ToolResult.error(hasName
+                    ? "Launch configuration not found: '" + configName + "'" //$NON-NLS-1$ //$NON-NLS-2$
+                    : "No runtime-client launch configuration for project '" + projectName //$NON-NLS-1$
+                        + "' and application '" + applicationId //$NON-NLS-1$
+                        + "'. Use list_configurations to see what's available.").toJson(); //$NON-NLS-1$
+            }
+
+            if (!LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID.equals(LaunchConfigUtils.getConfigTypeId(matchingConfig)))
+            {
+                return ToolResult.error("Launch configuration '" + matchingConfig.getName() //$NON-NLS-1$
+                    + "' is not a runtime-client config — YAXUnit tests require one.").toJson(); //$NON-NLS-1$
+            }
+
+            // Derive effective project/application from the resolved config so
+            // subsequent validation and the success response match reality.
+            String effectiveProject = LaunchConfigUtils.readAttribute(matchingConfig,
+                LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+            String effectiveAppId = LaunchConfigUtils.readAttribute(matchingConfig,
+                LaunchConfigUtils.ATTR_APPLICATION_ID, ""); //$NON-NLS-1$
+            if (projectName == null || projectName.isEmpty())
+            {
+                projectName = effectiveProject;
+            }
+            if (applicationId == null || applicationId.isEmpty())
+            {
+                applicationId = effectiveAppId;
+            }
+
+            if (projectName == null || projectName.isEmpty())
+            {
+                return ToolResult.error("Launch configuration '" + matchingConfig.getName() //$NON-NLS-1$
+                    + "' has no project attribute set").toJson(); //$NON-NLS-1$
+            }
+
+            String notReady = ProjectStateChecker.checkReadyOrError(projectName);
+            if (notReady != null)
+            {
+                return ToolResult.error(notReady).toJson();
+            }
+
             IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
             if (project == null || !project.exists())
             {
@@ -136,32 +187,20 @@ public class DebugYaxunitTestsTool implements IMcpTool
             {
                 return ToolResult.error("IApplicationManager service not available").toJson(); //$NON-NLS-1$
             }
-            try
+            if (applicationId != null && !applicationId.isEmpty())
             {
-                Optional<IApplication> appOpt = appManager.getApplication(project, applicationId);
-                if (!appOpt.isPresent())
+                try
                 {
-                    return ToolResult.error("Application not found: " + applicationId).toJson(); //$NON-NLS-1$
+                    Optional<IApplication> appOpt = appManager.getApplication(project, applicationId);
+                    if (!appOpt.isPresent())
+                    {
+                        return ToolResult.error("Application not found: " + applicationId).toJson(); //$NON-NLS-1$
+                    }
                 }
-            }
-            catch (ApplicationException e)
-            {
-                return ToolResult.error("Failed to validate application: " + e.getMessage()).toJson(); //$NON-NLS-1$
-            }
-
-            ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
-            ILaunchConfigurationType configType =
-                launchManager.getLaunchConfigurationType(LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID);
-            if (configType == null)
-            {
-                return ToolResult.error("Launch configuration type not found").toJson(); //$NON-NLS-1$
-            }
-            ILaunchConfiguration matchingConfig = LaunchConfigUtils.findLaunchConfig(
-                launchManager, configType, projectName, applicationId);
-            if (matchingConfig == null)
-            {
-                return ToolResult.error("No launch configuration for project '" + projectName //$NON-NLS-1$
-                        + "' and application '" + applicationId + "'. Create one in EDT first.").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+                catch (ApplicationException e)
+                {
+                    return ToolResult.error("Failed to validate application: " + e.getMessage()).toJson(); //$NON-NLS-1$
+                }
             }
 
             // Prepare a unique report dir + xUnitParams.json (uses native path separators

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetVariablesTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetVariablesTool.java
@@ -104,7 +104,20 @@ public class GetVariablesTool implements IMcpTool
             }
             else
             {
-                return ToolResult.error("Provide either frameRef or threadId").toJson(); //$NON-NLS-1$
+                // Fallback: if exactly one active debug launch is suspended, use its top frame.
+                String appId = DebugSessionRegistry.findLoneActiveApplicationId();
+                DebugSessionRegistry.SuspendSnapshot snap = appId != null ? registry.getSnapshot(appId) : null;
+                if (snap == null)
+                {
+                    return ToolResult.error("Provide frameRef or threadId — no single suspended debug " //$NON-NLS-1$
+                        + "launch available for auto-resolution. Call wait_for_break first.").toJson(); //$NON-NLS-1$
+                }
+                IStackFrame[] frames = snap.thread.getStackFrames();
+                if (frames.length == 0)
+                {
+                    return ToolResult.error("suspended thread has no stack frames").toJson(); //$NON-NLS-1$
+                }
+                frame = frames[Math.min(Math.max(frameIndex, 0), frames.length - 1)];
             }
 
             List<Map<String, Object>> vars;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListConfigurationsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListConfigurationsTool.java
@@ -26,22 +26,25 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool;
 import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
 
 /**
- * Lists EDT debug launch configurations (runtime client + Attach) with their
- * current running state.
+ * Lists EDT launch configurations — runtime-client, Attach (RemoteRuntime /
+ * LocalRuntime), and any other config in the 1C/EDT namespace — together with
+ * their current running state. This is the discovery step that precedes
+ * {@code debug_launch}, {@code run_yaxunit_tests}, {@code debug_yaxunit_tests}
+ * and {@code update_database}: once the MCP client knows the exact
+ * {@code name}, it can target that configuration by name without having to
+ * juggle applicationId/project pairs.
  *
- * <p>Intended as the first step of the server-side debugging workflow:
+ * <p>Intended workflow for server-side debugging:
  * <ol>
- *   <li>{@code list_debug_configurations({type: "attach"})} — see what Attach
- *       configs exist and which one is already running.</li>
- *   <li>{@code debug_launch({launchConfigurationName})} — start it if it's
- *       not running.</li>
- *   <li>Standard debug flow: {@code set_breakpoint}, {@code wait_for_break},
- *       {@code get_variables}, {@code step}, {@code resume}, etc.</li>
+ *   <li>{@code list_configurations({type: "attach"})} — see available Attach
+ *       configs, their infobase aliases, and whether any is already running.</li>
+ *   <li>{@code debug_launch({launchConfigurationName: ...})} — attach to it.</li>
+ *   <li>{@code set_breakpoint} → {@code wait_for_break} → standard debug flow.</li>
  * </ol>
  */
-public class ListDebugConfigurationsTool implements IMcpTool
+public class ListConfigurationsTool implements IMcpTool
 {
-    public static final String NAME = "list_debug_configurations"; //$NON-NLS-1$
+    public static final String NAME = "list_configurations"; //$NON-NLS-1$
 
     @Override
     public String getName()
@@ -52,12 +55,14 @@ public class ListDebugConfigurationsTool implements IMcpTool
     @Override
     public String getDescription()
     {
-        return "List EDT debug launch configurations with their running state. " //$NON-NLS-1$
-            + "Each entry carries configuration name, type, attach flag, applicationId " //$NON-NLS-1$
+        return "List EDT launch configurations (runtime client + Attach + other 1C types) " //$NON-NLS-1$
+            + "with their current running state. Each entry carries the configuration name " //$NON-NLS-1$
+            + "(use it as launchConfigurationName in debug_launch / run_yaxunit_tests / " //$NON-NLS-1$
+            + "debug_yaxunit_tests / update_database), type id, attach flag, applicationId " //$NON-NLS-1$
             + "(real or synthetic 'attach:<name>'), project, infobase alias, debug server URL, " //$NON-NLS-1$
-            + "and a 'running' flag (plus 'suspended' when the debug session is paused). " //$NON-NLS-1$
-            + "Use type='attach' to only list Attach configurations (for server-side debugging — " //$NON-NLS-1$
-            + "HTTP services, background jobs), or type='client' / type='all' (default)."; //$NON-NLS-1$
+            + "and a 'running' flag (plus 'suspended' when the session is paused on a breakpoint). " //$NON-NLS-1$
+            + "Use type='attach' for server-side debug setups (HTTP services, background jobs), " //$NON-NLS-1$
+            + "type='client' for 1C:Enterprise client configs, or type='all' (default)."; //$NON-NLS-1$
     }
 
     @Override
@@ -66,7 +71,7 @@ public class ListDebugConfigurationsTool implements IMcpTool
         return JsonSchemaBuilder.object()
             .stringProperty("type", //$NON-NLS-1$
                 "Filter: 'attach' (RemoteRuntime + LocalRuntime), 'client' (RuntimeClient), " //$NON-NLS-1$
-                    + "or 'all' (default)") //$NON-NLS-1$
+                    + "or 'all' (default — any 1C/EDT launch config)") //$NON-NLS-1$
             .stringProperty("projectName", "Optional project name filter") //$NON-NLS-1$ //$NON-NLS-2$
             .build();
     }
@@ -94,12 +99,13 @@ public class ListDebugConfigurationsTool implements IMcpTool
             Map<String, ILaunch> liveByAppId = indexLiveLaunches(launchManager);
 
             List<Map<String, Object>> configs = new ArrayList<>();
-            for (ILaunchConfiguration cfg : LaunchConfigUtils.getAllDebugConfigs(launchManager))
+            for (ILaunchConfiguration cfg : LaunchConfigUtils.getAllEdtConfigs(launchManager))
             {
                 String typeId = LaunchConfigUtils.getConfigTypeId(cfg);
                 boolean isAttach = LaunchConfigUtils.isAttachConfigTypeId(typeId);
+                boolean isClient = LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID.equals(typeId);
 
-                if (!matchesTypeFilter(typeFilter, isAttach))
+                if (!matchesTypeFilter(typeFilter, isAttach, isClient))
                 {
                     continue;
                 }
@@ -116,6 +122,7 @@ public class ListDebugConfigurationsTool implements IMcpTool
                 entry.put("name", cfg.getName()); //$NON-NLS-1$
                 entry.put("type", typeId); //$NON-NLS-1$
                 entry.put("attach", isAttach); //$NON-NLS-1$
+
                 String appId = LaunchConfigUtils.getApplicationIdFor(cfg);
                 if (appId != null)
                 {
@@ -157,12 +164,12 @@ public class ListDebugConfigurationsTool implements IMcpTool
         }
         catch (Exception e)
         {
-            Activator.logError("Error in list_debug_configurations", e); //$NON-NLS-1$
+            Activator.logError("Error in list_configurations", e); //$NON-NLS-1$
             return ToolResult.error("Error: " + e.getMessage()).toJson(); //$NON-NLS-1$
         }
     }
 
-    private static boolean matchesTypeFilter(String filter, boolean isAttach)
+    private static boolean matchesTypeFilter(String filter, boolean isAttach, boolean isClient)
     {
         if (filter == null || filter.isEmpty() || "all".equalsIgnoreCase(filter)) //$NON-NLS-1$
         {
@@ -175,7 +182,7 @@ public class ListDebugConfigurationsTool implements IMcpTool
         if ("client".equalsIgnoreCase(filter) || "runtime".equalsIgnoreCase(filter) //$NON-NLS-1$ //$NON-NLS-2$
             || "runtimeClient".equalsIgnoreCase(filter)) //$NON-NLS-1$
         {
-            return !isAttach;
+            return isClient;
         }
         // Unknown filter — be permissive.
         return true;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListDebugConfigurationsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListDebugConfigurationsTool.java
@@ -1,0 +1,232 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.core.model.IDebugTarget;
+import org.eclipse.debug.core.model.IThread;
+
+import com.ditrix.edt.mcp.server.Activator;
+import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
+import com.ditrix.edt.mcp.server.protocol.JsonUtils;
+import com.ditrix.edt.mcp.server.protocol.ToolResult;
+import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
+
+/**
+ * Lists EDT debug launch configurations (runtime client + Attach) with their
+ * current running state.
+ *
+ * <p>Intended as the first step of the server-side debugging workflow:
+ * <ol>
+ *   <li>{@code list_debug_configurations({type: "attach"})} — see what Attach
+ *       configs exist and which one is already running.</li>
+ *   <li>{@code debug_launch({launchConfigurationName})} — start it if it's
+ *       not running.</li>
+ *   <li>Standard debug flow: {@code set_breakpoint}, {@code wait_for_break},
+ *       {@code get_variables}, {@code step}, {@code resume}, etc.</li>
+ * </ol>
+ */
+public class ListDebugConfigurationsTool implements IMcpTool
+{
+    public static final String NAME = "list_debug_configurations"; //$NON-NLS-1$
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "List EDT debug launch configurations with their running state. " //$NON-NLS-1$
+            + "Each entry carries configuration name, type, attach flag, applicationId " //$NON-NLS-1$
+            + "(real or synthetic 'attach:<name>'), project, infobase alias, debug server URL, " //$NON-NLS-1$
+            + "and a 'running' flag (plus 'suspended' when the debug session is paused). " //$NON-NLS-1$
+            + "Use type='attach' to only list Attach configurations (for server-side debugging — " //$NON-NLS-1$
+            + "HTTP services, background jobs), or type='client' / type='all' (default)."; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getInputSchema()
+    {
+        return JsonSchemaBuilder.object()
+            .stringProperty("type", //$NON-NLS-1$
+                "Filter: 'attach' (RemoteRuntime + LocalRuntime), 'client' (RuntimeClient), " //$NON-NLS-1$
+                    + "or 'all' (default)") //$NON-NLS-1$
+            .stringProperty("projectName", "Optional project name filter") //$NON-NLS-1$ //$NON-NLS-2$
+            .build();
+    }
+
+    @Override
+    public ResponseType getResponseType()
+    {
+        return ResponseType.JSON;
+    }
+
+    @Override
+    public String execute(Map<String, String> params)
+    {
+        String typeFilter = JsonUtils.extractStringArgument(params, "type"); //$NON-NLS-1$
+        String projectFilter = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
+
+        try
+        {
+            ILaunchManager launchManager = LaunchConfigUtils.getLaunchManager();
+            if (launchManager == null)
+            {
+                return ToolResult.error("Launch manager is not available").toJson(); //$NON-NLS-1$
+            }
+
+            Map<String, ILaunch> liveByAppId = indexLiveLaunches(launchManager);
+
+            List<Map<String, Object>> configs = new ArrayList<>();
+            for (ILaunchConfiguration cfg : LaunchConfigUtils.getAllDebugConfigs(launchManager))
+            {
+                String typeId = LaunchConfigUtils.getConfigTypeId(cfg);
+                boolean isAttach = LaunchConfigUtils.isAttachConfigTypeId(typeId);
+
+                if (!matchesTypeFilter(typeFilter, isAttach))
+                {
+                    continue;
+                }
+
+                String project = LaunchConfigUtils.readAttribute(cfg,
+                    LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+                if (projectFilter != null && !projectFilter.isEmpty()
+                    && !projectFilter.equals(project))
+                {
+                    continue;
+                }
+
+                Map<String, Object> entry = new LinkedHashMap<>();
+                entry.put("name", cfg.getName()); //$NON-NLS-1$
+                entry.put("type", typeId); //$NON-NLS-1$
+                entry.put("attach", isAttach); //$NON-NLS-1$
+                String appId = LaunchConfigUtils.getApplicationIdFor(cfg);
+                if (appId != null)
+                {
+                    entry.put("applicationId", appId); //$NON-NLS-1$
+                }
+                if (!project.isEmpty())
+                {
+                    entry.put("project", project); //$NON-NLS-1$
+                }
+
+                String alias = LaunchConfigUtils.readAttribute(cfg,
+                    LaunchConfigUtils.ATTR_DEBUG_INFOBASE_ALIAS, ""); //$NON-NLS-1$
+                if (!alias.isEmpty())
+                {
+                    entry.put("infobaseAlias", alias); //$NON-NLS-1$
+                }
+                String url = LaunchConfigUtils.readAttribute(cfg,
+                    LaunchConfigUtils.ATTR_DEBUG_SERVER_URL, ""); //$NON-NLS-1$
+                if (!url.isEmpty())
+                {
+                    entry.put("debugServerUrl", url); //$NON-NLS-1$
+                }
+
+                ILaunch liveLaunch = appId != null ? liveByAppId.get(appId) : null;
+                boolean running = liveLaunch != null;
+                entry.put("running", running); //$NON-NLS-1$
+                if (running)
+                {
+                    entry.put("mode", liveLaunch.getLaunchMode()); //$NON-NLS-1$
+                    entry.put("suspended", anyThreadSuspended(liveLaunch)); //$NON-NLS-1$
+                }
+                configs.add(entry);
+            }
+
+            return ToolResult.success()
+                .put("configurations", configs) //$NON-NLS-1$
+                .put("count", configs.size()) //$NON-NLS-1$
+                .toJson();
+        }
+        catch (Exception e)
+        {
+            Activator.logError("Error in list_debug_configurations", e); //$NON-NLS-1$
+            return ToolResult.error("Error: " + e.getMessage()).toJson(); //$NON-NLS-1$
+        }
+    }
+
+    private static boolean matchesTypeFilter(String filter, boolean isAttach)
+    {
+        if (filter == null || filter.isEmpty() || "all".equalsIgnoreCase(filter)) //$NON-NLS-1$
+        {
+            return true;
+        }
+        if ("attach".equalsIgnoreCase(filter)) //$NON-NLS-1$
+        {
+            return isAttach;
+        }
+        if ("client".equalsIgnoreCase(filter) || "runtime".equalsIgnoreCase(filter) //$NON-NLS-1$ //$NON-NLS-2$
+            || "runtimeClient".equalsIgnoreCase(filter)) //$NON-NLS-1$
+        {
+            return !isAttach;
+        }
+        // Unknown filter — be permissive.
+        return true;
+    }
+
+    private static Map<String, ILaunch> indexLiveLaunches(ILaunchManager mgr)
+    {
+        Map<String, ILaunch> map = new LinkedHashMap<>();
+        DebugPlugin plugin = DebugPlugin.getDefault();
+        if (plugin == null)
+        {
+            return map;
+        }
+        for (ILaunch launch : mgr.getLaunches())
+        {
+            if (launch.isTerminated())
+            {
+                continue;
+            }
+            String appId = LaunchConfigUtils.getApplicationIdFor(launch);
+            if (appId != null)
+            {
+                map.putIfAbsent(appId, launch);
+            }
+        }
+        return map;
+    }
+
+    private static boolean anyThreadSuspended(ILaunch launch)
+    {
+        try
+        {
+            for (IDebugTarget t : launch.getDebugTargets())
+            {
+                if (t == null || t.isTerminated())
+                {
+                    continue;
+                }
+                for (IThread th : t.getThreads())
+                {
+                    if (th.isSuspended())
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // best-effort
+        }
+        return false;
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ResumeTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ResumeTool.java
@@ -21,6 +21,11 @@ import com.ditrix.edt.mcp.server.utils.DebugSessionRegistry;
 /**
  * Resumes a suspended debug thread (or, if {@code applicationId} is given,
  * resumes all threads of the matching debug target).
+ *
+ * <p>If neither parameter is given and there is exactly one active debug launch,
+ * that launch is used as a fallback — useful for Attach configurations whose
+ * synthetic applicationId is not known to the caller, and for the common
+ * one-session workflow.
  */
 public class ResumeTool implements IMcpTool
 {
@@ -36,7 +41,8 @@ public class ResumeTool implements IMcpTool
     public String getDescription()
     {
         return "Resume a suspended debug thread or all threads of a debug target. " //$NON-NLS-1$
-            + "Either pass threadId (from wait_for_break) or applicationId."; //$NON-NLS-1$
+            + "Pass threadId (from wait_for_break) or applicationId. " //$NON-NLS-1$
+            + "With no arguments, resumes the single active debug launch if exactly one exists."; //$NON-NLS-1$
     }
 
     @Override
@@ -44,7 +50,8 @@ public class ResumeTool implements IMcpTool
     {
         return JsonSchemaBuilder.object()
             .integerProperty("threadId", "Thread id from wait_for_break") //$NON-NLS-1$ //$NON-NLS-2$
-            .stringProperty("applicationId", "Application id (resumes all threads of this target)") //$NON-NLS-1$ //$NON-NLS-2$
+            .stringProperty("applicationId", //$NON-NLS-1$
+                "Application id (real or 'attach:<configName>' — resumes all threads of this target)") //$NON-NLS-1$
             .build();
     }
 
@@ -61,6 +68,7 @@ public class ResumeTool implements IMcpTool
         String applicationId = JsonUtils.extractStringArgument(params, "applicationId"); //$NON-NLS-1$
 
         DebugSessionRegistry registry = DebugSessionRegistry.get();
+        registry.ensureListenerRegistered();
 
         try
         {
@@ -69,7 +77,7 @@ public class ResumeTool implements IMcpTool
                 IThread thread = registry.getThread(threadId);
                 if (thread == null)
                 {
-                    return ToolResult.error("stale threadId").toJson(); //$NON-NLS-1$
+                    return ToolResult.error("stale threadId — call wait_for_break again").toJson(); //$NON-NLS-1$
                 }
                 if (!thread.canResume())
                 {
@@ -79,21 +87,36 @@ public class ResumeTool implements IMcpTool
                 thread.resume();
                 return ToolResult.success().put("resumed", true).put("scope", "thread").toJson(); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             }
-            if (applicationId != null && !applicationId.isEmpty())
+
+            String effectiveAppId = (applicationId != null && !applicationId.isEmpty())
+                ? applicationId
+                : DebugSessionRegistry.findLoneActiveApplicationId();
+
+            if (effectiveAppId == null)
             {
-                IDebugTarget target = DebugSessionRegistry.findActiveTarget(applicationId);
-                if (target == null)
-                {
-                    return ToolResult.error("no active debug target for applicationId: " + applicationId).toJson(); //$NON-NLS-1$
-                }
-                if (!target.canResume())
-                {
-                    return ToolResult.error("debug target cannot resume").toJson(); //$NON-NLS-1$
-                }
-                target.resume();
-                return ToolResult.success().put("resumed", true).put("scope", "target").toJson(); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                return ToolResult.error("Provide threadId or applicationId — no single active debug " //$NON-NLS-1$
+                    + "launch available for auto-resolution. Use debug_status to list active launches.").toJson(); //$NON-NLS-1$
             }
-            return ToolResult.error("Provide either threadId or applicationId").toJson(); //$NON-NLS-1$
+
+            IDebugTarget target = DebugSessionRegistry.findActiveTarget(effectiveAppId);
+            if (target == null)
+            {
+                return ToolResult.error("no active debug target for applicationId: " + effectiveAppId).toJson(); //$NON-NLS-1$
+            }
+            if (!target.canResume())
+            {
+                return ToolResult.error("debug target cannot resume").toJson(); //$NON-NLS-1$
+            }
+            target.resume();
+            ToolResult res = ToolResult.success()
+                .put("resumed", true) //$NON-NLS-1$
+                .put("scope", "target") //$NON-NLS-1$ //$NON-NLS-2$
+                .put("applicationId", effectiveAppId); //$NON-NLS-1$
+            if (applicationId == null || applicationId.isEmpty())
+            {
+                res.put("autoResolved", true); //$NON-NLS-1$
+            }
+            return res.toJson();
         }
         catch (Exception e)
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
@@ -95,8 +95,11 @@ public class RunYaxunitTestsTool implements IMcpTool
     public String getInputSchema()
     {
         return JsonSchemaBuilder.object()
-            .stringProperty("projectName", "EDT project name (required)", true) //$NON-NLS-1$ //$NON-NLS-2$
-            .stringProperty("applicationId", "Application ID from get_applications (required)", true) //$NON-NLS-1$ //$NON-NLS-2$
+            .stringProperty("launchConfigurationName", //$NON-NLS-1$
+                "Exact EDT runtime-client launch configuration name (preferred; from list_configurations)") //$NON-NLS-1$
+            .stringProperty("projectName", "EDT project name (required if launchConfigurationName is omitted)") //$NON-NLS-1$ //$NON-NLS-2$
+            .stringProperty("applicationId", //$NON-NLS-1$
+                "Application ID from get_applications (required if launchConfigurationName is omitted)") //$NON-NLS-1$
             .stringProperty("extensions", "Comma-separated extension names to filter tests by extension") //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty("modules", "Comma-separated module names to filter tests") //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty("tests", "Comma-separated test names in Module.Method format") //$NON-NLS-1$ //$NON-NLS-2$
@@ -113,6 +116,7 @@ public class RunYaxunitTestsTool implements IMcpTool
     @Override
     public String execute(Map<String, String> params)
     {
+        String configName = JsonUtils.extractStringArgument(params, "launchConfigurationName"); //$NON-NLS-1$
         String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
         String applicationId = JsonUtils.extractStringArgument(params, "applicationId"); //$NON-NLS-1$
         String extensions = JsonUtils.extractStringArgument(params, "extensions"); //$NON-NLS-1$
@@ -124,26 +128,24 @@ public class RunYaxunitTestsTool implements IMcpTool
             timeout = 1;
         }
 
-        if (projectName == null || projectName.isEmpty())
+        boolean hasName = configName != null && !configName.isEmpty();
+        if (!hasName)
         {
-            return "**Error:** projectName is required"; //$NON-NLS-1$
-        }
-
-        if (applicationId == null || applicationId.isEmpty())
-        {
-            return "**Error:** applicationId is required. Use get_applications to get application list."; //$NON-NLS-1$
-        }
-
-        String notReadyError = ProjectStateChecker.checkReadyOrError(projectName);
-        if (notReadyError != null)
-        {
-            return "**Error:** " + notReadyError; //$NON-NLS-1$
+            if (projectName == null || projectName.isEmpty())
+            {
+                return "**Error:** projectName is required (or pass launchConfigurationName)"; //$NON-NLS-1$
+            }
+            if (applicationId == null || applicationId.isEmpty())
+            {
+                return "**Error:** applicationId is required (or pass launchConfigurationName). " //$NON-NLS-1$
+                    + "Use get_applications or list_configurations."; //$NON-NLS-1$
+            }
         }
 
         ensureLaunchListenerRegistered();
         purgeTerminatedLaunches();
 
-        return runTests(projectName, applicationId, extensions, modules, tests, timeout);
+        return runTests(configName, projectName, applicationId, extensions, modules, tests, timeout);
     }
 
     /**
@@ -160,11 +162,60 @@ public class RunYaxunitTestsTool implements IMcpTool
      * The temp directory is NEVER deleted in finally — the caller can invoke the tool again to fetch
      * the result. Old runs are cleaned up automatically before starting a new launch.
      */
-    private String runTests(String projectName, String applicationId,
+    private String runTests(String configName, String projectName, String applicationId,
             String extensions, String modules, String tests, int timeout)
     {
         try
         {
+            ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
+            if (launchManager == null)
+            {
+                return "**Error:** Launch manager is not available"; //$NON-NLS-1$
+            }
+
+            ILaunchConfiguration matchingConfig = LaunchConfigUtils.resolveLaunchConfig(
+                    launchManager, configName, projectName, applicationId);
+            if (matchingConfig == null)
+            {
+                boolean hasName = configName != null && !configName.isEmpty();
+                return hasName
+                    ? "**Error:** Launch configuration not found: '" + configName + "'. " //$NON-NLS-1$ //$NON-NLS-2$
+                        + "Use list_configurations to see what's available." //$NON-NLS-1$
+                    : buildNoConfigError(launchManager,
+                        launchManager.getLaunchConfigurationType(LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID),
+                        projectName, applicationId);
+            }
+            if (!LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID.equals(LaunchConfigUtils.getConfigTypeId(matchingConfig)))
+            {
+                return "**Error:** Launch configuration '" + matchingConfig.getName() //$NON-NLS-1$
+                    + "' is not a runtime-client config — YAXUnit tests require one."; //$NON-NLS-1$
+            }
+
+            // Derive effective project/application from the resolved config.
+            String effectiveProject = LaunchConfigUtils.readAttribute(matchingConfig,
+                LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+            String effectiveAppId = LaunchConfigUtils.readAttribute(matchingConfig,
+                LaunchConfigUtils.ATTR_APPLICATION_ID, ""); //$NON-NLS-1$
+            if (projectName == null || projectName.isEmpty())
+            {
+                projectName = effectiveProject;
+            }
+            if (applicationId == null || applicationId.isEmpty())
+            {
+                applicationId = effectiveAppId;
+            }
+            if (projectName == null || projectName.isEmpty())
+            {
+                return "**Error:** Launch configuration '" + matchingConfig.getName() //$NON-NLS-1$
+                    + "' has no project attribute set"; //$NON-NLS-1$
+            }
+
+            String notReadyError = ProjectStateChecker.checkReadyOrError(projectName);
+            if (notReadyError != null)
+            {
+                return "**Error:** " + notReadyError; //$NON-NLS-1$
+            }
+
             IWorkspace workspace = ResourcesPlugin.getWorkspace();
             IProject project = workspace.getRoot().getProject(projectName);
 
@@ -184,23 +235,28 @@ public class RunYaxunitTestsTool implements IMcpTool
                 return "**Error:** IApplicationManager service is not available"; //$NON-NLS-1$
             }
 
-            try
+            if (applicationId != null && !applicationId.isEmpty())
             {
-                Optional<IApplication> appOpt = appManager.getApplication(project, applicationId);
-                if (!appOpt.isPresent())
+                try
                 {
-                    return "**Error:** Application not found: " + applicationId //$NON-NLS-1$
-                            + ". Use get_applications to get valid application IDs."; //$NON-NLS-1$
+                    Optional<IApplication> appOpt = appManager.getApplication(project, applicationId);
+                    if (!appOpt.isPresent())
+                    {
+                        return "**Error:** Application not found: " + applicationId //$NON-NLS-1$
+                                + ". Use get_applications to get valid application IDs."; //$NON-NLS-1$
+                    }
+                }
+                catch (ApplicationException e)
+                {
+                    Activator.logError("Error checking application", e); //$NON-NLS-1$
+                    return "**Error:** Failed to validate application: " + applicationId //$NON-NLS-1$
+                            + " (" + e.getMessage() + ")"; //$NON-NLS-1$ //$NON-NLS-2$
                 }
             }
-            catch (ApplicationException e)
-            {
-                Activator.logError("Error checking application", e); //$NON-NLS-1$
-                return "**Error:** Failed to validate application: " + applicationId //$NON-NLS-1$
-                        + " (" + e.getMessage() + ")"; //$NON-NLS-1$ //$NON-NLS-2$
-            }
 
-            String runKey = projectName + ":" + applicationId + ":" //$NON-NLS-1$ //$NON-NLS-2$
+            // Use the launch config name as the run-key root — stable across
+            // (project, applicationId) vs. launchConfigurationName call styles.
+            String runKey = matchingConfig.getName() + ":" //$NON-NLS-1$
                     + sha1(safe(extensions) + "|" + safe(modules) + "|" + safe(tests)); //$NON-NLS-1$ //$NON-NLS-2$
             Path reportDir = stableReportDir(runKey);
 
@@ -233,28 +289,6 @@ public class RunYaxunitTestsTool implements IMcpTool
             {
                 Activator.logInfo("Returning cached YAXUnit results from " + cached); //$NON-NLS-1$
                 return readResults(cached);
-            }
-
-            ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
-            if (launchManager == null)
-            {
-                return "**Error:** Launch manager is not available"; //$NON-NLS-1$
-            }
-
-            ILaunchConfigurationType configType = launchManager
-                    .getLaunchConfigurationType(LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID);
-            if (configType == null)
-            {
-                return "**Error:** Launch configuration type not found: " //$NON-NLS-1$
-                        + LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID;
-            }
-
-            ILaunchConfiguration matchingConfig = LaunchConfigUtils.findLaunchConfig(
-                    launchManager, configType, projectName, applicationId);
-
-            if (matchingConfig == null)
-            {
-                return buildNoConfigError(launchManager, configType, projectName, applicationId);
             }
 
             // Atomically reuse an existing active launch for the same runKey, or create exactly

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/StepTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/StepTool.java
@@ -135,7 +135,7 @@ public class StepTool implements IMcpTool
                     .put("reason", "timeout") //$NON-NLS-1$ //$NON-NLS-2$
                     .toJson();
             }
-            return WaitForBreakTool.buildSnapshotResponse(snapshot, registry);
+            return WaitForBreakTool.buildSnapshotResponse(snapshot, registry, appId, false);
         }
         catch (InterruptedException e)
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
@@ -14,6 +14,9 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
@@ -22,6 +25,7 @@ import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
 import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
 import com.ditrix.edt.mcp.server.utils.ProjectStateChecker;
 import com.e1c.g5.dt.applications.ApplicationException;
 import com.e1c.g5.dt.applications.ApplicationUpdateState;
@@ -47,54 +51,94 @@ public class UpdateDatabaseTool implements IMcpTool
     @Override
     public String getDescription()
     {
-        return "Update database (infobase) for an application. " + //$NON-NLS-1$
-               "Requires application ID from get_applications tool. " + //$NON-NLS-1$
-               "Supports full update (complete reload) and incremental update (changes only)."; //$NON-NLS-1$
+        return "Update database (infobase) for an application. " //$NON-NLS-1$
+            + "Target the application either by launchConfigurationName (preferred; " //$NON-NLS-1$
+            + "from list_configurations) or by projectName + applicationId (from get_applications). " //$NON-NLS-1$
+            + "Supports full update (complete reload) and incremental update (changes only)."; //$NON-NLS-1$
     }
-    
+
     @Override
     public String getInputSchema()
     {
         return JsonSchemaBuilder.object()
-            .stringProperty("projectName", "EDT project name (required)", true) //$NON-NLS-1$ //$NON-NLS-2$
-            .stringProperty("applicationId", "Application ID from get_applications (required)", true) //$NON-NLS-1$ //$NON-NLS-2$
+            .stringProperty("launchConfigurationName", //$NON-NLS-1$
+                "Exact EDT runtime-client launch configuration name (preferred; from list_configurations)") //$NON-NLS-1$
+            .stringProperty("projectName", "EDT project name (required if launchConfigurationName is omitted)") //$NON-NLS-1$ //$NON-NLS-2$
+            .stringProperty("applicationId", //$NON-NLS-1$
+                "Application ID from get_applications (required if launchConfigurationName is omitted)") //$NON-NLS-1$
             .booleanProperty("fullUpdate", "If true - full reload, if false - incremental update (default: false)") //$NON-NLS-1$ //$NON-NLS-2$
             .booleanProperty("autoRestructure", "Automatically apply restructurization if needed (default: true)") //$NON-NLS-1$ //$NON-NLS-2$
             .build();
     }
-    
+
     @Override
     public ResponseType getResponseType()
     {
         return ResponseType.JSON;
     }
-    
+
     @Override
     public String execute(Map<String, String> params)
     {
+        String configName = JsonUtils.extractStringArgument(params, "launchConfigurationName"); //$NON-NLS-1$
         String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
         String applicationId = JsonUtils.extractStringArgument(params, "applicationId"); //$NON-NLS-1$
         boolean fullUpdate = JsonUtils.extractBooleanArgument(params, "fullUpdate", false); //$NON-NLS-1$
         boolean autoRestructure = JsonUtils.extractBooleanArgument(params, "autoRestructure", true); //$NON-NLS-1$
-        
-        // Validate required parameters
-        if (projectName == null || projectName.isEmpty())
+
+        boolean hasName = configName != null && !configName.isEmpty();
+        if (!hasName)
         {
-            return ToolResult.error("projectName is required").toJson(); //$NON-NLS-1$
+            if (projectName == null || projectName.isEmpty())
+            {
+                return ToolResult.error("projectName is required (or pass launchConfigurationName)").toJson(); //$NON-NLS-1$
+            }
+            if (applicationId == null || applicationId.isEmpty())
+            {
+                return ToolResult.error("applicationId is required (or pass launchConfigurationName). " //$NON-NLS-1$
+                    + "Use get_applications or list_configurations.").toJson(); //$NON-NLS-1$
+            }
         }
-        
-        if (applicationId == null || applicationId.isEmpty())
+
+        // Resolve via launch config if name is given — it fixes the project + applicationId pair.
+        if (hasName)
         {
-            return ToolResult.error("applicationId is required. Use get_applications to get application list.").toJson(); //$NON-NLS-1$
+            ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
+            if (launchManager == null)
+            {
+                return ToolResult.error("Launch manager is not available").toJson(); //$NON-NLS-1$
+            }
+            ILaunchConfiguration cfg = LaunchConfigUtils.findLaunchConfigByName(launchManager, configName);
+            if (cfg == null)
+            {
+                return ToolResult.error("Launch configuration not found: '" + configName //$NON-NLS-1$
+                    + "'. Use list_configurations to see what's available.").toJson(); //$NON-NLS-1$
+            }
+            if (!LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID.equals(LaunchConfigUtils.getConfigTypeId(cfg)))
+            {
+                return ToolResult.error("Launch configuration '" + cfg.getName() //$NON-NLS-1$
+                    + "' is not a runtime-client config — update_database requires one.").toJson(); //$NON-NLS-1$
+            }
+            String cfgProject = LaunchConfigUtils.readAttribute(cfg,
+                LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+            String cfgAppId = LaunchConfigUtils.readAttribute(cfg,
+                LaunchConfigUtils.ATTR_APPLICATION_ID, ""); //$NON-NLS-1$
+            if (cfgProject.isEmpty() || cfgAppId.isEmpty())
+            {
+                return ToolResult.error("Launch configuration '" + cfg.getName() //$NON-NLS-1$
+                    + "' has no project or applicationId attribute — cannot derive update target.").toJson(); //$NON-NLS-1$
+            }
+            projectName = cfgProject;
+            applicationId = cfgAppId;
         }
-        
+
         // Check if project is ready for operations
         String notReadyError = ProjectStateChecker.checkReadyOrError(projectName);
         if (notReadyError != null)
         {
             return ToolResult.error(notReadyError).toJson();
         }
-        
+
         return updateDatabase(projectName, applicationId, fullUpdate, autoRestructure);
     }
     

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WaitForBreakTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WaitForBreakTool.java
@@ -29,6 +29,11 @@ import com.ditrix.edt.mcp.server.utils.DebugSessionRegistry;
  * <p>If the application is already suspended at the time of the call, returns
  * immediately. If the timeout expires without a suspend, returns
  * {@code {hit:false, reason:"timeout"}} — the launch is NOT terminated.
+ *
+ * <p>{@code applicationId} may be a real id from {@code get_applications} or the
+ * synthetic {@code attach:<configName>} id reported by {@code debug_status} for
+ * Attach launches. If omitted and exactly one EDT debug launch is active, that
+ * launch is auto-resolved.
  */
 public class WaitForBreakTool implements IMcpTool
 {
@@ -44,8 +49,10 @@ public class WaitForBreakTool implements IMcpTool
     @Override
     public String getDescription()
     {
-        return "Wait for a debug suspend event (e.g. breakpoint hit) on the given " //$NON-NLS-1$
-            + "application. Returns the suspended thread/frame snapshot, or {hit:false} on timeout. " //$NON-NLS-1$
+        return "Wait for a debug suspend event (e.g. breakpoint hit) on the given application. " //$NON-NLS-1$
+            + "Returns the suspended thread/frame snapshot, or {hit:false} on timeout. " //$NON-NLS-1$
+            + "applicationId may be real or synthetic 'attach:<configName>'. " //$NON-NLS-1$
+            + "If omitted and exactly one EDT debug launch is active, that launch is used. " //$NON-NLS-1$
             + "Does NOT terminate the launch on timeout — call again to keep waiting."; //$NON-NLS-1$
     }
 
@@ -53,7 +60,9 @@ public class WaitForBreakTool implements IMcpTool
     public String getInputSchema()
     {
         return JsonSchemaBuilder.object()
-            .stringProperty("applicationId", "Application id of the running debug session (required)", true) //$NON-NLS-1$ //$NON-NLS-2$
+            .stringProperty("applicationId", //$NON-NLS-1$
+                "Application id of the running debug session (real or 'attach:<configName>'). " //$NON-NLS-1$
+                    + "Optional if exactly one debug launch is active.") //$NON-NLS-1$
             .integerProperty("timeout", "Wait window in seconds (default: 60)") //$NON-NLS-1$ //$NON-NLS-2$
             .build();
     }
@@ -73,13 +82,21 @@ public class WaitForBreakTool implements IMcpTool
         {
             timeout = 1;
         }
-        if (applicationId == null || applicationId.isEmpty())
-        {
-            return ToolResult.error("applicationId is required").toJson(); //$NON-NLS-1$
-        }
 
         DebugSessionRegistry registry = DebugSessionRegistry.get();
         registry.ensureListenerRegistered();
+
+        boolean autoResolved = false;
+        if (applicationId == null || applicationId.isEmpty())
+        {
+            applicationId = DebugSessionRegistry.findLoneActiveApplicationId();
+            if (applicationId == null)
+            {
+                return ToolResult.error("applicationId is required — no single active debug launch " //$NON-NLS-1$
+                    + "available for auto-resolution. Use debug_status to list active launches.").toJson(); //$NON-NLS-1$
+            }
+            autoResolved = true;
+        }
 
         // Proactively scan live targets for threads already suspended before the
         // listener was registered (e.g. manual breakpoint hit in EDT, or suspend
@@ -92,12 +109,17 @@ public class WaitForBreakTool implements IMcpTool
                 registry.waitForSuspend(applicationId, timeout * 1000L);
             if (snapshot == null)
             {
-                return ToolResult.success()
+                ToolResult r = ToolResult.success()
                     .put("hit", false) //$NON-NLS-1$
                     .put("reason", "timeout") //$NON-NLS-1$ //$NON-NLS-2$
-                    .toJson();
+                    .put("applicationId", applicationId); //$NON-NLS-1$
+                if (autoResolved)
+                {
+                    r.put("autoResolved", true); //$NON-NLS-1$
+                }
+                return r.toJson();
             }
-            return buildSnapshotResponse(snapshot, registry);
+            return buildSnapshotResponse(snapshot, registry, applicationId, autoResolved);
         }
         catch (InterruptedException e)
         {
@@ -151,7 +173,7 @@ public class WaitForBreakTool implements IMcpTool
      * (get_variables, evaluate_expression, step) can refer back to it.
      */
     static String buildSnapshotResponse(DebugSessionRegistry.SuspendSnapshot snapshot,
-            DebugSessionRegistry registry) throws Exception
+            DebugSessionRegistry registry, String applicationId, boolean autoResolved) throws Exception
     {
         IThread thread = snapshot.thread;
         List<Map<String, Object>> frames = new ArrayList<>();
@@ -178,7 +200,12 @@ public class WaitForBreakTool implements IMcpTool
             .put("hit", true) //$NON-NLS-1$
             .put("threadId", snapshot.threadId) //$NON-NLS-1$
             .put("threadName", thread.getName()) //$NON-NLS-1$
+            .put("applicationId", applicationId) //$NON-NLS-1$
             .put("frames", frames); //$NON-NLS-1$
+        if (autoResolved)
+        {
+            result.put("autoResolved", true); //$NON-NLS-1$
+        }
         if (!frames.isEmpty())
         {
             result.put("topFrameRef", frames.get(0).get("frameRef")); //$NON-NLS-1$ //$NON-NLS-2$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DebugSessionRegistry.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DebugSessionRegistry.java
@@ -6,7 +6,9 @@
 
 package com.ditrix.edt.mcp.server.utils;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -30,8 +32,10 @@ import com.ditrix.edt.mcp.server.Activator;
  *
  * <p>The registry installs a single {@link IDebugEventSetListener} on the
  * Eclipse {@link DebugPlugin} on first use. Suspend events are recorded per
- * launch (keyed by {@code applicationId} extracted from the launch configuration);
- * resume/terminate events purge the cached snapshot and any associated IDs.
+ * launch (keyed by {@code applicationId} extracted from the launch configuration —
+ * real {@code ATTR_APPLICATION_ID} for runtime-client launches, or the synthetic
+ * {@code attach:<configName>} id for attach launches); resume/terminate events
+ * purge the cached snapshot and any associated IDs.
  */
 public final class DebugSessionRegistry
 {
@@ -284,10 +288,17 @@ public final class DebugSessionRegistry
         return framesById.get(frameRef);
     }
 
+    /** Returns the most recent suspend snapshot for the given appId, or {@code null}. */
+    public SuspendSnapshot getSnapshot(String applicationId)
+    {
+        return applicationId != null ? snapshots.get(applicationId) : null;
+    }
+
     /**
      * Walks the launch configuration of the given thread/target/launch and pulls
-     * the {@code ATTR_APPLICATION_ID} attribute. Returns {@code null} if it can't
-     * be determined (orphan launch, missing attribute, etc.).
+     * a stable applicationId: the real {@code ATTR_APPLICATION_ID} for runtime-client
+     * launches, or the synthetic {@code attach:<configName>} id for attach launches.
+     * Returns {@code null} if it can't be determined (orphan launch, unknown config type).
      */
     public static String findApplicationIdFor(IThread thread)
     {
@@ -316,17 +327,12 @@ public final class DebugSessionRegistry
 
     public static String findApplicationIdFor(ILaunch launch)
     {
-        if (launch == null || launch.getLaunchConfiguration() == null)
-        {
-            return null;
-        }
-        return LaunchConfigUtils.readAttribute(launch.getLaunchConfiguration(),
-                LaunchConfigUtils.ATTR_APPLICATION_ID, null);
+        return LaunchConfigUtils.getApplicationIdFor(launch);
     }
 
     /**
      * Searches for an active (non-terminated) {@link IDebugTarget} whose launch
-     * configuration {@code ATTR_APPLICATION_ID} equals the given value.
+     * resolves to the given applicationId (real or synthetic).
      */
     public static IDebugTarget findActiveTarget(String applicationId)
     {
@@ -373,6 +379,44 @@ public final class DebugSessionRegistry
         info.put("liveThreads", threadsById.size()); //$NON-NLS-1$
         info.put("liveFrames", framesById.size()); //$NON-NLS-1$
         return info;
+    }
+
+    /**
+     * Returns all applicationIds (real or synthetic) that currently have an
+     * active, non-terminated debug launch in the Eclipse launch manager.
+     */
+    public static List<String> listActiveApplicationIds()
+    {
+        List<String> ids = new ArrayList<>();
+        DebugPlugin debugPlugin = DebugPlugin.getDefault();
+        if (debugPlugin == null)
+        {
+            return ids;
+        }
+        ILaunchManager mgr = debugPlugin.getLaunchManager();
+        for (ILaunch launch : mgr.getLaunches())
+        {
+            if (launch.isTerminated())
+            {
+                continue;
+            }
+            String appId = findApplicationIdFor(launch);
+            if (appId != null && !ids.contains(appId))
+            {
+                ids.add(appId);
+            }
+        }
+        return ids;
+    }
+
+    /**
+     * Convenience: returns the applicationId of the single active, non-terminated
+     * debug launch, or {@code null} if there is none or more than one.
+     */
+    public static String findLoneActiveApplicationId()
+    {
+        List<String> ids = listActiveApplicationIds();
+        return ids.size() == 1 ? ids.get(0) : null;
     }
 
     /** For tests only — drops all cached state. */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchConfigUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchConfigUtils.java
@@ -148,8 +148,14 @@ public final class LaunchConfigUtils
     }
 
     /**
-     * Finds the best matching runtime-client launch configuration for the given
-     * project and application. Attach configs are not considered here.
+     * Finds the launch configuration of the given {@code configType} that matches
+     * {@code project + applicationId} <em>exactly</em>. Returns {@code null} if
+     * no exact match exists.
+     *
+     * <p>Historically this method also fell back to "first config for the same
+     * project" which silently routed runs to an unrelated launch configuration.
+     * That fallback has been removed — callers should either use this strict
+     * lookup or {@link #findLaunchConfigByName(ILaunchManager, String)}.
      *
      * @param launchManager Eclipse launch manager (must not be null)
      * @param configType    1C runtime client config type (must not be null)
@@ -162,10 +168,7 @@ public final class LaunchConfigUtils
     {
         try
         {
-            ILaunchConfiguration[] allConfigs = launchManager.getLaunchConfigurations(configType);
-
-            // 1. Exact match: project + application
-            for (ILaunchConfiguration config : allConfigs)
+            for (ILaunchConfiguration config : launchManager.getLaunchConfigurations(configType))
             {
                 try
                 {
@@ -182,23 +185,6 @@ public final class LaunchConfigUtils
                     Activator.logError("Error reading launch configuration: " + config.getName(), e); //$NON-NLS-1$
                 }
             }
-
-            // 2. Fallback: any config for the same project
-            for (ILaunchConfiguration config : allConfigs)
-            {
-                try
-                {
-                    String configProject = config.getAttribute(ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
-                    if (projectName.equals(configProject))
-                    {
-                        return config;
-                    }
-                }
-                catch (CoreException e)
-                {
-                    // Skip unreadable config
-                }
-            }
         }
         catch (CoreException e)
         {
@@ -206,6 +192,42 @@ public final class LaunchConfigUtils
         }
 
         return null;
+    }
+
+    /**
+     * Resolves a launch configuration from a dual input: either an explicit
+     * {@code launchConfigurationName} (searched across all EDT debug config
+     * types) or a {@code projectName + applicationId} pair (strict match
+     * against runtime-client configs only).
+     *
+     * <p>At least one of the two must be provided. When both are provided and
+     * the named config doesn't match the given {@code projectName}/{@code applicationId},
+     * the name wins — callers pre-resolve the config and can then cross-check.
+     *
+     * @return resolved config, or {@code null} if nothing matches.
+     */
+    public static ILaunchConfiguration resolveLaunchConfig(ILaunchManager launchManager,
+            String launchConfigurationName, String projectName, String applicationId)
+    {
+        if (launchManager == null)
+        {
+            return null;
+        }
+        if (launchConfigurationName != null && !launchConfigurationName.isEmpty())
+        {
+            return findLaunchConfigByName(launchManager, launchConfigurationName);
+        }
+        if (projectName == null || projectName.isEmpty()
+            || applicationId == null || applicationId.isEmpty())
+        {
+            return null;
+        }
+        ILaunchConfigurationType type = launchManager.getLaunchConfigurationType(LAUNCH_CONFIG_TYPE_ID);
+        if (type == null)
+        {
+            return null;
+        }
+        return findLaunchConfig(launchManager, type, projectName, applicationId);
     }
 
     /**
@@ -295,6 +317,47 @@ public final class LaunchConfigUtils
             }
         }
         return result;
+    }
+
+    /**
+     * Returns all 1C:EDT launch configurations — any config whose type id is
+     * in the 1C namespace ({@code com._1c.} or {@code com.e1c.}). Covers runtime
+     * client, attach (remote/local) and mobile types; ignores unrelated Eclipse
+     * launches (Java apps, Ant tasks, etc.).
+     */
+    public static List<ILaunchConfiguration> getAllEdtConfigs(ILaunchManager launchManager)
+    {
+        List<ILaunchConfiguration> result = new ArrayList<>();
+        if (launchManager == null)
+        {
+            return result;
+        }
+        try
+        {
+            for (ILaunchConfiguration config : launchManager.getLaunchConfigurations())
+            {
+                if (isEdtConfig(config))
+                {
+                    result.add(config);
+                }
+            }
+        }
+        catch (CoreException e)
+        {
+            Activator.logError("Error listing launch configurations", e); //$NON-NLS-1$
+        }
+        return result;
+    }
+
+    /**
+     * Returns {@code true} if the given launch configuration belongs to the 1C/EDT
+     * namespace.
+     */
+    public static boolean isEdtConfig(ILaunchConfiguration config)
+    {
+        String typeId = getConfigTypeId(config);
+        return typeId.startsWith("com._1c.") //$NON-NLS-1$
+            || typeId.startsWith("com.e1c."); //$NON-NLS-1$
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchConfigUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchConfigUtils.java
@@ -6,7 +6,14 @@
 
 package com.ditrix.edt.mcp.server.utils;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchManager;
@@ -16,14 +23,33 @@ import com.ditrix.edt.mcp.server.Activator;
 /**
  * Shared helpers for searching and inspecting 1C:EDT launch configurations.
  *
- * Lookup order is consistent across all tools that need a launch configuration:
- * exact match by project name + application id, then a fallback to the first
- * configuration that matches the project name only.
+ * <p>Covers two families:
+ * <ul>
+ *   <li>Runtime client configs ({@link #LAUNCH_CONFIG_TYPE_ID}) — launch a new
+ *       1cv8c client and attach the debugger to it. Carry both
+ *       {@link #ATTR_PROJECT_NAME} and {@link #ATTR_APPLICATION_ID}.</li>
+ *   <li>Attach configs ({@link #TYPE_REMOTE_RUNTIME}, {@link #TYPE_LOCAL_RUNTIME})
+ *       — attach to an already-running 1C:Enterprise debug server (ragent/rphost).
+ *       These carry {@link #ATTR_PROJECT_NAME} but typically no
+ *       {@link #ATTR_APPLICATION_ID}; instead the infobase is identified via
+ *       {@link #ATTR_DEBUG_INFOBASE_ALIAS}, {@link #ATTR_INFOBASE_UUID} and
+ *       {@link #ATTR_DEBUG_SERVER_URL}.</li>
+ * </ul>
  */
 public final class LaunchConfigUtils
 {
     /** 1C:EDT Runtime Client launch configuration type id. */
     public static final String LAUNCH_CONFIG_TYPE_ID = "com._1c.g5.v8.dt.launching.core.RuntimeClient"; //$NON-NLS-1$
+
+    /** Attach to 1C:Enterprise Debug Server (remote cluster debug server). */
+    public static final String TYPE_REMOTE_RUNTIME = "com._1c.g5.v8.dt.debug.core.RemoteRuntime"; //$NON-NLS-1$
+
+    /** Attach to a locally spawned debug server. */
+    public static final String TYPE_LOCAL_RUNTIME = "com._1c.g5.v8.dt.debug.core.LocalRuntime"; //$NON-NLS-1$
+
+    /** All debug-launch config types understood by this plugin. */
+    public static final List<String> ALL_DEBUG_CONFIG_TYPE_IDS = Collections.unmodifiableList(
+        Arrays.asList(LAUNCH_CONFIG_TYPE_ID, TYPE_REMOTE_RUNTIME, TYPE_LOCAL_RUNTIME));
 
     /** Launch configuration attribute: target project name. */
     public static final String ATTR_PROJECT_NAME = "com._1c.g5.v8.dt.debug.core.ATTR_PROJECT_NAME"; //$NON-NLS-1$
@@ -34,13 +60,96 @@ public final class LaunchConfigUtils
     /** Launch configuration attribute: startup option string passed to 1cv8c.exe via /C. */
     public static final String ATTR_STARTUP_OPTION = "com._1c.g5.v8.dt.launching.core.ATTR_STARTUP_OPTION"; //$NON-NLS-1$
 
+    /** Attach configs: infobase alias used by the cluster (e.g. "mr_tradev8"). */
+    public static final String ATTR_DEBUG_INFOBASE_ALIAS = "com._1c.g5.v8.dt.debug.core.ATTR_DEBUG_INFOBASE_ALIAS"; //$NON-NLS-1$
+
+    /** Attach configs: infobase UUID (alternative to alias). */
+    public static final String ATTR_INFOBASE_UUID = "com._1c.g5.v8.dt.debug.core.ATTR_INFOBASE_UUID"; //$NON-NLS-1$
+
+    /** Remote attach: URL of the HTTP debug server (e.g. "http://localhost:1550"). */
+    public static final String ATTR_DEBUG_SERVER_URL = "com._1c.g5.v8.dt.debug.core.ATTR_DEBUG_SERVER_URL"; //$NON-NLS-1$
+
+    /** Synthetic applicationId prefix for Attach launches that don't carry ATTR_APPLICATION_ID. */
+    public static final String ATTACH_APP_ID_PREFIX = "attach:"; //$NON-NLS-1$
+
     private LaunchConfigUtils()
     {
         // utility class
     }
 
     /**
-     * Finds the best matching launch configuration for the given project and application.
+     * Returns {@code true} for any EDT debug-server Attach configuration type.
+     */
+    public static boolean isAttachConfigTypeId(String typeId)
+    {
+        return TYPE_REMOTE_RUNTIME.equals(typeId) || TYPE_LOCAL_RUNTIME.equals(typeId);
+    }
+
+    /**
+     * Returns {@code true} if the given launch configuration is of an Attach type.
+     */
+    public static boolean isAttachConfig(ILaunchConfiguration config)
+    {
+        if (config == null)
+        {
+            return false;
+        }
+        try
+        {
+            ILaunchConfigurationType type = config.getType();
+            return type != null && isAttachConfigTypeId(type.getIdentifier());
+        }
+        catch (CoreException e)
+        {
+            return false;
+        }
+    }
+
+    /**
+     * Returns a non-null, stable identifier for any EDT debug launch.
+     *
+     * <p>For runtime-client launches this is the real {@code ATTR_APPLICATION_ID}.
+     * For Attach launches, {@code ATTR_APPLICATION_ID} may be absent; in that case
+     * we fall back to {@code attach:<configName>} — stable across calls for the
+     * same EDT launch configuration, and addressable via {@code debug_status}.
+     *
+     * @return applicationId (real or synthetic), or {@code null} if the launch
+     *         is not an EDT debug launch at all.
+     */
+    public static String getApplicationIdFor(ILaunchConfiguration config)
+    {
+        if (config == null)
+        {
+            return null;
+        }
+        String realId = readAttribute(config, ATTR_APPLICATION_ID, null);
+        if (realId != null && !realId.isEmpty())
+        {
+            return realId;
+        }
+        if (isAttachConfig(config))
+        {
+            return ATTACH_APP_ID_PREFIX + config.getName();
+        }
+        return null;
+    }
+
+    /**
+     * Same as {@link #getApplicationIdFor(ILaunchConfiguration)} but takes a live
+     * {@link ILaunch}.
+     */
+    public static String getApplicationIdFor(ILaunch launch)
+    {
+        if (launch == null)
+        {
+            return null;
+        }
+        return getApplicationIdFor(launch.getLaunchConfiguration());
+    }
+
+    /**
+     * Finds the best matching runtime-client launch configuration for the given
+     * project and application. Attach configs are not considered here.
      *
      * @param launchManager Eclipse launch manager (must not be null)
      * @param configType    1C runtime client config type (must not be null)
@@ -100,6 +209,45 @@ public final class LaunchConfigUtils
     }
 
     /**
+     * Searches all EDT debug launch config types (runtime client + attach) for
+     * a configuration with the given exact name.
+     *
+     * @param launchManager Eclipse launch manager (must not be null)
+     * @param name          launch configuration name as shown in EDT UI
+     * @return matching configuration, or {@code null} if none found
+     */
+    public static ILaunchConfiguration findLaunchConfigByName(ILaunchManager launchManager, String name)
+    {
+        if (launchManager == null || name == null || name.isEmpty())
+        {
+            return null;
+        }
+        for (String typeId : ALL_DEBUG_CONFIG_TYPE_IDS)
+        {
+            ILaunchConfigurationType type = launchManager.getLaunchConfigurationType(typeId);
+            if (type == null)
+            {
+                continue;
+            }
+            try
+            {
+                for (ILaunchConfiguration config : launchManager.getLaunchConfigurations(type))
+                {
+                    if (name.equals(config.getName()))
+                    {
+                        return config;
+                    }
+                }
+            }
+            catch (CoreException e)
+            {
+                Activator.logError("Error searching launch configurations of type " + typeId, e); //$NON-NLS-1$
+            }
+        }
+        return null;
+    }
+
+    /**
      * Returns all launch configurations of the 1C runtime client type, or an empty array on error.
      */
     public static ILaunchConfiguration[] getAllRuntimeClientConfigs(ILaunchManager launchManager,
@@ -117,6 +265,60 @@ public final class LaunchConfigUtils
     }
 
     /**
+     * Returns all debug-capable launch configurations (runtime client + attach)
+     * known to the given launch manager.
+     */
+    public static List<ILaunchConfiguration> getAllDebugConfigs(ILaunchManager launchManager)
+    {
+        List<ILaunchConfiguration> result = new ArrayList<>();
+        if (launchManager == null)
+        {
+            return result;
+        }
+        for (String typeId : ALL_DEBUG_CONFIG_TYPE_IDS)
+        {
+            ILaunchConfigurationType type = launchManager.getLaunchConfigurationType(typeId);
+            if (type == null)
+            {
+                continue;
+            }
+            try
+            {
+                for (ILaunchConfiguration config : launchManager.getLaunchConfigurations(type))
+                {
+                    result.add(config);
+                }
+            }
+            catch (CoreException e)
+            {
+                Activator.logError("Error listing launch configurations of type " + typeId, e); //$NON-NLS-1$
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the launch configuration type id for a given launch, or the
+     * empty string if it cannot be determined.
+     */
+    public static String getConfigTypeId(ILaunchConfiguration config)
+    {
+        if (config == null)
+        {
+            return ""; //$NON-NLS-1$
+        }
+        try
+        {
+            ILaunchConfigurationType type = config.getType();
+            return type != null ? type.getIdentifier() : ""; //$NON-NLS-1$
+        }
+        catch (CoreException e)
+        {
+            return ""; //$NON-NLS-1$
+        }
+    }
+
+    /**
      * Reads a string attribute from a launch configuration, returning {@code defaultValue} on error.
      */
     public static String readAttribute(ILaunchConfiguration config, String attribute, String defaultValue)
@@ -129,5 +331,15 @@ public final class LaunchConfigUtils
         {
             return defaultValue;
         }
+    }
+
+    /**
+     * Convenience: returns the Eclipse launch manager or {@code null} if the debug
+     * plugin is unavailable.
+     */
+    public static ILaunchManager getLaunchManager()
+    {
+        DebugPlugin plugin = DebugPlugin.getDefault();
+        return plugin != null ? plugin.getLaunchManager() : null;
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupTest.java
@@ -118,7 +118,7 @@ public class ToolGroupTest
     {
         assertEquals(ToolGroup.CORE, ToolGroup.getGroupForTool("get_edt_version"));
         assertEquals(ToolGroup.PROBLEMS, ToolGroup.getGroupForTool("get_project_errors"));
-        assertEquals(ToolGroup.APPLICATIONS, ToolGroup.getGroupForTool("list_debug_configurations"));
+        assertEquals(ToolGroup.APPLICATIONS, ToolGroup.getGroupForTool("list_configurations"));
         assertEquals(ToolGroup.DEBUG, ToolGroup.getGroupForTool("set_breakpoint"));
         assertEquals(ToolGroup.BSL_CODE, ToolGroup.getGroupForTool("read_module_source"));
         assertEquals(ToolGroup.REFACTORING, ToolGroup.getGroupForTool("rename_metadata_object"));

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupTest.java
@@ -118,6 +118,7 @@ public class ToolGroupTest
     {
         assertEquals(ToolGroup.CORE, ToolGroup.getGroupForTool("get_edt_version"));
         assertEquals(ToolGroup.PROBLEMS, ToolGroup.getGroupForTool("get_project_errors"));
+        assertEquals(ToolGroup.APPLICATIONS, ToolGroup.getGroupForTool("list_debug_configurations"));
         assertEquals(ToolGroup.DEBUG, ToolGroup.getGroupForTool("set_breakpoint"));
         assertEquals(ToolGroup.BSL_CODE, ToolGroup.getGroupForTool("read_module_source"));
         assertEquals(ToolGroup.REFACTORING, ToolGroup.getGroupForTool("rename_metadata_object"));


### PR DESCRIPTION
## Summary

- Fix `debug_launch` / `debug_status` / `wait_for_break` / `resume` / `get_variables` / `step` so they can drive **Attach to 1C:Enterprise Debug Server** launches (`RemoteRuntime` / `LocalRuntime`), which are the only way to debug server-side 1C code via MCP: HTTP services, server calls, scheduled jobs, background jobs, external connections.
- Introduce a stable synthetic `attach:<configName>` applicationId so the registry, suspend snapshots and thread/frame caches light up for attach launches just like they do for runtime-client launches.
- Add `launchConfigurationName` to `debug_launch` so any EDT debug configuration (attach or runtime-client) can be started by its exact EDT name, without needing a real `applicationId` from `get_applications`.
- Fall back to the single active debug launch when the caller cannot supply a `threadId` / `applicationId` / `frameRef` — previously this was a dead end for attach sessions.

Fixes #91.

## Design

### Synthetic applicationId for Attach launches

Attach configurations usually don't carry `ATTR_APPLICATION_ID` (they identify the infobase via `ATTR_DEBUG_INFOBASE_ALIAS`, `ATTR_INFOBASE_UUID` and `ATTR_DEBUG_SERVER_URL`), so the registry's `findApplicationIdFor(launch)` used to return `null` for them and the suspend listener dropped every event on the floor.

`LaunchConfigUtils.getApplicationIdFor(...)` now returns the real attribute when present, or `"attach:" + configName` otherwise. `DebugSessionRegistry.findApplicationIdFor(ILaunch)` delegates to the helper, so:

- `onSuspend` / `onResumeOrTerminate` register and clean up attach sessions correctly.
- `findActiveTarget(applicationId)` resolves both real and synthetic ids.
- `wait_for_break` returns a proper `{threadId, topFrameRef, frames[]}` snapshot, and follow-up tools work against it.

### `debug_launch` by name

New optional parameter `launchConfigurationName` searches across all EDT debug config types (`RuntimeClient`, `RemoteRuntime`, `LocalRuntime`) for an exact name match and launches it. For attach configs the DB-update preflight is skipped. The response carries the resolved `applicationId` (real or synthetic), the configuration type, and an `attach: true/false` flag.

The legacy `projectName + applicationId` path is untouched.

The `availableConfigurations` fallback list now includes attach configs with their infobase alias and debug server URL, so the MCP client can discover what's on offer.

### Single-session fallback

`resume()` / `wait_for_break()` / `get_variables()` now succeed without arguments if there is exactly one active EDT debug launch in the workspace — the common interactive-debugging case. Each response sets `autoResolved: true` so the caller can tell it happened.

### `debug_status`

Each entry now carries `launchConfiguration`, `configurationType`, `attach`, `project`, `infobaseAlias`, `debugServerUrl`, and a `registered` flag indicating whether the registry has a live suspend snapshot for it. Non-EDT launches (stray Java runs etc.) are excluded.

## Test plan

- [x] All modified files compile cleanly against the EDT runtime classes (`javac --release 17` against decompiled EDT 2026 classes).
- [ ] Automated build (CI on this PR) green.
- [ ] Manual E2E: runtime-client launch still works (`debug_launch` with `projectName` + `applicationId`, breakpoint hit, resume).
- [ ] Manual E2E: Attach launch.
  - Create an `Attach to 1C:Enterprise Debug Server` config in EDT with infobase `Dev:32541/mr_tradev8` and debug URL `http://localhost:1550`.
  - `debug_launch({launchConfigurationName: "<config name>"})` — expect `attach: true` and a synthetic `attach:<config name>` applicationId.
  - `set_breakpoint(...)` on a line in an HTTP service handler.
  - `curl` the HTTP service endpoint → `rphost` suspends.
  - `wait_for_break()` (no args) or `wait_for_break({applicationId: "attach:<config name>"})` → returns `threadId` + `topFrameRef`.
  - `get_variables({frameRef: ...})` → returns BSL variables from the server frame.
  - `step({threadId, kind: "over"})` → stops on the next BSL line.
  - `resume()` → `rphost` resumes and the `curl` request completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)