### PR TITLE
Add Hide Groups toggle and visibility manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ MCP (Model Context Protocol) server plugin for 1C:EDT, enabling AI assistants (C
 - 🎯 **Status Bar** - Real-time server status with tool name, execution time, and interactive controls
 - ⚡ **Interruptible Operations** - Cancel long-running operations and send signals to AI agent
 - 🏷️ **Metadata Tags** - Organize objects with custom tags, filter Navigator, keyboard shortcuts (Ctrl+Alt+1-0), multiselect support
-- 📁 **Metadata Groups** - Create custom folder hierarchy in Navigator tree per metadata collection
+- 📁 **Metadata Groups** - Create custom folder hierarchy in Navigator tree per metadata collection, with a toolbar toggle to hide groups temporarily
 - ✏️ **Metadata Refactoring** - Rename/delete metadata objects with full cascading updates across BSL code, forms and metadata; add new attributes to existing objects
 - 🛠️ **Tool Management** - Enable/disable tools by group, presets (Analysis Only, Code Review, Development), per-tool parameter defaults
 
@@ -1231,6 +1231,7 @@ Grouped objects appear inside their group folders in the Navigator tree:
 - Groups are created per metadata collection (Catalogs, Common modules, Documents, etc.)
 - Objects inside groups are still accessible via standard EDT navigation
 - Ungrouped objects appear at the end of the list
+- Use the **Hide Groups** toggle button in the Navigator toolbar to temporarily hide virtual group folders and show grouped objects in their original collections again
 
 ### Group Operations
 
@@ -1242,6 +1243,7 @@ Grouped objects appear inside their group folders in the Navigator tree:
 | Copy group name | Select group → **Ctrl+C** |
 | Delete group | Right-click group → **Delete** |
 | Rename group | Right-click group → **Rename...** |
+| Hide/show groups | Click **Hide Groups** in the Navigator toolbar |
 
 ### Where Groups Are Stored
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/plugin.xml
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/plugin.xml
@@ -252,6 +252,13 @@
                tooltip="Filter navigator by tags"
                style="toggle">
          </command>
+         <command
+               commandId="com.ditrix.edt.mcp.server.groups.hideGroups"
+               icon="icons/group.png"
+               label="Hide Groups"
+               tooltip="Hide virtual groups in the Navigator"
+               style="toggle">
+         </command>
       </menuContribution>
       
       <!-- Filter by Tag in EDT Navigator view menu -->
@@ -415,6 +422,16 @@
             name="Remove from Group"
             description="Remove object from group (return to original location)">
       </command>
+      <command
+            categoryId="com.ditrix.edt.mcp.server.groups.category"
+            id="com.ditrix.edt.mcp.server.groups.hideGroups"
+            name="Hide Groups"
+            description="Hide virtual groups in the Navigator">
+         <state
+               class="org.eclipse.ui.handlers.RegistryToggleState:false"
+               id="org.eclipse.ui.commands.toggleState">
+         </state>
+      </command>
    </extension>
    
    <!-- Handlers for group commands -->
@@ -462,6 +479,10 @@
             class="com.ditrix.edt.mcp.server.groups.handlers.RemoveFromGroupHandler"
             commandId="com.ditrix.edt.mcp.server.groups.removeFromGroup">
          <!-- Handler has setEnabled() that checks for EObjects in groups -->
+      </handler>
+      <handler
+            class="com.ditrix.edt.mcp.server.groups.handlers.HideGroupsHandler"
+            commandId="com.ditrix.edt.mcp.server.groups.hideGroups">
       </handler>
       <!-- Copy handler for groups - copies group name to clipboard -->
       <handler

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/HideGroupsHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/HideGroupsHandler.java
@@ -1,0 +1,19 @@
+package com.ditrix.edt.mcp.server.groups.handlers;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+
+import com.ditrix.edt.mcp.server.groups.ui.GroupVisibilityManager;
+
+/**
+ * Handler for toggling Navigator groups visibility.
+ */
+public class HideGroupsHandler extends AbstractHandler {
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        GroupVisibilityManager.getInstance().toggleGroupsHidden();
+        return null;
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupContentProvider.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupContentProvider.java
@@ -78,6 +78,10 @@ public class GroupContentProvider implements ICommonContentProvider, IGroupChang
     
     @Override
     public Object[] getChildren(Object parentElement) {
+        if (GroupVisibilityManager.getInstance().areGroupsHidden()) {
+            return NO_CHILDREN;
+        }
+
         // Handle collection folders (CommonModules, Catalogs, etc.)
         if (isCollectionAdapter(parentElement)) {
             return getChildrenForCollection(parentElement);
@@ -146,6 +150,10 @@ public class GroupContentProvider implements ICommonContentProvider, IGroupChang
     
     @Override
     public boolean hasChildren(Object element) {
+        if (GroupVisibilityManager.getInstance().areGroupsHidden()) {
+            return false;
+        }
+
         if (element instanceof GroupNavigatorAdapter groupAdapter) {
             Group group = groupAdapter.getGroup();
             // Has children if has nested groups or objects

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupVisibilityManager.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupVisibilityManager.java
@@ -1,0 +1,104 @@
+package com.ditrix.edt.mcp.server.groups.ui;
+
+import org.eclipse.core.commands.Command;
+import org.eclipse.core.commands.State;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.commands.ICommandService;
+import org.eclipse.ui.handlers.RegistryToggleState;
+import org.eclipse.ui.navigator.CommonNavigator;
+import org.eclipse.ui.navigator.CommonViewer;
+
+import com.ditrix.edt.mcp.server.Activator;
+import com.ditrix.edt.mcp.server.tags.TagConstants;
+
+/**
+ * Keeps the Navigator group visibility toggle state.
+ */
+public final class GroupVisibilityManager {
+
+    public static final String HIDE_GROUPS_COMMAND_ID = "com.ditrix.edt.mcp.server.groups.hideGroups"; //$NON-NLS-1$
+
+    private static GroupVisibilityManager instance;
+
+    private volatile boolean groupsHidden;
+
+    private GroupVisibilityManager() {
+        Display.getDefault().asyncExec(() -> updateToggleState(false));
+    }
+
+    public static synchronized GroupVisibilityManager getInstance() {
+        if (instance == null) {
+            instance = new GroupVisibilityManager();
+        }
+        return instance;
+    }
+
+    public boolean areGroupsHidden() {
+        return groupsHidden;
+    }
+
+    public void toggleGroupsHidden() {
+        setGroupsHidden(!groupsHidden);
+    }
+
+    public void setGroupsHidden(boolean hidden) {
+        groupsHidden = hidden;
+        updateToggleState(hidden);
+        refreshNavigator();
+        Activator.logInfo("Navigator groups " + (hidden ? "hidden" : "shown")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    private void refreshNavigator() {
+        Display display = Display.getDefault();
+        if (display == null || display.isDisposed()) {
+            return;
+        }
+
+        display.asyncExec(() -> {
+            try {
+                CommonNavigator navigator = getNavigator();
+                if (navigator == null) {
+                    return;
+                }
+
+                CommonViewer viewer = navigator.getCommonViewer();
+                if (viewer != null && viewer.getControl() != null && !viewer.getControl().isDisposed()) {
+                    viewer.refresh();
+                }
+            } catch (Exception e) {
+                Activator.logError("Failed to refresh Navigator after changing group visibility", e); //$NON-NLS-1$
+            }
+        });
+    }
+
+    private void updateToggleState(boolean hidden) {
+        try {
+            ICommandService commandService = PlatformUI.getWorkbench().getService(ICommandService.class);
+            if (commandService != null) {
+                Command command = commandService.getCommand(HIDE_GROUPS_COMMAND_ID);
+                if (command != null) {
+                    State state = command.getState(RegistryToggleState.STATE_ID);
+                    if (state != null) {
+                        state.setValue(hidden);
+                        commandService.refreshElements(HIDE_GROUPS_COMMAND_ID, null);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // Ignore visual feedback errors.
+        }
+    }
+
+    private CommonNavigator getNavigator() {
+        IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+        if (window != null && window.getActivePage() != null) {
+            var viewPart = window.getActivePage().findView(TagConstants.NAVIGATOR_VIEW_ID);
+            if (viewPart instanceof CommonNavigator navigator) {
+                return navigator;
+            }
+        }
+        return null;
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupedObjectsFilter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupedObjectsFilter.java
@@ -29,6 +29,10 @@ public class GroupedObjectsFilter extends ViewerFilter {
     
     @Override
     public boolean select(Viewer viewer, Object parentElement, Object element) {
+        if (GroupVisibilityManager.getInstance().areGroupsHidden()) {
+            return true;
+        }
+
         // Check if search/filter is active on the viewer
         // When search is active, we should show all objects (disable group filtering)
         if (isSearchActive(viewer)) {


### PR DESCRIPTION
Introduce a Navigator "Hide Groups" feature: add a new toggle command and handler, a GroupVisibilityManager singleton that tracks toggle state, updates the command UI state, and refreshes the Common Navigator. Update GroupContentProvider and GroupedObjectsFilter to respect the hidden state so virtual group folders are suppressed when toggled. Also update plugin.xml to register the command and handler, and update README to document the toolbar toggle and Navigator usage.