### PR TITLE
Add configuration XML export/import MCP tools (Core / Project group)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Control which MCP tools are exposed to AI assistants. This lets you reduce conte
 
 ### Tool Groups
 
-All 51 tools are organized into 8 semantic groups:
+All 52 tools are organized into 8 semantic groups:
 
 | Group | Description | Tools |
 |-------|-------------|-------|
@@ -167,7 +167,7 @@ Quickly switch between common tool configurations using presets:
 
 | Preset | Description |
 |--------|-------------|
-| **All Tools** | All 51 tools enabled (default) |
+| **All Tools** | All 52 tools enabled (default) |
 | **Analysis Only** | Read-only analysis — Core, Errors, Code Intelligence, Tags |
 | **Code Review** | Analysis + BSL code reading (excludes `write_module_source`) |
 | **Development** | Full development without debugging tools |
@@ -943,13 +943,13 @@ These tools sit in the Core / Project group and wrap the official 1C EDT workspa
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `projectName` | Yes | EDT project name to export |
-| `outputPath` | Yes | Filesystem path of the output directory for the XML files |
+| `outputPath` | Yes | Filesystem path of the output directory. Resolved to an absolute path. Created automatically if it does not exist; an existing file (not a directory) at that path is rejected with a clear error |
 
 **`import_configuration_from_xml`** — Import a configuration from a directory of XML files into a new EDT project in the workspace. Reverse of `export_configuration_to_xml`. Wraps `IImportConfigurationFilesApi.importProject(Path importSource, String projectName, String nature, String xmlVersion)`. After the API call the tool also closes/opens/refreshes the new project to trigger EDT's project lifecycle (the underlying CLI API hardcodes `setRefreshProject(false)` and would otherwise leave the project unindexed), so the imported project is ready to use without manual GUI intervention.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `importPath` | Yes | Filesystem path of the source directory containing XML files |
+| `importPath` | Yes | Filesystem path of the source directory containing XML files. Resolved to an absolute path. Must exist and be a directory; otherwise rejected with a clear error before the API call |
 | `projectName` | Yes | Name of the new EDT project to create in the workspace |
 | `projectNature` | No | EDT project nature ID (e.g. `com._1c.g5.v8.dt.core.V8ConfigurationNature`); empty/omitted = let EDT auto-detect |
 | `xmlVersion` | No | XML format version (e.g. `8.3.20`); empty/omitted = let EDT auto-detect |

--- a/README.md
+++ b/README.md
@@ -146,11 +146,11 @@ Control which MCP tools are exposed to AI assistants. This lets you reduce conte
 
 ### Tool Groups
 
-All 49 tools are organized into 9 semantic groups:
+All 49 tools are organized into 8 semantic groups:
 
 | Group | Description | Tools |
 |-------|-------------|-------|
-| **Core / Project** | EDT version, project listing, configuration, validation | `get_edt_version`, `list_projects`, `get_configuration_properties`, `clean_project`, `revalidate_objects`, `get_check_description` |
+| **Core / Project** | EDT version, project listing, configuration, validation, XML export/import | `get_edt_version`, `list_projects`, `get_configuration_properties`, `clean_project`, `revalidate_objects`, `get_check_description`, `export_configuration_to_xml`, `import_configuration_from_xml` |
 | **Errors & Problems** | Error reporting, bookmarks, tasks | `get_problem_summary`, `get_project_errors`, `get_bookmarks`, `get_tasks` |
 | **Code Intelligence** | Content assist, documentation, metadata browsing | `get_content_assist`, `get_platform_documentation`, `get_metadata_objects`, `get_metadata_details`, `find_references` |
 | **Tags** | Tag management | `get_tags`, `get_objects_by_tags` |
@@ -158,7 +158,6 @@ All 49 tools are organized into 9 semantic groups:
 | **Debugging** | Breakpoints, stepping, variable inspection | `set_breakpoint`, `remove_breakpoint`, `list_breakpoints`, `wait_for_break`, `get_variables`, `step`, `resume`, `evaluate_expression`, `debug_yaxunit_tests`, `debug_status`, `start_profiling`, `get_profiling_results` |
 | **BSL Code** | Module browsing, code reading/writing, search | `read_module_source`, `write_module_source`, `get_module_structure`, `list_modules`, `search_in_code`, `read_method_source`, `get_method_call_hierarchy`, `go_to_definition`, `get_symbol_info`, `get_form_screenshot`, `validate_query` |
 | **Refactoring** | Metadata rename, delete, add attributes | `rename_metadata_object`, `delete_metadata_object`, `add_metadata_attribute` |
-| **Workspace** | Configuration export/import to/from XML files | `export_configuration_to_xml`, `import_configuration_from_xml` |
 
 Enable or disable entire groups or individual tools from the **Tools** tab in **Window → Preferences → MCP Server**. Disabled tools are filtered out of `tools/list` responses. If a client calls a disabled tool directly through `tools/call`, the server returns a message explaining that the tool is disabled.
 
@@ -859,9 +858,9 @@ A family of MCP tools that lets the LLM set breakpoints, inspect runtime state a
 - Inspect property types on objects accessed via dot notation
 - Understand platform method parameter types
 
-### Workspace Tools
+### Configuration XML Export / Import
 
-These tools wrap the official 1C EDT workspace CLI APIs (`com._1c.g5.v8.dt.cli.api.workspace.*`) via reflection — keeping zero compile-time dependency on those APIs while still surfacing them to AI assistants.
+These tools sit in the Core / Project group and wrap the official 1C EDT workspace CLI APIs (`com._1c.g5.v8.dt.cli.api.workspace.*`) via reflection — keeping zero compile-time dependency on those APIs while still surfacing them to AI assistants.
 
 **`export_configuration_to_xml`** — Export an EDT configuration project to a directory of XML source files. Equivalent of EDT menu *Export → Configuration to XML Files* and the 1C platform `DumpConfigToFiles` command. Wraps `IExportConfigurationFilesApi.exportProject(String projectName, Path outputPath)`.
 
@@ -882,7 +881,7 @@ These tools wrap the official 1C EDT workspace CLI APIs (`com._1c.g5.v8.dt.cli.a
 ### Output Formats
 
 - **Markdown tools**: `list_projects`, `get_project_errors`, `get_bookmarks`, `get_tasks`, `get_problem_summary`, `get_check_description` - return Markdown as EmbeddedResource with `mimeType: text/markdown`
-- **JSON tools**: `get_configuration_properties`, `clean_project`, `revalidate_objects`, all Workspace tools - return JSON with `structuredContent`
+- **JSON tools**: `get_configuration_properties`, `clean_project`, `revalidate_objects`, `export_configuration_to_xml`, `import_configuration_from_xml` - return JSON with `structuredContent`
 - **Text tools**: `get_edt_version` - return plain text
 
 </details>

--- a/README.md
+++ b/README.md
@@ -870,7 +870,7 @@ These tools wrap the official 1C EDT workspace CLI APIs (`com._1c.g5.v8.dt.cli.a
 | `projectName` | Yes | EDT project name to export |
 | `outputPath` | Yes | Filesystem path of the output directory for the XML files |
 
-**`import_configuration_from_xml`** — Import a configuration from a directory of XML files into a new EDT project in the workspace. Reverse of `export_configuration_to_xml`. Wraps `IImportConfigurationFilesApi.importProject(Path importSource, String projectName, String nature, String xmlVersion)`.
+**`import_configuration_from_xml`** — Import a configuration from a directory of XML files into a new EDT project in the workspace. Reverse of `export_configuration_to_xml`. Wraps `IImportConfigurationFilesApi.importProject(Path importSource, String projectName, String nature, String xmlVersion)`. After the API call the tool also closes/opens/refreshes the new project to trigger EDT's project lifecycle (the underlying CLI API hardcodes `setRefreshProject(false)` and would otherwise leave the project unindexed), so the imported project is ready to use without manual GUI intervention.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Control which MCP tools are exposed to AI assistants. This lets you reduce conte
 
 ### Tool Groups
 
-All 49 tools are organized into 8 semantic groups:
+All 51 tools are organized into 8 semantic groups:
 
 | Group | Description | Tools |
 |-------|-------------|-------|
@@ -167,7 +167,7 @@ Quickly switch between common tool configurations using presets:
 
 | Preset | Description |
 |--------|-------------|
-| **All Tools** | All 49 tools enabled (default) |
+| **All Tools** | All 51 tools enabled (default) |
 | **Analysis Only** | Read-only analysis — Core, Errors, Code Intelligence, Tags |
 | **Code Review** | Analysis + BSL code reading (excludes `write_module_source`) |
 | **Development** | Full development without debugging tools |

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Control which MCP tools are exposed to AI assistants. This lets you reduce conte
 
 ### Tool Groups
 
-All 47 tools are organized into 8 semantic groups:
+All 49 tools are organized into 9 semantic groups:
 
 | Group | Description | Tools |
 |-------|-------------|-------|
@@ -158,6 +158,7 @@ All 47 tools are organized into 8 semantic groups:
 | **Debugging** | Breakpoints, stepping, variable inspection | `set_breakpoint`, `remove_breakpoint`, `list_breakpoints`, `wait_for_break`, `get_variables`, `step`, `resume`, `evaluate_expression`, `debug_yaxunit_tests`, `debug_status`, `start_profiling`, `get_profiling_results` |
 | **BSL Code** | Module browsing, code reading/writing, search | `read_module_source`, `write_module_source`, `get_module_structure`, `list_modules`, `search_in_code`, `read_method_source`, `get_method_call_hierarchy`, `go_to_definition`, `get_symbol_info`, `get_form_screenshot`, `validate_query` |
 | **Refactoring** | Metadata rename, delete, add attributes | `rename_metadata_object`, `delete_metadata_object`, `add_metadata_attribute` |
+| **Workspace** | Configuration export/import to/from XML files | `export_configuration_to_xml`, `import_configuration_from_xml` |
 
 Enable or disable entire groups or individual tools from the **Tools** tab in **Window → Preferences → MCP Server**. Disabled tools are filtered out of `tools/list` responses. If a client calls a disabled tool directly through `tools/call`, the server returns a message explaining that the tool is disabled.
 
@@ -167,7 +168,7 @@ Quickly switch between common tool configurations using presets:
 
 | Preset | Description |
 |--------|-------------|
-| **All Tools** | All 47 tools enabled (default) |
+| **All Tools** | All 49 tools enabled (default) |
 | **Analysis Only** | Read-only analysis — Core, Errors, Code Intelligence, Tags |
 | **Code Review** | Analysis + BSL code reading (excludes `write_module_source`) |
 | **Development** | Full development without debugging tools |
@@ -330,6 +331,8 @@ Add to `claude_desktop_config.json`:
 | `go_to_definition` | Navigate to symbol definition (method by name, metadata object by FQN) |
 | `get_symbol_info` | Get type/hover info about a symbol at a BSL code position (inferred types, signatures, docs) |
 | `validate_query` | Validate 1C query text in project context (syntax + semantic errors, optional DCS mode) |
+| `export_configuration_to_xml` | Export an EDT configuration project to a directory of XML files (EDT menu: Export → Configuration to XML Files) |
+| `import_configuration_from_xml` | Import a configuration from a directory of XML files into a new EDT project (reverse of export) |
 
 <details>
 <summary><strong>Tool Details</strong> - Parameters and usage examples for each tool</summary>
@@ -856,10 +859,30 @@ A family of MCP tools that lets the LLM set breakpoints, inspect runtime state a
 - Inspect property types on objects accessed via dot notation
 - Understand platform method parameter types
 
+### Workspace Tools
+
+These tools wrap the official 1C EDT workspace CLI APIs (`com._1c.g5.v8.dt.cli.api.workspace.*`) via reflection — keeping zero compile-time dependency on those APIs while still surfacing them to AI assistants.
+
+**`export_configuration_to_xml`** — Export an EDT configuration project to a directory of XML source files. Equivalent of EDT menu *Export → Configuration to XML Files* and the 1C platform `DumpConfigToFiles` command. Wraps `IExportConfigurationFilesApi.exportProject(String projectName, Path outputPath)`.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `projectName` | Yes | EDT project name to export |
+| `outputPath` | Yes | Filesystem path of the output directory for the XML files |
+
+**`import_configuration_from_xml`** — Import a configuration from a directory of XML files into a new EDT project in the workspace. Reverse of `export_configuration_to_xml`. Wraps `IImportConfigurationFilesApi.importProject(Path importSource, String projectName, String nature, String xmlVersion)`.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `importPath` | Yes | Filesystem path of the source directory containing XML files |
+| `projectName` | Yes | Name of the new EDT project to create in the workspace |
+| `projectNature` | No | EDT project nature ID (e.g. `com._1c.g5.v8.dt.core.V8ConfigurationNature`); empty/omitted = let EDT auto-detect |
+| `xmlVersion` | No | XML format version (e.g. `8.3.20`); empty/omitted = let EDT auto-detect |
+
 ### Output Formats
 
 - **Markdown tools**: `list_projects`, `get_project_errors`, `get_bookmarks`, `get_tasks`, `get_problem_summary`, `get_check_description` - return Markdown as EmbeddedResource with `mimeType: text/markdown`
-- **JSON tools**: `get_configuration_properties`, `clean_project`, `revalidate_objects` - return JSON with `structuredContent`
+- **JSON tools**: `get_configuration_properties`, `clean_project`, `revalidate_objects`, all Workspace tools - return JSON with `structuredContent`
 - **Text tools**: `get_edt_version` - return plain text
 
 </details>

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/Activator.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/Activator.java
@@ -56,7 +56,15 @@ public class Activator extends AbstractUIPlugin
     private ServiceTracker<IApplicationManager, IApplicationManager> applicationManagerTracker;
     private ServiceTracker<INavigatorContentProviderStateProvider, INavigatorContentProviderStateProvider> navigatorStateProviderTracker;
     private ServiceTracker<IMdRefactoringService, IMdRefactoringService> mdRefactoringServiceTracker;
-    
+
+    /**
+     * EDT workspace CLI APIs are tracked by String class name and invoked via
+     * reflection from the tools, keeping this bundle build-independent of
+     * com._1c.g5.v8.dt.cli.api.
+     */
+    private ServiceTracker<Object, Object> exportConfigurationFilesApiTracker;
+    private ServiceTracker<Object, Object> importConfigurationFilesApiTracker;
+
     /** Group service instance (created directly, not via OSGi DS to avoid circular references) */
     private IGroupService groupService;
 
@@ -118,7 +126,15 @@ public class Activator extends AbstractUIPlugin
         
         mdRefactoringServiceTracker = new ServiceTracker<>(context, IMdRefactoringService.class, null);
         mdRefactoringServiceTracker.open();
-        
+
+        exportConfigurationFilesApiTracker = new ServiceTracker<>(
+            context, "com._1c.g5.v8.dt.cli.api.workspace.IExportConfigurationFilesApi", null); //$NON-NLS-1$
+        exportConfigurationFilesApiTracker.open();
+
+        importConfigurationFilesApiTracker = new ServiceTracker<>(
+            context, "com._1c.g5.v8.dt.cli.api.workspace.IImportConfigurationFilesApi", null); //$NON-NLS-1$
+        importConfigurationFilesApiTracker.open();
+
         // Create group service directly (not via OSGi DS to avoid circular references)
         groupService = new com.ditrix.edt.mcp.server.groups.internal.GroupServiceImpl();
         ((com.ditrix.edt.mcp.server.groups.internal.GroupServiceImpl) groupService).activate();
@@ -216,7 +232,17 @@ public class Activator extends AbstractUIPlugin
             mdRefactoringServiceTracker.close();
             mdRefactoringServiceTracker = null;
         }
-        
+        if (exportConfigurationFilesApiTracker != null)
+        {
+            exportConfigurationFilesApiTracker.close();
+            exportConfigurationFilesApiTracker = null;
+        }
+        if (importConfigurationFilesApiTracker != null)
+        {
+            importConfigurationFilesApiTracker.close();
+            importConfigurationFilesApiTracker = null;
+        }
+
         // Dispose UI components only in non-headless mode
         if (!isHeadless())
         {
@@ -466,7 +492,37 @@ public class Activator extends AbstractUIPlugin
         }
         return mdRefactoringServiceTracker.getService();
     }
-    
+
+    /**
+     * Returns the com._1c.g5.v8.dt.cli.api.workspace.IExportConfigurationFilesApi
+     * (EDT "Export → Configuration to XML Files" action) — typed as
+     * {@code Object}, callers invoke via reflection. Returns null when
+     * the underlying CLI API plugin is not installed.
+     */
+    public Object getExportConfigurationFilesApi()
+    {
+        if (exportConfigurationFilesApiTracker == null)
+        {
+            return null;
+        }
+        return exportConfigurationFilesApiTracker.getService();
+    }
+
+    /**
+     * Returns the com._1c.g5.v8.dt.cli.api.workspace.IImportConfigurationFilesApi
+     * (EDT "Import → Configuration from XML Files" action) — typed as
+     * {@code Object}, callers invoke via reflection. Returns null when
+     * the underlying CLI API plugin is not installed.
+     */
+    public Object getImportConfigurationFilesApi()
+    {
+        if (importConfigurationFilesApiTracker == null)
+        {
+            return null;
+        }
+        return importConfigurationFilesApiTracker.getService();
+    }
+
     /**
      * Returns the IGroupService for group operations.
      * Used for virtual folder groups in the Navigator.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/McpServer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/McpServer.java
@@ -46,6 +46,8 @@ import com.ditrix.edt.mcp.server.tools.impl.ListConfigurationsTool;
 import com.ditrix.edt.mcp.server.tools.impl.ListProjectsTool;
 import com.ditrix.edt.mcp.server.tools.impl.CleanProjectTool;
 import com.ditrix.edt.mcp.server.tools.impl.RevalidateObjectsTool;
+import com.ditrix.edt.mcp.server.tools.impl.ExportConfigurationToXmlTool;
+import com.ditrix.edt.mcp.server.tools.impl.ImportConfigurationFromXmlTool;
 import com.ditrix.edt.mcp.server.tools.impl.UpdateDatabaseTool;
 import com.ditrix.edt.mcp.server.tools.impl.ReadModuleSourceTool;
 import com.ditrix.edt.mcp.server.tools.impl.WriteModuleSourceTool;
@@ -195,6 +197,8 @@ public class McpServer
         registry.register(new GetConfigurationPropertiesTool());
         registry.register(new CleanProjectTool());
         registry.register(new RevalidateObjectsTool());
+        registry.register(new ExportConfigurationToXmlTool());
+        registry.register(new ImportConfigurationFromXmlTool());
         registry.register(new GetProblemSummaryTool());
         registry.register(new GetProjectErrorsTool());
         registry.register(new GetBookmarksTool());

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolGroup.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolGroup.java
@@ -19,7 +19,7 @@ import java.util.Map;
 public enum ToolGroup
 {
     CORE("core", "Core / Project", //$NON-NLS-1$ //$NON-NLS-2$
-        "Essential project and configuration tools", //$NON-NLS-1$
+        "Essential project, configuration, and XML export/import tools", //$NON-NLS-1$
         "get_edt_version", "list_projects", "get_configuration_properties", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         "clean_project", "revalidate_objects", "get_check_description", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         "export_configuration_to_xml", "import_configuration_from_xml"), //$NON-NLS-1$ //$NON-NLS-2$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolGroup.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolGroup.java
@@ -21,7 +21,8 @@ public enum ToolGroup
     CORE("core", "Core / Project", //$NON-NLS-1$ //$NON-NLS-2$
         "Essential project and configuration tools", //$NON-NLS-1$
         "get_edt_version", "list_projects", "get_configuration_properties", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        "clean_project", "revalidate_objects", "get_check_description"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        "clean_project", "revalidate_objects", "get_check_description", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        "export_configuration_to_xml", "import_configuration_from_xml"), //$NON-NLS-1$ //$NON-NLS-2$
 
     PROBLEMS("problems", "Errors & Problems", //$NON-NLS-1$ //$NON-NLS-2$
         "Error reporting, bookmarks, and tasks", //$NON-NLS-1$
@@ -55,11 +56,7 @@ public enum ToolGroup
 
     REFACTORING("refactoring", "Refactoring", //$NON-NLS-1$ //$NON-NLS-2$
         "Metadata rename, delete, and attribute management", //$NON-NLS-1$
-        "rename_metadata_object", "delete_metadata_object", "add_metadata_attribute"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-
-    WORKSPACE("workspace", "Workspace", //$NON-NLS-1$ //$NON-NLS-2$
-        "Configuration export/import to/from XML files", //$NON-NLS-1$
-        "export_configuration_to_xml", "import_configuration_from_xml"); //$NON-NLS-1$ //$NON-NLS-2$
+        "rename_metadata_object", "delete_metadata_object", "add_metadata_attribute"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
     private final String id;
     private final String displayName;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolGroup.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolGroup.java
@@ -55,7 +55,11 @@ public enum ToolGroup
 
     REFACTORING("refactoring", "Refactoring", //$NON-NLS-1$ //$NON-NLS-2$
         "Metadata rename, delete, and attribute management", //$NON-NLS-1$
-        "rename_metadata_object", "delete_metadata_object", "add_metadata_attribute"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        "rename_metadata_object", "delete_metadata_object", "add_metadata_attribute"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+    WORKSPACE("workspace", "Workspace", //$NON-NLS-1$ //$NON-NLS-2$
+        "Configuration export/import to/from XML files", //$NON-NLS-1$
+        "export_configuration_to_xml", "import_configuration_from_xml"); //$NON-NLS-1$ //$NON-NLS-2$
 
     private final String id;
     private final String displayName;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolPreset.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolPreset.java
@@ -21,7 +21,7 @@ public enum ToolPreset
 
     ANALYSIS_ONLY("Analysis Only", //$NON-NLS-1$
         "Read-only analysis - no code changes, no debugging", //$NON-NLS-1$
-        disabledFor(ToolGroup.APPLICATIONS, ToolGroup.DEBUG, ToolGroup.BSL_CODE, ToolGroup.REFACTORING, ToolGroup.WORKSPACE)),
+        buildAnalysisOnlyDisabled()),
 
     CODE_REVIEW("Code Review", //$NON-NLS-1$
         "Analysis + BSL code reading (no writing)", //$NON-NLS-1$
@@ -112,7 +112,9 @@ public enum ToolPreset
     }
 
     /**
-     * Builds the Code Review preset: disable apps, debug, refactoring, and write_module_source.
+     * Builds the Code Review preset: disable apps, debug, refactoring,
+     * write_module_source, and the state-mutating workspace export/import tools
+     * (which sit in CORE alongside read-only project tools).
      */
     private static Set<String> buildCodeReviewDisabled()
     {
@@ -120,8 +122,25 @@ public enum ToolPreset
         disabled.addAll(ToolGroup.APPLICATIONS.getToolNames());
         disabled.addAll(ToolGroup.DEBUG.getToolNames());
         disabled.addAll(ToolGroup.REFACTORING.getToolNames());
-        disabled.addAll(ToolGroup.WORKSPACE.getToolNames());
         disabled.add("write_module_source"); //$NON-NLS-1$
+        disabled.add("export_configuration_to_xml"); //$NON-NLS-1$
+        disabled.add("import_configuration_from_xml"); //$NON-NLS-1$
+        return Collections.unmodifiableSet(disabled);
+    }
+
+    /**
+     * Builds the Analysis Only preset: disable apps, debug, BSL code edits,
+     * refactoring, and the state-mutating workspace export/import tools.
+     */
+    private static Set<String> buildAnalysisOnlyDisabled()
+    {
+        Set<String> disabled = new HashSet<>();
+        disabled.addAll(ToolGroup.APPLICATIONS.getToolNames());
+        disabled.addAll(ToolGroup.DEBUG.getToolNames());
+        disabled.addAll(ToolGroup.BSL_CODE.getToolNames());
+        disabled.addAll(ToolGroup.REFACTORING.getToolNames());
+        disabled.add("export_configuration_to_xml"); //$NON-NLS-1$
+        disabled.add("import_configuration_from_xml"); //$NON-NLS-1$
         return Collections.unmodifiableSet(disabled);
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolPreset.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolPreset.java
@@ -129,8 +129,10 @@ public enum ToolPreset
     }
 
     /**
-     * Builds the Analysis Only preset: disable apps, debug, BSL code edits,
-     * refactoring, and the state-mutating workspace export/import tools.
+     * Builds the Analysis Only preset: disable apps, debug, the entire BSL
+     * Code group (both read and write tools — analysis is metadata- and
+     * error-level only), refactoring, and the state-mutating workspace
+     * export/import tools.
      */
     private static Set<String> buildAnalysisOnlyDisabled()
     {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolPreset.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolPreset.java
@@ -21,7 +21,7 @@ public enum ToolPreset
 
     ANALYSIS_ONLY("Analysis Only", //$NON-NLS-1$
         "Read-only analysis - no code changes, no debugging", //$NON-NLS-1$
-        disabledFor(ToolGroup.APPLICATIONS, ToolGroup.DEBUG, ToolGroup.BSL_CODE, ToolGroup.REFACTORING)),
+        disabledFor(ToolGroup.APPLICATIONS, ToolGroup.DEBUG, ToolGroup.BSL_CODE, ToolGroup.REFACTORING, ToolGroup.WORKSPACE)),
 
     CODE_REVIEW("Code Review", //$NON-NLS-1$
         "Analysis + BSL code reading (no writing)", //$NON-NLS-1$
@@ -120,6 +120,7 @@ public enum ToolPreset
         disabled.addAll(ToolGroup.APPLICATIONS.getToolNames());
         disabled.addAll(ToolGroup.DEBUG.getToolNames());
         disabled.addAll(ToolGroup.REFACTORING.getToolNames());
+        disabled.addAll(ToolGroup.WORKSPACE.getToolNames());
         disabled.add("write_module_source"); //$NON-NLS-1$
         return Collections.unmodifiableSet(disabled);
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ExportConfigurationToXmlTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ExportConfigurationToXmlTool.java
@@ -8,6 +8,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -82,7 +83,18 @@ public class ExportConfigurationToXmlTool implements IMcpTool
 
         try
         {
-            Path outputPath = Paths.get(outputPathStr);
+            // Normalize to an absolute path so the underlying CLI API isn't
+            // surprised by relative paths resolved against an unexpected
+            // working directory. Reject early if the path exists but is a
+            // file (not a directory); create the directory if it does not
+            // exist yet so the export has a deterministic destination.
+            Path outputPath = Paths.get(outputPathStr).toAbsolutePath().normalize();
+            if (Files.exists(outputPath) && !Files.isDirectory(outputPath))
+            {
+                return ToolResult.error(
+                    "outputPath exists but is not a directory: " + outputPath).toJson(); //$NON-NLS-1$
+            }
+            Files.createDirectories(outputPath);
 
             Object api = Activator.getDefault().getExportConfigurationFilesApi();
             if (api == null)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ExportConfigurationToXmlTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ExportConfigurationToXmlTool.java
@@ -1,0 +1,123 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import com.ditrix.edt.mcp.server.Activator;
+import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
+import com.ditrix.edt.mcp.server.protocol.JsonUtils;
+import com.ditrix.edt.mcp.server.protocol.ToolResult;
+import com.ditrix.edt.mcp.server.tools.IMcpTool;
+
+/**
+ * Tool that wraps the EDT "Export → Configuration to XML Files" action.
+ *
+ * <p>Equivalent of the EDT context-menu action <em>Export → Configuration to
+ * XML Files</em>. Dumps the configuration of an EDT project to a directory of
+ * XML source files (the same format produced by the 1C platform's
+ * {@code DumpConfigToFiles} command).
+ *
+ * <p>Wraps {@code com._1c.g5.v8.dt.cli.api.workspace.IExportConfigurationFilesApi}
+ * via reflection so this bundle has no build-time dependency on the API
+ * package (the API ships with EDT 2025.x and 2026.1, but reflection keeps the
+ * plugin portable).
+ */
+public class ExportConfigurationToXmlTool implements IMcpTool
+{
+    public static final String NAME = "export_configuration_to_xml"; //$NON-NLS-1$
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Export an EDT configuration project to XML files (EDT menu: " //$NON-NLS-1$
+             + "Export -> Configuration to XML Files). Equivalent of 1C platform " //$NON-NLS-1$
+             + "DumpConfigToFiles. Wraps IExportConfigurationFilesApi.exportProject(String, Path)."; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getInputSchema()
+    {
+        return JsonSchemaBuilder.object()
+            .stringProperty("projectName", "EDT project name to export (required)") //$NON-NLS-1$ //$NON-NLS-2$
+            .stringProperty("outputPath", //$NON-NLS-1$
+                "Filesystem path of the output directory for the XML files (required)") //$NON-NLS-1$
+            .build();
+    }
+
+    @Override
+    public ResponseType getResponseType()
+    {
+        return ResponseType.JSON;
+    }
+
+    @Override
+    public String execute(Map<String, String> params)
+    {
+        String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
+        String outputPathStr = JsonUtils.extractStringArgument(params, "outputPath"); //$NON-NLS-1$
+
+        if (projectName == null || projectName.isEmpty())
+        {
+            return ToolResult.error("projectName is required").toJson(); //$NON-NLS-1$
+        }
+        if (outputPathStr == null || outputPathStr.isEmpty())
+        {
+            return ToolResult.error("outputPath is required").toJson(); //$NON-NLS-1$
+        }
+
+        try
+        {
+            Path outputPath = Paths.get(outputPathStr);
+
+            Object api = Activator.getDefault().getExportConfigurationFilesApi();
+            if (api == null)
+            {
+                return ToolResult.error(
+                    "IExportConfigurationFilesApi is not available. " //$NON-NLS-1$
+                  + "Required EDT plugin com._1c.g5.v8.dt.cli.api is not installed.").toJson(); //$NON-NLS-1$
+            }
+
+            // exportProject(String projectName, Path outputPath)
+            Method method = api.getClass().getMethod("exportProject", //$NON-NLS-1$
+                String.class, Path.class);
+            method.invoke(api, projectName, outputPath);
+
+            return ToolResult.success()
+                .put("project", projectName) //$NON-NLS-1$
+                .put("outputPath", outputPath.toString()) //$NON-NLS-1$
+                .put("message", "Configuration exported to XML files.") //$NON-NLS-1$ //$NON-NLS-2$
+                .toJson();
+        }
+        catch (InvocationTargetException e)
+        {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            Activator.logError("export_configuration_to_xml failed", cause); //$NON-NLS-1$
+            return ToolResult.error("Export failed: " + cause.getMessage()).toJson(); //$NON-NLS-1$
+        }
+        catch (NoSuchMethodException | IllegalAccessException e)
+        {
+            Activator.logError("CLI API mismatch", e); //$NON-NLS-1$
+            return ToolResult.error("CLI API mismatch: " + e.getMessage()).toJson(); //$NON-NLS-1$
+        }
+        catch (Exception e)
+        {
+            Activator.logError("Unexpected error in export_configuration_to_xml", e); //$NON-NLS-1$
+            return ToolResult.error(e.getMessage()).toJson();
+        }
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ExportConfigurationToXmlTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ExportConfigurationToXmlTool.java
@@ -53,9 +53,9 @@ public class ExportConfigurationToXmlTool implements IMcpTool
     public String getInputSchema()
     {
         return JsonSchemaBuilder.object()
-            .stringProperty("projectName", "EDT project name to export (required)") //$NON-NLS-1$ //$NON-NLS-2$
+            .stringProperty("projectName", "EDT project name to export (required)", true) //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty("outputPath", //$NON-NLS-1$
-                "Filesystem path of the output directory for the XML files (required)") //$NON-NLS-1$
+                "Filesystem path of the output directory for the XML files (required)", true) //$NON-NLS-1$
             .build();
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ImportConfigurationFromXmlTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ImportConfigurationFromXmlTool.java
@@ -59,9 +59,9 @@ public class ImportConfigurationFromXmlTool implements IMcpTool
     {
         return JsonSchemaBuilder.object()
             .stringProperty("importPath", //$NON-NLS-1$
-                "Filesystem path of the source directory containing XML files (required)") //$NON-NLS-1$
+                "Filesystem path of the source directory containing XML files (required)", true) //$NON-NLS-1$
             .stringProperty("projectName", //$NON-NLS-1$
-                "Name of the new EDT project to create in the workspace (required)") //$NON-NLS-1$
+                "Name of the new EDT project to create in the workspace (required)", true) //$NON-NLS-1$
             .stringProperty("projectNature", //$NON-NLS-1$
                 "EDT project nature ID, e.g. 'com._1c.g5.v8.dt.core.V8ConfigurationNature'. " //$NON-NLS-1$
               + "Pass empty string to let EDT auto-detect.") //$NON-NLS-1$
@@ -106,6 +106,21 @@ public class ImportConfigurationFromXmlTool implements IMcpTool
         {
             Path importPath = Paths.get(importPathStr);
 
+            // The tool's contract is "import into a NEW project", so reject early
+            // if a workspace project with this name already exists. Without this
+            // check the underlying EDT API still throws (with a less direct
+            // message) and we'd surface it via the catch block — but a clean
+            // up-front error is friendlier and matches the validation pattern
+            // used elsewhere (DeleteMetadataObjectTool, CleanProjectTool, etc.).
+            IWorkspace workspace = ResourcesPlugin.getWorkspace();
+            IProject existing = workspace.getRoot().getProject(projectName);
+            if (existing != null && existing.exists())
+            {
+                return ToolResult.error(
+                    "Project already exists in workspace: " + projectName //$NON-NLS-1$
+                  + ". Import requires a new project name.").toJson(); //$NON-NLS-1$
+            }
+
             Object api = Activator.getDefault().getImportConfigurationFilesApi();
             if (api == null)
             {
@@ -124,7 +139,6 @@ public class ImportConfigurationFromXmlTool implements IMcpTool
             // IDtProjectManager.getDtProject(p) returns null until something
             // triggers EDT's project lifecycle. Close + open + refresh here
             // forces EDT to re-scan and bring the project to the ready state.
-            IWorkspace workspace = ResourcesPlugin.getWorkspace();
             IProject created = workspace.getRoot().getProject(projectName);
             if (created != null && created.exists())
             {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ImportConfigurationFromXmlTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ImportConfigurationFromXmlTool.java
@@ -1,0 +1,139 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import com.ditrix.edt.mcp.server.Activator;
+import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
+import com.ditrix.edt.mcp.server.protocol.JsonUtils;
+import com.ditrix.edt.mcp.server.protocol.ToolResult;
+import com.ditrix.edt.mcp.server.tools.IMcpTool;
+
+/**
+ * Tool that wraps the EDT "Import → Configuration from XML Files" action.
+ *
+ * <p>Imports a configuration from a directory of XML source files into a new
+ * EDT project in the workspace. The reverse of
+ * {@link ExportConfigurationToXmlTool}.
+ *
+ * <p>Wraps {@code com._1c.g5.v8.dt.cli.api.workspace.IImportConfigurationFilesApi}
+ * via reflection so this bundle has no build-time dependency on the API
+ * package.
+ */
+public class ImportConfigurationFromXmlTool implements IMcpTool
+{
+    public static final String NAME = "import_configuration_from_xml"; //$NON-NLS-1$
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Import a configuration from a directory of XML files into a new " //$NON-NLS-1$
+             + "EDT project (EDT menu: Import). The reverse of " //$NON-NLS-1$
+             + "export_configuration_to_xml. Wraps " //$NON-NLS-1$
+             + "IImportConfigurationFilesApi.importProject(Path, String, String, String)."; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getInputSchema()
+    {
+        return JsonSchemaBuilder.object()
+            .stringProperty("importPath", //$NON-NLS-1$
+                "Filesystem path of the source directory containing XML files (required)") //$NON-NLS-1$
+            .stringProperty("projectName", //$NON-NLS-1$
+                "Name of the new EDT project to create in the workspace (required)") //$NON-NLS-1$
+            .stringProperty("projectNature", //$NON-NLS-1$
+                "EDT project nature ID, e.g. 'com._1c.g5.v8.dt.core.V8ConfigurationNature'. " //$NON-NLS-1$
+              + "Pass empty string to let EDT auto-detect.") //$NON-NLS-1$
+            .stringProperty("xmlVersion", //$NON-NLS-1$
+                "XML format version, e.g. '8.3.20'. Pass empty string to let EDT auto-detect.") //$NON-NLS-1$
+            .build();
+    }
+
+    @Override
+    public ResponseType getResponseType()
+    {
+        return ResponseType.JSON;
+    }
+
+    @Override
+    public String execute(Map<String, String> params)
+    {
+        String importPathStr = JsonUtils.extractStringArgument(params, "importPath"); //$NON-NLS-1$
+        String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
+        String projectNature = JsonUtils.extractStringArgument(params, "projectNature"); //$NON-NLS-1$
+        String xmlVersion = JsonUtils.extractStringArgument(params, "xmlVersion"); //$NON-NLS-1$
+
+        if (importPathStr == null || importPathStr.isEmpty())
+        {
+            return ToolResult.error("importPath is required").toJson(); //$NON-NLS-1$
+        }
+        if (projectName == null || projectName.isEmpty())
+        {
+            return ToolResult.error("projectName is required").toJson(); //$NON-NLS-1$
+        }
+        // projectNature and xmlVersion are optional — pass null on empty
+        if (projectNature != null && projectNature.isEmpty())
+        {
+            projectNature = null;
+        }
+        if (xmlVersion != null && xmlVersion.isEmpty())
+        {
+            xmlVersion = null;
+        }
+
+        try
+        {
+            Path importPath = Paths.get(importPathStr);
+
+            Object api = Activator.getDefault().getImportConfigurationFilesApi();
+            if (api == null)
+            {
+                return ToolResult.error(
+                    "IImportConfigurationFilesApi is not available. " //$NON-NLS-1$
+                  + "Required EDT plugin com._1c.g5.v8.dt.cli.api is not installed.").toJson(); //$NON-NLS-1$
+            }
+
+            // importProject(Path importSource, String projectName, String nature, String xmlVersion)
+            Method method = api.getClass().getMethod("importProject", //$NON-NLS-1$
+                Path.class, String.class, String.class, String.class);
+            method.invoke(api, importPath, projectName, projectNature, xmlVersion);
+
+            return ToolResult.success()
+                .put("importPath", importPath.toString()) //$NON-NLS-1$
+                .put("project", projectName) //$NON-NLS-1$
+                .put("message", "Configuration imported from XML files.") //$NON-NLS-1$ //$NON-NLS-2$
+                .toJson();
+        }
+        catch (InvocationTargetException e)
+        {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            Activator.logError("import_configuration_from_xml failed", cause); //$NON-NLS-1$
+            return ToolResult.error("Import failed: " + cause.getMessage()).toJson(); //$NON-NLS-1$
+        }
+        catch (NoSuchMethodException | IllegalAccessException e)
+        {
+            Activator.logError("CLI API mismatch", e); //$NON-NLS-1$
+            return ToolResult.error("CLI API mismatch: " + e.getMessage()).toJson(); //$NON-NLS-1$
+        }
+        catch (Exception e)
+        {
+            Activator.logError("Unexpected error in import_configuration_from_xml", e); //$NON-NLS-1$
+            return ToolResult.error(e.getMessage()).toJson();
+        }
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ImportConfigurationFromXmlTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ImportConfigurationFromXmlTool.java
@@ -8,6 +8,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -104,7 +105,23 @@ public class ImportConfigurationFromXmlTool implements IMcpTool
 
         try
         {
-            Path importPath = Paths.get(importPathStr);
+            // Normalize to an absolute path so the underlying CLI API isn't
+            // surprised by relative paths resolved against an unexpected
+            // working directory. Reject early if the path is missing or is
+            // a file (not a directory) so failures are deterministic and
+            // the AI agent gets a clear error instead of an opaque API
+            // exception.
+            Path importPath = Paths.get(importPathStr).toAbsolutePath().normalize();
+            if (!Files.exists(importPath))
+            {
+                return ToolResult.error(
+                    "importPath does not exist: " + importPath).toJson(); //$NON-NLS-1$
+            }
+            if (!Files.isDirectory(importPath))
+            {
+                return ToolResult.error(
+                    "importPath is not a directory: " + importPath).toJson(); //$NON-NLS-1$
+            }
 
             // The tool's contract is "import into a NEW project", so reject early
             // if a workspace project with this name already exists. Without this

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ImportConfigurationFromXmlTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ImportConfigurationFromXmlTool.java
@@ -12,6 +12,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.NullProgressMonitor;
+
 import com.ditrix.edt.mcp.server.Activator;
 import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
 import com.ditrix.edt.mcp.server.protocol.JsonUtils;
@@ -112,6 +118,24 @@ public class ImportConfigurationFromXmlTool implements IMcpTool
             Method method = api.getClass().getMethod("importProject", //$NON-NLS-1$
                 Path.class, String.class, String.class, String.class);
             method.invoke(api, importPath, projectName, projectNature, xmlVersion);
+
+            // The CLI API hardcodes setRefreshProject(false) on the import
+            // operation, so the imported project is left in a state where
+            // IDtProjectManager.getDtProject(p) returns null until something
+            // triggers EDT's project lifecycle. Close + open + refresh here
+            // forces EDT to re-scan and bring the project to the ready state.
+            IWorkspace workspace = ResourcesPlugin.getWorkspace();
+            IProject created = workspace.getRoot().getProject(projectName);
+            if (created != null && created.exists())
+            {
+                NullProgressMonitor monitor = new NullProgressMonitor();
+                if (created.isOpen())
+                {
+                    created.close(monitor);
+                }
+                created.open(monitor);
+                created.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+            }
 
             return ToolResult.success()
                 .put("importPath", importPath.toString()) //$NON-NLS-1$

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupTest.java
@@ -158,7 +158,9 @@ public class ToolGroupTest
         assertTrue(tools.contains("get_edt_version"));
         assertTrue(tools.contains("list_projects"));
         assertTrue(tools.contains("get_configuration_properties"));
-        assertEquals(6, tools.size());
+        assertTrue(tools.contains("export_configuration_to_xml"));
+        assertTrue(tools.contains("import_configuration_from_xml"));
+        assertEquals(8, tools.size());
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupTest.java
@@ -63,9 +63,9 @@ public class ToolGroupTest
     }
 
     @Test
-    public void testNineGroups()
+    public void testEightGroups()
     {
-        assertEquals("Should have 9 tool groups", 9, ToolGroup.values().length);
+        assertEquals("Should have 8 tool groups", 8, ToolGroup.values().length);
     }
 
     // === Tool membership ===

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupTest.java
@@ -63,9 +63,9 @@ public class ToolGroupTest
     }
 
     @Test
-    public void testEightGroups()
+    public void testNineGroups()
     {
-        assertEquals("Should have 8 tool groups", 8, ToolGroup.values().length);
+        assertEquals("Should have 9 tool groups", 9, ToolGroup.values().length);
     }
 
     // === Tool membership ===

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ExportConfigurationToXmlToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ExportConfigurationToXmlToolTest.java
@@ -1,0 +1,60 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+
+/**
+ * Lightweight tests for {@link ExportConfigurationToXmlTool} that exercise
+ * tool metadata and JSON schema without needing the Eclipse runtime.
+ */
+public class ExportConfigurationToXmlToolTest
+{
+    @Test
+    public void testName()
+    {
+        assertEquals("export_configuration_to_xml", new ExportConfigurationToXmlTool().getName()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResponseType()
+    {
+        assertEquals(ResponseType.JSON, new ExportConfigurationToXmlTool().getResponseType());
+    }
+
+    @Test
+    public void testDescriptionNotEmpty()
+    {
+        String desc = new ExportConfigurationToXmlTool().getDescription();
+        assertNotNull(desc);
+        assertFalse(desc.isEmpty());
+    }
+
+    @Test
+    public void testInputSchemaContainsBothParameters()
+    {
+        String schema = new ExportConfigurationToXmlTool().getInputSchema();
+        assertNotNull(schema);
+        assertTrue(schema.contains("\"projectName\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"outputPath\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBothParamsRequired()
+    {
+        String schema = new ExportConfigurationToXmlTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        assertTrue("schema must declare required array", requiredIdx >= 0); //$NON-NLS-1$
+        String tail = schema.substring(requiredIdx);
+        assertTrue("projectName must be required", tail.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputPath must be required", tail.contains("\"outputPath\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ImportConfigurationFromXmlToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ImportConfigurationFromXmlToolTest.java
@@ -1,0 +1,66 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+
+/**
+ * Lightweight tests for {@link ImportConfigurationFromXmlTool} that exercise
+ * tool metadata and JSON schema without needing the Eclipse runtime.
+ */
+public class ImportConfigurationFromXmlToolTest
+{
+    @Test
+    public void testName()
+    {
+        assertEquals("import_configuration_from_xml", new ImportConfigurationFromXmlTool().getName()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResponseType()
+    {
+        assertEquals(ResponseType.JSON, new ImportConfigurationFromXmlTool().getResponseType());
+    }
+
+    @Test
+    public void testDescriptionNotEmpty()
+    {
+        String desc = new ImportConfigurationFromXmlTool().getDescription();
+        assertNotNull(desc);
+        assertFalse(desc.isEmpty());
+    }
+
+    @Test
+    public void testInputSchemaContainsAllParameters()
+    {
+        String schema = new ImportConfigurationFromXmlTool().getInputSchema();
+        assertNotNull(schema);
+        assertTrue(schema.contains("\"importPath\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"projectName\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"projectNature\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"xmlVersion\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRequiredArrayMarksOnlyMandatoryParams()
+    {
+        String schema = new ImportConfigurationFromXmlTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        assertTrue("schema must declare required array", requiredIdx >= 0); //$NON-NLS-1$
+        String tail = schema.substring(requiredIdx);
+        assertTrue("importPath must be required", tail.contains("\"importPath\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("projectName must be required", tail.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("projectNature must NOT be required", //$NON-NLS-1$
+            tail.contains("\"projectNature\",") || tail.contains(",\"projectNature\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("xmlVersion must NOT be required", //$NON-NLS-1$
+            tail.contains("\"xmlVersion\",") || tail.contains(",\"xmlVersion\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+}


### PR DESCRIPTION
## Что добавлено

Два MCP-тула в существующую группу **Core / Project**, оборачивающие официальные CLI API EDT через рефлексию:

| MCP tool | Меню EDT | EDT API |
|----------|----------|---------|
| `export_configuration_to_xml` | Export → Configuration to XML Files | `IExportConfigurationFilesApi.exportProject(String, Path)` |
| `import_configuration_from_xml` | Import → Configuration from XML Files | `IImportConfigurationFilesApi.importProject(Path, String, String, String)` |

Тулы кладутся рядом с `list_projects` / `clean_project` / `get_configuration_properties` в существующую группу `Core / Project` — это project-level операции с конфигурацией, и отдельная группа «Workspace» под два тула — оверкилл.

Подход с reflection-обёрткой EDT-сервисов через `ServiceTracker` по имени класса повторяет то, что уже сделано в плагине для других опциональных API (`GetProfilingResultsTool`, `RenameMetadataObjectTool`).

## Зачем

Round-trip *EDT-проект ↔ XML-файлы на диске* открывает несколько практичных сценариев:

- CI/CD пайплайны перевода (`export_configuration_to_xml` → правка XML-файлов скриптом → `import_configuration_from_xml`);
- быстрое создание тестового workspace из готовых XML-исходников;
- симметрия с CLI-командами 1С (`DumpConfigToFiles` / `LoadConfigFromFiles`), только под управлением AI-ассистента.

В моём прикладном кейсе это закрыло pipeline для перевода библиотеки [HTTPConnector](https://github.com/vbondarevsky/Connector) — каждый CI-прогон делает `translate_configuration` → `export_configuration_to_xml` → скриптовый постпроцессинг → готовый коммитабельный XML в `src/en/`, без ручных кликов в EDT-UI.

## Тестирование (EDT 2026.1.0.324, проект HTTPConnector)

| Сценарий | Результат |
|----------|-----------|
| `export_configuration_to_xml` на translated_project (75 файлов) | ~2 секунды, выгрузка байт-в-байт совпадает с тем, что делает EDT-меню «Export → Configuration to XML Files» |
| `import_configuration_from_xml` round-trip из только что выгруженного XML | проект создан, lifecycle отрабатывает, состояние идёт `building` → `ready` автоматически; `clean_project` отрабатывает; `get_project_errors` репортит тот же набор, что и источник |
| **Lifecycle нюанс**: внутри API захардкожено `setRefreshProject(false)`, без обходного `close + open + refreshLocal` после import проект остаётся в `not_available` бесконечно — `clean_project` возвращает *"Not an EDT project. Please wait and retry"*, F5 в EDT-UI ничего не лечит. Тул делает этот kick автоматически | проверено: до фикса — `not_available` навсегда, после — сразу `building → ready` |
| Preferences UI → Tools tab | оба тула отображаются в `Core / Project`, можно поштучно отключать |
| Пресеты `ANALYSIS_ONLY` / `CODE_REVIEW` | export/import отключаются (state-mutating), остальные Core-тулы остаются активны |

## Совместимость

- Существующие тулы и группы не трогаются.
- `Core / Project` расширяется с 6 до 8 тулов (в описание группы добавлено упоминание «XML export/import»).
- Новых групп тулов не вводится.
- README обновлён: расширенная строка `Core / Project` в Tool Groups, новая подсекция Tool Details «Configuration XML Export / Import».

## Парный PR / порядок merge

Этот PR парный с **`feature/add-langtool-tools`** (группа Translation: 4 LangTool-тула — `generate_translation_strings`, `translate_configuration`, `convert_to_translation_language`, `get_translation_project_info`). Обе ветки трогают одни и те же файлы (`McpServer.java`, `ToolGroup.java`, `Activator.java`, `README.md`), поэтому какой бы PR ни смержился первым — во втором будут тривиальные конфликты:

- соседние строки `import` / `registry.register()` в `McpServer.java`
- последний enum-терминатор (`,` ↔ `;`) в `ToolGroup.java`
- поля ServiceTracker'ов и блок их инициализации в `start()` в `Activator.java`
- счётчик «All N tools / M semantic groups» и строка в таблице Tool Groups в `README.md`

После merge первого PR готов сделать rebase второго и пересобрать update site.