### PR TITLE
Switch read_module_source output to YAML frontmatter + clean source

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Add to `claude_desktop_config.json`:
 | `get_form_screenshot` | Capture PNG screenshot of form WYSIWYG editor (embedded image resource) |
 | `list_modules` | List all BSL modules in a project with module type and parent object |
 | `get_module_structure` | Get BSL module structure: procedures/functions, signatures, regions, parameters |
-| `read_module_source` | Read BSL module source code with line numbers (full file or line range) |
+| `read_module_source` | Read BSL module source code with YAML frontmatter metadata (full file or line range) |
 | `write_module_source` | Write BSL source code to metadata object modules (searchReplace, replace, append) with syntax check |
 | `read_method_source` | Read a specific procedure/function from a BSL module by name |
 | `search_in_code` | Full-text/regex search across BSL modules with outputMode: full/count/files |
@@ -713,7 +713,7 @@ A family of MCP tools that lets the LLM set breakpoints, inspect runtime state a
 
 #### Read Module Source Tool
 
-**`read_module_source`** - Read BSL module source code from EDT project. Returns source with line numbers. Supports reading full file or a specific line range. Max 5000 lines per call.
+**`read_module_source`** - Read BSL module source code from EDT project. Returns source with YAML frontmatter metadata (`startLine`, `endLine`, `totalLines`). Supports reading full file or a specific line range. Max 5000 lines per call.
 
 **Parameters:**
 | Parameter | Required | Description |
@@ -722,6 +722,13 @@ A family of MCP tools that lets the LLM set breakpoints, inspect runtime state a
 | `modulePath` | Yes | Path from `src/` folder (e.g. `CommonModules/MyModule/Module.bsl` or `Documents/SalesOrder/ObjectModule.bsl`) |
 | `startLine` | No | Start line number (1-based, inclusive). If omitted, reads from beginning |
 | `endLine` | No | End line number (1-based, inclusive). If omitted, reads to end |
+
+**Returns:** Markdown with YAML frontmatter followed by a fenced `bsl` code block containing clean source (no line-number prefixes). Frontmatter fields:
+
+- `projectName`, `module` — echo of input parameters
+- `startLine`, `endLine` — actual 1-based range returned (omitted for an empty file)
+- `totalLines` — total line count of the file
+- `truncated: true` — present only when the requested range was clamped by the 5000-line limit
 
 #### Write Module Source Tool
 

--- a/README.md
+++ b/README.md
@@ -713,7 +713,7 @@ A family of MCP tools that lets the LLM set breakpoints, inspect runtime state a
 
 #### Read Module Source Tool
 
-**`read_module_source`** - Read BSL module source code from EDT project. Returns source with YAML frontmatter metadata (`startLine`, `endLine`, `totalLines`). Supports reading full file or a specific line range. Max 5000 lines per call.
+**`read_module_source`** - Read BSL module source code from EDT project. Returns source with YAML frontmatter metadata (`startLine`, `endLine`, `totalLines`). Supports reading full file or a specific line range. The per-call line limit is configurable in **Window → Preferences → MCP Server → Tools** (`maxLines`, default 5000).
 
 **Parameters:**
 | Parameter | Required | Description |
@@ -728,7 +728,7 @@ A family of MCP tools that lets the LLM set breakpoints, inspect runtime state a
 - `projectName`, `module` — echo of input parameters
 - `startLine`, `endLine` — actual 1-based range returned (omitted for an empty file)
 - `totalLines` — total line count of the file
-- `truncated: true` — present only when the requested range was clamped by the 5000-line limit
+- `truncated: true` — present only when the requested range was clamped by the configured line limit (`maxLines` setting)
 
 #### Write Module Source Tool
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolParameterSettings.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolParameterSettings.java
@@ -116,6 +116,10 @@ public final class ToolParameterSettings
             new ParameterDef("contextLines", "Context lines", //$NON-NLS-1$ //$NON-NLS-2$
                 "Lines of context around each match", 2, 0, 5))); //$NON-NLS-1$
 
+        map.put("read_module_source", Collections.singletonList( //$NON-NLS-1$
+            new ParameterDef("maxLines", "Max lines", //$NON-NLS-1$ //$NON-NLS-2$
+                "Maximum lines to return per call", 5000, 100, 50000))); //$NON-NLS-1$
+
         TOOL_PARAMETERS = Collections.unmodifiableMap(map);
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
@@ -14,6 +14,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Path;
 
+import com.ditrix.edt.mcp.server.preferences.ToolParameterSettings;
 import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
 import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
@@ -22,16 +23,16 @@ import com.ditrix.edt.mcp.server.utils.FrontMatter;
 /**
  * Tool to read BSL module source code (whole file or line range).
  * Returns YAML frontmatter (projectName, module, startLine, endLine, totalLines;
- * plus truncated: true when clamped by MAX_LINES) followed by the source in a
- * fenced bsl block. For an empty file, startLine/endLine are omitted and
- * totalLines is 0. Max 5000 lines per call.
+ * plus truncated: true when clamped by the configured line limit) followed by
+ * the source in a fenced bsl block. For an empty file, startLine/endLine are
+ * omitted and totalLines is 0.
  */
 public class ReadModuleSourceTool implements IMcpTool
 {
     public static final String NAME = "read_module_source"; //$NON-NLS-1$
 
-    /** Maximum lines to return in a single call */
-    private static final int MAX_LINES = 5000;
+    /** Fallback when the {@code maxLines} tool parameter is not configured */
+    private static final int DEFAULT_MAX_LINES = 5000;
 
     @Override
     public String getName()
@@ -44,10 +45,10 @@ public class ReadModuleSourceTool implements IMcpTool
     {
         return "Read BSL module source code from EDT project. " + //$NON-NLS-1$
                "Returns YAML frontmatter (projectName, module, startLine, endLine, totalLines; " + //$NON-NLS-1$
-               "plus truncated: true when the range was clamped by the 5000-line limit) " + //$NON-NLS-1$
+               "plus truncated: true when the range was clamped by the configured line limit) " + //$NON-NLS-1$
                "followed by clean source in a fenced bsl block (no line-number prefixes). " + //$NON-NLS-1$
                "For an empty file, startLine/endLine are omitted and totalLines is 0. " + //$NON-NLS-1$
-               "Supports reading full file or a specific line range. Max 5000 lines per call."; //$NON-NLS-1$
+               "Supports reading full file or a specific line range."; //$NON-NLS-1$
     }
 
     @Override
@@ -144,11 +145,13 @@ public class ReadModuleSourceTool implements IMcpTool
                 to = Math.max(from, Math.min(endLine, totalLines));
             }
 
-            // Clamp to MAX_LINES
+            // Clamp to the configured line limit
+            int maxLines = ToolParameterSettings.getInstance()
+                .getParameterValue(NAME, "maxLines", DEFAULT_MAX_LINES); //$NON-NLS-1$
             boolean truncated = false;
-            if (to - from + 1 > MAX_LINES)
+            if (to - from + 1 > maxLines)
             {
-                to = from + MAX_LINES - 1;
+                to = from + maxLines - 1;
                 truncated = true;
             }
 
@@ -169,7 +172,7 @@ public class ReadModuleSourceTool implements IMcpTool
      * @param from 1-based start line (inclusive); ignored when totalLines == 0
      * @param to 1-based end line (inclusive); ignored when totalLines == 0
      * @param totalLines total line count in the file (0 for empty file)
-     * @param truncated true if the returned range was clamped by MAX_LINES
+     * @param truncated true if the returned range was clamped by the configured line limit
      * @return formatted result string
      */
     static String formatOutput(String projectName, String modulePath, List<String> allLines,

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
@@ -43,7 +43,10 @@ public class ReadModuleSourceTool implements IMcpTool
     public String getDescription()
     {
         return "Read BSL module source code from EDT project. " + //$NON-NLS-1$
-               "Returns source with YAML frontmatter metadata (startLine, endLine, totalLines). " + //$NON-NLS-1$
+               "Returns YAML frontmatter (projectName, module, startLine, endLine, totalLines; " + //$NON-NLS-1$
+               "plus truncated: true when the range was clamped by the 5000-line limit) " + //$NON-NLS-1$
+               "followed by clean source in a fenced bsl block (no line-number prefixes). " + //$NON-NLS-1$
+               "For an empty file, startLine/endLine are omitted and totalLines is 0. " + //$NON-NLS-1$
                "Supports reading full file or a specific line range. Max 5000 lines per call."; //$NON-NLS-1$
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
@@ -17,10 +17,14 @@ import org.eclipse.core.runtime.Path;
 import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
 import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.FrontMatter;
 
 /**
  * Tool to read BSL module source code (whole file or line range).
- * Supports reading with line numbers, range extraction, and large file protection.
+ * Returns YAML frontmatter metadata (startLine, endLine, totalLines; plus
+ * {@code truncated: true} only when the range was clamped by MAX_LINES)
+ * followed by the source in a fenced bsl block. Supports range extraction and
+ * large file protection (max 5000 lines per call).
  */
 public class ReadModuleSourceTool implements IMcpTool
 {
@@ -39,8 +43,8 @@ public class ReadModuleSourceTool implements IMcpTool
     public String getDescription()
     {
         return "Read BSL module source code from EDT project. " + //$NON-NLS-1$
-               "Returns source with line numbers. Supports reading full file or a specific line range. " + //$NON-NLS-1$
-               "Max 5000 lines per call."; //$NON-NLS-1$
+               "Returns source with YAML frontmatter metadata (startLine, endLine, totalLines). " + //$NON-NLS-1$
+               "Supports reading full file or a specific line range. Max 5000 lines per call."; //$NON-NLS-1$
     }
 
     @Override
@@ -121,7 +125,7 @@ public class ReadModuleSourceTool implements IMcpTool
             // Handle empty file
             if (totalLines == 0)
             {
-                return "## " + modulePath + "\n\n**Lines:** 0 (empty file)\n\n```bsl\n```\n"; //$NON-NLS-1$ //$NON-NLS-2$
+                return formatOutput(projectName, modulePath, allLines, 0, 0, 0, false);
             }
 
             // Determine range
@@ -145,29 +149,57 @@ public class ReadModuleSourceTool implements IMcpTool
                 truncated = true;
             }
 
-            // Build output
-            StringBuilder sb = new StringBuilder();
-            sb.append("## ").append(modulePath).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            sb.append("**Lines:** ").append(from).append("-").append(to); //$NON-NLS-1$ //$NON-NLS-2$
-            sb.append(" of ").append(totalLines).append(" total"); //$NON-NLS-1$ //$NON-NLS-2$
-            if (truncated)
-            {
-                sb.append(" (truncated to ").append(MAX_LINES).append(" lines)"); //$NON-NLS-1$ //$NON-NLS-2$
-            }
-            sb.append("\n\n"); //$NON-NLS-1$
-
-            sb.append("```bsl\n"); //$NON-NLS-1$
-            for (int i = from - 1; i < to; i++)
-            {
-                sb.append(String.format("%d: %s\n", i + 1, allLines.get(i))); //$NON-NLS-1$
-            }
-            sb.append("```\n"); //$NON-NLS-1$
-
-            return sb.toString();
+            return formatOutput(projectName, modulePath, allLines, from, to, totalLines, truncated);
         }
         catch (Exception e)
         {
             return "Error reading file: " + e.getMessage(); //$NON-NLS-1$
         }
+    }
+
+    /**
+     * Formats module source output as YAML frontmatter + fenced BSL code block.
+     *
+     * @param projectName EDT project name (for frontmatter)
+     * @param modulePath path from src/ (for frontmatter)
+     * @param allLines all source lines of the file
+     * @param from 1-based start line (inclusive); ignored when totalLines == 0
+     * @param to 1-based end line (inclusive); ignored when totalLines == 0
+     * @param totalLines total line count in the file (0 for empty file)
+     * @param truncated true if the returned range was clamped by MAX_LINES
+     * @return formatted result string
+     */
+    static String formatOutput(String projectName, String modulePath, List<String> allLines,
+        int from, int to, int totalLines, boolean truncated)
+    {
+        FrontMatter fm = FrontMatter.create()
+            .put("projectName", projectName) //$NON-NLS-1$
+            .put("module", modulePath); //$NON-NLS-1$
+
+        if (totalLines > 0)
+        {
+            fm.put("startLine", from) //$NON-NLS-1$
+                .put("endLine", to); //$NON-NLS-1$
+        }
+
+        fm.put("totalLines", totalLines); //$NON-NLS-1$
+
+        if (truncated)
+        {
+            fm.put("truncated", true); //$NON-NLS-1$
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("```bsl\n"); //$NON-NLS-1$
+        if (totalLines > 0)
+        {
+            for (int i = from - 1; i < to; i++)
+            {
+                sb.append(allLines.get(i)).append('\n');
+            }
+        }
+        sb.append("```\n"); //$NON-NLS-1$
+
+        return fm.wrapContent(sb.toString());
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
@@ -21,10 +21,10 @@ import com.ditrix.edt.mcp.server.utils.FrontMatter;
 
 /**
  * Tool to read BSL module source code (whole file or line range).
- * Returns YAML frontmatter metadata (startLine, endLine, totalLines; plus
- * {@code truncated: true} only when the range was clamped by MAX_LINES)
- * followed by the source in a fenced bsl block. Supports range extraction and
- * large file protection (max 5000 lines per call).
+ * Returns YAML frontmatter (projectName, module, startLine, endLine, totalLines;
+ * plus truncated: true when clamped by MAX_LINES) followed by the source in a
+ * fenced bsl block. For an empty file, startLine/endLine are omitted and
+ * totalLines is 0. Max 5000 lines per call.
  */
 public class ReadModuleSourceTool implements IMcpTool
 {

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceToolTest.java
@@ -1,0 +1,191 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2026 Diversus23 (https://github.com/Diversus23)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+
+/**
+ * Tests for {@link ReadModuleSourceTool}.
+ * <p>
+ * Tests cover: tool metadata, parameter validation, result file name generation,
+ * and output formatting (formatOutput helper).
+ * <p>
+ * Note: tests that require Eclipse workspace (actual file I/O) are covered by E2E tests.
+ */
+public class ReadModuleSourceToolTest
+{
+    // ==================== Tool metadata ====================
+
+    @Test
+    public void testName()
+    {
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        assertEquals("read_module_source", tool.getName()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResponseType()
+    {
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        assertEquals(ResponseType.MARKDOWN, tool.getResponseType());
+    }
+
+    @Test
+    public void testDescriptionNotEmpty()
+    {
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        assertNotNull(tool.getDescription());
+        assertFalse(tool.getDescription().isEmpty());
+    }
+
+    @Test
+    public void testDescriptionDoesNotMentionLineNumberPrefix()
+    {
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        String desc = tool.getDescription();
+
+        // New contract: line numbers live in frontmatter, not inside the code block
+        assertFalse("description should not say 'with line numbers'", //$NON-NLS-1$
+            desc.toLowerCase().contains("with line numbers")); //$NON-NLS-1$
+        assertTrue("description should mention frontmatter", //$NON-NLS-1$
+            desc.toLowerCase().contains("frontmatter")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testInputSchemaContainsRequiredParameters()
+    {
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        String schema = tool.getInputSchema();
+
+        assertNotNull(schema);
+        assertTrue(schema.contains("\"projectName\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"modulePath\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"startLine\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"endLine\"")); //$NON-NLS-1$
+    }
+
+    // ==================== Result file name ====================
+
+    @Test
+    public void testResultFileNameWithModulePath()
+    {
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("modulePath", "CommonModules/MyModule/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        String fileName = tool.getResultFileName(params);
+        assertEquals("source-commonmodules-mymodule-module.bsl.md", fileName); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResultFileNameWithoutModulePath()
+    {
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        Map<String, String> params = new HashMap<>();
+
+        String fileName = tool.getResultFileName(params);
+        assertEquals("module-source.md", fileName); //$NON-NLS-1$
+    }
+
+    // ==================== Required parameter validation ====================
+
+    @Test
+    public void testExecuteMissingProjectName()
+    {
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("modulePath", "CommonModules/MyModule/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        String result = tool.execute(params);
+        assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteMissingModulePath()
+    {
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "TestProject"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        String result = tool.execute(params);
+        assertTrue(result.contains("modulePath is required")); //$NON-NLS-1$
+    }
+
+    // ==================== formatOutput ====================
+
+    @Test
+    public void testFormatOutputNormal()
+    {
+        List<String> lines = Arrays.asList(
+            "Процедура МояПроцедура()", //$NON-NLS-1$
+            "    Сообщить(\"Привет\");", //$NON-NLS-1$
+            "КонецПроцедуры"); //$NON-NLS-1$
+
+        String result = ReadModuleSourceTool.formatOutput(
+            "MyProject", "CommonModules/MyModule/Module.bsl", lines, 1, 3, 3, false); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertTrue("must contain frontmatter start", result.startsWith("---\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must contain projectName", result.contains("projectName: MyProject\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must contain module", //$NON-NLS-1$
+            result.contains("module: CommonModules/MyModule/Module.bsl\n")); //$NON-NLS-1$
+        assertTrue("must contain startLine", result.contains("startLine: 1\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must contain endLine", result.contains("endLine: 3\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must contain totalLines", result.contains("totalLines: 3\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("must NOT contain truncated when false", result.contains("truncated")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must contain bsl code fence", result.contains("```bsl\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("body must contain raw line 1", //$NON-NLS-1$
+            result.contains("Процедура МояПроцедура()\n")); //$NON-NLS-1$
+        assertTrue("body must contain raw line 2", //$NON-NLS-1$
+            result.contains("    Сообщить(\"Привет\");\n")); //$NON-NLS-1$
+        assertFalse("body must NOT contain line-number prefix", result.contains("1: ")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("body must NOT contain line-number prefix", result.contains("2: ")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must end with closing fence + newline", result.endsWith("```\n")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatOutputTruncated()
+    {
+        List<String> lines = Arrays.asList(
+            "line1", "line2", "line3", "line4", "line5"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+
+        // Simulate: file has 15000 lines, we return 1-5000 truncated
+        String result = ReadModuleSourceTool.formatOutput(
+            "MyProject", "CommonModules/Big/Module.bsl", lines, 1, 5, 15000, true); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertTrue("must contain truncated: true", result.contains("truncated: true\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must contain totalLines", result.contains("totalLines: 15000\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must contain startLine", result.contains("startLine: 1\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must contain endLine", result.contains("endLine: 5\n")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatOutputEmptyFile()
+    {
+        List<String> lines = Collections.emptyList();
+
+        String result = ReadModuleSourceTool.formatOutput(
+            "MyProject", "CommonModules/Empty/Module.bsl", lines, 0, 0, 0, false); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertTrue("must contain projectName", result.contains("projectName: MyProject\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must contain totalLines: 0", result.contains("totalLines: 0\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("must NOT contain startLine on empty file", result.contains("startLine")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("must NOT contain endLine on empty file", result.contains("endLine")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("must NOT contain truncated on empty file", result.contains("truncated")); //$NON-NLS-1$ //$NON-NLS-2$
+        // Empty bsl block: opening fence, no body, closing fence
+        assertTrue("must contain empty bsl block", result.contains("```bsl\n```\n")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+}


### PR DESCRIPTION
Line numbers no longer prefix each source line; they move to YAML frontmatter as startLine/endLine/totalLines, matching the pattern already used by read_method_source. The `truncated: true` field appears only when the range was clamped by MAX_LINES.

- Extract package-private formatOutput(...) helper for testability; execute() delegates to it for both empty and non-empty cases.
- Update tool description and class JavaDoc to reflect the new contract; drop the "## path" markdown header and "**Lines:**" row since those values now live in the frontmatter.
- Add ReadModuleSourceToolTest with 12 unit tests: metadata, parameter validation, result file naming, description contract, and three formatOutput scenarios (normal / truncated / empty file).

This is a breaking change to the read_module_source response format; the updated getDescription() advertises the new contract so MCP clients pick it up on tools/list refresh.