### PR TITLE
Add terminate_launch tool with auto-chain for YAXUnit runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ MCP (Model Context Protocol) server plugin for 1C:EDT, enabling AI assistants (C
 - 🧪 **Query Validation** - Validate 1C query text in project context (syntax + semantic errors, optional DCS mode)
 - 🧩 **BSL Code Analysis** - Browse modules, inspect structure, read/write methods, search code, and analyze call hierarchy
 - 🖼️ **Form Inspection** - Get PNG screenshots and YAML layout snapshots from the form WYSIWYG editor
-- 🚀 **Application Management** - Get applications, update database, launch in debug mode
+- 🚀 **Application Management** - Get applications, update database, launch in debug mode, terminate EDT-launched 1С clients
 - 🎯 **Status Bar** - Real-time server status with tool name, execution time, and interactive controls
 - ⚡ **Interruptible Operations** - Cancel long-running operations and send signals to AI agent
 - 🏷️ **Metadata Tags** - Organize objects with custom tags, filter Navigator, keyboard shortcuts (Ctrl+Alt+1-0), multiselect support
@@ -176,7 +176,7 @@ Control which MCP tools are exposed to AI assistants. This lets you reduce conte
 
 ### Tool Groups
 
-All 56 tools are organized into 9 semantic groups:
+All 57 tools are organized into 9 semantic groups:
 
 | Group | Description | Tools |
 |-------|-------------|-------|
@@ -184,7 +184,7 @@ All 56 tools are organized into 9 semantic groups:
 | **Errors & Problems** | Error reporting, bookmarks, tasks | `get_problem_summary`, `get_project_errors`, `get_bookmarks`, `get_tasks` |
 | **Code Intelligence** | Content assist, documentation, metadata browsing | `get_content_assist`, `get_platform_documentation`, `get_metadata_objects`, `get_metadata_details`, `list_subsystems`, `get_subsystem_content`, `find_references` |
 | **Tags** | Tag management | `get_tags`, `get_objects_by_tags` |
-| **Applications & Testing** | App management, database updates, testing | `get_applications`, `list_configurations`, `update_database`, `debug_launch`, `run_yaxunit_tests` |
+| **Applications & Testing** | App management, database updates, launch, termination, testing | `get_applications`, `list_configurations`, `update_database`, `debug_launch`, `terminate_launch`, `run_yaxunit_tests` |
 | **Debugging** | Breakpoints, stepping, variable inspection | `set_breakpoint`, `remove_breakpoint`, `list_breakpoints`, `wait_for_break`, `get_variables`, `step`, `resume`, `evaluate_expression`, `debug_yaxunit_tests`, `debug_status`, `start_profiling`, `get_profiling_results` |
 | **BSL Code** | Module browsing, code reading/writing, search, form inspection | `read_module_source`, `write_module_source`, `get_module_structure`, `list_modules`, `search_in_code`, `read_method_source`, `get_method_call_hierarchy`, `go_to_definition`, `get_symbol_info`, `get_form_layout_snapshot`, `get_form_screenshot`, `validate_query` |
 | **Refactoring** | Metadata rename, delete, add attributes | `rename_metadata_object`, `delete_metadata_object`, `add_metadata_attribute` |
@@ -198,7 +198,7 @@ Quickly switch between common tool configurations using presets:
 
 | Preset | Description |
 |--------|-------------|
-| **All Tools** | All 56 tools enabled (default) |
+| **All Tools** | All 57 tools enabled (default) |
 | **Analysis Only** | Read-only analysis — Core, Errors, Code Intelligence, Tags |
 | **Code Review** | Analysis + BSL code reading (excludes `write_module_source`) |
 | **Development** | Full development without debugging tools |
@@ -218,6 +218,8 @@ Some tools have configurable default values for parameters like result limits. T
 | `get_content_assist` | Result limit | 100 | 1–1000 |
 | `search_in_code` | Max results | 100 | 1–500 |
 | `search_in_code` | Context lines | 2 | 0–5 |
+| `read_module_source` | Max lines | 500 | 100–50000 |
+| `terminate_launch` | Termination timeout (sec) | 10 | 1–120 |
 
 Configure these in the Tools tab by selecting a tool that has configurable parameters — the parameter editors appear in the details panel below the tool tree.
 
@@ -339,6 +341,7 @@ Add to `claude_desktop_config.json`:
 | `list_configurations` | List EDT launch configurations (runtime-client + Attach) with current running / suspended state |
 | `update_database` | Update database (infobase) with full or incremental update mode — by `launchConfigurationName` or `projectName + applicationId` |
 | `debug_launch` | Launch application in debug mode — by `launchConfigurationName` (any type, incl. Attach to 1C:Enterprise Debug Server) or `projectName + applicationId` |
+| `terminate_launch` | Terminate 1С launches started from this EDT instance — by `launchConfigurationName`, `projectName + applicationId`, or `all=true` (requires `confirm=true`). Externally started 1С clients are not affected. Attach configurations are disconnected, not killed |
 | `run_yaxunit_tests` | Run YAXUnit tests for a project: launches 1C with `RunUnitTests`, parses JUnit XML, returns Markdown report |
 | `debug_yaxunit_tests` | Launch YAXUnit tests in DEBUG mode so breakpoints fire (autonomous LLM debug cycle) |
 | `set_breakpoint` | Set a 1C BSL line breakpoint (accepts EDT module path or absolute path) |
@@ -709,6 +712,9 @@ Add to `claude_desktop_config.json`:
 | `fullUpdate` | No | If true - full reload, if false - incremental update (default: false) |
 | `autoRestructure` | No | Automatically apply restructurization if needed (default: true) |
 
+**Notes:**
+- If a 1С client launched from this EDT is currently running against the target infobase, the update typically fails because the IB is held in exclusive use. Run `list_configurations` to check for `running: true`; if so, call `terminate_launch` first (it only affects launches started from this EDT), then retry `update_database`.
+
 #### Debug Launch Tool
 
 **`debug_launch`** - Start an EDT debug session. Works for both runtime-client configs (spawns `1cv8c`) and **Attach to 1C:Enterprise Debug Server** configs (attaches to a running `ragent`/`rphost`, required for debugging server-side code — HTTP services, server calls, scheduled and background jobs).
@@ -724,9 +730,47 @@ Add to `claude_desktop_config.json`:
 **Notes:**
 - Requires a launch configuration to be created in EDT first (Run → Run Configurations...).
 - For an Attach config, `debug_launch` returns `applicationId: "attach:<name>"` — a stable synthetic id used by `wait_for_break`, `resume`, `debug_status` and friends.
-- If the config is already running in debug mode, the tool short-circuits with `alreadyRunning: true` instead of spawning a duplicate launch.
+- If the config is already running in debug mode, the tool short-circuits with `alreadyRunning: true` instead of spawning a duplicate launch. To force a clean restart (e.g. after code changes that require a fresh client session), call `terminate_launch` first, then `debug_launch` again.
 - If no configuration exists, returns list of available configurations (runtime client + attach) so the MCP client can discover what's on offer.
 - `updateBeforeLaunch=true` skips update if database is already up to date.
+
+#### Terminate Launch Tool
+
+**`terminate_launch`** - Terminate 1С launches that were started from **this** EDT instance (runtime-client or Attach). Only launches visible via the Eclipse launch manager can be affected — 1С clients started externally (Designer, ad-hoc `1cv8c.exe`, another EDT) are never touched. This is a constructive guarantee of the Eclipse Debug Platform, not a heuristic.
+
+**Selection modes (mutually exclusive):**
+
+| Mode | Required parameters | Effect |
+|------|--------------------|--------|
+| **By config name** | `launchConfigurationName` | Terminate the single live launch of that configuration |
+| **By project + application** | `projectName` + `applicationId` | Terminate the single live launch matching both attributes |
+| **All** | `all=true` + `confirm=true` (optionally narrowed by `projectName`) | Terminate every live EDT launch (or every live launch of the given project) |
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `launchConfigurationName` | One mode | Exact EDT launch configuration name (from `list_configurations`) |
+| `projectName` | One mode | EDT project name. With `applicationId` — single launch; with `all=true` — narrows scope to one project |
+| `applicationId` | One mode | Application ID from `get_applications`. Requires `projectName`, cannot be combined with `all=true` |
+| `all` | One mode | Terminate every live EDT launch. Requires `confirm=true`. Default: `false` |
+| `confirm` | When `all=true` | Must be `true` to actually perform mass termination — guard against accidents |
+| `force` | No | On polite timeout, escalate to `IProcess.terminate()` (OS-level kill). May lose unsaved 1С state. Default: `false`. Ignored for Attach |
+| `timeoutSeconds` | No | Polite-wait window per launch. Default: `10`, clamped to `[1, 120]` |
+| `includeAttach` | No | Whether to act on Attach configurations (RemoteRuntime / LocalRuntime). When `true` (default), Attach launches are **disconnected** — the 1С cluster keeps running |
+
+**Behaviour notes:**
+
+- **Runtime-client launches** are stopped via `ILaunch.terminate()`. If the launch does not become terminated within `timeoutSeconds`, the result is `timeout` (unless `force=true`, which then triggers `IProcess.terminate()`).
+- **Attach launches** are disconnected via `IDisconnect.disconnect()` on each debug target. The 1С server (`ragent` / `rphost`) is never killed by this tool. `force=true` is ignored for Attach.
+- **`already_terminated`** launches are reported as such (not an error) — useful when the same call is retried.
+- **`not_found`** is returned (as a success response with empty list and explanatory body) when no live launch matches the request. This lets agents probe idempotently.
+- The response is Markdown. Single-launch results render as a `# Launch Terminated` block with key facts; multi-launch results render as `## Terminated` / `## Detached` / `## Timed Out` / `## Errors` sections with tables.
+
+**Typical workflow:**
+
+1. `list_configurations` — see which configurations are currently `running: true`.
+2. `terminate_launch` with the appropriate mode.
+3. Re-run `list_configurations` to verify (`running: false`).
 
 #### Run YAXUnit Tests Tool
 
@@ -742,11 +786,13 @@ Add to `claude_desktop_config.json`:
 | `modules` | No | Comma-separated common-module names to run (e.g. `OM_tmrlGlovoCatalog`) |
 | `tests` | No | Comma-separated test names in `Module.Method` format |
 | `timeout` | No | Polling window in seconds (default: 60). On expiry returns **Pending**; call again to keep waiting |
+| `updateBeforeLaunch` | No | Auto-chain (default: `true`). Before spawning a new launch, terminate any live 1С client running this configuration and run a silent DB update — so EDT's launch delegate skips its modal "Update database?" dialog that would block the MCP call. Set `false` to keep legacy behaviour. |
 
 **Notes:**
 - Requires a launch configuration in EDT for the project/application and the YAXUnit extension installed in the infobase.
 - The launch is **not** terminated when the polling window expires — call the tool again with identical arguments to keep waiting and fetch the result once 1C closes.
 - Reports are stored under `%TEMP%/edt-mcp-yaxunit/<sanitized-key>_<sha1>/` (`junit.xml` + `report.md` + `xUnitParams.json`). The directory name is derived from `projectName:applicationId:filterHash` — sanitized and suffixed with a SHA-1 hash to avoid collisions. A fresh `junit.xml` (younger than 5 minutes) is reused without restarting 1C.
+- The auto-chain (`updateBeforeLaunch=true`) reuses the `terminate_launch` configurable timeout from preferences. If a live launch cannot be terminated within that window, the tool aborts with a clear error instead of falling through to the interactive dialog. Pass `updateBeforeLaunch=false` to skip the auto-chain and let EDT's delegate decide (may show dialogs). When the auto-chain actually terminated a previous launch, the returned Markdown report is prefixed with a one-line `> **Pre-launch:** …` quote.
 
 #### Server-Side Debugging (Attach to 1C:Enterprise Debug Server)
 
@@ -789,6 +835,7 @@ A family of MCP tools that lets the LLM set breakpoints, inspect runtime state a
 - `frameRef` and `threadId` are reissued on every SUSPEND event. After `resume`/`step` the previous ids become stale (the tool returns a clear error).
 - `evaluate_expression` runs arbitrary BSL inside the running 1C process. Use it deliberately.
 - The actual 1C BSL breakpoint class is loaded via reflection at runtime — if the EDT version exposes it under a different name, `Activator.logError` will surface the failure and the breakpoint falls back to a marker shim.
+- `debug_yaxunit_tests` accepts the same `updateBeforeLaunch` parameter as `run_yaxunit_tests` (default `true`) — before the debug launch it terminates any live client of this configuration and runs a silent DB update, so EDT's launch delegate skips its modal "Update database?" dialog. On success the JSON response includes a `preLaunch` field when the chain actually terminated a previous launch.
 
 ### BSL Code Analysis Tools
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/McpServer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/McpServer.java
@@ -72,6 +72,7 @@ import com.ditrix.edt.mcp.server.tools.impl.WaitForBreakTool;
 import com.ditrix.edt.mcp.server.tools.impl.GetVariablesTool;
 import com.ditrix.edt.mcp.server.tools.impl.StartProfilingTool;
 import com.ditrix.edt.mcp.server.tools.impl.StepTool;
+import com.ditrix.edt.mcp.server.tools.impl.TerminateLaunchTool;
 import com.ditrix.edt.mcp.server.tools.impl.ResumeTool;
 import com.ditrix.edt.mcp.server.tools.impl.EvaluateExpressionTool;
 import com.ditrix.edt.mcp.server.tools.impl.DebugStatusTool;
@@ -228,6 +229,7 @@ public class McpServer
         registry.register(new DebugLaunchTool());
         registry.register(new ListConfigurationsTool());
         registry.register(new RunYaxunitTestsTool());
+        registry.register(new TerminateLaunchTool());
 
         // Debug inspection tools (breakpoints + suspended state)
         registry.register(new SetBreakpointTool());

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolGroup.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolGroup.java
@@ -38,9 +38,9 @@ public enum ToolGroup
         "get_tags", "get_objects_by_tags"), //$NON-NLS-1$ //$NON-NLS-2$
 
     APPLICATIONS("applications", "Applications & Testing", //$NON-NLS-1$ //$NON-NLS-2$
-        "Application management, database update, launch, and testing", //$NON-NLS-1$
+        "Application management, database update, launch, termination, and testing", //$NON-NLS-1$
         "get_applications", "list_configurations", "update_database", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        "debug_launch", "run_yaxunit_tests"), //$NON-NLS-1$ //$NON-NLS-2$
+        "debug_launch", "terminate_launch", "run_yaxunit_tests"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
     DEBUG("debug", "Debugging", //$NON-NLS-1$ //$NON-NLS-2$
         "Breakpoints, stepping, variables, expression evaluation, and profiling", //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolParameterSettings.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolParameterSettings.java
@@ -124,6 +124,12 @@ public final class ToolParameterSettings
             new ParameterDef("maxLines", "Max lines", //$NON-NLS-1$ //$NON-NLS-2$
                 "Maximum lines to return per call", 500, 100, 50000))); //$NON-NLS-1$
 
+        map.put("terminate_launch", Collections.singletonList( //$NON-NLS-1$
+            new ParameterDef("timeoutSeconds", "Termination timeout (sec)", //$NON-NLS-1$ //$NON-NLS-2$
+                "How long to wait for a polite ILaunch.terminate() to take effect before " //$NON-NLS-1$
+                    + "reporting timeout (or escalating to force-kill when force=true)", //$NON-NLS-1$
+                10, 1, 120)));
+
         TOOL_PARAMETERS = Collections.unmodifiableMap(map);
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
@@ -10,8 +10,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -29,15 +27,12 @@ import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
 import com.ditrix.edt.mcp.server.utils.DebugSessionRegistry;
 import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
+import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils;
 import com.ditrix.edt.mcp.server.utils.ProjectStateChecker;
 import com.e1c.g5.dt.applications.ApplicationException;
-import com.e1c.g5.dt.applications.ApplicationUpdateState;
-import com.e1c.g5.dt.applications.ApplicationUpdateType;
-import com.e1c.g5.dt.applications.ExecutionContext;
 import com.e1c.g5.dt.applications.IApplication;
 import com.e1c.g5.dt.applications.IApplicationManager;
 
-import org.eclipse.swt.widgets.Shell;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
@@ -303,10 +298,15 @@ public class DebugLaunchTool implements IMcpTool
                 return already.toJson();
             }
 
-            // Update database before launch if requested
+            // Update database before launch if requested. Routes through the
+            // shared LaunchLifecycleUtils.updateApplicationIfNeeded so debug_launch
+            // analyses "does the IB need updating?" the same way the YAXUnit tools
+            // do: skip on UPDATED, wait on BEING_UPDATED, incremental-update otherwise.
             if (updateBeforeLaunch && appManager != null && application != null)
             {
-                String updateError = updateDatabase(appManager, application);
+                String updateError = LaunchLifecycleUtils
+                    .updateApplicationIfNeeded(project, applicationId, appManager)
+                    .orElse(null);
                 if (updateError != null)
                 {
                     return ToolResult.error(updateError).toJson();
@@ -393,69 +393,10 @@ public class DebugLaunchTool implements IMcpTool
         {
             return null;
         }
-        try
-        {
-            Optional<IApplication> appOpt = appManager.getApplication(project, applicationId);
-            if (!appOpt.isPresent())
-            {
-                return null;
-            }
-            return updateDatabase(appManager, appOpt.get());
-        }
-        catch (ApplicationException e)
-        {
-            Activator.logError("Error resolving application for DB update", e); //$NON-NLS-1$
-            return null;
-        }
-    }
-
-    private String updateDatabase(IApplicationManager appManager, IApplication application)
-    {
-        try
-        {
-            ApplicationUpdateState updateState = appManager.getUpdateState(application);
-            if (updateState == ApplicationUpdateState.UPDATED
-                || updateState == ApplicationUpdateState.BEING_UPDATED)
-            {
-                return null;
-            }
-
-            Activator.logInfo("Updating database before launch: application=" + application.getId()); //$NON-NLS-1$
-
-            ExecutionContext context = new ExecutionContext();
-            Display display = Display.getDefault();
-            if (display != null && !display.isDisposed())
-            {
-                final Shell[] shellHolder = new Shell[1];
-                display.syncExec(() -> {
-                    shellHolder[0] = display.getActiveShell();
-                    if (shellHolder[0] == null)
-                    {
-                        Shell[] shells = display.getShells();
-                        if (shells.length > 0)
-                        {
-                            shellHolder[0] = shells[0];
-                        }
-                    }
-                });
-                if (shellHolder[0] != null)
-                {
-                    context.setProperty(ExecutionContext.ACTIVE_SHELL_NAME, shellHolder[0]);
-                }
-            }
-
-            IProgressMonitor monitor = new NullProgressMonitor();
-            ApplicationUpdateState stateAfter = appManager.update(application,
-                ApplicationUpdateType.INCREMENTAL, context, monitor);
-            Activator.logInfo("Database update completed: stateAfter=" + stateAfter); //$NON-NLS-1$
-            return null;
-        }
-        catch (ApplicationException e)
-        {
-            Activator.logError("Error updating database before launch", e); //$NON-NLS-1$
-            return "Failed to update database before launch: " + e.getMessage() //$NON-NLS-1$
-                + ". You can retry with updateBeforeLaunch=false to skip update."; //$NON-NLS-1$
-        }
+        // Shared update analysis: skip on UPDATED, wait on BEING_UPDATED, otherwise
+        // incremental-update — same path as the YAXUnit auto-chain.
+        return LaunchLifecycleUtils.updateApplicationIfNeeded(project, applicationId, appManager)
+            .orElse(null);
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
@@ -19,6 +19,7 @@ import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.core.model.IDebugTarget;
 import org.eclipse.swt.widgets.Display;
 
 import com.ditrix.edt.mcp.server.Activator;
@@ -70,7 +71,11 @@ public class DebugLaunchTool implements IMcpTool
             + "Pass launchConfigurationName to run any existing EDT debug configuration by name " //$NON-NLS-1$
             + "(runtime client OR 'Attach to 1C:Enterprise Debug Server' — required for debugging " //$NON-NLS-1$
             + "server-side code: HTTP services, background jobs, scheduled jobs). " //$NON-NLS-1$
-            + "Otherwise pass projectName + applicationId to launch the matching runtime-client config."; //$NON-NLS-1$
+            + "Otherwise pass projectName + applicationId to launch the matching runtime-client config. " //$NON-NLS-1$
+            + "If a previous launch of the same configuration is still alive, the tool short-circuits " //$NON-NLS-1$
+            + "with `alreadyRunning: true` and does NOT spawn a fresh client — to force a clean restart " //$NON-NLS-1$
+            + "(e.g. after code changes that require a new session), call `terminate_launch` first, " //$NON-NLS-1$
+            + "then `debug_launch` again."; //$NON-NLS-1$
     }
 
     @Override
@@ -268,6 +273,34 @@ public class DebugLaunchTool implements IMcpTool
                     Activator.logError("Error checking application", e); //$NON-NLS-1$
                     // Continue - we'll try to find launch config anyway
                 }
+            }
+
+            // If this application already has a live debug session, short-circuit
+            // — mirrors the launchConfigurationName path so both call styles behave
+            // the same. To force a fresh launch, terminate_launch first.
+            IDebugTarget activeTarget = DebugSessionRegistry.findActiveTarget(applicationId);
+            if (activeTarget != null)
+            {
+                String activeConfigName = activeTarget.getLaunch() != null
+                    && activeTarget.getLaunch().getLaunchConfiguration() != null
+                        ? activeTarget.getLaunch().getLaunchConfiguration().getName()
+                        : null;
+                Activator.logInfo("debug_launch short-circuit (alreadyRunning): project=" //$NON-NLS-1$
+                    + projectName + ", applicationId=" + applicationId //$NON-NLS-1$
+                    + ", activeConfig=" + activeConfigName); //$NON-NLS-1$
+                ToolResult already = ToolResult.success()
+                    .put("project", projectName) //$NON-NLS-1$
+                    .put("applicationId", applicationId) //$NON-NLS-1$
+                    .put("attach", false) //$NON-NLS-1$
+                    .put("alreadyRunning", true) //$NON-NLS-1$
+                    .put("mode", "debug") //$NON-NLS-1$ //$NON-NLS-2$
+                    .put("message", "Launch configuration is already running — skipped re-launch. " //$NON-NLS-1$ //$NON-NLS-2$
+                        + "Call terminate_launch first to force a fresh session.");
+                if (activeConfigName != null)
+                {
+                    already.put("launchConfiguration", activeConfigName); //$NON-NLS-1$
+                }
+                return already.toJson();
             }
 
             // Update database before launch if requested

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugYaxunitTestsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugYaxunitTestsTool.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
@@ -31,6 +32,8 @@ import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
 import com.ditrix.edt.mcp.server.utils.DebugSessionRegistry;
 import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
+import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils;
+import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils.PreLaunchResult;
 import com.ditrix.edt.mcp.server.utils.ProjectStateChecker;
 import com.e1c.g5.dt.applications.ApplicationException;
 import com.e1c.g5.dt.applications.IApplication;
@@ -88,6 +91,12 @@ public class DebugYaxunitTestsTool implements IMcpTool
             .stringProperty("extensions", "Comma-separated extension names to filter tests by extension") //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty("modules", "Comma-separated module names to filter tests") //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty("tests", "Comma-separated test names in Module.Method format (recommended: pin to one test)") //$NON-NLS-1$ //$NON-NLS-2$
+            .booleanProperty("updateBeforeLaunch", //$NON-NLS-1$
+                "Auto-chain (default: true): before spawning the debug launch, " //$NON-NLS-1$
+                    + "politely terminate any live 1С client running this configuration " //$NON-NLS-1$
+                    + "and run a silent DB update — so EDT's launch delegate does not pop " //$NON-NLS-1$
+                    + "its modal 'Update database?' dialog that would block the MCP call. " //$NON-NLS-1$
+                    + "Set false to keep legacy behaviour (delegate decides; dialog may appear).") //$NON-NLS-1$
             .build();
     }
 
@@ -106,6 +115,8 @@ public class DebugYaxunitTestsTool implements IMcpTool
         String extensions = JsonUtils.extractStringArgument(params, "extensions"); //$NON-NLS-1$
         String modules = JsonUtils.extractStringArgument(params, "modules"); //$NON-NLS-1$
         String tests = JsonUtils.extractStringArgument(params, "tests"); //$NON-NLS-1$
+        boolean updateBeforeLaunch = JsonUtils.extractBooleanArgument(params, //$NON-NLS-1$
+            "updateBeforeLaunch", true); //$NON-NLS-1$
 
         boolean hasName = configName != null && !configName.isEmpty();
         if (!hasName)
@@ -217,34 +228,68 @@ public class DebugYaxunitTestsTool implements IMcpTool
             // Make sure suspend listener is in place before the launch starts producing events.
             DebugSessionRegistry.get().ensureListenerRegistered();
 
-            ILaunchConfigurationWorkingCopy workingCopy = matchingConfig.getWorkingCopy();
-            String startupOption = "RunUnitTests=" + paramsFile.toString(); //$NON-NLS-1$
-            workingCopy.setAttribute(LaunchConfigUtils.ATTR_STARTUP_OPTION, startupOption);
-
-            Activator.logInfo("Launching YAXUnit tests in DEBUG mode: config=" + matchingConfig.getName() //$NON-NLS-1$
-                + ", startup=" + startupOption); //$NON-NLS-1$
-
-            // Launch the working copy directly so our ATTR_STARTUP_OPTION mutation
-            // actually takes effect (DebugUITools.launch on a working copy can
-            // re-resolve to the saved config and silently drop our changes).
-            try
+            // Auto-chain + spawn under the per-key lock — closes the window
+            // between workingCopy.launch() and registerOwnedLaunch in which a
+            // concurrent call against the same IB could otherwise terminate
+            // this fresh debug launch. Different (project, applicationId) pairs
+            // run in parallel.
+            PreLaunchResult preLaunch = null;
+            synchronized (LaunchLifecycleUtils.lockFor(projectName, applicationId))
             {
-                workingCopy.launch(ILaunchManager.DEBUG_MODE, new org.eclipse.core.runtime.NullProgressMonitor());
-            }
-            catch (Exception ex)
-            {
-                Activator.logError("Failed to launch YAXUnit in debug mode", ex); //$NON-NLS-1$
-                return ToolResult.error("Launch failed: " + ex.getMessage()).toJson(); //$NON-NLS-1$
+                if (updateBeforeLaunch)
+                {
+                    int terminateTimeout = LaunchLifecycleUtils.getDefaultTerminateTimeoutSeconds();
+                    preLaunch = LaunchLifecycleUtils.prepareForFreshLaunch(launchManager, project,
+                        applicationId, appManager, terminateTimeout);
+                    if (!preLaunch.isOk())
+                    {
+                        return ToolResult.error("Pre-launch preparation failed: " //$NON-NLS-1$
+                            + preLaunch.getError()
+                            + ". If the previous launch is stuck, call terminate_launch " //$NON-NLS-1$
+                            + "with force=true and retry. As a last resort, pass " //$NON-NLS-1$
+                            + "updateBeforeLaunch=false — but the EDT launch delegate may " //$NON-NLS-1$
+                            + "then pop a modal dialog that blocks the MCP call.").toJson(); //$NON-NLS-1$
+                    }
+                }
+
+                ILaunchConfigurationWorkingCopy workingCopy = matchingConfig.getWorkingCopy();
+                String startupOption = "RunUnitTests=" + paramsFile.toString(); //$NON-NLS-1$
+                workingCopy.setAttribute(LaunchConfigUtils.ATTR_STARTUP_OPTION, startupOption);
+
+                Activator.logInfo("Launching YAXUnit tests in DEBUG mode: config=" + matchingConfig.getName() //$NON-NLS-1$
+                    + ", startup=" + startupOption); //$NON-NLS-1$
+
+                // Launch the working copy directly so our ATTR_STARTUP_OPTION mutation
+                // actually takes effect (DebugUITools.launch on a working copy can
+                // re-resolve to the saved config and silently drop our changes).
+                try
+                {
+                    ILaunch spawned = workingCopy.launch(ILaunchManager.DEBUG_MODE,
+                        new org.eclipse.core.runtime.NullProgressMonitor());
+                    // Register inside the per-key lock so a concurrent auto-chain
+                    // for the same IB sees this launch as owned and refuses to
+                    // terminate it.
+                    LaunchLifecycleUtils.registerOwnedLaunch(spawned);
+                }
+                catch (Exception ex)
+                {
+                    Activator.logError("Failed to launch YAXUnit in debug mode", ex); //$NON-NLS-1$
+                    return ToolResult.error("Launch failed: " + ex.getMessage()).toJson(); //$NON-NLS-1$
+                }
             }
 
-            return ToolResult.success()
+            ToolResult result = ToolResult.success()
                 .put("launched", true) //$NON-NLS-1$
                 .put("projectName", projectName) //$NON-NLS-1$
                 .put("applicationId", applicationId) //$NON-NLS-1$
                 .put("reportDir", reportDir.toString()) //$NON-NLS-1$
                 .put("junitXml", junitFile.toString()) //$NON-NLS-1$
-                .put("nextStep", "call wait_for_break with the same applicationId") //$NON-NLS-1$ //$NON-NLS-2$
-                .toJson();
+                .put("nextStep", "call wait_for_break with the same applicationId"); //$NON-NLS-1$ //$NON-NLS-2$
+            if (preLaunch != null && preLaunch.getTerminatedCount() > 0)
+            {
+                result.put("preLaunch", preLaunch.summary()); //$NON-NLS-1$
+            }
+            return result.toJson();
         }
         catch (Exception e)
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
@@ -43,6 +43,8 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool;
 import com.ditrix.edt.mcp.server.utils.JUnitMarkdownFormatter;
 import com.ditrix.edt.mcp.server.utils.JUnitTestResults;
 import com.ditrix.edt.mcp.server.utils.JUnitXmlParser;
+import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils;
+import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils.PreLaunchResult;
 import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
 import com.ditrix.edt.mcp.server.utils.ProjectStateChecker;
 import com.e1c.g5.dt.applications.ApplicationException;
@@ -104,6 +106,12 @@ public class RunYaxunitTestsTool implements IMcpTool
             .stringProperty("modules", "Comma-separated module names to filter tests") //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty("tests", "Comma-separated test names in Module.Method format") //$NON-NLS-1$ //$NON-NLS-2$
             .integerProperty("timeout", "Polling window in seconds (default: 60). On expiry returns Pending; call again to keep waiting.") //$NON-NLS-1$ //$NON-NLS-2$
+            .booleanProperty("updateBeforeLaunch", //$NON-NLS-1$
+                "Auto-chain (default: true): before spawning a new test launch, " //$NON-NLS-1$
+                    + "politely terminate any live 1С client running this configuration " //$NON-NLS-1$
+                    + "and run a silent DB update — so EDT's launch delegate does not pop " //$NON-NLS-1$
+                    + "its modal 'Update database?' dialog that would block the MCP call. " //$NON-NLS-1$
+                    + "Set false to keep legacy behaviour (delegate decides; dialog may appear).") //$NON-NLS-1$
             .build();
     }
 
@@ -127,6 +135,8 @@ public class RunYaxunitTestsTool implements IMcpTool
         {
             timeout = 1;
         }
+        boolean updateBeforeLaunch = JsonUtils.extractBooleanArgument(params, //$NON-NLS-1$
+            "updateBeforeLaunch", true); //$NON-NLS-1$
 
         boolean hasName = configName != null && !configName.isEmpty();
         if (!hasName)
@@ -145,7 +155,8 @@ public class RunYaxunitTestsTool implements IMcpTool
         ensureLaunchListenerRegistered();
         purgeTerminatedLaunches();
 
-        return runTests(configName, projectName, applicationId, extensions, modules, tests, timeout);
+        return runTests(configName, projectName, applicationId, extensions, modules, tests,
+            timeout, updateBeforeLaunch);
     }
 
     /**
@@ -163,7 +174,7 @@ public class RunYaxunitTestsTool implements IMcpTool
      * the result. Old runs are cleaned up automatically before starting a new launch.
      */
     private String runTests(String configName, String projectName, String applicationId,
-            String extensions, String modules, String tests, int timeout)
+            String extensions, String modules, String tests, int timeout, boolean updateBeforeLaunch)
     {
         try
         {
@@ -291,10 +302,8 @@ public class RunYaxunitTestsTool implements IMcpTool
                 return readResults(cached);
             }
 
-            // Atomically reuse an existing active launch for the same runKey, or create exactly
-            // one new launch. Cleanup + params write is inside the critical section so a concurrent
-            // call cannot overwrite the params while the first is starting.
-            ILaunch launch;
+            // Phase 1 (quick, JVM-wide): try to reuse an active launch for this runKey.
+            ILaunch launch = null;
             synchronized (ACTIVE_LAUNCHES)
             {
                 ILaunch concurrent = ACTIVE_LAUNCHES.get(runKey);
@@ -303,42 +312,90 @@ public class RunYaxunitTestsTool implements IMcpTool
                     Activator.logInfo("Reusing active YAXUnit launch for runKey=" + runKey); //$NON-NLS-1$
                     launch = concurrent;
                 }
-                else
+                else if (concurrent != null)
                 {
-                    if (concurrent != null)
+                    ACTIVE_LAUNCHES.remove(runKey);
+                }
+            }
+
+            // Phases 2 + 3 under the per-key lock — this serialises auto-chain
+            // and spawn across both YAXUnit tools for the same IB, and closes
+            // the narrow window between workingCopy.launch() and
+            // registerOwnedLaunch where a concurrent call could otherwise
+            // terminate this fresh launch before it's registered. Different
+            // (project, applicationId) pairs are unaffected.
+            PreLaunchResult preLaunch = null;
+            if (launch == null)
+            {
+                synchronized (LaunchLifecycleUtils.lockFor(projectName, applicationId))
+                {
+                    // Phase 2: auto-chain (LaunchLifecycleUtils.prepareForFreshLaunch
+                    // re-acquires the same monitor — Java synchronized is reentrant).
+                    if (updateBeforeLaunch)
                     {
-                        ACTIVE_LAUNCHES.remove(runKey);
+                        int terminateTimeout = LaunchLifecycleUtils.getDefaultTerminateTimeoutSeconds();
+                        preLaunch = LaunchLifecycleUtils.prepareForFreshLaunch(launchManager,
+                            project, applicationId, appManager, terminateTimeout);
+                        if (!preLaunch.isOk())
+                        {
+                            return "**Error:** Pre-launch preparation failed: " //$NON-NLS-1$
+                                + preLaunch.getError()
+                                + "\n\nIf the previous launch is stuck, call `terminate_launch` " //$NON-NLS-1$
+                                + "with `force=true` and retry. As a last resort, pass " //$NON-NLS-1$
+                                + "`updateBeforeLaunch=false` — but the EDT launch delegate may " //$NON-NLS-1$
+                                + "then pop a modal dialog that blocks the MCP call."; //$NON-NLS-1$
+                        }
                     }
 
-                    // Prepare a clean report dir and write the params file inside the lock.
-                    cleanupTempDir(reportDir);
-                    Files.createDirectories(reportDir);
-                    Path paramsFile = reportDir.resolve("xUnitParams.json"); //$NON-NLS-1$
-                    String paramsJson = buildParamsJson(reportDir.resolve("junit.xml").toString(), //$NON-NLS-1$
-                            extensions, modules, tests);
-                    Files.write(paramsFile, paramsJson.getBytes(StandardCharsets.UTF_8));
-                    Activator.logInfo("YAXUnit params written to: " + paramsFile); //$NON-NLS-1$
+                    // Phase 3: re-check ACTIVE_LAUNCHES under JVM-wide sync (another
+                    // thread may have spawned for the same runKey while we waited
+                    // on the per-key lock), then either reuse or spawn.
+                    synchronized (ACTIVE_LAUNCHES)
+                    {
+                        ILaunch racer = ACTIVE_LAUNCHES.get(runKey);
+                        if (racer != null && !racer.isTerminated())
+                        {
+                            Activator.logInfo("Reusing YAXUnit launch spawned during auto-chain: runKey=" //$NON-NLS-1$
+                                + runKey);
+                            launch = racer;
+                        }
+                        else
+                        {
+                            cleanupTempDir(reportDir);
+                            Files.createDirectories(reportDir);
+                            Path paramsFile = reportDir.resolve("xUnitParams.json"); //$NON-NLS-1$
+                            String paramsJson = buildParamsJson(reportDir.resolve("junit.xml").toString(), //$NON-NLS-1$
+                                    extensions, modules, tests);
+                            Files.write(paramsFile, paramsJson.getBytes(StandardCharsets.UTF_8));
+                            Activator.logInfo("YAXUnit params written to: " + paramsFile); //$NON-NLS-1$
 
-                    ILaunchConfigurationWorkingCopy workingCopy = matchingConfig.getWorkingCopy();
-                    String startupOption = "RunUnitTests=" + paramsFile.toString(); //$NON-NLS-1$
-                    workingCopy.setAttribute(LaunchConfigUtils.ATTR_STARTUP_OPTION, startupOption);
+                            ILaunchConfigurationWorkingCopy workingCopy = matchingConfig.getWorkingCopy();
+                            String startupOption = "RunUnitTests=" + paramsFile.toString(); //$NON-NLS-1$
+                            workingCopy.setAttribute(LaunchConfigUtils.ATTR_STARTUP_OPTION, startupOption);
 
-                    Activator.logInfo("Launching YAXUnit tests: config=" + matchingConfig.getName() //$NON-NLS-1$
-                            + ", startup=" + startupOption); //$NON-NLS-1$
+                            Activator.logInfo("Launching YAXUnit tests: config=" + matchingConfig.getName() //$NON-NLS-1$
+                                    + ", startup=" + startupOption); //$NON-NLS-1$
 
-                    launch = workingCopy.launch(ILaunchManager.RUN_MODE, new NullProgressMonitor());
-                    ACTIVE_LAUNCHES.put(runKey, launch);
+                            launch = workingCopy.launch(ILaunchManager.RUN_MODE,
+                                new NullProgressMonitor());
+                            // Register BEFORE leaving the per-key lock so a concurrent
+                            // auto-chain on the same IB sees this launch as owned and
+                            // refuses to terminate it.
+                            LaunchLifecycleUtils.registerOwnedLaunch(launch);
+                            ACTIVE_LAUNCHES.put(runKey, launch);
+                        }
+                    }
                 }
             }
 
             String pollResult = pollLaunch(launch, reportDir, timeout, runKey);
             if (pollResult != null)
             {
-                return pollResult;
+                return prependPreLaunchInfo(preLaunch, pollResult);
             }
 
             // Polling window expired — return Pending without terminating the launch.
-            return buildPendingMessage(reportDir);
+            return prependPreLaunchInfo(preLaunch, buildPendingMessage(reportDir));
         }
         catch (CoreException e)
         {
@@ -482,6 +539,7 @@ public class RunYaxunitTestsTool implements IMcpTool
             return;
         }
         ACTIVE_LAUNCHES.entrySet().removeIf(e -> e.getValue() == launch);
+        LaunchLifecycleUtils.unregisterOwnedLaunch(launch);
     }
 
     /** Defensive sweep that drops any terminated launches still lingering in the map. */
@@ -503,6 +561,20 @@ public class RunYaxunitTestsTool implements IMcpTool
                 + "Report directory: `" + reportDir + "`\n\n" //$NON-NLS-1$ //$NON-NLS-2$
                 + "Call `run_yaxunit_tests` again with the same arguments to wait further " //$NON-NLS-1$
                 + "and fetch the JUnit XML once the launch completes.\n"; //$NON-NLS-1$
+    }
+
+    /**
+     * Prepends a one-line pre-launch summary to the given report, but only when
+     * the auto-chain actually terminated a live launch — a no-op chain is silent
+     * to avoid cluttering reports.
+     */
+    private static String prependPreLaunchInfo(PreLaunchResult preLaunch, String report)
+    {
+        if (preLaunch == null || preLaunch.getTerminatedCount() == 0)
+        {
+            return report;
+        }
+        return "> **Pre-launch:** " + preLaunch.summary() + "\n\n" + report; //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchTool.java
@@ -25,6 +25,7 @@ import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
 import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
 import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
+import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils;
 
 /**
  * Terminates 1С launches started from this EDT instance. The set of
@@ -381,14 +382,14 @@ public class TerminateLaunchTool implements IMcpTool
             else
             {
                 launch.terminate();
-                if (waitForTerminated(launch, timeoutSeconds * 1000L))
+                if (LaunchLifecycleUtils.waitForTerminated(launch, timeoutSeconds * 1000L))
                 {
                     result.code = R_TERMINATED;
                 }
                 else if (force)
                 {
                     forceTerminateProcesses(launch);
-                    if (waitForTerminated(launch, FORCE_GRACE_MS))
+                    if (LaunchLifecycleUtils.waitForTerminated(launch, FORCE_GRACE_MS))
                     {
                         result.code = R_FORCE_TERMINATED;
                     }
@@ -457,28 +458,6 @@ public class TerminateLaunchTool implements IMcpTool
                     + safeConfigName(launch), e);
             }
         }
-    }
-
-    private static boolean waitForTerminated(ILaunch launch, long maxMillis)
-    {
-        long deadline = System.currentTimeMillis() + maxMillis;
-        while (System.currentTimeMillis() < deadline)
-        {
-            if (launch.isTerminated())
-            {
-                return true;
-            }
-            try
-            {
-                Thread.sleep(LaunchConfigUtils.LAUNCH_POLL_INTERVAL_MS);
-            }
-            catch (InterruptedException e)
-            {
-                Thread.currentThread().interrupt();
-                return launch.isTerminated();
-            }
-        }
-        return launch.isTerminated();
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchTool.java
@@ -1,0 +1,846 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2026 Diversus23 (https://github.com/Diversus23)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.debug.core.DebugException;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.core.model.IDebugTarget;
+import org.eclipse.debug.core.model.IDisconnect;
+import org.eclipse.debug.core.model.IProcess;
+
+import com.ditrix.edt.mcp.server.Activator;
+import com.ditrix.edt.mcp.server.preferences.ToolParameterSettings;
+import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
+import com.ditrix.edt.mcp.server.protocol.JsonUtils;
+import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
+
+/**
+ * Terminates 1С launches started from this EDT instance. The set of
+ * affectable launches is constrained by {@link ILaunchManager#getLaunches()} —
+ * any 1С client started externally (Designer, ad-hoc {@code 1cv8c.exe},
+ * another EDT instance) is invisible to this tool and therefore safe.
+ *
+ * <p>Three selection modes (mutually exclusive):
+ * <ul>
+ *   <li>{@code launchConfigurationName} — single live launch by exact config name.</li>
+ *   <li>{@code projectName + applicationId} — single live launch by project + appId.</li>
+ *   <li>{@code all=true} (requires {@code confirm=true}) — every live EDT launch,
+ *       optionally narrowed by {@code projectName}.</li>
+ * </ul>
+ *
+ * <p>Attach launches ({@code RemoteRuntime} / {@code LocalRuntime}) are
+ * disconnected, not killed — the 1С cluster keeps running. Set
+ * {@code includeAttach=false} to skip them entirely.
+ *
+ * <p>By default the tool waits up to {@code timeoutSeconds} for a polite
+ * {@link ILaunch#terminate()} to take effect. With {@code force=true}, an
+ * unfinished termination escalates to {@link IProcess#terminate()} on the
+ * launch's processes — this can lose unsaved 1С state.
+ */
+public class TerminateLaunchTool implements IMcpTool
+{
+    public static final String NAME = "terminate_launch"; //$NON-NLS-1$
+
+    /** Fallback polite-wait window in seconds, used when preferences cannot be read. */
+    private static final int DEFAULT_TIMEOUT_SECONDS = 10;
+
+    /** Hard cap on polite wait, prevents accidental long blocks. */
+    private static final int MAX_TIMEOUT_SECONDS = 120;
+
+    /** Extra grace given to force-terminate after the polite window expires. */
+    private static final int FORCE_GRACE_MS = 3000;
+
+    /** Result codes (also written into the Markdown response). */
+    private static final String R_TERMINATED = "terminated"; //$NON-NLS-1$
+    private static final String R_FORCE_TERMINATED = "force_terminated"; //$NON-NLS-1$
+    private static final String R_DETACHED = "detached"; //$NON-NLS-1$
+    private static final String R_TIMEOUT = "timeout"; //$NON-NLS-1$
+    private static final String R_ALREADY_TERMINATED = "already_terminated"; //$NON-NLS-1$
+    private static final String R_ERROR = "error"; //$NON-NLS-1$
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Terminate one or more 1С launches that were started from THIS EDT instance " //$NON-NLS-1$
+            + "(runtime-client or Attach). Only launches visible via the Eclipse launch manager " //$NON-NLS-1$
+            + "can be affected — 1С clients started externally (Designer, ad-hoc 1cv8c.exe, " //$NON-NLS-1$
+            + "another EDT) are never touched. " //$NON-NLS-1$
+            + "Select target via launchConfigurationName, or projectName+applicationId, " //$NON-NLS-1$
+            + "or all=true (requires confirm=true). " //$NON-NLS-1$
+            + "Attach configurations are disconnected (the 1С server keeps running) — " //$NON-NLS-1$
+            + "set includeAttach=false to skip them. " //$NON-NLS-1$
+            + "Use list_configurations first to see what is currently running."; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getInputSchema()
+    {
+        return JsonSchemaBuilder.object()
+            .stringProperty("launchConfigurationName", //$NON-NLS-1$
+                "Exact EDT launch configuration name (from list_configurations) to terminate.") //$NON-NLS-1$
+            .stringProperty("projectName", //$NON-NLS-1$
+                "EDT project name. Combine with applicationId for a single launch, or with " //$NON-NLS-1$
+                    + "all=true to narrow 'terminate all' to one project.") //$NON-NLS-1$
+            .stringProperty("applicationId", //$NON-NLS-1$
+                "Application ID from get_applications. Requires projectName.") //$NON-NLS-1$
+            .booleanProperty("all", //$NON-NLS-1$
+                "Terminate every live EDT launch (optionally narrowed by projectName). " //$NON-NLS-1$
+                    + "Requires confirm=true. Default: false.") //$NON-NLS-1$
+            .booleanProperty("confirm", //$NON-NLS-1$
+                "Must be true when all=true. Guard against accidental mass termination.") //$NON-NLS-1$
+            .booleanProperty("force", //$NON-NLS-1$
+                "If a polite ILaunch.terminate() does not finish within timeoutSeconds, " //$NON-NLS-1$
+                    + "escalate to IProcess.terminate() (OS-level kill). " //$NON-NLS-1$
+                    + "May lose unsaved 1С state. Default: false. Ignored for Attach.") //$NON-NLS-1$
+            .integerProperty("timeoutSeconds", //$NON-NLS-1$
+                "How long to wait for a polite termination per launch. " //$NON-NLS-1$
+                    + "Default is configured in EDT preferences (MCP Server → Tools → terminate_launch), " //$NON-NLS-1$
+                    + "factory default 10. Clamped to [1, 120].") //$NON-NLS-1$
+            .booleanProperty("includeAttach", //$NON-NLS-1$
+                "Whether to act on Attach configurations (RemoteRuntime/LocalRuntime). " //$NON-NLS-1$
+                    + "When true, Attach launches are disconnected (the 1С cluster keeps running). " //$NON-NLS-1$
+                    + "Default: true.") //$NON-NLS-1$
+            .build();
+    }
+
+    @Override
+    public ResponseType getResponseType()
+    {
+        return ResponseType.MARKDOWN;
+    }
+
+    @Override
+    public String getResultFileName(Map<String, String> params)
+    {
+        String name = JsonUtils.extractStringArgument(params, "launchConfigurationName"); //$NON-NLS-1$
+        if (name != null && !name.isEmpty())
+        {
+            String safe = name.replaceAll("[^a-zA-Z0-9._-]", "-").toLowerCase(); //$NON-NLS-1$ //$NON-NLS-2$
+            return "terminate-" + safe + ".md"; //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        boolean all = JsonUtils.extractBooleanArgument(params, "all", false); //$NON-NLS-1$
+        if (all)
+        {
+            String project = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
+            if (project != null && !project.isEmpty())
+            {
+                String safe = project.replaceAll("[^a-zA-Z0-9._-]", "-").toLowerCase(); //$NON-NLS-1$ //$NON-NLS-2$
+                return "terminate-all-" + safe + ".md"; //$NON-NLS-1$ //$NON-NLS-2$
+            }
+            return "terminate-all.md"; //$NON-NLS-1$
+        }
+        // projectName + applicationId mode — include both in the filename so
+        // parallel calls against different IBs don't overwrite each other's
+        // result file.
+        String project = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
+        String appId = JsonUtils.extractStringArgument(params, "applicationId"); //$NON-NLS-1$
+        if (project != null && !project.isEmpty() && appId != null && !appId.isEmpty())
+        {
+            String safeProject = project.replaceAll("[^a-zA-Z0-9._-]", "-").toLowerCase(); //$NON-NLS-1$ //$NON-NLS-2$
+            String safeAppId = appId.replaceAll("[^a-zA-Z0-9._-]", "-").toLowerCase(); //$NON-NLS-1$ //$NON-NLS-2$
+            // Truncate to keep the path short — agents sometimes pass long UUIDs.
+            if (safeAppId.length() > 16)
+            {
+                safeAppId = safeAppId.substring(0, 16);
+            }
+            return "terminate-" + safeProject + "-" + safeAppId + ".md"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        }
+        return "terminate-launch.md"; //$NON-NLS-1$
+    }
+
+    @Override
+    public String execute(Map<String, String> params)
+    {
+        String configName = JsonUtils.extractStringArgument(params, "launchConfigurationName"); //$NON-NLS-1$
+        String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
+        String applicationId = JsonUtils.extractStringArgument(params, "applicationId"); //$NON-NLS-1$
+        boolean all = JsonUtils.extractBooleanArgument(params, "all", false); //$NON-NLS-1$
+        boolean confirm = JsonUtils.extractBooleanArgument(params, "confirm", false); //$NON-NLS-1$
+        boolean force = JsonUtils.extractBooleanArgument(params, "force", false); //$NON-NLS-1$
+        boolean includeAttach = JsonUtils.extractBooleanArgument(params, "includeAttach", true); //$NON-NLS-1$
+        int configuredDefault = ToolParameterSettings.getInstance()
+            .getParameterValue(NAME, "timeoutSeconds", DEFAULT_TIMEOUT_SECONDS); //$NON-NLS-1$
+        int timeoutSeconds = JsonUtils.extractIntArgument(params, "timeoutSeconds", configuredDefault); //$NON-NLS-1$
+        if (timeoutSeconds < 1)
+        {
+            timeoutSeconds = 1;
+        }
+        else if (timeoutSeconds > MAX_TIMEOUT_SECONDS)
+        {
+            timeoutSeconds = MAX_TIMEOUT_SECONDS;
+        }
+
+        boolean hasName = configName != null && !configName.isEmpty();
+        boolean hasProject = projectName != null && !projectName.isEmpty();
+        boolean hasAppId = applicationId != null && !applicationId.isEmpty();
+
+        String validationError = validateSelection(hasName, hasProject, hasAppId, all, confirm);
+        if (validationError != null)
+        {
+            return validationError;
+        }
+
+        try
+        {
+            ILaunchManager launchManager = LaunchConfigUtils.getLaunchManager();
+            if (launchManager == null)
+            {
+                return "**Error:** Launch manager is not available."; //$NON-NLS-1$
+            }
+
+            List<ILaunch> targets = selectTargets(launchManager, configName, projectName,
+                applicationId, all, hasName, hasProject, hasAppId);
+
+            if (!includeAttach)
+            {
+                Iterator<ILaunch> it = targets.iterator();
+                while (it.hasNext())
+                {
+                    if (LaunchConfigUtils.isAttachConfig(it.next().getLaunchConfiguration()))
+                    {
+                        it.remove();
+                    }
+                }
+            }
+
+            if (targets.isEmpty())
+            {
+                return renderNothingToTerminate(configName, projectName, applicationId, all,
+                    includeAttach);
+            }
+
+            // For all=true with confirmation, additionally guard the count threshold —
+            // not strictly required, but useful evidence in the response.
+            List<TerminationResult> results = new ArrayList<>();
+            for (ILaunch launch : targets)
+            {
+                results.add(terminateOne(launch, timeoutSeconds, force));
+            }
+
+            return renderResults(results, configName, projectName, applicationId, all,
+                includeAttach);
+        }
+        catch (RuntimeException e)
+        {
+            Activator.logError("Error in terminate_launch", e); //$NON-NLS-1$
+            return "**Error:** " + e.getMessage(); //$NON-NLS-1$
+        }
+    }
+
+    private static String validateSelection(boolean hasName, boolean hasProject, boolean hasAppId,
+            boolean all, boolean confirm)
+    {
+        // Count engaged modes — each set of params that activates a selection mode.
+        int modeCount = 0;
+        if (hasName)
+        {
+            modeCount++;
+        }
+        if (hasProject && hasAppId)
+        {
+            modeCount++;
+        }
+        if (all)
+        {
+            modeCount++;
+        }
+
+        if (modeCount > 1)
+        {
+            return "**Error:** Selection modes are mutually exclusive. " //$NON-NLS-1$
+                + "Choose ONE of: `launchConfigurationName`, " //$NON-NLS-1$
+                + "`projectName + applicationId`, or `all=true`."; //$NON-NLS-1$
+        }
+        // applicationId without all=true makes sense only paired with projectName.
+        // When hasName is set, name fully determines the target — extras are ignored.
+        if (hasAppId && !hasProject && !all && !hasName)
+        {
+            return "**Error:** `applicationId` requires `projectName`."; //$NON-NLS-1$
+        }
+        // applicationId is meaningless with all=true — that mode is project-scoped at best.
+        if (hasAppId && all)
+        {
+            return "**Error:** `applicationId` cannot be combined with `all=true`. " //$NON-NLS-1$
+                + "Use `projectName + applicationId` for a single launch, or " //$NON-NLS-1$
+                + "`all=true` (optionally with `projectName`) for mass termination."; //$NON-NLS-1$
+        }
+        // projectName alone, without applicationId and without all=true, is ambiguous.
+        if (hasProject && !hasAppId && !all && !hasName)
+        {
+            return "**Error:** `projectName` alone is not a selection. " //$NON-NLS-1$
+                + "Add `applicationId` for a single launch, or `all=true` " //$NON-NLS-1$
+                + "to terminate every live launch of that project."; //$NON-NLS-1$
+        }
+        if (modeCount == 0)
+        {
+            return "**Error:** Provide exactly one of: `launchConfigurationName`, " //$NON-NLS-1$
+                + "`projectName + applicationId`, or `all=true`."; //$NON-NLS-1$
+        }
+        if (all && !confirm)
+        {
+            return "**Error:** Confirmation required: pass `confirm=true` to terminate " //$NON-NLS-1$
+                + "ALL EDT-launched 1С instances. Use `list_configurations` first to see " //$NON-NLS-1$
+                + "what is currently running."; //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    private static List<ILaunch> selectTargets(ILaunchManager launchManager, String configName,
+            String projectName, String applicationId, boolean all, boolean hasName,
+            boolean hasProject, boolean hasAppId)
+    {
+        List<ILaunch> targets = new ArrayList<>();
+        if (hasName)
+        {
+            ILaunch launch = LaunchConfigUtils.findLiveLaunchByName(launchManager, configName);
+            if (launch != null)
+            {
+                targets.add(launch);
+            }
+            return targets;
+        }
+        if (hasProject && hasAppId)
+        {
+            // Scope search to the project first, then match applicationId. Avoids a false
+            // not_found if some other project happens to carry the same applicationId
+            // (ATTR_APPLICATION_ID is an arbitrary EDT-assigned string with per-project
+            // uniqueness only).
+            for (ILaunch launch : LaunchConfigUtils.getAllLiveLaunches(launchManager, projectName))
+            {
+                if (applicationId.equals(LaunchConfigUtils.getApplicationIdFor(launch)))
+                {
+                    targets.add(launch);
+                    break;
+                }
+            }
+            return targets;
+        }
+        if (all)
+        {
+            String projectFilter = hasProject ? projectName : null;
+            targets.addAll(LaunchConfigUtils.getAllLiveLaunches(launchManager, projectFilter));
+        }
+        return targets;
+    }
+
+    /**
+     * Terminates a single launch and reports the outcome. Attach launches are
+     * disconnected via {@link IDisconnect}; runtime-client launches go through
+     * {@link ILaunch#terminate()} with optional {@link IProcess#terminate()}
+     * escalation on timeout.
+     */
+    private static TerminationResult terminateOne(ILaunch launch, int timeoutSeconds, boolean force)
+    {
+        TerminationResult result = new TerminationResult(launch);
+        if (launch.isTerminated())
+        {
+            result.code = R_ALREADY_TERMINATED;
+            return result;
+        }
+
+        long start = System.currentTimeMillis();
+        boolean attach = result.attach;
+        try
+        {
+            if (attach)
+            {
+                disconnectAll(launch);
+                // For attach launches, "done" means every debug target is either
+                // terminated or disconnected — NOT that ILaunch.isTerminated() flips.
+                // Per Eclipse Debug Platform contract, disconnect leaves the debuggee
+                // running, so isTerminated may stay false indefinitely.
+                if (waitForAttachDone(launch, timeoutSeconds * 1000L))
+                {
+                    result.code = R_DETACHED;
+                }
+                else
+                {
+                    result.code = R_TIMEOUT;
+                    result.note = "Attach disconnect did not complete in time. " //$NON-NLS-1$
+                        + "The debugger may still be detaching."; //$NON-NLS-1$
+                }
+            }
+            else
+            {
+                launch.terminate();
+                if (waitForTerminated(launch, timeoutSeconds * 1000L))
+                {
+                    result.code = R_TERMINATED;
+                }
+                else if (force)
+                {
+                    forceTerminateProcesses(launch);
+                    if (waitForTerminated(launch, FORCE_GRACE_MS))
+                    {
+                        result.code = R_FORCE_TERMINATED;
+                    }
+                    else
+                    {
+                        result.code = R_TIMEOUT;
+                        result.note = "Force-terminate sent but launch still not marked terminated."; //$NON-NLS-1$
+                    }
+                }
+                else
+                {
+                    result.code = R_TIMEOUT;
+                    result.note = "Still terminating in background. " //$NON-NLS-1$
+                        + "Re-run with `force=true` to kill the OS process."; //$NON-NLS-1$
+                }
+            }
+        }
+        catch (DebugException e)
+        {
+            Activator.logError("Error terminating launch " + result.configName, e); //$NON-NLS-1$
+            result.code = R_ERROR;
+            result.note = e.getMessage();
+        }
+        result.durationMs = System.currentTimeMillis() - start;
+        return result;
+    }
+
+    private static void disconnectAll(ILaunch launch) throws DebugException
+    {
+        boolean any = false;
+        for (IDebugTarget target : launch.getDebugTargets())
+        {
+            if (target instanceof IDisconnect)
+            {
+                IDisconnect d = (IDisconnect) target;
+                if (d.canDisconnect())
+                {
+                    d.disconnect();
+                    any = true;
+                }
+            }
+        }
+        // If no debug target supports disconnect, fall back to a regular terminate —
+        // for attach configs this is rare, but we should not silently no-op.
+        if (!any && launch.canTerminate())
+        {
+            launch.terminate();
+        }
+    }
+
+    private static void forceTerminateProcesses(ILaunch launch)
+    {
+        for (IProcess process : launch.getProcesses())
+        {
+            if (process == null || process.isTerminated())
+            {
+                continue;
+            }
+            try
+            {
+                process.terminate();
+            }
+            catch (DebugException e)
+            {
+                Activator.logError("Error force-terminating process for launch " //$NON-NLS-1$
+                    + safeConfigName(launch), e);
+            }
+        }
+    }
+
+    private static boolean waitForTerminated(ILaunch launch, long maxMillis)
+    {
+        long deadline = System.currentTimeMillis() + maxMillis;
+        while (System.currentTimeMillis() < deadline)
+        {
+            if (launch.isTerminated())
+            {
+                return true;
+            }
+            try
+            {
+                Thread.sleep(LaunchConfigUtils.LAUNCH_POLL_INTERVAL_MS);
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+                return launch.isTerminated();
+            }
+        }
+        return launch.isTerminated();
+    }
+
+    /**
+     * Wait criterion for attach launches: success when every debug target is
+     * either terminated OR disconnected. Per Eclipse Debug Platform contract,
+     * {@link IDisconnect#disconnect()} does not flip {@link ILaunch#isTerminated()};
+     * the 1С server keeps running, only the debugger detaches.
+     */
+    private static boolean waitForAttachDone(ILaunch launch, long maxMillis)
+    {
+        long deadline = System.currentTimeMillis() + maxMillis;
+        while (System.currentTimeMillis() < deadline)
+        {
+            if (isAttachDetached(launch))
+            {
+                return true;
+            }
+            try
+            {
+                Thread.sleep(LaunchConfigUtils.LAUNCH_POLL_INTERVAL_MS);
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+                return isAttachDetached(launch);
+            }
+        }
+        return isAttachDetached(launch);
+    }
+
+    private static boolean isAttachDetached(ILaunch launch)
+    {
+        if (launch.isTerminated())
+        {
+            return true;
+        }
+        IDebugTarget[] targets = launch.getDebugTargets();
+        if (targets.length == 0)
+        {
+            // Eclipse Launch is "terminated" only when all processes AND targets
+            // are terminated; with zero targets we already know the launch state.
+            return false;
+        }
+        for (IDebugTarget target : targets)
+        {
+            if (target == null)
+            {
+                continue;
+            }
+            if (target.isTerminated())
+            {
+                continue;
+            }
+            if (target instanceof IDisconnect && ((IDisconnect) target).isDisconnected())
+            {
+                continue;
+            }
+            return false;
+        }
+        return true;
+    }
+
+    private static String safeConfigName(ILaunch launch)
+    {
+        ILaunchConfiguration cfg = launch.getLaunchConfiguration();
+        return cfg != null ? cfg.getName() : "<unknown>"; //$NON-NLS-1$
+    }
+
+    // === Rendering ===
+
+    private static String renderNothingToTerminate(String configName, String projectName,
+            String applicationId, boolean all, boolean includeAttach)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("# No Running Launches\n\n"); //$NON-NLS-1$
+        sb.append("**Result:** not_found\n"); //$NON-NLS-1$
+        sb.append("**Scope:** ").append(formatScope(configName, projectName, applicationId, all)) //$NON-NLS-1$
+            .append('\n');
+        if (!includeAttach)
+        {
+            sb.append("**includeAttach:** false\n"); //$NON-NLS-1$
+        }
+        sb.append('\n');
+        sb.append("No live EDT launch matched the request. Use `list_configurations` to see " //$NON-NLS-1$
+            + "what is currently running (look for entries with `running: true`)."); //$NON-NLS-1$
+        return sb.toString();
+    }
+
+    private static String renderResults(List<TerminationResult> results, String configName,
+            String projectName, String applicationId, boolean all, boolean includeAttach)
+    {
+        int terminated = 0;
+        int detached = 0;
+        int timedOut = 0;
+        int errors = 0;
+        int alreadyTerminated = 0;
+        for (TerminationResult r : results)
+        {
+            switch (r.code)
+            {
+                case R_TERMINATED:
+                case R_FORCE_TERMINATED:
+                    terminated++;
+                    break;
+                case R_DETACHED:
+                    detached++;
+                    break;
+                case R_TIMEOUT:
+                    timedOut++;
+                    break;
+                case R_ERROR:
+                    errors++;
+                    break;
+                case R_ALREADY_TERMINATED:
+                    alreadyTerminated++;
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        boolean hasIssues = timedOut > 0 || errors > 0;
+        StringBuilder sb = new StringBuilder();
+        if (results.size() == 1 && !hasIssues)
+        {
+            renderSingle(sb, results.get(0));
+        }
+        else
+        {
+            sb.append("# Launches Terminated"); //$NON-NLS-1$
+            if (hasIssues)
+            {
+                sb.append(" (with issues)"); //$NON-NLS-1$
+            }
+            sb.append("\n\n"); //$NON-NLS-1$
+            sb.append("**Total:** ").append(results.size()) //$NON-NLS-1$
+                .append(" (terminated: ").append(terminated) //$NON-NLS-1$
+                .append(", detached: ").append(detached) //$NON-NLS-1$
+                .append(", timeout: ").append(timedOut) //$NON-NLS-1$
+                .append(", already_terminated: ").append(alreadyTerminated) //$NON-NLS-1$
+                .append(", errors: ").append(errors).append(")\n"); //$NON-NLS-1$ //$NON-NLS-2$
+            sb.append("**Scope:** ").append(formatScope(configName, projectName, applicationId, all)) //$NON-NLS-1$
+                .append('\n');
+            if (!includeAttach)
+            {
+                sb.append("**includeAttach:** false\n"); //$NON-NLS-1$
+            }
+
+            appendSection(sb, "## Terminated", results, //$NON-NLS-1$
+                r -> R_TERMINATED.equals(r.code) || R_FORCE_TERMINATED.equals(r.code), false);
+            appendSection(sb, "## Detached (Attach configurations)", results, //$NON-NLS-1$
+                r -> R_DETACHED.equals(r.code), true);
+            appendSection(sb, "## Already Terminated", results, //$NON-NLS-1$
+                r -> R_ALREADY_TERMINATED.equals(r.code), false);
+            appendIssueSection(sb, "## Timed Out", results, R_TIMEOUT); //$NON-NLS-1$
+            appendIssueSection(sb, "## Errors", results, R_ERROR); //$NON-NLS-1$
+        }
+
+        if (detached > 0)
+        {
+            sb.append("\n> Attach configurations only disconnect the debugger — " //$NON-NLS-1$
+                + "the 1С server (ragent/rphost) keeps running. " //$NON-NLS-1$
+                + "Pass `includeAttach=false` to skip Attach launches entirely.\n"); //$NON-NLS-1$
+        }
+        sb.append("\n> Only launches started from this EDT instance are affected. " //$NON-NLS-1$
+            + "Externally launched 1С clients are not touched by this tool.\n"); //$NON-NLS-1$
+        return sb.toString();
+    }
+
+    private static void renderSingle(StringBuilder sb, TerminationResult r)
+    {
+        switch (r.code)
+        {
+            case R_TERMINATED:
+            case R_FORCE_TERMINATED:
+                sb.append("# Launch Terminated\n\n"); //$NON-NLS-1$
+                break;
+            case R_DETACHED:
+                sb.append("# Launch Detached\n\n"); //$NON-NLS-1$
+                break;
+            case R_ALREADY_TERMINATED:
+                sb.append("# Launch Already Terminated\n\n"); //$NON-NLS-1$
+                break;
+            case R_TIMEOUT:
+                sb.append("# Launch Termination Timed Out\n\n"); //$NON-NLS-1$
+                break;
+            case R_ERROR:
+                sb.append("# Launch Termination Failed\n\n"); //$NON-NLS-1$
+                break;
+            default:
+                sb.append("# Launch Termination Result\n\n"); //$NON-NLS-1$
+                break;
+        }
+        sb.append("**Result:** ").append(r.code).append('\n'); //$NON-NLS-1$
+        sb.append("**Launch configuration:** ").append(r.configName).append('\n'); //$NON-NLS-1$
+        if (r.projectName != null && !r.projectName.isEmpty())
+        {
+            sb.append("**Project:** ").append(r.projectName).append('\n'); //$NON-NLS-1$
+        }
+        if (r.applicationId != null && !r.applicationId.isEmpty())
+        {
+            sb.append("**Application ID:** ").append(r.applicationId).append('\n'); //$NON-NLS-1$
+        }
+        if (r.mode != null && !r.mode.isEmpty())
+        {
+            sb.append("**Mode:** ").append(r.mode).append('\n'); //$NON-NLS-1$
+        }
+        sb.append("**Attach:** ").append(r.attach ? "Yes" : "No").append('\n'); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        sb.append("**Duration:** ").append(r.durationMs).append(" ms\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (r.note != null && !r.note.isEmpty())
+        {
+            sb.append("**Note:** ").append(r.note).append('\n'); //$NON-NLS-1$
+        }
+    }
+
+    private static void appendSection(StringBuilder sb, String heading,
+            List<TerminationResult> results, java.util.function.Predicate<TerminationResult> filter,
+            boolean attachSection)
+    {
+        List<TerminationResult> matching = new ArrayList<>();
+        for (TerminationResult r : results)
+        {
+            if (filter.test(r))
+            {
+                matching.add(r);
+            }
+        }
+        if (matching.isEmpty())
+        {
+            return;
+        }
+        sb.append('\n').append(heading).append("\n\n"); //$NON-NLS-1$
+        if (attachSection)
+        {
+            sb.append("| Configuration | Project | Debug Server URL | Infobase Alias | Duration |\n"); //$NON-NLS-1$
+            sb.append("|---|---|---|---|---|\n"); //$NON-NLS-1$
+            for (TerminationResult r : matching)
+            {
+                sb.append("| ").append(escape(r.configName)) //$NON-NLS-1$
+                    .append(" | ").append(escape(r.projectName)) //$NON-NLS-1$
+                    .append(" | ").append(escape(r.debugServerUrl)) //$NON-NLS-1$
+                    .append(" | ").append(escape(r.infobaseAlias)) //$NON-NLS-1$
+                    .append(" | ").append(r.durationMs).append(" ms |\n"); //$NON-NLS-1$ //$NON-NLS-2$
+            }
+        }
+        else
+        {
+            sb.append("| Configuration | Project | Application ID | Mode | Result | Duration |\n"); //$NON-NLS-1$
+            sb.append("|---|---|---|---|---|---|\n"); //$NON-NLS-1$
+            for (TerminationResult r : matching)
+            {
+                sb.append("| ").append(escape(r.configName)) //$NON-NLS-1$
+                    .append(" | ").append(escape(r.projectName)) //$NON-NLS-1$
+                    .append(" | ").append(escape(r.applicationId)) //$NON-NLS-1$
+                    .append(" | ").append(escape(r.mode)) //$NON-NLS-1$
+                    .append(" | ").append(r.code) //$NON-NLS-1$
+                    .append(" | ").append(r.durationMs).append(" ms |\n"); //$NON-NLS-1$ //$NON-NLS-2$
+            }
+        }
+    }
+
+    private static void appendIssueSection(StringBuilder sb, String heading,
+            List<TerminationResult> results, String code)
+    {
+        List<TerminationResult> matching = new ArrayList<>();
+        for (TerminationResult r : results)
+        {
+            if (code.equals(r.code))
+            {
+                matching.add(r);
+            }
+        }
+        if (matching.isEmpty())
+        {
+            return;
+        }
+        sb.append('\n').append(heading).append("\n\n"); //$NON-NLS-1$
+        sb.append("| Configuration | Project | Application ID | Attach | Note |\n"); //$NON-NLS-1$
+        sb.append("|---|---|---|---|---|\n"); //$NON-NLS-1$
+        for (TerminationResult r : matching)
+        {
+            sb.append("| ").append(escape(r.configName)) //$NON-NLS-1$
+                .append(" | ").append(escape(r.projectName)) //$NON-NLS-1$
+                .append(" | ").append(escape(r.applicationId)) //$NON-NLS-1$
+                .append(" | ").append(r.attach ? "Yes" : "No") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                .append(" | ").append(escape(r.note)).append(" |\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+    }
+
+    private static String formatScope(String configName, String projectName, String applicationId,
+            boolean all)
+    {
+        if (configName != null && !configName.isEmpty())
+        {
+            return "launchConfigurationName=" + configName; //$NON-NLS-1$
+        }
+        if (all)
+        {
+            return projectName != null && !projectName.isEmpty()
+                ? "all live launches of project=" + projectName //$NON-NLS-1$
+                : "all live EDT launches"; //$NON-NLS-1$
+        }
+        StringBuilder sb = new StringBuilder();
+        if (projectName != null && !projectName.isEmpty())
+        {
+            sb.append("project=").append(projectName); //$NON-NLS-1$
+        }
+        if (applicationId != null && !applicationId.isEmpty())
+        {
+            if (sb.length() > 0)
+            {
+                sb.append(", "); //$NON-NLS-1$
+            }
+            sb.append("applicationId=").append(applicationId); //$NON-NLS-1$
+        }
+        return sb.length() > 0 ? sb.toString() : "<empty>"; //$NON-NLS-1$
+    }
+
+    private static String escape(String value)
+    {
+        if (value == null || value.isEmpty())
+        {
+            return ""; //$NON-NLS-1$
+        }
+        // Markdown table cell: escape pipes and collapse newlines.
+        return value.replace("|", "\\|").replace("\n", " "); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+    }
+
+    /**
+     * Captured snapshot of a launch's identity at termination time, plus the
+     * outcome of the termination attempt. Built eagerly so the rendering code
+     * can read the values after the underlying {@link ILaunch} is gone.
+     */
+    private static final class TerminationResult
+    {
+        final String configName;
+        final String projectName;
+        final String applicationId;
+        final boolean attach;
+        final String mode;
+        final String debugServerUrl;
+        final String infobaseAlias;
+        String code;
+        String note;
+        long durationMs;
+
+        TerminationResult(ILaunch launch)
+        {
+            ILaunchConfiguration cfg = launch.getLaunchConfiguration();
+            this.configName = cfg != null ? cfg.getName() : "<unknown>"; //$NON-NLS-1$
+            this.projectName = cfg != null
+                ? LaunchConfigUtils.readAttribute(cfg, LaunchConfigUtils.ATTR_PROJECT_NAME, "") //$NON-NLS-1$
+                : ""; //$NON-NLS-1$
+            this.applicationId = LaunchConfigUtils.getApplicationIdFor(launch);
+            this.attach = LaunchConfigUtils.isAttachConfig(cfg);
+            this.mode = launch.getLaunchMode();
+            this.debugServerUrl = cfg != null
+                ? LaunchConfigUtils.readAttribute(cfg, LaunchConfigUtils.ATTR_DEBUG_SERVER_URL, "") //$NON-NLS-1$
+                : ""; //$NON-NLS-1$
+            this.infobaseAlias = cfg != null
+                ? LaunchConfigUtils.readAttribute(cfg, LaunchConfigUtils.ATTR_DEBUG_INFOBASE_ALIAS, "") //$NON-NLS-1$
+                : ""; //$NON-NLS-1$
+        }
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
@@ -54,7 +54,11 @@ public class UpdateDatabaseTool implements IMcpTool
         return "Update database (infobase) for an application. " //$NON-NLS-1$
             + "Target the application either by launchConfigurationName (preferred; " //$NON-NLS-1$
             + "from list_configurations) or by projectName + applicationId (from get_applications). " //$NON-NLS-1$
-            + "Supports full update (complete reload) and incremental update (changes only)."; //$NON-NLS-1$
+            + "Supports full update (complete reload) and incremental update (changes only). " //$NON-NLS-1$
+            + "IMPORTANT: if a 1С client launched from this EDT is currently running against " //$NON-NLS-1$
+            + "the target infobase, the update typically fails because the IB is held in exclusive " //$NON-NLS-1$
+            + "use. Check `list_configurations` for `running: true`; if so, call `terminate_launch` " //$NON-NLS-1$
+            + "first (it only affects launches started from this EDT instance), then retry."; //$NON-NLS-1$
     }
 
     @Override

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
@@ -17,7 +17,6 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchManager;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
 import com.ditrix.edt.mcp.server.Activator;
@@ -26,6 +25,7 @@ import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
 import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
+import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils;
 import com.ditrix.edt.mcp.server.utils.ProjectStateChecker;
 import com.e1c.g5.dt.applications.ApplicationException;
 import com.e1c.g5.dt.applications.ApplicationUpdateState;
@@ -202,31 +202,15 @@ public class UpdateDatabaseTool implements IMcpTool
                     ? ApplicationUpdateType.FULL 
                     : ApplicationUpdateType.INCREMENTAL;
             
-            // Create execution context with Shell from UI thread
+            // Create execution context with the active Shell so EDT can parent
+            // its dialogs. Shared SWT-grab lives in LaunchLifecycleUtils.
             ExecutionContext context = new ExecutionContext();
-            
-            // Get Shell from Display and set it in context
-            Display display = Display.getDefault();
-            if (display != null && !display.isDisposed())
+            Shell shell = LaunchLifecycleUtils.grabActiveShell();
+            if (shell != null)
             {
-                final Shell[] shellHolder = new Shell[1];
-                display.syncExec(() -> {
-                    shellHolder[0] = display.getActiveShell();
-                    if (shellHolder[0] == null)
-                    {
-                        Shell[] shells = display.getShells();
-                        if (shells.length > 0)
-                        {
-                            shellHolder[0] = shells[0];
-                        }
-                    }
-                });
-                if (shellHolder[0] != null)
-                {
-                    context.setProperty(ExecutionContext.ACTIVE_SHELL_NAME, shellHolder[0]);
-                }
+                context.setProperty(ExecutionContext.ACTIVE_SHELL_NAME, shell);
             }
-            
+
             Activator.logInfo("Update database: project=" + projectName +  //$NON-NLS-1$
                     ", application=" + applicationId +  //$NON-NLS-1$
                     ", type=" + updateType +  //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchConfigUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchConfigUtils.java
@@ -38,6 +38,13 @@ import com.ditrix.edt.mcp.server.Activator;
  */
 public final class LaunchConfigUtils
 {
+    /**
+     * Poll interval (milliseconds) for waiting on launch state transitions —
+     * termination, disconnection, DB update settling. Shared by all callers
+     * that need to spin-wait on Eclipse debug API state.
+     */
+    public static final int LAUNCH_POLL_INTERVAL_MS = 100;
+
     /** 1C:EDT Runtime Client launch configuration type id. */
     public static final String LAUNCH_CONFIG_TYPE_ID = "com._1c.g5.v8.dt.launching.core.RuntimeClient"; //$NON-NLS-1$
 
@@ -405,4 +412,81 @@ public final class LaunchConfigUtils
         DebugPlugin plugin = DebugPlugin.getDefault();
         return plugin != null ? plugin.getLaunchManager() : null;
     }
+
+    /**
+     * Returns all live (non-terminated) EDT launches in the launch manager.
+     *
+     * <p>This is the exhaustive set of 1С processes that the current EDT instance
+     * spawned (runtime-client) or attached to (Attach). Externally started 1С
+     * clients never appear here — that is a constructive guarantee of the
+     * Eclipse Debug Platform.
+     *
+     * @param launchManager Eclipse launch manager (must not be null)
+     * @param projectFilter optional project name; when non-empty, only launches
+     *                      whose configuration carries this {@code ATTR_PROJECT_NAME}
+     *                      are returned
+     * @return list of live launches (possibly empty)
+     */
+    public static List<ILaunch> getAllLiveLaunches(ILaunchManager launchManager, String projectFilter)
+    {
+        List<ILaunch> result = new ArrayList<>();
+        if (launchManager == null)
+        {
+            return result;
+        }
+        for (ILaunch launch : launchManager.getLaunches())
+        {
+            if (launch == null || launch.isTerminated())
+            {
+                continue;
+            }
+            ILaunchConfiguration config = launch.getLaunchConfiguration();
+            if (config == null || !isEdtConfig(config))
+            {
+                continue;
+            }
+            if (projectFilter != null && !projectFilter.isEmpty())
+            {
+                String project = readAttribute(config, ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+                if (!projectFilter.equals(project))
+                {
+                    continue;
+                }
+            }
+            result.add(launch);
+        }
+        return result;
+    }
+
+    /**
+     * Finds the live (non-terminated) launch whose configuration has the given
+     * exact name.
+     *
+     * @return matching launch, or {@code null} if no live launch carries that name
+     */
+    public static ILaunch findLiveLaunchByName(ILaunchManager launchManager, String name)
+    {
+        if (launchManager == null || name == null || name.isEmpty())
+        {
+            return null;
+        }
+        for (ILaunch launch : launchManager.getLaunches())
+        {
+            if (launch == null || launch.isTerminated())
+            {
+                continue;
+            }
+            ILaunchConfiguration config = launch.getLaunchConfiguration();
+            // Filter to EDT/1С configs only — config names are not unique across
+            // Eclipse launch types, so without this an unrelated Java/JUnit/etc.
+            // launch with a matching name would be selected and (with force=true)
+            // killed.
+            if (config != null && isEdtConfig(config) && name.equals(config.getName()))
+            {
+                return launch;
+            }
+        }
+        return null;
+    }
+
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
@@ -16,6 +16,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.swt.SWTError;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
@@ -464,7 +465,18 @@ public final class LaunchLifecycleUtils
 
     private static Shell grabActiveShell()
     {
-        Display display = Display.getDefault();
+        Display display;
+        try
+        {
+            // Headless-окружения (CI Linux без X-сервера, EDT через CLI без UI)
+            // не могут инициализировать SWT — gtk_init_check() бросает SWTError.
+            // В таком случае диалогов всё равно не будет, поэтому отдаём null.
+            display = Display.getDefault();
+        }
+        catch (SWTError | UnsatisfiedLinkError e)
+        {
+            return null;
+        }
         if (display == null || display.isDisposed())
         {
             return null;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
@@ -442,6 +442,60 @@ public final class LaunchLifecycleUtils
                 terminated++;
             }
 
+            // Second pass: stale Attach launches on the same project. Attach
+            // configs don't carry a real ATTR_APPLICATION_ID — getApplicationIdFor
+            // synthesises "attach:<name>", which never equals a runtime client's
+            // UUID, so the per-applicationId loop above never sweeps them. A
+            // lingering Attach (e.g. left over from a previous debug session) can
+            // mask which 1С client really holds the IB and clutter diagnostics,
+            // so disconnect it before the new spawn. Killing an Attach launch is
+            // just a debugger disconnect — the 1С server keeps running, no
+            // unsaved state is at risk.
+            for (ILaunch live : LaunchConfigUtils.getAllLiveLaunches(launchManager,
+                project.getName()))
+            {
+                if (!LaunchConfigUtils.isAttachConfig(live.getLaunchConfiguration()))
+                {
+                    continue;
+                }
+                String name = live.getLaunchConfiguration() != null
+                    ? live.getLaunchConfiguration().getName() : "<unknown>"; //$NON-NLS-1$
+                // Defensive: today both YAXUnit tools register only runtime
+                // launches, so an Attach in OWNED is purely hypothetical. If a
+                // future tool starts registering Attach launches as owned, we
+                // intentionally fast-fail here rather than skipping — at the
+                // attach-pass level we don't know which IB the foreign attach
+                // targets, and silent skip would risk a spawn that hangs on a
+                // locked IB until the MCP timeout. The error message points the
+                // caller at terminate_launch, which is the right escape hatch.
+                if (OWNED_LAUNCHES.contains(live))
+                {
+                    return new PreLaunchResult(false, terminated,
+                        "An Attach debug session for this project is owned by another " //$NON-NLS-1$
+                            + "MCP tool (launch '" + name + "'). Wait for it to finish, " //$NON-NLS-1$ //$NON-NLS-2$
+                            + "or call `terminate_launch` to disconnect it first."); //$NON-NLS-1$
+                }
+                boolean done = terminateAndWait(live, terminateTimeoutSeconds);
+                if (!done)
+                {
+                    // An Attach disconnect that doesn't complete is unusual but
+                    // not fatal to the test run: Attach launches don't hold the
+                    // IB lock (the foreign 1С client does), so a stuck disconnect
+                    // shouldn't block the new spawn. Log and continue.
+                    Activator.logError("Could not disconnect stale Attach launch '" //$NON-NLS-1$
+                        + name + "' within " + terminateTimeoutSeconds //$NON-NLS-1$
+                        + "s, continuing with the auto-chain", null); //$NON-NLS-1$
+                    continue;
+                }
+                // Surface attach disconnects in the log because the per-call
+                // PreLaunchResult counter slips them into the same total as
+                // runtime terminations — without this line, post-mortems can't
+                // tell which launches the second pass swept.
+                Activator.logInfo("Pre-launch auto-chain disconnected stale Attach launch '" //$NON-NLS-1$
+                    + name + "' on project " + project.getName()); //$NON-NLS-1$
+                terminated++;
+            }
+
             Optional<String> updateErr = updateApplicationIfNeeded(project, applicationId,
                 appManager);
             if (updateErr.isPresent())

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
@@ -1,6 +1,6 @@
 /**
  * MCP Server for EDT
- * Copyright (C) 2025 Diversus23 (https://github.com/Diversus23)
+ * Copyright (C) 2026 Diversus23 (https://github.com/Diversus23)
  * Licensed under AGPL-3.0-or-later
  */
 
@@ -517,14 +517,23 @@ public final class LaunchLifecycleUtils
             .getParameterValue("terminate_launch", "timeoutSeconds", 10); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
-    private static Shell grabActiveShell()
+    /**
+     * Returns the active SWT {@link Shell} (or the first available one) to seed
+     * an {@link ExecutionContext} so EDT can parent its dialogs correctly.
+     * Returns {@code null} in headless environments where no shell exists.
+     *
+     * <p>Shared by every tool that builds an {@code ExecutionContext} before
+     * calling {@link IApplicationManager#update} (update_database, debug_launch,
+     * the YAXUnit auto-chain) so the SWT-grab logic lives in exactly one place.
+     */
+    public static Shell grabActiveShell()
     {
         Display display;
         try
         {
-            // Headless-окружения (CI Linux без X-сервера, EDT через CLI без UI)
-            // не могут инициализировать SWT — gtk_init_check() бросает SWTError.
-            // В таком случае диалогов всё равно не будет, поэтому отдаём null.
+            // Headless environments (CI Linux with no X server, EDT via CLI with
+            // no UI) cannot initialise SWT — gtk_init_check() throws SWTError.
+            // No dialogs will appear there anyway, so we return null.
             display = Display.getDefault();
         }
         catch (SWTError | UnsatisfiedLinkError e)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
@@ -1,0 +1,486 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 Diversus23 (https://github.com/Diversus23)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.debug.core.DebugException;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+import com.ditrix.edt.mcp.server.Activator;
+import com.ditrix.edt.mcp.server.preferences.ToolParameterSettings;
+import com.e1c.g5.dt.applications.ApplicationException;
+import com.e1c.g5.dt.applications.ApplicationUpdateState;
+import com.e1c.g5.dt.applications.ApplicationUpdateType;
+import com.e1c.g5.dt.applications.ExecutionContext;
+import com.e1c.g5.dt.applications.IApplication;
+import com.e1c.g5.dt.applications.IApplicationManager;
+
+/**
+ * Shared helpers for the "prepare for a fresh launch" sequence used by tools
+ * that spawn 1С clients via {@code workingCopy.launch()} (YAXUnit run/debug
+ * tools, etc.).
+ *
+ * <p>The sequence is needed because EDT's launch delegate brings up its
+ * interactive "Update database before launch?" dialog whenever the
+ * configuration has unsynced changes, and that dialog blocks the MCP call
+ * indefinitely — especially if a 1С client is already holding the infobase in
+ * exclusive use, in which case even pressing OK fails on the lock.
+ *
+ * <p>By terminating any live launch of the target configuration first and
+ * then running {@link IApplicationManager#update} programmatically, we leave
+ * the IB in {@link ApplicationUpdateState#UPDATED} state — at which point the
+ * launch delegate skips the dialog entirely.
+ */
+public final class LaunchLifecycleUtils
+{
+    /**
+     * Per-{@code project + applicationId} locks that serialise the auto-chain
+     * (terminate-and-update) across MCP tools. Without this, two concurrent
+     * MCP calls targeting the same IB could race on {@code terminateAndWait}
+     * and {@code appManager.update()}. Keys are interned tuples and never
+     * removed — the set of (project, applicationId) pairs is finite in
+     * practice (one per EDT launch configuration).
+     */
+    private static final ConcurrentMap<String, Object> KEY_LOCKS = new ConcurrentHashMap<>();
+
+    /**
+     * Set of {@link ILaunch} instances that any MCP tool currently owns via
+     * the auto-chain. The auto-chain will refuse to terminate any launch in
+     * this set — instead it returns an error suggesting the caller wait or
+     * call {@code terminate_launch} explicitly. Both {@code run_yaxunit_tests}
+     * and {@code debug_yaxunit_tests} register their spawned launches here so
+     * concurrent calls to either tool against the same IB protect each other.
+     *
+     * <p>Identity-equals is intentional: Eclipse {@code Launch} (the default
+     * {@link ILaunch} implementation) inherits {@code Object.equals}, and we
+     * register exactly the instance returned by {@code workingCopy.launch()}.
+     * Terminated entries are pruned lazily inside {@link #prepareForFreshLaunch}.
+     */
+    private static final Set<ILaunch> OWNED_LAUNCHES = ConcurrentHashMap.newKeySet();
+
+    private LaunchLifecycleUtils()
+    {
+        // Utility class
+    }
+
+    /**
+     * Registers a launch as owned by the auto-chain. After this call,
+     * {@link #prepareForFreshLaunch} will refuse to terminate it — pass the
+     * launch through {@code terminate_launch} explicitly to stop it.
+     *
+     * <p>Callers must invoke this with the exact {@link ILaunch} reference
+     * returned by {@code workingCopy.launch()} so identity-equals lookups
+     * inside the auto-chain work.
+     */
+    public static void registerOwnedLaunch(ILaunch launch)
+    {
+        if (launch != null)
+        {
+            OWNED_LAUNCHES.add(launch);
+        }
+    }
+
+    /**
+     * Removes a launch from the owned registry. Optional — terminated launches
+     * are pruned automatically on the next {@link #prepareForFreshLaunch} call.
+     */
+    public static void unregisterOwnedLaunch(ILaunch launch)
+    {
+        if (launch != null)
+        {
+            OWNED_LAUNCHES.remove(launch);
+        }
+    }
+
+    /**
+     * Returns the monitor object used to serialise {@link #prepareForFreshLaunch}
+     * for the given {@code project + applicationId} pair. Callers that also
+     * need the same lock around their own pre-launch steps (e.g. updating a
+     * working copy) can synchronise on the returned object.
+     *
+     * <p>The internal key uses a NUL ({@code \u0000}) separator because
+     * Eclipse project names may contain spaces and other printable characters,
+     * which would otherwise allow keys to collide (e.g. {@code project="My",
+     * appId="Project x"} vs {@code project="My Project", appId="x"}).
+     */
+    public static Object lockFor(String projectName, String applicationId)
+    {
+        String key = (projectName != null ? projectName : "") //$NON-NLS-1$
+            + "\u0000" + (applicationId != null ? applicationId : ""); //$NON-NLS-1$ //$NON-NLS-2$
+        return KEY_LOCKS.computeIfAbsent(key, k -> new Object());
+    }
+
+    /**
+     * Result of {@link #prepareForFreshLaunch}. Either {@code ok=true} (caller
+     * may proceed with the launch) or {@code ok=false} with a populated
+     * {@link #error} (caller must abort).
+     */
+    public static final class PreLaunchResult
+    {
+        private final boolean ok;
+        private final int terminatedCount;
+        private final String error;
+
+        private PreLaunchResult(boolean ok, int terminatedCount, String error)
+        {
+            this.ok = ok;
+            this.terminatedCount = terminatedCount;
+            this.error = error;
+        }
+
+        public boolean isOk()
+        {
+            return ok;
+        }
+
+        public int getTerminatedCount()
+        {
+            return terminatedCount;
+        }
+
+        public String getError()
+        {
+            return error;
+        }
+
+        /**
+         * Returns a single-line human-readable summary, suitable for inclusion in
+         * a Markdown report or a JSON {@code preLaunch} field.
+         */
+        public String summary()
+        {
+            if (!ok)
+            {
+                return "failed: " + error; //$NON-NLS-1$
+            }
+            if (terminatedCount == 0)
+            {
+                return "no-op (no live launch held the lock; DB ready)"; //$NON-NLS-1$
+            }
+            return "terminated " + terminatedCount //$NON-NLS-1$
+                + " live launch" + (terminatedCount == 1 ? "" : "es") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                + "; DB ready"; //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Polls until {@link ILaunch#isTerminated} or the timeout elapses.
+     *
+     * @return {@code true} if the launch is terminated after the call
+     */
+    public static boolean waitForTerminated(ILaunch launch, long maxMillis)
+    {
+        long deadline = System.currentTimeMillis() + maxMillis;
+        while (System.currentTimeMillis() < deadline)
+        {
+            if (launch.isTerminated())
+            {
+                return true;
+            }
+            try
+            {
+                Thread.sleep(LaunchConfigUtils.LAUNCH_POLL_INTERVAL_MS);
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+                return launch.isTerminated();
+            }
+        }
+        return launch.isTerminated();
+    }
+
+    /**
+     * Politely terminates the given launch and waits up to {@code timeoutSeconds}
+     * for it to complete. Does NOT escalate to {@code IProcess.terminate()};
+     * callers that need force-kill semantics should use {@code terminate_launch}
+     * directly.
+     *
+     * @return {@code true} if the launch is terminated after the call
+     */
+    public static boolean terminateAndWait(ILaunch launch, int timeoutSeconds)
+    {
+        if (launch == null)
+        {
+            return true;
+        }
+        if (launch.isTerminated())
+        {
+            return true;
+        }
+        try
+        {
+            launch.terminate();
+        }
+        catch (DebugException e)
+        {
+            Activator.logError("Error initiating launch termination", e); //$NON-NLS-1$
+            return false;
+        }
+        return waitForTerminated(launch, Math.max(1, timeoutSeconds) * 1000L);
+    }
+
+    /**
+     * Brings the given application's database to {@link ApplicationUpdateState#UPDATED}
+     * if needed, using the same programmatic path as {@code update_database}.
+     * Skips the work when the state is already {@code UPDATED} or {@code BEING_UPDATED}.
+     *
+     * <p>Returns {@code Optional.empty()} on success (or no-op); on failure,
+     * returns a populated error message.
+     */
+    public static Optional<String> updateApplicationIfNeeded(IProject project, String applicationId,
+            IApplicationManager appManager)
+    {
+        if (appManager == null)
+        {
+            return Optional.of("IApplicationManager service is not available"); //$NON-NLS-1$
+        }
+        if (project == null || !project.exists() || !project.isOpen())
+        {
+            return Optional.of("Project is not available: " //$NON-NLS-1$
+                + (project != null ? project.getName() : "<null>")); //$NON-NLS-1$
+        }
+        try
+        {
+            Optional<IApplication> appOpt = appManager.getApplication(project, applicationId);
+            if (!appOpt.isPresent())
+            {
+                return Optional.of("Application not found: " + applicationId); //$NON-NLS-1$
+            }
+            IApplication application = appOpt.get();
+            ApplicationUpdateState state = appManager.getUpdateState(application);
+            if (state == ApplicationUpdateState.UPDATED)
+            {
+                return Optional.empty();
+            }
+            if (state == ApplicationUpdateState.BEING_UPDATED)
+            {
+                // Another caller (or a UI gesture) is already updating this IB.
+                // Wait for it to settle into UPDATED — if we proceeded to launch
+                // now, the delegate could still hit a locked / half-updated IB.
+                long maxMillis = getDefaultTerminateTimeoutSeconds() * 1000L;
+                state = waitForUpdateSettled(appManager, application, maxMillis);
+                if (state == ApplicationUpdateState.UPDATED)
+                {
+                    return Optional.empty();
+                }
+                return Optional.of("Another update is in progress and did not " //$NON-NLS-1$
+                    + "settle within " + (maxMillis / 1000) + "s (final state: " //$NON-NLS-1$ //$NON-NLS-2$
+                    + state + "). Retry shortly, or increase the " //$NON-NLS-1$
+                    + "`terminate_launch.timeoutSeconds` preference if your IB " //$NON-NLS-1$
+                    + "updates take longer.");
+            }
+            ExecutionContext context = new ExecutionContext();
+            Shell shell = grabActiveShell();
+            if (shell != null)
+            {
+                context.setProperty(ExecutionContext.ACTIVE_SHELL_NAME, shell);
+            }
+            Activator.logInfo("Pre-launch DB update: application=" + applicationId //$NON-NLS-1$
+                + ", stateBefore=" + state); //$NON-NLS-1$
+            ApplicationUpdateState after = appManager.update(application,
+                ApplicationUpdateType.INCREMENTAL, context, new NullProgressMonitor());
+            Activator.logInfo("Pre-launch DB update completed: stateAfter=" + after); //$NON-NLS-1$
+            // Post-condition gate: the auto-chain promises the IB will be in
+            // UPDATED state before workingCopy.launch() runs, otherwise the
+            // launch delegate would still see "DB needs update" and pop its
+            // modal dialog — which is exactly what we are trying to avoid.
+            if (after == ApplicationUpdateState.UPDATED)
+            {
+                return Optional.empty();
+            }
+            if (after == ApplicationUpdateState.BEING_UPDATED)
+            {
+                // appManager.update() returned but the state machine still
+                // reports an update in progress (async path). Wait for it.
+                long maxMillis = getDefaultTerminateTimeoutSeconds() * 1000L;
+                after = waitForUpdateSettled(appManager, application, maxMillis);
+                if (after == ApplicationUpdateState.UPDATED)
+                {
+                    return Optional.empty();
+                }
+            }
+            return Optional.of("Database update finished with state " + after //$NON-NLS-1$
+                + " (expected UPDATED). Inspect the EDT problems view, " //$NON-NLS-1$
+                + "or call `update_database` with `fullUpdate=true` / " //$NON-NLS-1$
+                + "`autoRestructure=true` to handle restructurization, then retry."); //$NON-NLS-1$
+        }
+        catch (ApplicationException e)
+        {
+            Activator.logError("Error during pre-launch DB update", e); //$NON-NLS-1$
+            return Optional.of("Database update failed: " + e.getMessage()); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Polls {@link IApplicationManager#getUpdateState} until it leaves
+     * {@link ApplicationUpdateState#BEING_UPDATED} or the deadline elapses.
+     * Used when another caller is mid-update — we must not start a launch
+     * against an IB whose update is still running.
+     */
+    private static ApplicationUpdateState waitForUpdateSettled(IApplicationManager appManager,
+            IApplication application, long maxMillis)
+    {
+        long deadline = System.currentTimeMillis() + maxMillis;
+        ApplicationUpdateState state = ApplicationUpdateState.BEING_UPDATED;
+        while (System.currentTimeMillis() < deadline)
+        {
+            try
+            {
+                state = appManager.getUpdateState(application);
+            }
+            catch (ApplicationException e)
+            {
+                Activator.logError("Error polling update state", e); //$NON-NLS-1$
+                return state;
+            }
+            if (state != ApplicationUpdateState.BEING_UPDATED)
+            {
+                return state;
+            }
+            try
+            {
+                Thread.sleep(LaunchConfigUtils.LAUNCH_POLL_INTERVAL_MS);
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+                return state;
+            }
+        }
+        return state;
+    }
+
+    /**
+     * Auto-chain executed before {@code workingCopy.launch()} when the caller
+     * wants to bypass EDT's interactive "Update database?" dialog:
+     * <ol>
+     *   <li>Find every live launch matching {@code project + applicationId};</li>
+     *   <li>Politely terminate each and wait — aborts on timeout (the IB would
+     *       still be locked, defeating the purpose);</li>
+     *   <li>Run {@link #updateApplicationIfNeeded} to settle the IB in
+     *       {@code UPDATED} state — the launch delegate then skips its dialog.</li>
+     * </ol>
+     *
+     * <p>If any step fails, the result has {@code ok=false} and the caller must
+     * abort instead of falling through to a launch that would hang on a modal.
+     *
+     * @param launchManager           Eclipse launch manager
+     * @param project                 target project
+     * @param applicationId           target {@code ATTR_APPLICATION_ID}
+     * @param appManager              EDT application manager
+     * @param terminateTimeoutSeconds polite-wait window per live launch
+     */
+    public static PreLaunchResult prepareForFreshLaunch(ILaunchManager launchManager,
+            IProject project, String applicationId, IApplicationManager appManager,
+            int terminateTimeoutSeconds)
+    {
+        if (launchManager == null)
+        {
+            return new PreLaunchResult(false, 0, "Launch manager is not available"); //$NON-NLS-1$
+        }
+        if (project == null)
+        {
+            return new PreLaunchResult(false, 0, "Project is null"); //$NON-NLS-1$
+        }
+
+        // Per-key lock prevents concurrent run_yaxunit_tests / debug_yaxunit_tests
+        // calls targeting the same IB from racing on terminate + update. Other
+        // (project, applicationId) pairs are unaffected. Java synchronized is
+        // reentrant, so callers may already hold this monitor when wrapping
+        // their full spawn+register sequence around the auto-chain.
+        synchronized (lockFor(project.getName(), applicationId))
+        {
+            // Prune terminated entries so a stale registration cannot
+            // permanently block future auto-chains.
+            OWNED_LAUNCHES.removeIf(ILaunch::isTerminated);
+
+            int terminated = 0;
+            for (ILaunch live : LaunchConfigUtils.getAllLiveLaunches(launchManager,
+                project.getName()))
+            {
+                if (!applicationId.equals(LaunchConfigUtils.getApplicationIdFor(live)))
+                {
+                    continue;
+                }
+                String name = live.getLaunchConfiguration() != null
+                    ? live.getLaunchConfiguration().getName() : "<unknown>"; //$NON-NLS-1$
+                // Identity-equals lookup against the OWNED registry — relies on
+                // the invariant that callers pass the exact ILaunch instance
+                // returned by workingCopy.launch() to registerOwnedLaunch.
+                if (OWNED_LAUNCHES.contains(live))
+                {
+                    return new PreLaunchResult(false, terminated,
+                        "Another test run is already in progress for this IB " //$NON-NLS-1$
+                            + "(launch '" + name + "'). Wait for it to finish " //$NON-NLS-1$ //$NON-NLS-2$
+                            + "(call this tool again later with the same arguments), " //$NON-NLS-1$
+                            + "or call `terminate_launch` to stop it first."); //$NON-NLS-1$
+                }
+                boolean done = terminateAndWait(live, terminateTimeoutSeconds);
+                if (!done)
+                {
+                    return new PreLaunchResult(false, terminated,
+                        "Could not terminate previous launch '" + name //$NON-NLS-1$
+                            + "' within " + terminateTimeoutSeconds //$NON-NLS-1$
+                            + "s. Call `terminate_launch` with `force=true` to kill " //$NON-NLS-1$
+                            + "the stuck process, then retry."); //$NON-NLS-1$
+                }
+                terminated++;
+            }
+
+            Optional<String> updateErr = updateApplicationIfNeeded(project, applicationId,
+                appManager);
+            if (updateErr.isPresent())
+            {
+                return new PreLaunchResult(false, terminated, updateErr.get());
+            }
+            return new PreLaunchResult(true, terminated, null);
+        }
+    }
+
+    /**
+     * Convenience: returns the configured default terminate timeout (in seconds)
+     * shared with the {@code terminate_launch} tool, so the auto-chain honours
+     * the same preference.
+     */
+    public static int getDefaultTerminateTimeoutSeconds()
+    {
+        return ToolParameterSettings.getInstance()
+            .getParameterValue("terminate_launch", "timeoutSeconds", 10); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    private static Shell grabActiveShell()
+    {
+        Display display = Display.getDefault();
+        if (display == null || display.isDisposed())
+        {
+            return null;
+        }
+        final Shell[] holder = new Shell[1];
+        display.syncExec(() -> {
+            holder[0] = display.getActiveShell();
+            if (holder[0] == null)
+            {
+                Shell[] shells = display.getShells();
+                if (shells.length > 0)
+                {
+                    holder[0] = shells[0];
+                }
+            }
+        });
+        return holder[0];
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/META-INF/MANIFEST.MF
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/META-INF/MANIFEST.MF
@@ -9,4 +9,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: com.ditrix.edt.mcp.server.tests
 Import-Package: org.junit;version="4.13.0",
  org.junit.runner;version="4.13.0",
- org.junit.runners;version="4.13.0"
+ org.junit.runners;version="4.13.0",
+ org.mockito,
+ org.mockito.invocation,
+ org.mockito.stubbing

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupTest.java
@@ -174,6 +174,16 @@ public class ToolGroupTest
     }
 
     @Test
+    public void testApplicationsGroupIncludesTerminateLaunch()
+    {
+        List<String> tools = ToolGroup.APPLICATIONS.getToolNames();
+        assertTrue("terminate_launch must be registered in APPLICATIONS group",
+            tools.contains("terminate_launch"));
+        // Reverse lookup must agree
+        assertEquals(ToolGroup.APPLICATIONS, ToolGroup.getGroupForTool("terminate_launch"));
+    }
+
+    @Test
     public void testRefactoringGroupContents()
     {
         List<String> tools = ToolGroup.REFACTORING.getToolNames();

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolParameterSettingsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolParameterSettingsTest.java
@@ -152,6 +152,22 @@ public class ToolParameterSettingsTest
             ToolParameterSettings.buildKey("get_project_errors", "limit"));
     }
 
+    // === terminate_launch.timeoutSeconds ===
+
+    @Test
+    public void testTerminateLaunchExposesTimeoutSecondsParam()
+    {
+        List<ParameterDef> params = settings.getParametersForTool("terminate_launch");
+        assertEquals("terminate_launch should have exactly 1 configurable parameter",
+            1, params.size());
+        ParameterDef def = params.get(0);
+        assertEquals("timeoutSeconds", def.getName());
+        assertEquals("default termination timeout should be 10 seconds",
+            10, def.getDefaultValue());
+        assertEquals("min should be 1 second", 1, def.getMinValue());
+        assertEquals("max should be 120 seconds", 120, def.getMaxValue());
+    }
+
     // === All configurable tools belong to groups ===
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DebugYaxunitTestsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DebugYaxunitTestsToolTest.java
@@ -1,0 +1,101 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.tools.IMcpTool;
+
+/**
+ * Tests for {@link DebugYaxunitTestsTool}.
+ *
+ * Mirrors {@link RunYaxunitTestsToolTest} — verifies tool identity, response
+ * type, schema, and parameter validation at the entry point. The actual
+ * Eclipse launch path is out of scope (needs runtime).
+ */
+public class DebugYaxunitTestsToolTest
+{
+    @Test
+    public void testToolName()
+    {
+        IMcpTool tool = new DebugYaxunitTestsTool();
+        assertEquals("debug_yaxunit_tests", tool.getName());
+    }
+
+    @Test
+    public void testResponseTypeJson()
+    {
+        DebugYaxunitTestsTool tool = new DebugYaxunitTestsTool();
+        assertEquals(IMcpTool.ResponseType.JSON, tool.getResponseType());
+    }
+
+    @Test
+    public void testDescriptionNotEmpty()
+    {
+        IMcpTool tool = new DebugYaxunitTestsTool();
+        String desc = tool.getDescription();
+        assertNotNull(desc);
+        assertTrue("description should not be empty", desc.length() > 0);
+    }
+
+    @Test
+    public void testSchemaDeclaresExpectedFields()
+    {
+        IMcpTool tool = new DebugYaxunitTestsTool();
+        String schema = tool.getInputSchema();
+        assertNotNull(schema);
+        assertTrue(schema.contains("\"launchConfigurationName\""));
+        assertTrue(schema.contains("\"projectName\""));
+        assertTrue(schema.contains("\"applicationId\""));
+        assertTrue(schema.contains("\"extensions\""));
+        assertTrue(schema.contains("\"modules\""));
+        assertTrue(schema.contains("\"tests\""));
+        assertTrue("schema must include updateBeforeLaunch (auto-chain switch)",
+            schema.contains("\"updateBeforeLaunch\""));
+    }
+
+    @Test
+    public void testExecuteMissingProjectName()
+    {
+        IMcpTool tool = new DebugYaxunitTestsTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("applicationId", "some-app-id");
+        String result = tool.execute(params);
+        assertNotNull(result);
+        assertTrue("must mention projectName", result.contains("projectName"));
+        // JSON tool: error field is "error", not "**Error:**"
+        assertTrue("must indicate error", result.contains("\"error\""));
+    }
+
+    @Test
+    public void testExecuteMissingApplicationId()
+    {
+        IMcpTool tool = new DebugYaxunitTestsTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject");
+        String result = tool.execute(params);
+        assertNotNull(result);
+        assertTrue("must mention applicationId", result.contains("applicationId"));
+        assertTrue("must indicate error", result.contains("\"error\""));
+    }
+
+    @Test
+    public void testExecuteEmptyParams()
+    {
+        IMcpTool tool = new DebugYaxunitTestsTool();
+        String result = tool.execute(new HashMap<String, String>());
+        assertNotNull(result);
+        assertTrue("must indicate error", result.contains("\"error\""));
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchToolTest.java
@@ -1,0 +1,210 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.tools.IMcpTool;
+
+/**
+ * Tests for {@link TerminateLaunchTool}.
+ *
+ * Verifies tool identity, schema completeness, and the parameter validation
+ * branches in {@code validateSelection}. Does not exercise the actual
+ * Eclipse-runtime termination flow.
+ */
+public class TerminateLaunchToolTest
+{
+    // === Identity ===
+
+    @Test
+    public void testToolName()
+    {
+        IMcpTool tool = new TerminateLaunchTool();
+        assertEquals("terminate_launch", tool.getName());
+    }
+
+    @Test
+    public void testResponseTypeMarkdown()
+    {
+        IMcpTool tool = new TerminateLaunchTool();
+        assertEquals(IMcpTool.ResponseType.MARKDOWN, tool.getResponseType());
+    }
+
+    @Test
+    public void testDescriptionNotEmpty()
+    {
+        IMcpTool tool = new TerminateLaunchTool();
+        String desc = tool.getDescription();
+        assertNotNull(desc);
+        assertTrue("description should not be empty", desc.length() > 0);
+        assertTrue("description should mention EDT-only guarantee",
+            desc.toLowerCase().contains("edt"));
+    }
+
+    // === Schema ===
+
+    @Test
+    public void testSchemaDeclaresAllParameters()
+    {
+        IMcpTool tool = new TerminateLaunchTool();
+        String schema = tool.getInputSchema();
+        assertNotNull(schema);
+        assertTrue(schema.contains("\"launchConfigurationName\""));
+        assertTrue(schema.contains("\"projectName\""));
+        assertTrue(schema.contains("\"applicationId\""));
+        assertTrue(schema.contains("\"all\""));
+        assertTrue(schema.contains("\"confirm\""));
+        assertTrue(schema.contains("\"force\""));
+        assertTrue(schema.contains("\"timeoutSeconds\""));
+        assertTrue(schema.contains("\"includeAttach\""));
+    }
+
+    @Test
+    public void testSchemaHasNoRequiredFields()
+    {
+        // All selection modes are optional individually — the tool validates
+        // their combinations at runtime, not via JSON schema.
+        IMcpTool tool = new TerminateLaunchTool();
+        String schema = tool.getInputSchema();
+        // Required list should be empty (i.e. "required":[])
+        assertTrue("required array should be present and empty",
+            schema.contains("\"required\":[]"));
+    }
+
+    @Test
+    public void testFileNameByConfigName()
+    {
+        TerminateLaunchTool tool = new TerminateLaunchTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("launchConfigurationName", "My Config / ThinClient");
+        String name = tool.getResultFileName(params);
+        assertTrue("file name should derive from config name",
+            name.startsWith("terminate-") && name.endsWith(".md"));
+        // Should be sanitised — no slashes or spaces in the middle
+        assertTrue("file name should be sanitised", !name.contains(" "));
+        assertTrue("file name should be sanitised", !name.contains("/"));
+    }
+
+    @Test
+    public void testFileNameForAllMode()
+    {
+        TerminateLaunchTool tool = new TerminateLaunchTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("all", "true");
+        assertEquals("terminate-all.md", tool.getResultFileName(params));
+    }
+
+    @Test
+    public void testFileNameForAllModeWithProject()
+    {
+        TerminateLaunchTool tool = new TerminateLaunchTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("all", "true");
+        params.put("projectName", "MyProject");
+        assertEquals("terminate-all-myproject.md", tool.getResultFileName(params));
+    }
+
+    // === validateSelection — error messages from execute() ===
+
+    @Test
+    public void testEmptyParamsReturnsProvideOneOfError()
+    {
+        IMcpTool tool = new TerminateLaunchTool();
+        String result = tool.execute(new HashMap<String, String>());
+        assertNotNull(result);
+        assertTrue("must be an error", result.startsWith("**Error:**"));
+        assertTrue("must mention 'Provide exactly one of'",
+            result.contains("Provide exactly one of"));
+    }
+
+    @Test
+    public void testApplicationIdWithoutProjectName()
+    {
+        IMcpTool tool = new TerminateLaunchTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("applicationId", "8e2a-fake-id");
+        String result = tool.execute(params);
+        assertTrue(result.startsWith("**Error:**"));
+        assertTrue("must explain applicationId requires projectName",
+            result.contains("`applicationId` requires `projectName`"));
+    }
+
+    @Test
+    public void testProjectNameAloneIsAmbiguous()
+    {
+        IMcpTool tool = new TerminateLaunchTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject");
+        String result = tool.execute(params);
+        assertTrue(result.startsWith("**Error:**"));
+        assertTrue("must explain projectName alone is not a selection",
+            result.contains("`projectName` alone is not a selection"));
+    }
+
+    @Test
+    public void testAllWithoutConfirm()
+    {
+        IMcpTool tool = new TerminateLaunchTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("all", "true");
+        String result = tool.execute(params);
+        assertTrue(result.startsWith("**Error:**"));
+        assertTrue("must require confirm=true",
+            result.contains("Confirmation required")
+                && result.contains("confirm=true"));
+    }
+
+    @Test
+    public void testApplicationIdCannotBeCombinedWithAll()
+    {
+        IMcpTool tool = new TerminateLaunchTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("applicationId", "8e2a-fake-id");
+        params.put("all", "true");
+        params.put("confirm", "true");
+        String result = tool.execute(params);
+        assertTrue(result.startsWith("**Error:**"));
+        assertTrue("must explain applicationId vs all incompatibility",
+            result.contains("`applicationId` cannot be combined with `all=true`"));
+    }
+
+    @Test
+    public void testNameAndAllAreMutuallyExclusive()
+    {
+        IMcpTool tool = new TerminateLaunchTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("launchConfigurationName", "SomeConfig");
+        params.put("all", "true");
+        params.put("confirm", "true");
+        String result = tool.execute(params);
+        assertTrue(result.startsWith("**Error:**"));
+        assertTrue("must report mutual exclusivity",
+            result.contains("mutually exclusive"));
+    }
+
+    @Test
+    public void testNameAndProjectAppIdAreMutuallyExclusive()
+    {
+        IMcpTool tool = new TerminateLaunchTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("launchConfigurationName", "SomeConfig");
+        params.put("projectName", "Proj");
+        params.put("applicationId", "app-id");
+        String result = tool.execute(params);
+        assertTrue(result.startsWith("**Error:**"));
+        assertTrue("must report mutual exclusivity",
+            result.contains("mutually exclusive"));
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtilsPrepareTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtilsPrepareTest.java
@@ -1,0 +1,247 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchManager;
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils.PreLaunchResult;
+import com.e1c.g5.dt.applications.ApplicationUpdateState;
+import com.e1c.g5.dt.applications.IApplication;
+import com.e1c.g5.dt.applications.IApplicationManager;
+
+/**
+ * Mock-driven tests for {@link LaunchLifecycleUtils#prepareForFreshLaunch}.
+ *
+ * <p>Covers the auto-chain's behaviour against live launches whose
+ * {@code applicationId} does not match the one being prepared — specifically
+ * stale Attach launches, which carry a synthetic {@code "attach:<name>"} id
+ * that can never equal a runtime client's real application UUID. Before the
+ * fix, such launches were silently skipped, leaving the system in a state
+ * where the next {@code workingCopy.launch()} would hang on a locked IB.
+ */
+public class LaunchLifecycleUtilsPrepareTest
+{
+    private static final String PROJECT_NAME = "MyProject";
+    private static final String RUNTIME_APP_ID = "real-app-uuid";
+
+    private static IProject mockOpenProject()
+    {
+        IProject project = mock(IProject.class);
+        when(project.exists()).thenReturn(true);
+        when(project.isOpen()).thenReturn(true);
+        when(project.getName()).thenReturn(PROJECT_NAME);
+        return project;
+    }
+
+    /**
+     * Wires the given mock launch so {@code isTerminated()} flips to true the
+     * moment {@code terminate()} is invoked — required for
+     * {@link LaunchLifecycleUtils#terminateAndWait} to observe success without
+     * spinning until the polling timeout.
+     */
+    private static AtomicBoolean wireSelfTerminating(ILaunch launch) throws Exception
+    {
+        AtomicBoolean terminated = new AtomicBoolean(false);
+        when(launch.isTerminated()).thenAnswer(inv -> terminated.get());
+        doAnswer(inv -> {
+            terminated.set(true);
+            return null;
+        }).when(launch).terminate();
+        return terminated;
+    }
+
+    private static ILaunchConfiguration mockAttachConfig(String name, String projectName)
+            throws Exception
+    {
+        ILaunchConfigurationType type = mock(ILaunchConfigurationType.class);
+        when(type.getIdentifier()).thenReturn(LaunchConfigUtils.TYPE_LOCAL_RUNTIME);
+
+        ILaunchConfiguration cfg = mock(ILaunchConfiguration.class);
+        when(cfg.getType()).thenReturn(type);
+        when(cfg.getName()).thenReturn(name);
+        when(cfg.getAttribute(eq(LaunchConfigUtils.ATTR_PROJECT_NAME), anyString()))
+            .thenReturn(projectName);
+        when(cfg.getAttribute(eq(LaunchConfigUtils.ATTR_APPLICATION_ID), nullable(String.class)))
+            .thenReturn(null);
+        return cfg;
+    }
+
+    private static ILaunchConfiguration mockRuntimeConfig(String name, String projectName,
+            String applicationId) throws Exception
+    {
+        ILaunchConfigurationType type = mock(ILaunchConfigurationType.class);
+        when(type.getIdentifier()).thenReturn(LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID);
+
+        ILaunchConfiguration cfg = mock(ILaunchConfiguration.class);
+        when(cfg.getType()).thenReturn(type);
+        when(cfg.getName()).thenReturn(name);
+        when(cfg.getAttribute(eq(LaunchConfigUtils.ATTR_PROJECT_NAME), anyString()))
+            .thenReturn(projectName);
+        when(cfg.getAttribute(eq(LaunchConfigUtils.ATTR_APPLICATION_ID), nullable(String.class)))
+            .thenReturn(applicationId);
+        return cfg;
+    }
+
+    /**
+     * Stubs {@code appManager} so that {@link LaunchLifecycleUtils#updateApplicationIfNeeded}
+     * short-circuits as a no-op (state already UPDATED). Lets the test focus on
+     * the terminate phase without dragging in the update mock surface.
+     */
+    private static IApplicationManager mockUpToDateAppManager() throws Exception
+    {
+        IApplication app = mock(IApplication.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplication(any(IProject.class), eq(RUNTIME_APP_ID)))
+            .thenReturn(Optional.of(app));
+        when(mgr.getUpdateState(app)).thenReturn(ApplicationUpdateState.UPDATED);
+        return mgr;
+    }
+
+    @Test
+    public void testStaleAttachOnSameProjectIsSwept() throws Exception
+    {
+        // The user's scenario: a previous debug session left an attach launch
+        // hanging around. Its applicationId is the synthetic "attach:<name>",
+        // which never equals the runtime client's real UUID. Before the fix
+        // this launch was silently skipped — and the next workingCopy.launch()
+        // would block on the locked IB. After the fix it must be disconnected.
+        ILaunchConfiguration attachCfg = mockAttachConfig(
+            "Процесс отладки 1С", PROJECT_NAME);
+        ILaunch attachLaunch = mock(ILaunch.class);
+        when(attachLaunch.getLaunchConfiguration()).thenReturn(attachCfg);
+        wireSelfTerminating(attachLaunch);
+
+        ILaunchManager launchManager = mock(ILaunchManager.class);
+        when(launchManager.getLaunches()).thenReturn(new ILaunch[] { attachLaunch });
+
+        PreLaunchResult result = LaunchLifecycleUtils.prepareForFreshLaunch(
+            launchManager, mockOpenProject(), RUNTIME_APP_ID, mockUpToDateAppManager(), 2);
+
+        assertTrue("auto-chain must succeed: " + result.getError(), result.isOk());
+        assertEquals("stale attach must be counted as swept",
+            1, result.getTerminatedCount());
+        verify(attachLaunch, atLeastOnce()).terminate();
+    }
+
+    @Test
+    public void testOwnedAttachIsProtected() throws Exception
+    {
+        // If the lingering attach launch is owned by another MCP tool
+        // (registered via registerOwnedLaunch), the auto-chain must refuse to
+        // disconnect it — symmetric with the existing protection for owned
+        // runtime launches — so concurrent MCP calls don't sabotage each other.
+        ILaunchConfiguration attachCfg = mockAttachConfig(
+            "Owned Debug Session", PROJECT_NAME);
+        ILaunch attachLaunch = mock(ILaunch.class);
+        when(attachLaunch.getLaunchConfiguration()).thenReturn(attachCfg);
+        // Belt-and-suspenders: even though the implementation must check
+        // OWNED_LAUNCHES *before* terminateAndWait (and verify(never).terminate
+        // below proves we did), wire self-termination so a future refactor that
+        // reorders the checks fails loudly with verify() instead of hanging the
+        // suite for `timeoutSeconds` per iteration.
+        wireSelfTerminating(attachLaunch);
+
+        ILaunchManager launchManager = mock(ILaunchManager.class);
+        when(launchManager.getLaunches()).thenReturn(new ILaunch[] { attachLaunch });
+
+        try
+        {
+            LaunchLifecycleUtils.registerOwnedLaunch(attachLaunch);
+
+            PreLaunchResult result = LaunchLifecycleUtils.prepareForFreshLaunch(
+                launchManager, mockOpenProject(), RUNTIME_APP_ID,
+                mockUpToDateAppManager(), 2);
+
+            assertFalse("owned attach must block the chain", result.isOk());
+            assertTrue("error must mention the owning launch by name",
+                result.getError() != null
+                    && result.getError().contains("Owned Debug Session"));
+            verify(attachLaunch, never()).terminate();
+        }
+        finally
+        {
+            LaunchLifecycleUtils.unregisterOwnedLaunch(attachLaunch);
+        }
+    }
+
+    @Test
+    public void testRuntimeLaunchWithMatchingAppIdStillTerminated() throws Exception
+    {
+        // Guard against regressions in the original per-applicationId terminate
+        // pass: a live runtime launch on the same (project, applicationId) must
+        // still be terminated even after we add the attach-sweep second pass.
+        ILaunchConfiguration runtimeCfg = mockRuntimeConfig(
+            "MyApp.RuntimeClient", PROJECT_NAME, RUNTIME_APP_ID);
+        ILaunch runtimeLaunch = mock(ILaunch.class);
+        when(runtimeLaunch.getLaunchConfiguration()).thenReturn(runtimeCfg);
+        wireSelfTerminating(runtimeLaunch);
+
+        ILaunchManager launchManager = mock(ILaunchManager.class);
+        when(launchManager.getLaunches()).thenReturn(new ILaunch[] { runtimeLaunch });
+
+        PreLaunchResult result = LaunchLifecycleUtils.prepareForFreshLaunch(
+            launchManager, mockOpenProject(), RUNTIME_APP_ID, mockUpToDateAppManager(), 2);
+
+        assertTrue("auto-chain must succeed: " + result.getError(), result.isOk());
+        assertEquals(1, result.getTerminatedCount());
+        verify(runtimeLaunch, atLeastOnce()).terminate();
+    }
+
+    @Test
+    public void testRuntimePlusAttachSweepCountedTogether() throws Exception
+    {
+        // Both passes should fire and the counter should reflect both — useful
+        // signal in the pre-launch summary that something non-trivial was
+        // cleaned up before the new spawn.
+        ILaunchConfiguration runtimeCfg = mockRuntimeConfig(
+            "MyApp.RuntimeClient", PROJECT_NAME, RUNTIME_APP_ID);
+        ILaunch runtimeLaunch = mock(ILaunch.class);
+        when(runtimeLaunch.getLaunchConfiguration()).thenReturn(runtimeCfg);
+        wireSelfTerminating(runtimeLaunch);
+
+        ILaunchConfiguration attachCfg = mockAttachConfig(
+            "Process Debug 1С", PROJECT_NAME);
+        ILaunch attachLaunch = mock(ILaunch.class);
+        when(attachLaunch.getLaunchConfiguration()).thenReturn(attachCfg);
+        wireSelfTerminating(attachLaunch);
+
+        ILaunchManager launchManager = mock(ILaunchManager.class);
+        when(launchManager.getLaunches())
+            .thenReturn(new ILaunch[] { runtimeLaunch, attachLaunch });
+
+        PreLaunchResult result = LaunchLifecycleUtils.prepareForFreshLaunch(
+            launchManager, mockOpenProject(), RUNTIME_APP_ID, mockUpToDateAppManager(), 2);
+
+        assertTrue("auto-chain must succeed: " + result.getError(), result.isOk());
+        assertEquals("both runtime and attach must be counted",
+            2, result.getTerminatedCount());
+        verify(runtimeLaunch, atLeastOnce()).terminate();
+        verify(attachLaunch, atLeastOnce()).terminate();
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtilsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtilsTest.java
@@ -1,0 +1,148 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Constructor;
+
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils.PreLaunchResult;
+
+/**
+ * Tests for {@link LaunchLifecycleUtils}.
+ *
+ * <p>Focus is on {@link PreLaunchResult} construction and {@code summary()}
+ * formatting — the parts that don't require an Eclipse runtime. The actual
+ * {@code prepareForFreshLaunch} / {@code terminateAndWait} / {@code
+ * updateApplicationIfNeeded} flows need {@code ILaunchManager} +
+ * {@code IApplicationManager} and are covered by mvn verify compilation
+ * against the EDT target platform.
+ */
+public class LaunchLifecycleUtilsTest
+{
+    @Test
+    public void testFailedResultSummaryIncludesError()
+    {
+        PreLaunchResult result = newResult(false, 0, "boom");
+        assertFalse(result.isOk());
+        assertEquals("boom", result.getError());
+        assertTrue("summary should expose the error",
+            result.summary().contains("failed") && result.summary().contains("boom"));
+    }
+
+    @Test
+    public void testOkZeroTerminatedIsNoOp()
+    {
+        PreLaunchResult result = newResult(true, 0, null);
+        assertTrue(result.isOk());
+        assertNull(result.getError());
+        assertEquals(0, result.getTerminatedCount());
+        String summary = result.summary();
+        assertTrue("no-op summary should say so",
+            summary.contains("no-op") && summary.contains("DB ready"));
+    }
+
+    @Test
+    public void testOkOneTerminatedSingularPhrasing()
+    {
+        PreLaunchResult result = newResult(true, 1, null);
+        String summary = result.summary();
+        assertTrue("must mention terminated count",
+            summary.contains("terminated 1 live launch"));
+        // singular: no trailing "es"
+        assertFalse("singular should not say 'launches'",
+            summary.contains("launches"));
+        assertTrue("DB readiness phrased", summary.contains("DB ready"));
+    }
+
+    @Test
+    public void testOkMultipleTerminatedPluralPhrasing()
+    {
+        PreLaunchResult result = newResult(true, 3, null);
+        String summary = result.summary();
+        assertTrue("must use plural 'launches'",
+            summary.contains("terminated 3 live launches"));
+        assertTrue("DB readiness phrased", summary.contains("DB ready"));
+    }
+
+    @Test
+    public void testTerminateTimeoutPreferenceFallback()
+    {
+        // Outside the Eclipse OSGi runtime the preference store is unavailable,
+        // so this must fall back to the parameter's static default (10s).
+        int value = LaunchLifecycleUtils.getDefaultTerminateTimeoutSeconds();
+        assertTrue("timeout should be a sane positive value",
+            value >= 1 && value <= 120);
+    }
+
+    @Test
+    public void testTerminateAndWaitNullLaunchIsNoOp()
+    {
+        // No Eclipse mock needed for this branch — null short-circuits immediately.
+        assertTrue("null launch must be treated as already terminated",
+            LaunchLifecycleUtils.terminateAndWait(null, 1));
+    }
+
+    @Test
+    public void testRegisterOwnedLaunchNullIsNoOp()
+    {
+        // Should not throw.
+        LaunchLifecycleUtils.registerOwnedLaunch(null);
+        LaunchLifecycleUtils.unregisterOwnedLaunch(null);
+    }
+
+    @Test
+    public void testLockForReturnsSameInstanceForSameKey()
+    {
+        Object a = LaunchLifecycleUtils.lockFor("MyProject", "app-1");
+        Object b = LaunchLifecycleUtils.lockFor("MyProject", "app-1");
+        assertEquals("same (project, appId) must return same lock instance", a, b);
+    }
+
+    @Test
+    public void testLockForDistinguishesProjectsWithSpaces()
+    {
+        // Guards against printable-delimiter collisions:
+        //   {project='My', appId='Project x'} vs {project='My Project', appId='x'}.
+        Object a = LaunchLifecycleUtils.lockFor("My", "Project x");
+        Object b = LaunchLifecycleUtils.lockFor("My Project", "x");
+        assertFalse("locks for distinct (project, appId) must not collide", a == b);
+    }
+
+    /**
+     * Reflective constructor invocation because PreLaunchResult's constructor
+     * is private (the class is only instantiated by {@code prepareForFreshLaunch}).
+     */
+    private static PreLaunchResult newResult(boolean ok, int terminated, String error)
+    {
+        try
+        {
+            Constructor<PreLaunchResult> ctor = PreLaunchResult.class.getDeclaredConstructor(
+                boolean.class, int.class, String.class);
+            ctor.setAccessible(true);
+            return ctor.newInstance(ok, terminated, error);
+        }
+        catch (ReflectiveOperationException e)
+        {
+            throw new RuntimeException("Failed to instantiate PreLaunchResult via reflection", e);
+        }
+    }
+
+    @Test
+    public void testPreLaunchResultFieldAccessors()
+    {
+        PreLaunchResult result = newResult(true, 2, null);
+        assertEquals(2, result.getTerminatedCount());
+        assertTrue(result.isOk());
+        assertNull(result.getError());
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtilsUpdateTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtilsUpdateTest.java
@@ -1,0 +1,211 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.core.resources.IProject;
+import org.junit.Test;
+
+import com.e1c.g5.dt.applications.ApplicationException;
+import com.e1c.g5.dt.applications.ApplicationUpdateState;
+import com.e1c.g5.dt.applications.ApplicationUpdateType;
+import com.e1c.g5.dt.applications.ExecutionContext;
+import com.e1c.g5.dt.applications.IApplication;
+import com.e1c.g5.dt.applications.IApplicationManager;
+
+/**
+ * Mock-driven tests for {@link LaunchLifecycleUtils#updateApplicationIfNeeded}.
+ *
+ * <p>Covers the post-update state branches that determine whether the
+ * auto-chain proceeds to {@code workingCopy.launch()} or aborts with a clear
+ * error — including the previously-broken branch where {@code appManager.update()}
+ * returned a non-{@code UPDATED} state and the auto-chain still claimed success.
+ */
+public class LaunchLifecycleUtilsUpdateTest
+{
+    private static final String APP_ID = "app-1";
+
+    private static IProject mockOpenProject()
+    {
+        IProject project = mock(IProject.class);
+        when(project.exists()).thenReturn(true);
+        when(project.isOpen()).thenReturn(true);
+        when(project.getName()).thenReturn("MyProject");
+        return project;
+    }
+
+    @Test
+    public void testNullAppManagerReturnsError()
+    {
+        Optional<String> result = LaunchLifecycleUtils.updateApplicationIfNeeded(
+            mockOpenProject(), APP_ID, null);
+        assertTrue(result.isPresent());
+        assertTrue("error must mention IApplicationManager",
+            result.get().contains("IApplicationManager"));
+    }
+
+    @Test
+    public void testNullProjectReturnsError()
+    {
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        Optional<String> result = LaunchLifecycleUtils.updateApplicationIfNeeded(
+            null, APP_ID, mgr);
+        assertTrue(result.isPresent());
+        assertTrue("error must mention project availability",
+            result.get().contains("Project is not available"));
+    }
+
+    @Test
+    public void testApplicationNotFoundReturnsError() throws ApplicationException
+    {
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplication(any(IProject.class), eq(APP_ID)))
+            .thenReturn(Optional.empty());
+
+        Optional<String> result = LaunchLifecycleUtils.updateApplicationIfNeeded(
+            mockOpenProject(), APP_ID, mgr);
+        assertTrue(result.isPresent());
+        assertTrue("error must mention applicationId",
+            result.get().contains(APP_ID));
+    }
+
+    @Test
+    public void testAlreadyUpdatedIsNoOp() throws ApplicationException
+    {
+        IApplication app = mock(IApplication.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplication(any(IProject.class), eq(APP_ID)))
+            .thenReturn(Optional.of(app));
+        when(mgr.getUpdateState(app)).thenReturn(ApplicationUpdateState.UPDATED);
+
+        Optional<String> result = LaunchLifecycleUtils.updateApplicationIfNeeded(
+            mockOpenProject(), APP_ID, mgr);
+        assertFalse("UPDATED state must be a no-op", result.isPresent());
+        verify(mgr, never()).update(any(), any(), any(), any());
+    }
+
+    @Test
+    public void testBeingUpdatedThenSettlesUpdatedReturnsOk() throws ApplicationException
+    {
+        IApplication app = mock(IApplication.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplication(any(IProject.class), eq(APP_ID)))
+            .thenReturn(Optional.of(app));
+
+        // First call: BEING_UPDATED (entering the poll branch).
+        // Subsequent calls: UPDATED (settled).
+        AtomicInteger pollCount = new AtomicInteger(0);
+        when(mgr.getUpdateState(app)).thenAnswer(inv -> {
+            int n = pollCount.getAndIncrement();
+            return n == 0 ? ApplicationUpdateState.BEING_UPDATED : ApplicationUpdateState.UPDATED;
+        });
+
+        Optional<String> result = LaunchLifecycleUtils.updateApplicationIfNeeded(
+            mockOpenProject(), APP_ID, mgr);
+        assertFalse("polling to UPDATED must yield success", result.isPresent());
+        verify(mgr, never()).update(any(), any(), any(), any());
+    }
+
+    @Test
+    public void testUpdateCalledWhenStateNeedsUpdate() throws ApplicationException
+    {
+        IApplication app = mock(IApplication.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplication(any(IProject.class), eq(APP_ID)))
+            .thenReturn(Optional.of(app));
+        when(mgr.getUpdateState(app)).thenReturn(ApplicationUpdateState.INCREMENTAL_UPDATE_REQUIRED);
+        when(mgr.update(eq(app), eq(ApplicationUpdateType.INCREMENTAL),
+            any(ExecutionContext.class), any())).thenReturn(ApplicationUpdateState.UPDATED);
+
+        Optional<String> result = LaunchLifecycleUtils.updateApplicationIfNeeded(
+            mockOpenProject(), APP_ID, mgr);
+        assertFalse("update returning UPDATED must yield success", result.isPresent());
+        verify(mgr, times(1)).update(eq(app), eq(ApplicationUpdateType.INCREMENTAL),
+            any(ExecutionContext.class), any());
+    }
+
+    @Test
+    public void testUpdateReturnsNonUpdatedReturnsError() throws ApplicationException
+    {
+        // This is the bug-fix branch: appManager.update() returns a non-UPDATED state
+        // (e.g. FULL_UPDATE_REQUIRED because the INCREMENTAL we ran isn't enough) and
+        // we must NOT silently report success — otherwise the launch delegate would
+        // pop its modal "Update database?" dialog and block the MCP call.
+        IApplication app = mock(IApplication.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplication(any(IProject.class), eq(APP_ID)))
+            .thenReturn(Optional.of(app));
+        when(mgr.getUpdateState(app)).thenReturn(ApplicationUpdateState.INCREMENTAL_UPDATE_REQUIRED);
+        when(mgr.update(eq(app), any(), any(), any()))
+            .thenReturn(ApplicationUpdateState.FULL_UPDATE_REQUIRED);
+
+        Optional<String> result = LaunchLifecycleUtils.updateApplicationIfNeeded(
+            mockOpenProject(), APP_ID, mgr);
+        assertTrue("non-UPDATED post-state must yield an error", result.isPresent());
+        assertTrue("error must surface the final state",
+            result.get().contains("FULL_UPDATE_REQUIRED"));
+        assertTrue("error must mention update_database fallback",
+            result.get().contains("update_database"));
+    }
+
+    @Test
+    public void testUpdateReturnsBeingUpdatedThenSettles() throws ApplicationException
+    {
+        IApplication app = mock(IApplication.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplication(any(IProject.class), eq(APP_ID)))
+            .thenReturn(Optional.of(app));
+        when(mgr.getUpdateState(app)).thenReturn(ApplicationUpdateState.INCREMENTAL_UPDATE_REQUIRED);
+        when(mgr.update(eq(app), any(), any(), any()))
+            .thenAnswer(inv -> {
+                // After update returns, switch getUpdateState() to first BEING_UPDATED,
+                // then UPDATED on the next poll.
+                AtomicInteger pollAfter = new AtomicInteger(0);
+                when(mgr.getUpdateState(app)).thenAnswer(i -> {
+                    int n = pollAfter.getAndIncrement();
+                    return n == 0 ? ApplicationUpdateState.BEING_UPDATED
+                        : ApplicationUpdateState.UPDATED;
+                });
+                return ApplicationUpdateState.BEING_UPDATED;
+            });
+
+        Optional<String> result = LaunchLifecycleUtils.updateApplicationIfNeeded(
+            mockOpenProject(), APP_ID, mgr);
+        assertFalse("post-update poll to UPDATED must yield success", result.isPresent());
+    }
+
+    @Test
+    public void testUpdateThrowsApplicationExceptionReturnsError() throws ApplicationException
+    {
+        IApplication app = mock(IApplication.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplication(any(IProject.class), eq(APP_ID)))
+            .thenReturn(Optional.of(app));
+        when(mgr.getUpdateState(app)).thenReturn(ApplicationUpdateState.INCREMENTAL_UPDATE_REQUIRED);
+        when(mgr.update(eq(app), any(), any(), any()))
+            .thenThrow(new ApplicationException("update boom"));
+
+        Optional<String> result = LaunchLifecycleUtils.updateApplicationIfNeeded(
+            mockOpenProject(), APP_ID, mgr);
+        assertTrue(result.isPresent());
+        assertNotNull(result.get());
+        assertTrue("error must mention the failure", result.get().contains("update boom"));
+    }
+}


### PR DESCRIPTION
Introduces terminate_launch (by config name / project+appId / all) and an updateBeforeLaunch=true auto-chain in run_yaxunit_tests and debug_yaxunit_tests that politely terminates any live 1С client and runs a silent DB update so EDT's launch delegate skips its modal "Update database?" dialog that would otherwise block the MCP call.

Concurrent runs against the same IB are protected: a second call with a different runKey is rejected with a clear message instead of silently killing the first run's launch.

debug_launch now short-circuits with alreadyRunning=true when a debug session already exists for the applicationId symmetric with the launchConfigurationName path.

Close #110 