### PR TITLE
fix(get_project_errors): read markers inside BM read transaction

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -8,7 +8,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -216,27 +216,25 @@ public class GetProjectErrorsTool implements IMcpTool
                 }
             }
             
-            // Determine the set of projects to scan. Marker presentation must be resolved
-            // inside a BM read transaction, and a transaction is bound to a single project's
-            // model, so we collect markers project by project.
-            List<IProject> targetProjects = new ArrayList<>();
-            if (projectName != null && !projectName.isEmpty())
-            {
-                targetProjects.add(workspace.getRoot().getProject(projectName));
-            }
-            else
-            {
-                // getProject() does not touch resolvedDataCache, so this pass is safe.
-                Set<IProject> distinct = new LinkedHashSet<>();
-                markerManager.markers().forEach(marker -> {
-                    IProject markerProject = marker.getProject();
-                    if (markerProject != null)
-                    {
-                        distinct.add(markerProject);
-                    }
-                });
-                targetProjects.addAll(distinct);
-            }
+            // Group markers by project in a single pass. getProject() does not touch
+            // resolvedDataCache, so this is safe outside a BM transaction. Grouping once avoids
+            // re-streaming all markers per project (previously O(markers x projects)).
+            // Marker presentation must still be resolved inside a BM read transaction bound to
+            // a single project's model, so processing below stays project by project.
+            Map<IProject, List<Marker>> markersByProject = new LinkedHashMap<>();
+            markerManager.markers().forEach(marker -> {
+                IProject markerProject = marker.getProject();
+                if (markerProject == null || !markerProject.exists())
+                {
+                    return;
+                }
+                if (projectName != null && !projectName.isEmpty()
+                    && !projectName.equals(markerProject.getName()))
+                {
+                    return;
+                }
+                markersByProject.computeIfAbsent(markerProject, k -> new ArrayList<>()).add(marker);
+            });
             
             final List<ErrorInfo> errors = new ArrayList<>();
             // Markers whose presentation could not be resolved even inside a transaction.
@@ -247,30 +245,24 @@ public class GetProjectErrorsTool implements IMcpTool
             //    filter is active and the location could not be resolved to test membership.
             final int[] unresolvedShown = {0};
             final int[] unresolvedFilteredOut = {0};
-            final IMarkerManager finalMarkerManager = markerManager;
             
-            for (IProject project : targetProjects)
+            for (Map.Entry<IProject, List<Marker>> entry : markersByProject.entrySet())
             {
-                if (project == null || !project.exists())
-                {
-                    continue;
-                }
                 if (errors.size() >= limit)
                 {
                     break;
                 }
                 
-                final IProject finalProject = project;
+                final List<Marker> projectMarkers = entry.getValue();
                 final int remaining = limit - errors.size();
                 
                 // Resolve the project's BM model so getObjectPresentation() can lazily
                 // resolve the marker target inside a read transaction. The getModel(IProject)
                 // overload is the idiomatic path used across the plugin (FindReferencesTool,
                 // AddMetadataAttributeTool, tag tools), so no IDtProjectManager is needed.
-                IBmModel bmModel = bmModelManager != null ? bmModelManager.getModel(project) : null;
+                IBmModel bmModel = bmModelManager != null ? bmModelManager.getModel(entry.getKey()) : null;
                 
-                Runnable collector = () -> finalMarkerManager.markers()
-                    .filter(marker -> finalProject.equals(marker.getProject()))
+                Runnable collector = () -> projectMarkers.stream()
                     .map(marker -> buildIfMatches(marker, finalSeverityFilter, finalCheckId,
                         finalObjects, checkRepository, unresolvedShown, unresolvedFilteredOut))
                     .filter(error -> error != null)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -8,16 +8,24 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IProgressMonitor;
 
+import com._1c.g5.v8.bm.core.IBmTransaction;
+import com._1c.g5.v8.bm.integration.AbstractBmTask;
+import com._1c.g5.v8.bm.integration.IBmModel;
+import com._1c.g5.v8.dt.core.platform.IBmModelManager;
+import com._1c.g5.v8.dt.core.platform.IDtProject;
+import com._1c.g5.v8.dt.core.platform.IDtProjectManager;
 import com._1c.g5.v8.dt.validation.marker.IMarkerManager;
+import com._1c.g5.v8.dt.validation.marker.Marker;
 import com._1c.g5.v8.dt.validation.marker.MarkerSeverity;
 import com.e1c.g5.v8.dt.check.settings.ICheckRepository;
 import com.e1c.g5.v8.dt.check.settings.CheckUid;
@@ -39,6 +47,14 @@ import com.google.gson.JsonParser;
 /**
  * Tool to get detailed project errors with optional filters.
  * Uses EDT IMarkerManager for accessing configuration problems.
+ *
+ * <p>Marker presentation ({@link Marker#getObjectPresentation()}) is resolved lazily
+ * against the BM model and therefore must be read inside a BM read transaction.
+ * Markers restored from the persisted marker index (e.g. right after EDT startup) have
+ * a {@code null} {@code resolvedDataCache}; reading their presentation outside a
+ * transaction throws a {@link NullPointerException} that aborts the whole stream.
+ * To avoid this, markers are collected per project inside
+ * {@link IBmModel#executeReadonlyTask(AbstractBmTask)}.</p>
  */
 public class GetProjectErrorsTool implements IMcpTool
 {
@@ -158,7 +174,9 @@ public class GetProjectErrorsTool implements IMcpTool
                 return "# Error\n\nIMarkerManager service is not available"; //$NON-NLS-1$
             }
             
-            ICheckRepository checkRepository = Activator.getDefault().getCheckRepository();
+            final ICheckRepository checkRepository = Activator.getDefault().getCheckRepository();
+            IBmModelManager bmModelManager = Activator.getDefault().getBmModelManager();
+            IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
             
             IWorkspace workspace = ResourcesPlugin.getWorkspace();
             
@@ -175,6 +193,8 @@ public class GetProjectErrorsTool implements IMcpTool
                     // Invalid severity, will show all
                 }
             }
+            final MarkerSeverity finalSeverityFilter = severityFilter;
+            final String finalCheckId = checkId;
             
             // Validate project if specified
             if (projectName != null && !projectName.isEmpty())
@@ -186,10 +206,6 @@ public class GetProjectErrorsTool implements IMcpTool
                 }
             }
             
-            // Collect errors from EDT MarkerManager using proper stream operations
-            final MarkerSeverity finalSeverityFilter = severityFilter;
-            final String finalCheckId = checkId;
-            final String finalProjectName = projectName;
             // Normalize object FQNs to support both English and Russian metadata type names.
             // For each input FQN, generate all variants (original + English + Russian, lowercased)
             // so we can match markers regardless of the configuration language.
@@ -203,109 +219,86 @@ public class GetProjectErrorsTool implements IMcpTool
                 }
             }
             
-            // Use filter + limit instead of forEach with early return (which doesn't work)
-            final ICheckRepository finalCheckRepo = checkRepository;
-            List<ErrorInfo> errors = markerManager.markers()
-                .filter(marker -> {
-                    // Get project
+            // Determine the set of projects to scan. Marker presentation must be resolved
+            // inside a BM read transaction, and a transaction is bound to a single project's
+            // model, so we collect markers project by project.
+            List<IProject> targetProjects = new ArrayList<>();
+            if (projectName != null && !projectName.isEmpty())
+            {
+                targetProjects.add(workspace.getRoot().getProject(projectName));
+            }
+            else
+            {
+                // getProject() does not touch resolvedDataCache, so this pass is safe.
+                Set<IProject> distinct = new LinkedHashSet<>();
+                markerManager.markers().forEach(marker -> {
                     IProject markerProject = marker.getProject();
-                    if (markerProject == null)
+                    if (markerProject != null)
                     {
-                        return false;
+                        distinct.add(markerProject);
                     }
-                    
-                    // Check project filter
-                    if (finalProjectName != null && !finalProjectName.isEmpty() && 
-                        !markerProject.getName().equals(finalProjectName))
+                });
+                targetProjects.addAll(distinct);
+            }
+            
+            final List<ErrorInfo> errors = new ArrayList<>();
+            // Markers whose presentation could not be resolved even inside a transaction.
+            // They are NOT dropped: they are reported with a placeholder location and counted.
+            final int[] unresolved = {0};
+            final IMarkerManager finalMarkerManager = markerManager;
+            
+            for (IProject project : targetProjects)
+            {
+                if (project == null || !project.exists())
+                {
+                    continue;
+                }
+                if (errors.size() >= limit)
+                {
+                    break;
+                }
+                
+                final IProject finalProject = project;
+                final int remaining = limit - errors.size();
+                
+                // Resolve the project's BM model so getObjectPresentation() can lazily
+                // resolve the marker target inside a read transaction.
+                IBmModel bmModel = null;
+                if (bmModelManager != null && dtProjectManager != null)
+                {
+                    IDtProject dtProject = dtProjectManager.getDtProject(project);
+                    if (dtProject != null)
                     {
-                        return false;
+                        bmModel = bmModelManager.getModel(dtProject);
                     }
-                    
-                    // Check severity filter
-                    MarkerSeverity markerSeverity = marker.getSeverity();
-                    if (finalSeverityFilter != null && markerSeverity != finalSeverityFilter)
+                }
+                
+                Runnable collector = () -> finalMarkerManager.markers()
+                    .filter(marker -> finalProject.equals(marker.getProject()))
+                    .filter(marker -> matchesFilters(marker, finalSeverityFilter, finalCheckId,
+                        finalObjects, checkRepository, unresolved))
+                    .limit(remaining)
+                    .forEach(marker -> errors.add(toErrorInfo(marker, checkRepository, unresolved)));
+                
+                if (bmModel != null)
+                {
+                    bmModel.executeReadonlyTask(new AbstractBmTask<Void>("CollectProjectErrors") //$NON-NLS-1$
                     {
-                        return false;
-                    }
-                    
-                    // Check checkId filter
-                    String markerCheckId = marker.getCheckId();
-                    if (finalCheckId != null && !finalCheckId.isEmpty())
-                    {
-                        if (markerCheckId == null || 
-                            !markerCheckId.toLowerCase().contains(finalCheckId.toLowerCase()))
+                        @Override
+                        public Void execute(IBmTransaction transaction, IProgressMonitor monitor)
                         {
-                            return false;
+                            collector.run();
+                            return null;
                         }
-                    }
-                    
-                    // Check objects filter (FQN matching)
-                    if (!finalObjects.isEmpty())
-                    {
-                        String objectPresentation = marker.getObjectPresentation();
-                        if (objectPresentation == null || objectPresentation.isEmpty())
-                        {
-                            return false;
-                        }
-
-                        // Lowercase once for all comparisons
-                        String presentationLower = objectPresentation.toLowerCase();
-
-                        // Check if any FQN variant matches the object presentation
-                        // All variants in finalObjects are already lowercased
-                        boolean matchesAnyObject = false;
-                        for (String fqnVariant : finalObjects)
-                        {
-                            if (presentationLower.contains(fqnVariant))
-                            {
-                                matchesAnyObject = true;
-                                break;
-                            }
-                        }
-                        if (!matchesAnyObject)
-                        {
-                            return false;
-                        }
-                    }
-                    
-                    return true;
-                })
-                .limit(limit)
-                .map(marker -> {
-                    ErrorInfo error = new ErrorInfo();
-                    String shortUid = marker.getCheckId() != null ? marker.getCheckId() : ""; //$NON-NLS-1$
-                    error.checkCode = shortUid;
-                    
-                    // Try to convert short UID (e.g. "SU23") to symbolic check ID (e.g. "bsl-legacy-check-expression-type")
-                    if (finalCheckRepo != null && !shortUid.isEmpty() && marker.getProject() != null)
-                    {
-                        try
-                        {
-                            CheckUid checkUid = finalCheckRepo.getUidForShortUid(shortUid, marker.getProject());
-                            if (checkUid != null)
-                            {
-                                error.checkId = checkUid.getCheckId();
-                            }
-                        }
-                        catch (Exception e)
-                        {
-                            // Ignore - will use short UID instead
-                        }
-                    }
-                    
-                    // Check if documentation exists for this check
-                    error.hasDocumentation = false;
-                    if (error.checkId != null && !error.checkId.isEmpty())
-                    {
-                        error.hasDocumentation = GetCheckDescriptionTool.hasCheckDocumentation(error.checkId);
-                    }
-                    
-                    error.message = marker.getMessage() != null ? marker.getMessage() : ""; //$NON-NLS-1$
-                    error.objectPresentation = marker.getObjectPresentation() != null ? 
-                        marker.getObjectPresentation() : ""; //$NON-NLS-1$
-                    return error;
-                })
-                .collect(Collectors.toList());
+                    });
+                }
+                else
+                {
+                    // Not an EDT project (no BM model): best effort. Per-marker access is
+                    // still guarded, so an unresolved marker is reported, never dropped.
+                    collector.run();
+                }
+            }
             
             // Build Markdown response for better readability and context efficiency
             StringBuilder md = new StringBuilder();
@@ -357,12 +350,165 @@ public class GetProjectErrorsTool implements IMcpTool
                 }
             }
             
+            // Surface unresolved markers explicitly instead of silently dropping them.
+            if (unresolved[0] > 0)
+            {
+                md.append("\n> ⚠️ ").append(unresolved[0]) //$NON-NLS-1$
+                  .append(" marker(s) could not be resolved and are shown with a placeholder location. ") //$NON-NLS-1$
+                  .append("Run clean_project / revalidate_objects to refresh them."); //$NON-NLS-1$
+            }
+            
             return md.toString();
         }
         catch (Exception e)
         {
             Activator.logError("Error getting project errors", e); //$NON-NLS-1$
             return "# Error\n\nFailed to get project errors: " + e.getMessage(); //$NON-NLS-1$
+        }
+    }
+    
+    /**
+     * Applies the severity, checkId and objects filters to a single marker.
+     * Must be called inside a BM read transaction so that
+     * {@link Marker#getObjectPresentation()} can resolve.
+     */
+    private static boolean matchesFilters(Marker marker, MarkerSeverity severityFilter,
+        String checkId, Set<String> objects, ICheckRepository checkRepository, int[] unresolved)
+    {
+        // Severity filter
+        if (severityFilter != null && marker.getSeverity() != severityFilter)
+        {
+            return false;
+        }
+        
+        // checkId filter: match either the short UID (e.g. "SU23") or the symbolic id
+        // (e.g. "semicolon-missing"). The short UID alone is rarely what callers type.
+        if (checkId != null && !checkId.isEmpty() && !checkIdMatches(marker, checkId, checkRepository))
+        {
+            return false;
+        }
+        
+        // Objects filter (FQN matching against the resolved object presentation)
+        if (!objects.isEmpty())
+        {
+            String objectPresentation;
+            try
+            {
+                objectPresentation = marker.getObjectPresentation();
+            }
+            catch (Exception e)
+            {
+                // Cannot resolve the location, so we cannot decide membership for an
+                // explicit object filter. Count it so the caller is warned.
+                unresolved[0]++;
+                return false;
+            }
+            if (objectPresentation == null || objectPresentation.isEmpty())
+            {
+                return false;
+            }
+            
+            String presentationLower = objectPresentation.toLowerCase();
+            for (String fqnVariant : objects)
+            {
+                if (presentationLower.contains(fqnVariant))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+        
+        return true;
+    }
+    
+    /**
+     * Returns true when the user supplied checkId substring matches either the marker
+     * short UID or its symbolic check id.
+     */
+    private static boolean checkIdMatches(Marker marker, String checkId, ICheckRepository checkRepository)
+    {
+        String needle = checkId.toLowerCase();
+        String shortUid = marker.getCheckId();
+        if (shortUid != null && shortUid.toLowerCase().contains(needle))
+        {
+            return true;
+        }
+        if (checkRepository != null && shortUid != null && !shortUid.isEmpty() && marker.getProject() != null)
+        {
+            try
+            {
+                CheckUid uid = checkRepository.getUidForShortUid(shortUid, marker.getProject());
+                if (uid != null && uid.getCheckId() != null
+                    && uid.getCheckId().toLowerCase().contains(needle))
+                {
+                    return true;
+                }
+            }
+            catch (Exception e)
+            {
+                // Ignore - fall back to short UID comparison result
+            }
+        }
+        return false;
+    }
+    
+    /**
+     * Builds an {@link ErrorInfo} from a marker. Must be called inside a BM read
+     * transaction. If the object presentation cannot be resolved the marker is still
+     * reported with a placeholder location and counted via {@code unresolved}.
+     */
+    private static ErrorInfo toErrorInfo(Marker marker, ICheckRepository checkRepository, int[] unresolved)
+    {
+        ErrorInfo error = new ErrorInfo();
+        String shortUid = marker.getCheckId() != null ? marker.getCheckId() : ""; //$NON-NLS-1$
+        error.checkCode = shortUid;
+        
+        // Try to convert short UID (e.g. "SU23") to symbolic check ID (e.g. "bsl-legacy-check-expression-type")
+        if (checkRepository != null && !shortUid.isEmpty() && marker.getProject() != null)
+        {
+            try
+            {
+                CheckUid checkUid = checkRepository.getUidForShortUid(shortUid, marker.getProject());
+                if (checkUid != null)
+                {
+                    error.checkId = checkUid.getCheckId();
+                }
+            }
+            catch (Exception e)
+            {
+                // Ignore - will use short UID instead
+            }
+        }
+        
+        // Check if documentation exists for this check
+        error.hasDocumentation = false;
+        if (error.checkId != null && !error.checkId.isEmpty())
+        {
+            error.hasDocumentation = GetCheckDescriptionTool.hasCheckDocumentation(error.checkId);
+        }
+        
+        error.message = marker.getMessage() != null ? marker.getMessage() : ""; //$NON-NLS-1$
+        error.objectPresentation = safeObjectPresentation(marker, unresolved);
+        return error;
+    }
+    
+    /**
+     * Reads {@link Marker#getObjectPresentation()} defensively. On resolution failure the
+     * marker is kept (never dropped) with a placeholder location, and counted.
+     */
+    private static String safeObjectPresentation(Marker marker, int[] unresolved)
+    {
+        try
+        {
+            String presentation = marker.getObjectPresentation();
+            return presentation != null ? presentation : ""; //$NON-NLS-1$
+        }
+        catch (Exception e)
+        {
+            unresolved[0]++;
+            IProject project = marker.getProject();
+            return "<unresolved: " + (project != null ? project.getName() : "?") + ">"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         }
     }
     

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -81,7 +81,7 @@ public class GetProjectErrorsTool implements IMcpTool
         return JsonSchemaBuilder.object()
             .stringProperty("projectName", "Filter by project name (optional)") //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty("severity", "Filter by severity: ERRORS, BLOCKER, CRITICAL, MAJOR, MINOR, TRIVIAL (optional)") //$NON-NLS-1$ //$NON-NLS-2$
-            .stringProperty("checkId", "Filter by check ID substring (e.g. 'ql-temp-table-index') (optional)") //$NON-NLS-1$ //$NON-NLS-2$
+            .stringProperty("checkId", "Filter by check ID substring. Matches either the symbolic check id (e.g. 'ql-temp-table-index') or the short UID (e.g. 'SU23') (optional)") //$NON-NLS-1$ //$NON-NLS-2$
             .stringArrayProperty("objects", "Filter by object FQNs (e.g. ['Document.SalesOrder', 'Catalog.Products']). Russian type names supported (e.g. 'Документ.ПродажаТоваров'). Returns errors only from these objects.") //$NON-NLS-1$ //$NON-NLS-2$
             .integerProperty("limit", "Maximum number of results (default: 100, max: 1000)") //$NON-NLS-1$ //$NON-NLS-2$
             .build();

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -271,10 +271,11 @@ public class GetProjectErrorsTool implements IMcpTool
                 
                 Runnable collector = () -> finalMarkerManager.markers()
                     .filter(marker -> finalProject.equals(marker.getProject()))
-                    .filter(marker -> matchesFilters(marker, finalSeverityFilter, finalCheckId,
-                        finalObjects, checkRepository, unresolvedFilteredOut))
+                    .map(marker -> buildIfMatches(marker, finalSeverityFilter, finalCheckId,
+                        finalObjects, checkRepository, unresolvedShown, unresolvedFilteredOut))
+                    .filter(error -> error != null)
                     .limit(remaining)
-                    .forEach(marker -> errors.add(toErrorInfo(marker, checkRepository, unresolvedShown)));
+                    .forEach(errors::add);
                 
                 if (bmModel != null)
                 {
@@ -371,24 +372,34 @@ public class GetProjectErrorsTool implements IMcpTool
     }
     
     /**
-     * Applies the severity, checkId and objects filters to a single marker.
-     * Must be called inside a BM read transaction so that
-     * {@link Marker#getObjectPresentation()} can resolve.
+     * Applies the severity/checkId/objects filters to a single marker and, if it passes,
+     * builds its {@link ErrorInfo}. Returns {@code null} when the marker is filtered out.
+     *
+     * <p>Must be called inside a BM read transaction so that
+     * {@link Marker#getObjectPresentation()} can resolve. The symbolic check id is resolved
+     * exactly once here and reused for both the checkId filter and the resulting
+     * {@link ErrorInfo}, avoiding a second {@link ICheckRepository#getUidForShortUid} call.
+     * The filter order (severity -> checkId -> objects) is preserved so the
+     * {@code unresolvedFilteredOut} counter keeps the same semantics.</p>
      */
-    private static boolean matchesFilters(Marker marker, MarkerSeverity severityFilter,
-        String checkId, Set<String> objects, ICheckRepository checkRepository, int[] unresolvedFilteredOut)
+    private static ErrorInfo buildIfMatches(Marker marker, MarkerSeverity severityFilter, String checkId,
+        Set<String> objects, ICheckRepository checkRepository, int[] unresolvedShown, int[] unresolvedFilteredOut)
     {
         // Severity filter
         if (severityFilter != null && marker.getSeverity() != severityFilter)
         {
-            return false;
+            return null;
         }
+        
+        // Resolve the symbolic check id once; reused below for the checkId filter and display.
+        String shortUid = marker.getCheckId() != null ? marker.getCheckId() : ""; //$NON-NLS-1$
+        String symbolicCheckId = resolveSymbolicCheckId(marker, shortUid, checkRepository);
         
         // checkId filter: match either the short UID (e.g. "SU23") or the symbolic id
         // (e.g. "semicolon-missing"). The short UID alone is rarely what callers type.
-        if (checkId != null && !checkId.isEmpty() && !checkIdMatches(marker, checkId, checkRepository))
+        if (checkId != null && !checkId.isEmpty() && !checkIdMatches(shortUid, symbolicCheckId, checkId))
         {
-            return false;
+            return null;
         }
         
         // Objects filter (FQN matching against the resolved object presentation)
@@ -405,96 +416,78 @@ public class GetProjectErrorsTool implements IMcpTool
                 // explicit object filter. The marker is excluded from the result; count it
                 // separately so the caller is warned that it was filtered out, not shown.
                 unresolvedFilteredOut[0]++;
-                return false;
+                return null;
             }
             if (objectPresentation == null || objectPresentation.isEmpty())
             {
-                return false;
+                return null;
             }
             
             String presentationLower = objectPresentation.toLowerCase();
+            boolean matched = false;
             for (String fqnVariant : objects)
             {
                 if (presentationLower.contains(fqnVariant))
                 {
-                    return true;
+                    matched = true;
+                    break;
                 }
             }
-            return false;
+            if (!matched)
+            {
+                return null;
+            }
         }
         
-        return true;
+        // Build the ErrorInfo, reusing the already resolved symbolic check id.
+        ErrorInfo error = new ErrorInfo();
+        error.checkCode = shortUid;
+        error.checkId = symbolicCheckId;
+        error.hasDocumentation = symbolicCheckId != null && !symbolicCheckId.isEmpty()
+            && GetCheckDescriptionTool.hasCheckDocumentation(symbolicCheckId);
+        error.message = marker.getMessage() != null ? marker.getMessage() : ""; //$NON-NLS-1$
+        error.objectPresentation = safeObjectPresentation(marker, unresolvedShown);
+        return error;
+    }
+    
+    /**
+     * Resolves the symbolic check id (e.g. "bsl-legacy-check-expression-type") for a marker's
+     * short UID (e.g. "SU23") exactly once. Returns {@code null} when it cannot be resolved.
+     */
+    private static String resolveSymbolicCheckId(Marker marker, String shortUid, ICheckRepository checkRepository)
+    {
+        if (checkRepository == null || shortUid == null || shortUid.isEmpty() || marker.getProject() == null)
+        {
+            return null;
+        }
+        try
+        {
+            CheckUid uid = checkRepository.getUidForShortUid(shortUid, marker.getProject());
+            return uid != null ? uid.getCheckId() : null;
+        }
+        catch (Exception e)
+        {
+            // Ignore - caller falls back to the short UID
+            return null;
+        }
     }
     
     /**
      * Returns true when the user supplied checkId substring matches either the marker
-     * short UID or its symbolic check id.
+     * short UID or its already resolved symbolic check id.
      */
-    private static boolean checkIdMatches(Marker marker, String checkId, ICheckRepository checkRepository)
+    private static boolean checkIdMatches(String shortUid, String symbolicCheckId, String checkId)
     {
         String needle = checkId.toLowerCase();
-        String shortUid = marker.getCheckId();
         if (shortUid != null && shortUid.toLowerCase().contains(needle))
         {
             return true;
         }
-        if (checkRepository != null && shortUid != null && !shortUid.isEmpty() && marker.getProject() != null)
+        if (symbolicCheckId != null && symbolicCheckId.toLowerCase().contains(needle))
         {
-            try
-            {
-                CheckUid uid = checkRepository.getUidForShortUid(shortUid, marker.getProject());
-                if (uid != null && uid.getCheckId() != null
-                    && uid.getCheckId().toLowerCase().contains(needle))
-                {
-                    return true;
-                }
-            }
-            catch (Exception e)
-            {
-                // Ignore - fall back to short UID comparison result
-            }
+            return true;
         }
         return false;
-    }
-    
-    /**
-     * Builds an {@link ErrorInfo} from a marker. Must be called inside a BM read
-     * transaction. If the object presentation cannot be resolved the marker is still
-     * reported with a placeholder location and counted via {@code unresolvedShown}.
-     */
-    private static ErrorInfo toErrorInfo(Marker marker, ICheckRepository checkRepository, int[] unresolvedShown)
-    {
-        ErrorInfo error = new ErrorInfo();
-        String shortUid = marker.getCheckId() != null ? marker.getCheckId() : ""; //$NON-NLS-1$
-        error.checkCode = shortUid;
-        
-        // Try to convert short UID (e.g. "SU23") to symbolic check ID (e.g. "bsl-legacy-check-expression-type")
-        if (checkRepository != null && !shortUid.isEmpty() && marker.getProject() != null)
-        {
-            try
-            {
-                CheckUid checkUid = checkRepository.getUidForShortUid(shortUid, marker.getProject());
-                if (checkUid != null)
-                {
-                    error.checkId = checkUid.getCheckId();
-                }
-            }
-            catch (Exception e)
-            {
-                // Ignore - will use short UID instead
-            }
-        }
-        
-        // Check if documentation exists for this check
-        error.hasDocumentation = false;
-        if (error.checkId != null && !error.checkId.isEmpty())
-        {
-            error.hasDocumentation = GetCheckDescriptionTool.hasCheckDocumentation(error.checkId);
-        }
-        
-        error.message = marker.getMessage() != null ? marker.getMessage() : ""; //$NON-NLS-1$
-        error.objectPresentation = safeObjectPresentation(marker, unresolvedShown);
-        return error;
     }
     
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -374,7 +374,7 @@ public class GetProjectErrorsTool implements IMcpTool
      * The filter order (severity -> checkId -> objects) is preserved so the
      * {@code unresolvedFilteredOut} counter keeps the same semantics.</p>
      */
-    private static ErrorInfo buildIfMatches(Marker marker, MarkerSeverity severityFilter, String checkId,
+    static ErrorInfo buildIfMatches(Marker marker, MarkerSeverity severityFilter, String checkId,
         Set<String> objects, ICheckRepository checkRepository, int[] unresolvedShown, int[] unresolvedFilteredOut)
     {
         // Severity filter
@@ -466,7 +466,7 @@ public class GetProjectErrorsTool implements IMcpTool
      * Resolves the symbolic check id (e.g. "bsl-legacy-check-expression-type") for a marker's
      * short UID (e.g. "SU23") exactly once. Returns {@code null} when it cannot be resolved.
      */
-    private static String resolveSymbolicCheckId(Marker marker, String shortUid, ICheckRepository checkRepository)
+    static String resolveSymbolicCheckId(Marker marker, String shortUid, ICheckRepository checkRepository)
     {
         if (checkRepository == null || shortUid == null || shortUid.isEmpty() || marker.getProject() == null)
         {
@@ -488,7 +488,7 @@ public class GetProjectErrorsTool implements IMcpTool
      * Returns true when the user supplied checkId substring matches either the marker
      * short UID or its already resolved symbolic check id.
      */
-    private static boolean checkIdMatches(String shortUid, String symbolicCheckId, String checkId)
+    static boolean checkIdMatches(String shortUid, String symbolicCheckId, String checkId)
     {
         String needle = checkId.toLowerCase();
         if (shortUid != null && shortUid.toLowerCase().contains(needle))
@@ -506,7 +506,7 @@ public class GetProjectErrorsTool implements IMcpTool
      * Placeholder location for a marker whose {@link Marker#getObjectPresentation()} could not
      * be resolved, so the marker is reported instead of being dropped.
      */
-    private static String unresolvedPlaceholder(Marker marker)
+    static String unresolvedPlaceholder(Marker marker)
     {
         IProject project = marker.getProject();
         return "<unresolved: " + (project != null ? project.getName() : "?") + ">"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
@@ -515,7 +515,7 @@ public class GetProjectErrorsTool implements IMcpTool
     /**
      * Helper class to store error info.
      */
-    private static class ErrorInfo
+    static class ErrorInfo
     {
         String checkCode;          // Short UID like "SU23"
         String checkId;            // Symbolic ID like "bsl-legacy-check-expression-type"

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -243,8 +243,13 @@ public class GetProjectErrorsTool implements IMcpTool
             
             final List<ErrorInfo> errors = new ArrayList<>();
             // Markers whose presentation could not be resolved even inside a transaction.
-            // They are NOT dropped: they are reported with a placeholder location and counted.
-            final int[] unresolved = {0};
+            // They are NOT dropped, but they are surfaced differently depending on context,
+            // so we track the two cases separately to keep the warning text honest:
+            //  - unresolvedShown: reported in the table with a "<unresolved: ...>" placeholder;
+            //  - unresolvedFilteredOut: excluded from the result because an explicit objects
+            //    filter is active and the location could not be resolved to test membership.
+            final int[] unresolvedShown = {0};
+            final int[] unresolvedFilteredOut = {0};
             final IMarkerManager finalMarkerManager = markerManager;
             
             for (IProject project : targetProjects)
@@ -276,9 +281,9 @@ public class GetProjectErrorsTool implements IMcpTool
                 Runnable collector = () -> finalMarkerManager.markers()
                     .filter(marker -> finalProject.equals(marker.getProject()))
                     .filter(marker -> matchesFilters(marker, finalSeverityFilter, finalCheckId,
-                        finalObjects, checkRepository, unresolved))
+                        finalObjects, checkRepository, unresolvedFilteredOut))
                     .limit(remaining)
-                    .forEach(marker -> errors.add(toErrorInfo(marker, checkRepository, unresolved)));
+                    .forEach(marker -> errors.add(toErrorInfo(marker, checkRepository, unresolvedShown)));
                 
                 if (bmModel != null)
                 {
@@ -351,11 +356,18 @@ public class GetProjectErrorsTool implements IMcpTool
             }
             
             // Surface unresolved markers explicitly instead of silently dropping them.
-            if (unresolved[0] > 0)
+            // Two distinct cases, reported separately so each warning matches reality.
+            if (unresolvedShown[0] > 0)
             {
-                md.append("\n> ⚠️ ").append(unresolved[0]) //$NON-NLS-1$
+                md.append("\n> ⚠️ ").append(unresolvedShown[0]) //$NON-NLS-1$
                   .append(" marker(s) could not be resolved and are shown with a placeholder location. ") //$NON-NLS-1$
                   .append("Run clean_project / revalidate_objects to refresh them."); //$NON-NLS-1$
+            }
+            if (unresolvedFilteredOut[0] > 0)
+            {
+                md.append("\n> ⚠️ ").append(unresolvedFilteredOut[0]) //$NON-NLS-1$
+                  .append(" marker(s) were excluded from the object filter because their location could not be resolved. ") //$NON-NLS-1$
+                  .append("Run clean_project / revalidate_objects, or remove the objects filter, to include them."); //$NON-NLS-1$
             }
             
             return md.toString();
@@ -373,7 +385,7 @@ public class GetProjectErrorsTool implements IMcpTool
      * {@link Marker#getObjectPresentation()} can resolve.
      */
     private static boolean matchesFilters(Marker marker, MarkerSeverity severityFilter,
-        String checkId, Set<String> objects, ICheckRepository checkRepository, int[] unresolved)
+        String checkId, Set<String> objects, ICheckRepository checkRepository, int[] unresolvedFilteredOut)
     {
         // Severity filter
         if (severityFilter != null && marker.getSeverity() != severityFilter)
@@ -399,8 +411,9 @@ public class GetProjectErrorsTool implements IMcpTool
             catch (Exception e)
             {
                 // Cannot resolve the location, so we cannot decide membership for an
-                // explicit object filter. Count it so the caller is warned.
-                unresolved[0]++;
+                // explicit object filter. The marker is excluded from the result; count it
+                // separately so the caller is warned that it was filtered out, not shown.
+                unresolvedFilteredOut[0]++;
                 return false;
             }
             if (objectPresentation == null || objectPresentation.isEmpty())
@@ -456,9 +469,9 @@ public class GetProjectErrorsTool implements IMcpTool
     /**
      * Builds an {@link ErrorInfo} from a marker. Must be called inside a BM read
      * transaction. If the object presentation cannot be resolved the marker is still
-     * reported with a placeholder location and counted via {@code unresolved}.
+     * reported with a placeholder location and counted via {@code unresolvedShown}.
      */
-    private static ErrorInfo toErrorInfo(Marker marker, ICheckRepository checkRepository, int[] unresolved)
+    private static ErrorInfo toErrorInfo(Marker marker, ICheckRepository checkRepository, int[] unresolvedShown)
     {
         ErrorInfo error = new ErrorInfo();
         String shortUid = marker.getCheckId() != null ? marker.getCheckId() : ""; //$NON-NLS-1$
@@ -489,7 +502,7 @@ public class GetProjectErrorsTool implements IMcpTool
         }
         
         error.message = marker.getMessage() != null ? marker.getMessage() : ""; //$NON-NLS-1$
-        error.objectPresentation = safeObjectPresentation(marker, unresolved);
+        error.objectPresentation = safeObjectPresentation(marker, unresolvedShown);
         return error;
     }
     
@@ -497,7 +510,7 @@ public class GetProjectErrorsTool implements IMcpTool
      * Reads {@link Marker#getObjectPresentation()} defensively. On resolution failure the
      * marker is kept (never dropped) with a placeholder location, and counted.
      */
-    private static String safeObjectPresentation(Marker marker, int[] unresolved)
+    private static String safeObjectPresentation(Marker marker, int[] unresolvedShown)
     {
         try
         {
@@ -506,7 +519,7 @@ public class GetProjectErrorsTool implements IMcpTool
         }
         catch (Exception e)
         {
-            unresolved[0]++;
+            unresolvedShown[0]++;
             IProject project = marker.getProject();
             return "<unresolved: " + (project != null ? project.getName() : "?") + ">"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -22,8 +22,6 @@ import com._1c.g5.v8.bm.core.IBmTransaction;
 import com._1c.g5.v8.bm.integration.AbstractBmTask;
 import com._1c.g5.v8.bm.integration.IBmModel;
 import com._1c.g5.v8.dt.core.platform.IBmModelManager;
-import com._1c.g5.v8.dt.core.platform.IDtProject;
-import com._1c.g5.v8.dt.core.platform.IDtProjectManager;
 import com._1c.g5.v8.dt.validation.marker.IMarkerManager;
 import com._1c.g5.v8.dt.validation.marker.Marker;
 import com._1c.g5.v8.dt.validation.marker.MarkerSeverity;
@@ -176,7 +174,6 @@ public class GetProjectErrorsTool implements IMcpTool
             
             final ICheckRepository checkRepository = Activator.getDefault().getCheckRepository();
             IBmModelManager bmModelManager = Activator.getDefault().getBmModelManager();
-            IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
             
             IWorkspace workspace = ResourcesPlugin.getWorkspace();
             
@@ -267,16 +264,10 @@ public class GetProjectErrorsTool implements IMcpTool
                 final int remaining = limit - errors.size();
                 
                 // Resolve the project's BM model so getObjectPresentation() can lazily
-                // resolve the marker target inside a read transaction.
-                IBmModel bmModel = null;
-                if (bmModelManager != null && dtProjectManager != null)
-                {
-                    IDtProject dtProject = dtProjectManager.getDtProject(project);
-                    if (dtProject != null)
-                    {
-                        bmModel = bmModelManager.getModel(dtProject);
-                    }
-                }
+                // resolve the marker target inside a read transaction. The getModel(IProject)
+                // overload is the idiomatic path used across the plugin (FindReferencesTool,
+                // AddMetadataAttributeTool, tag tools), so no IDtProjectManager is needed.
+                IBmModel bmModel = bmModelManager != null ? bmModelManager.getModel(project) : null;
                 
                 Runnable collector = () -> finalMarkerManager.markers()
                     .filter(marker -> finalProject.equals(marker.getProject()))

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -402,15 +402,25 @@ public class GetProjectErrorsTool implements IMcpTool
             return null;
         }
         
+        // Resolve the object presentation once; reused for the objects filter and the ErrorInfo.
+        // Failure handling differs by context (see below), so we only record the outcome here.
+        String objectPresentation = null;
+        boolean presentationResolved;
+        try
+        {
+            String p = marker.getObjectPresentation();
+            objectPresentation = p != null ? p : ""; //$NON-NLS-1$
+            presentationResolved = true;
+        }
+        catch (Exception e)
+        {
+            presentationResolved = false;
+        }
+        
         // Objects filter (FQN matching against the resolved object presentation)
         if (!objects.isEmpty())
         {
-            String objectPresentation;
-            try
-            {
-                objectPresentation = marker.getObjectPresentation();
-            }
-            catch (Exception e)
+            if (!presentationResolved)
             {
                 // Cannot resolve the location, so we cannot decide membership for an
                 // explicit object filter. The marker is excluded from the result; count it
@@ -418,7 +428,7 @@ public class GetProjectErrorsTool implements IMcpTool
                 unresolvedFilteredOut[0]++;
                 return null;
             }
-            if (objectPresentation == null || objectPresentation.isEmpty())
+            if (objectPresentation.isEmpty())
             {
                 return null;
             }
@@ -439,14 +449,24 @@ public class GetProjectErrorsTool implements IMcpTool
             }
         }
         
-        // Build the ErrorInfo, reusing the already resolved symbolic check id.
+        // Build the ErrorInfo, reusing the already resolved symbolic check id and presentation.
         ErrorInfo error = new ErrorInfo();
         error.checkCode = shortUid;
         error.checkId = symbolicCheckId;
         error.hasDocumentation = symbolicCheckId != null && !symbolicCheckId.isEmpty()
             && GetCheckDescriptionTool.hasCheckDocumentation(symbolicCheckId);
         error.message = marker.getMessage() != null ? marker.getMessage() : ""; //$NON-NLS-1$
-        error.objectPresentation = safeObjectPresentation(marker, unresolvedShown);
+        if (presentationResolved)
+        {
+            error.objectPresentation = objectPresentation;
+        }
+        else
+        {
+            // No objects filter was active (otherwise we would have returned above): keep the
+            // marker with a placeholder location instead of dropping it, and count it.
+            unresolvedShown[0]++;
+            error.objectPresentation = unresolvedPlaceholder(marker);
+        }
         return error;
     }
     
@@ -491,22 +511,13 @@ public class GetProjectErrorsTool implements IMcpTool
     }
     
     /**
-     * Reads {@link Marker#getObjectPresentation()} defensively. On resolution failure the
-     * marker is kept (never dropped) with a placeholder location, and counted.
+     * Placeholder location for a marker whose {@link Marker#getObjectPresentation()} could not
+     * be resolved, so the marker is reported instead of being dropped.
      */
-    private static String safeObjectPresentation(Marker marker, int[] unresolvedShown)
+    private static String unresolvedPlaceholder(Marker marker)
     {
-        try
-        {
-            String presentation = marker.getObjectPresentation();
-            return presentation != null ? presentation : ""; //$NON-NLS-1$
-        }
-        catch (Exception e)
-        {
-            unresolvedShown[0]++;
-            IProject project = marker.getProject();
-            return "<unresolved: " + (project != null ? project.getName() : "?") + ">"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        }
+        IProject project = marker.getProject();
+        return "<unresolved: " + (project != null ? project.getName() : "?") + ">"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
     }
     
     /**

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
@@ -11,6 +11,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,6 +25,7 @@ import org.junit.Test;
 
 import com._1c.g5.v8.dt.validation.marker.Marker;
 import com._1c.g5.v8.dt.validation.marker.MarkerSeverity;
+import com.e1c.g5.v8.dt.check.settings.CheckUid;
 import com.e1c.g5.v8.dt.check.settings.ICheckRepository;
 import com.ditrix.edt.mcp.server.tools.impl.GetProjectErrorsTool.ErrorInfo;
 
@@ -117,6 +120,20 @@ public class GetProjectErrorsToolTest
         when(marker.getProject()).thenReturn(null);
         ICheckRepository repo = mock(ICheckRepository.class);
         assertNull(GetProjectErrorsTool.resolveSymbolicCheckId(marker, "SU23", repo)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResolveSymbolicCheckIdSuccess()
+    {
+        IProject project = project("Proj"); //$NON-NLS-1$
+        Marker marker = mock(Marker.class);
+        when(marker.getProject()).thenReturn(project);
+        CheckUid uid = checkUid("ql-temp-table-index"); //$NON-NLS-1$
+        ICheckRepository repo = mock(ICheckRepository.class);
+        when(repo.getUidForShortUid(eq("SU23"), any(IProject.class))).thenReturn(uid); //$NON-NLS-1$
+
+        assertEquals("ql-temp-table-index", //$NON-NLS-1$
+            GetProjectErrorsTool.resolveSymbolicCheckId(marker, "SU23", repo)); //$NON-NLS-1$
     }
 
     // ========== buildIfMatches: review point 1 counters ==========
@@ -248,6 +265,30 @@ public class GetProjectErrorsToolTest
     }
 
     @Test
+    public void testCheckIdFilterMatchesSymbolicId()
+    {
+        // checkId matches only the resolved symbolic id, not the short UID. Exercises the
+        // resolveSymbolicCheckId -> checkIdMatches integration inside buildIfMatches.
+        IProject project = project("Proj"); //$NON-NLS-1$
+        Marker marker = mock(Marker.class);
+        when(marker.getSeverity()).thenReturn(MarkerSeverity.MINOR);
+        when(marker.getCheckId()).thenReturn("SU23"); //$NON-NLS-1$
+        when(marker.getMessage()).thenReturn("msg"); //$NON-NLS-1$
+        when(marker.getProject()).thenReturn(project);
+        when(marker.getObjectPresentation()).thenReturn("Catalog.Foo"); //$NON-NLS-1$
+        CheckUid uid = checkUid("ql-temp-table-index"); //$NON-NLS-1$
+        ICheckRepository repo = mock(ICheckRepository.class);
+        when(repo.getUidForShortUid(eq("SU23"), any(IProject.class))).thenReturn(uid); //$NON-NLS-1$
+
+        ErrorInfo error = GetProjectErrorsTool.buildIfMatches(marker, null, "temp",
+            Collections.emptySet(), repo, new int[]{0}, new int[]{0}); //$NON-NLS-1$
+
+        assertNotNull(error);
+        assertEquals("SU23", error.checkCode); //$NON-NLS-1$
+        assertEquals("ql-temp-table-index", error.checkId); //$NON-NLS-1$
+    }
+
+    @Test
     public void testCheckIdFilterExcludes()
     {
         Marker marker = markerThatThrowsOnPresentation(MarkerSeverity.MINOR, "SU23", "msg", "Proj"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
@@ -291,6 +332,13 @@ public class GetProjectErrorsToolTest
         IProject project = mock(IProject.class);
         when(project.getName()).thenReturn(name);
         return project;
+    }
+
+    private static CheckUid checkUid(String symbolicCheckId)
+    {
+        CheckUid uid = mock(CheckUid.class);
+        when(uid.getCheckId()).thenReturn(symbolicCheckId);
+        return uid;
     }
 
     private static Set<String> singleton(String value)

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
@@ -1,0 +1,302 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2026 Diversus (https://github.com/Diversus23)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.core.resources.IProject;
+import org.junit.Test;
+
+import com._1c.g5.v8.dt.validation.marker.Marker;
+import com._1c.g5.v8.dt.validation.marker.MarkerSeverity;
+import com.e1c.g5.v8.dt.check.settings.ICheckRepository;
+import com.ditrix.edt.mcp.server.tools.impl.GetProjectErrorsTool.ErrorInfo;
+
+/**
+ * Unit tests for the marker filtering / building helpers of {@link GetProjectErrorsTool}.
+ *
+ * <p>Focuses on the review point 1 (PR #120) discrepancy: a marker whose location cannot
+ * be resolved must be counted as {@code unresolvedShown} when it is still reported with a
+ * placeholder, and as {@code unresolvedFilteredOut} when an explicit {@code objects} filter
+ * excludes it from the result. These two cases must never overlap.</p>
+ *
+ * <p>{@link Marker} / {@link IProject} / {@link ICheckRepository} are mocked with Mockito.
+ * The symbolic-check-id resolution success path goes through the platform
+ * {@code ICheckRepository.getUidForShortUid} + {@code CheckUid} and is exercised by e2e; the
+ * pure substring matching it feeds into is covered directly via {@link #checkIdMatches}.</p>
+ */
+public class GetProjectErrorsToolTest
+{
+    // ========== checkIdMatches (pure) ==========
+
+    @Test
+    public void testCheckIdMatchesByShortUid()
+    {
+        assertTrue(GetProjectErrorsTool.checkIdMatches("SU23", null, "su2")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testCheckIdMatchesBySymbolicId()
+    {
+        assertTrue(GetProjectErrorsTool.checkIdMatches("SU23", "ql-temp-table-index", "temp")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    @Test
+    public void testCheckIdMatchesCaseInsensitive()
+    {
+        assertTrue(GetProjectErrorsTool.checkIdMatches("Su23", null, "SU23")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(GetProjectErrorsTool.checkIdMatches(null, "QL-Temp-Table", "ql-temp")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testCheckIdMatchesNoMatch()
+    {
+        assertFalse(GetProjectErrorsTool.checkIdMatches("SU23", "ql-temp-table-index", "zzz")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    @Test
+    public void testCheckIdMatchesBothNull()
+    {
+        assertFalse(GetProjectErrorsTool.checkIdMatches(null, null, "anything")); //$NON-NLS-1$
+    }
+
+    // ========== unresolvedPlaceholder ==========
+
+    @Test
+    public void testUnresolvedPlaceholderWithProject()
+    {
+        IProject project = project("MyProject"); //$NON-NLS-1$
+        Marker marker = mock(Marker.class);
+        when(marker.getProject()).thenReturn(project);
+        assertEquals("<unresolved: MyProject>", GetProjectErrorsTool.unresolvedPlaceholder(marker)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testUnresolvedPlaceholderNullProject()
+    {
+        Marker marker = mock(Marker.class);
+        when(marker.getProject()).thenReturn(null);
+        assertEquals("<unresolved: ?>", GetProjectErrorsTool.unresolvedPlaceholder(marker)); //$NON-NLS-1$
+    }
+
+    // ========== resolveSymbolicCheckId null-guards ==========
+
+    @Test
+    public void testResolveSymbolicCheckIdNullRepository()
+    {
+        Marker marker = mock(Marker.class);
+        assertNull(GetProjectErrorsTool.resolveSymbolicCheckId(marker, "SU23", null)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResolveSymbolicCheckIdEmptyShortUid()
+    {
+        Marker marker = mock(Marker.class);
+        ICheckRepository repo = mock(ICheckRepository.class);
+        assertNull(GetProjectErrorsTool.resolveSymbolicCheckId(marker, "", repo)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResolveSymbolicCheckIdNullProject()
+    {
+        Marker marker = mock(Marker.class);
+        when(marker.getProject()).thenReturn(null);
+        ICheckRepository repo = mock(ICheckRepository.class);
+        assertNull(GetProjectErrorsTool.resolveSymbolicCheckId(marker, "SU23", repo)); //$NON-NLS-1$
+    }
+
+    // ========== buildIfMatches: review point 1 counters ==========
+
+    @Test
+    public void testObjectsFilterUnresolvedCountedAsFilteredOut()
+    {
+        // Active objects filter + presentation cannot be resolved -> excluded, counted as
+        // filteredOut only (NOT shown). This is the exact review point 1 discrepancy.
+        Marker marker = markerThatThrowsOnPresentation(MarkerSeverity.MINOR, "SU23", "msg", "Proj"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        int[] shown = {0};
+        int[] filteredOut = {0};
+
+        ErrorInfo error = GetProjectErrorsTool.buildIfMatches(marker, null, null,
+            singleton("catalog.foo"), null, shown, filteredOut); //$NON-NLS-1$
+
+        assertNull(error);
+        assertEquals(0, shown[0]);
+        assertEquals(1, filteredOut[0]);
+    }
+
+    @Test
+    public void testNoObjectsFilterUnresolvedCountedAsShown()
+    {
+        // No objects filter + presentation cannot be resolved -> reported with placeholder,
+        // counted as shown only (NOT filteredOut).
+        Marker marker = markerThatThrowsOnPresentation(MarkerSeverity.MINOR, "SU23", "msg", "Proj"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        int[] shown = {0};
+        int[] filteredOut = {0};
+
+        ErrorInfo error = GetProjectErrorsTool.buildIfMatches(marker, null, null,
+            Collections.emptySet(), null, shown, filteredOut);
+
+        assertNotNull(error);
+        assertEquals("<unresolved: Proj>", error.objectPresentation); //$NON-NLS-1$
+        assertEquals("SU23", error.checkCode); //$NON-NLS-1$
+        assertNull(error.checkId);
+        assertFalse(error.hasDocumentation);
+        assertEquals(1, shown[0]);
+        assertEquals(0, filteredOut[0]);
+    }
+
+    @Test
+    public void testResolvedMarkerNoCountersIncremented()
+    {
+        Marker marker = marker(MarkerSeverity.MINOR, "SU23", "msg", "Proj"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        when(marker.getObjectPresentation()).thenReturn("Catalog.Foo"); //$NON-NLS-1$
+        int[] shown = {0};
+        int[] filteredOut = {0};
+
+        ErrorInfo error = GetProjectErrorsTool.buildIfMatches(marker, null, null,
+            Collections.emptySet(), null, shown, filteredOut);
+
+        assertNotNull(error);
+        assertEquals("Catalog.Foo", error.objectPresentation); //$NON-NLS-1$
+        assertEquals("msg", error.message); //$NON-NLS-1$
+        assertEquals(0, shown[0]);
+        assertEquals(0, filteredOut[0]);
+    }
+
+    @Test
+    public void testObjectsFilterResolvedButEmptyPresentationExcludedWithoutCounter()
+    {
+        Marker marker = marker(MarkerSeverity.MINOR, "SU23", "msg", "Proj"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        when(marker.getObjectPresentation()).thenReturn(""); //$NON-NLS-1$
+        int[] shown = {0};
+        int[] filteredOut = {0};
+
+        ErrorInfo error = GetProjectErrorsTool.buildIfMatches(marker, null, null,
+            singleton("catalog.foo"), null, shown, filteredOut); //$NON-NLS-1$
+
+        assertNull(error);
+        assertEquals(0, shown[0]);
+        assertEquals(0, filteredOut[0]);
+    }
+
+    // ========== buildIfMatches: filters ==========
+
+    @Test
+    public void testSeverityFilterExcludes()
+    {
+        // Mismatching severity returns null before the presentation is ever read.
+        Marker marker = markerThatThrowsOnPresentation(MarkerSeverity.MINOR, "SU23", "msg", "Proj"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        int[] shown = {0};
+        int[] filteredOut = {0};
+
+        ErrorInfo error = GetProjectErrorsTool.buildIfMatches(marker, MarkerSeverity.MAJOR, null,
+            Collections.emptySet(), null, shown, filteredOut);
+
+        assertNull(error);
+        assertEquals(0, shown[0]);
+        assertEquals(0, filteredOut[0]);
+    }
+
+    @Test
+    public void testObjectsFilterMatchesSubstring()
+    {
+        Marker marker = marker(MarkerSeverity.MINOR, "SU23", "msg", "Proj"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        when(marker.getObjectPresentation()).thenReturn("Catalog.Foo"); //$NON-NLS-1$
+
+        ErrorInfo error = GetProjectErrorsTool.buildIfMatches(marker, null, null,
+            singleton("catalog.foo"), null, new int[]{0}, new int[]{0}); //$NON-NLS-1$
+
+        assertNotNull(error);
+    }
+
+    @Test
+    public void testObjectsFilterNoMatch()
+    {
+        Marker marker = marker(MarkerSeverity.MINOR, "SU23", "msg", "Proj"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        when(marker.getObjectPresentation()).thenReturn("Catalog.Foo"); //$NON-NLS-1$
+
+        ErrorInfo error = GetProjectErrorsTool.buildIfMatches(marker, null, null,
+            singleton("catalog.bar"), null, new int[]{0}, new int[]{0}); //$NON-NLS-1$
+
+        assertNull(error);
+    }
+
+    @Test
+    public void testCheckIdFilterMatchesShortUid()
+    {
+        Marker marker = marker(MarkerSeverity.MINOR, "SU23", "msg", "Proj"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        when(marker.getObjectPresentation()).thenReturn("Catalog.Foo"); //$NON-NLS-1$
+
+        ErrorInfo error = GetProjectErrorsTool.buildIfMatches(marker, null, "su2",
+            Collections.emptySet(), null, new int[]{0}, new int[]{0}); //$NON-NLS-1$
+
+        assertNotNull(error);
+    }
+
+    @Test
+    public void testCheckIdFilterExcludes()
+    {
+        Marker marker = markerThatThrowsOnPresentation(MarkerSeverity.MINOR, "SU23", "msg", "Proj"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        int[] shown = {0};
+        int[] filteredOut = {0};
+
+        // checkId does not match -> null before the presentation is read; no counter touched.
+        ErrorInfo error = GetProjectErrorsTool.buildIfMatches(marker, null, "zzz",
+            Collections.emptySet(), null, shown, filteredOut); //$NON-NLS-1$
+
+        assertNull(error);
+        assertEquals(0, shown[0]);
+        assertEquals(0, filteredOut[0]);
+    }
+
+    // ========== helpers ==========
+
+    private static Marker marker(MarkerSeverity severity, String checkId, String message, String projectName)
+    {
+        // Build the project mock first; stubbing one mock inside another's thenReturn() trips
+        // Mockito's UnfinishedStubbingException.
+        IProject project = project(projectName);
+        Marker marker = mock(Marker.class);
+        when(marker.getSeverity()).thenReturn(severity);
+        when(marker.getCheckId()).thenReturn(checkId);
+        when(marker.getMessage()).thenReturn(message);
+        when(marker.getProject()).thenReturn(project);
+        return marker;
+    }
+
+    private static Marker markerThatThrowsOnPresentation(MarkerSeverity severity, String checkId,
+        String message, String projectName)
+    {
+        Marker marker = marker(severity, checkId, message, projectName);
+        when(marker.getObjectPresentation()).thenThrow(new RuntimeException("cannot resolve")); //$NON-NLS-1$
+        return marker;
+    }
+
+    private static IProject project(String name)
+    {
+        IProject project = mock(IProject.class);
+        when(project.getName()).thenReturn(name);
+        return project;
+    }
+
+    private static Set<String> singleton(String value)
+    {
+        Set<String> set = new HashSet<>();
+        set.add(value);
+        return set;
+    }
+}


### PR DESCRIPTION
## Summary
- Исправлен NPE в `get_project_errors`: `resolvedDataCache` был null у маркеров, восстановленных из persisted index после старта EDT
- Чтение маркеров перенесено в `IBmModel.executeReadonlyTask`
- Маркеры не отбрасываются: placeholder `<unresolved: Project>` + warning
- Фильтр `checkId` работает по символическому id (`semicolon-missing`)

## Test plan
- [x] Unit-тесты: 594 passed
- [x] E2E: 28/28 passed, включая `get_project_errors`