### PR TITLE
Add actionable hint to read_module_source when output is truncated

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolParameterSettings.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolParameterSettings.java
@@ -122,7 +122,7 @@ public final class ToolParameterSettings
 
         map.put("read_module_source", Collections.singletonList( //$NON-NLS-1$
             new ParameterDef("maxLines", "Max lines", //$NON-NLS-1$ //$NON-NLS-2$
-                "Maximum lines to return per call", 5000, 100, 50000))); //$NON-NLS-1$
+                "Maximum lines to return per call", 500, 100, 50000))); //$NON-NLS-1$
 
         TOOL_PARAMETERS = Collections.unmodifiableMap(map);
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
@@ -32,7 +32,7 @@ public class ReadModuleSourceTool implements IMcpTool
     public static final String NAME = "read_module_source"; //$NON-NLS-1$
 
     /** Fallback when the {@code maxLines} tool parameter is not configured */
-    private static final int DEFAULT_MAX_LINES = 5000;
+    private static final int DEFAULT_MAX_LINES = 500;
 
     @Override
     public String getName()

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
@@ -23,9 +23,9 @@ import com.ditrix.edt.mcp.server.utils.FrontMatter;
 /**
  * Tool to read BSL module source code (whole file or line range).
  * Returns YAML frontmatter (projectName, module, startLine, endLine, totalLines;
- * plus truncated: true when clamped by the configured line limit) followed by
- * the source in a fenced bsl block. For an empty file, startLine/endLine are
- * omitted and totalLines is 0.
+ * plus truncated: true, nextStartLine, hint when clamped by the configured line
+ * limit) followed by the source in a fenced bsl block. For an empty file,
+ * startLine/endLine are omitted and totalLines is 0.
  */
 public class ReadModuleSourceTool implements IMcpTool
 {
@@ -45,10 +45,10 @@ public class ReadModuleSourceTool implements IMcpTool
     {
         return "Read BSL module source code from EDT project. " + //$NON-NLS-1$
                "Returns YAML frontmatter (projectName, module, startLine, endLine, totalLines; " + //$NON-NLS-1$
-               "plus truncated: true when the range was clamped by the configured line limit) " + //$NON-NLS-1$
-               "followed by clean source in a fenced bsl block (no line-number prefixes). " + //$NON-NLS-1$
-               "For an empty file, startLine/endLine are omitted and totalLines is 0. " + //$NON-NLS-1$
-               "Supports reading full file or a specific line range."; //$NON-NLS-1$
+               "plus truncated: true, nextStartLine and hint when the range was clamped by " + //$NON-NLS-1$
+               "the configured line limit) followed by clean source in a fenced bsl block " + //$NON-NLS-1$
+               "(no line-number prefixes). For an empty file, startLine/endLine are omitted " + //$NON-NLS-1$
+               "and totalLines is 0. Supports reading full file or a specific line range."; //$NON-NLS-1$
     }
 
     @Override
@@ -193,6 +193,11 @@ public class ReadModuleSourceTool implements IMcpTool
         if (truncated)
         {
             fm.put("truncated", true); //$NON-NLS-1$
+            fm.put("nextStartLine", to + 1); //$NON-NLS-1$
+            fm.put("hint", //$NON-NLS-1$
+                "Output clamped to the configured line limit. " //$NON-NLS-1$
+                + "To continue reading, call read_module_source again with startLine=nextStartLine. " //$NON-NLS-1$
+                + "For an overview of procedures, functions and regions, call get_module_structure."); //$NON-NLS-1$
         }
 
         StringBuilder sb = new StringBuilder();

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
@@ -196,7 +196,8 @@ public class ReadModuleSourceTool implements IMcpTool
             fm.put("nextStartLine", to + 1); //$NON-NLS-1$
             fm.put("hint", //$NON-NLS-1$
                 "Output clamped to the configured line limit. " //$NON-NLS-1$
-                + "To continue reading, call read_module_source again with startLine=nextStartLine. " //$NON-NLS-1$
+                + "To continue reading, call read_module_source again with the same projectName and modulePath " //$NON-NLS-1$
+                + "and startLine=" + (to + 1) + ". " //$NON-NLS-1$
                 + "For an overview of procedures, functions and regions, call get_module_structure."); //$NON-NLS-1$
         }
 

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceToolTest.java
@@ -170,6 +170,12 @@ public class ReadModuleSourceToolTest
         assertTrue("must contain totalLines", result.contains("totalLines: 15000\n")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("must contain startLine", result.contains("startLine: 1\n")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("must contain endLine", result.contains("endLine: 5\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must contain nextStartLine = endLine + 1", //$NON-NLS-1$
+            result.contains("nextStartLine: 6\n")); //$NON-NLS-1$
+        assertTrue("must contain hint mentioning get_module_structure", //$NON-NLS-1$
+            result.contains("get_module_structure")); //$NON-NLS-1$
+        assertTrue("must contain hint mentioning startLine=nextStartLine", //$NON-NLS-1$
+            result.contains("startLine=nextStartLine")); //$NON-NLS-1$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceToolTest.java
@@ -174,8 +174,8 @@ public class ReadModuleSourceToolTest
             result.contains("nextStartLine: 6\n")); //$NON-NLS-1$
         assertTrue("must contain hint mentioning get_module_structure", //$NON-NLS-1$
             result.contains("get_module_structure")); //$NON-NLS-1$
-        assertTrue("must contain hint mentioning startLine=nextStartLine", //$NON-NLS-1$
-            result.contains("startLine=nextStartLine")); //$NON-NLS-1$
+        assertTrue("must contain hint mentioning concrete startLine value", //$NON-NLS-1$
+            result.contains("startLine=6")); //$NON-NLS-1$
     }
 
     @Test


### PR DESCRIPTION
When the response is clamped by maxLines, the frontmatter now also exposes nextStartLine (the line to resume from) and a hint pointing to get_module_structure for an overview. This helps the agent continue reading or pivot to a structural view without relying on generic client-side "read in chunks" instructions, which can fire when the MCP client's token limit kicks in before maxLines does.