### PR TITLE
Compact YAXUnit test report traces (closes #112)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/JUnitMarkdownFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/JUnitMarkdownFormatter.java
@@ -7,6 +7,8 @@
 package com.ditrix.edt.mcp.server.utils;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Renders {@link JUnitTestResults} as a Markdown report.
@@ -16,6 +18,36 @@ import java.util.List;
  */
 public final class JUnitMarkdownFormatter
 {
+    /**
+     * Identifiers of YAXUnit-internal modules whose stack frames carry no
+     * diagnostic value — the assertion engine, the executor and the server-call
+     * plumbing. They are always identical framework frames, so collapsing them
+     * keeps the actionable user frames while drastically shrinking the report
+     * (see issue #112).
+     *
+     * <p>The tokens are 1C metadata object <em>names</em> (not synonyms), so
+     * they stay Cyrillic regardless of the platform UI language. The
+     * surrounding metadata-kind words ({@code ОбщийМодуль}/{@code CommonModule},
+     * {@code Модуль}/{@code Module}) <em>are</em> localized, so we deliberately
+     * key only on the dot-delimited module name to stay language-independent.
+     */
+    private static final String[] INTERNAL_FRAME_MODULE_TOKENS = {
+        ".ЮТУтверждения.", //$NON-NLS-1$
+        ".ЮТМетодыСлужебный.", //$NON-NLS-1$
+        ".ЮТИсполнительСлужебныйКлиентСервер.", //$NON-NLS-1$
+        ".ЮТИсполнительСлужебныйВызовСервера.", //$NON-NLS-1$
+    };
+
+    /**
+     * Matches a {@code [tag] <content>} wrapper (e.g. {@code [Failed] <...>})
+     * so the inner content can be compared with the failure message. The tag
+     * word is captured loosely to stay language-independent.
+     */
+    private static final Pattern BRACKET_WRAPPER = Pattern.compile("^\\[[^\\]]*\\]\\s*<(.*)>$"); //$NON-NLS-1$
+
+    /** Minimum length before a head/message overlap is treated as a real duplicate. */
+    private static final int MIN_DUPLICATE_LENGTH = 16;
+
     private JUnitMarkdownFormatter()
     {
         // utility class
@@ -64,9 +96,217 @@ public final class JUnitMarkdownFormatter
             }
             if (withTrace && tc.trace != null && !tc.trace.trim().isEmpty())
             {
-                sb.append("```\n").append(tc.trace.trim()).append("\n```\n"); //$NON-NLS-1$ //$NON-NLS-2$
+                String trace = compactTrace(tc.trace, tc.message);
+                if (!trace.isEmpty())
+                {
+                    sb.append("```\n").append(trace).append("\n```\n"); //$NON-NLS-1$ //$NON-NLS-2$
+                }
             }
         }
+    }
+
+    /**
+     * Compacts a YAXUnit stack trace for the report: drops the trailing engine
+     * value-dump that duplicates the failure message, then collapses contiguous
+     * runs of YAXUnit-internal frames into a single marker line. The raw trace
+     * is preserved untouched in the on-disk {@code junit.xml}.
+     *
+     * <p>The trimming keys on language-independent signals (YAXUnit module
+     * names and stack-frame structure), so it works on any platform UI language.
+     *
+     * @param trace the raw stack trace
+     * @param message the failure message, used to drop a head that merely
+     *            restates it (may be {@code null})
+     */
+    static String compactTrace(String trace, String message)
+    {
+        String trimmed = dropTrailingEngineDump(trace);
+        trimmed = dropDuplicateHead(trimmed, message);
+        return collapseInternalFrames(trimmed).trim();
+    }
+
+    /**
+     * Drops the head — the lines before the first stack frame — when it merely
+     * restates the failure message (the {@code [Failed] <...>} block or a bare
+     * message copy). The head is removed only when it clearly duplicates the
+     * message, so unique diagnostic text is preserved.
+     */
+    private static String dropDuplicateHead(String trace, String message)
+    {
+        if (message == null || message.isEmpty())
+        {
+            return trace;
+        }
+        String[] lines = trace.split("\n", -1); //$NON-NLS-1$
+        int firstFrame = -1;
+        for (int i = 0; i < lines.length; i++)
+        {
+            if (isStackFrame(lines[i]))
+            {
+                firstFrame = i;
+                break;
+            }
+        }
+        if (firstFrame <= 0)
+        {
+            // No head (the first line is already a frame) or no frames at all.
+            return trace;
+        }
+
+        StringBuilder headSb = new StringBuilder();
+        for (int i = 0; i < firstFrame; i++)
+        {
+            if (i > 0)
+            {
+                headSb.append('\n');
+            }
+            headSb.append(lines[i]);
+        }
+        if (!headDuplicatesMessage(headSb.toString(), message))
+        {
+            return trace;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = firstFrame; i < lines.length; i++)
+        {
+            if (i > firstFrame)
+            {
+                sb.append('\n');
+            }
+            sb.append(lines[i]);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Returns {@code true} when the trace head is just a restatement of the
+     * failure message — equal to it, a suffix of it (message carries an extra
+     * prefix such as {@code "Исполнения: "}) or its {@code [tag] <...>} wrapper.
+     */
+    private static boolean headDuplicatesMessage(String head, String message)
+    {
+        String normalizedMessage = normalizeWhitespace(message);
+        if (normalizedMessage.length() < MIN_DUPLICATE_LENGTH)
+        {
+            return false;
+        }
+        String normalizedHead = normalizeWhitespace(head);
+        return isRestatement(normalizedMessage, normalizedHead)
+                || isRestatement(normalizedMessage, stripBracketWrapper(normalizedHead));
+    }
+
+    private static boolean isRestatement(String message, String head)
+    {
+        if (head.length() < MIN_DUPLICATE_LENGTH)
+        {
+            return false;
+        }
+        return message.equals(head) || message.endsWith(head) || head.endsWith(message);
+    }
+
+    private static String stripBracketWrapper(String text)
+    {
+        Matcher matcher = BRACKET_WRAPPER.matcher(text);
+        return matcher.matches() ? matcher.group(1).trim() : text;
+    }
+
+    private static String normalizeWhitespace(String text)
+    {
+        return text.replaceAll("\\s+", " ").trim(); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Drops everything after the last stack-frame line. The engine value-dump
+     * that duplicates the failure message (the localized {@code [..]} error
+     * category and its {@code "#value"} payload) always trails the frames, so
+     * cutting after the last frame removes it without depending on the
+     * platform language.
+     */
+    private static String dropTrailingEngineDump(String trace)
+    {
+        String[] lines = trace.split("\n", -1); //$NON-NLS-1$
+        int lastFrame = -1;
+        for (int i = 0; i < lines.length; i++)
+        {
+            if (isStackFrame(lines[i]))
+            {
+                lastFrame = i;
+            }
+        }
+        if (lastFrame < 0)
+        {
+            // No recognizable frames — leave the trace untouched.
+            return trace;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i <= lastFrame; i++)
+        {
+            sb.append(lines[i]);
+            if (i < lastFrame)
+            {
+                sb.append('\n');
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Collapses each contiguous run of YAXUnit-internal frames into one marker
+     * line, keeping all other (actionable) frames intact.
+     */
+    private static String collapseInternalFrames(String trace)
+    {
+        StringBuilder sb = new StringBuilder();
+        int hidden = 0;
+        for (String line : trace.split("\n", -1)) //$NON-NLS-1$
+        {
+            if (isInternalFrame(line))
+            {
+                hidden++;
+                continue;
+            }
+            if (hidden > 0)
+            {
+                sb.append(hiddenMarker(hidden)).append('\n');
+                hidden = 0;
+            }
+            sb.append(line).append('\n');
+        }
+        if (hidden > 0)
+        {
+            sb.append(hiddenMarker(hidden)).append('\n');
+        }
+        return sb.toString();
+    }
+
+    /** A 1C stack-frame line looks like {@code {...}:statement}. */
+    private static boolean isStackFrame(String line)
+    {
+        String trimmed = line.trim();
+        return trimmed.startsWith("{") && trimmed.contains("}:"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    private static boolean isInternalFrame(String line)
+    {
+        String trimmed = line.trim();
+        if (!trimmed.startsWith("{")) //$NON-NLS-1$
+        {
+            return false;
+        }
+        for (String token : INTERNAL_FRAME_MODULE_TOKENS)
+        {
+            if (trimmed.contains(token))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String hiddenMarker(int count)
+    {
+        return "{… " + count + " internal YAXUnit frames hidden …}"; //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     private static void appendSkippedSection(StringBuilder sb, List<JUnitTestResults.TestCase> cases)

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/JUnitMarkdownFormatterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/JUnitMarkdownFormatterTest.java
@@ -6,6 +6,7 @@
 
 package com.ditrix.edt.mcp.server.utils;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -97,5 +98,214 @@ public class JUnitMarkdownFormatterTest
 
         String md = JUnitMarkdownFormatter.format(r);
         assertTrue(md.contains("```\nmulti\nline\ntrace\n```"));
+    }
+
+    @Test
+    public void testInternalYaxunitFramesCollapsed() throws Exception
+    {
+        JUnitTestResults r = parse(
+                "<testsuite name=\"S\" tests=\"1\" failures=\"1\">"
+                        + "<testcase classname=\"OM_a\" name=\"t\">"
+                        + "<failure message=\"msg\">"
+                        + "{YAXUNIT ОбщийМодуль.ЮТУтверждения.Модуль(2239)}:ВызватьИсключение;\n"
+                        + "{YAXUNIT ОбщийМодуль.ЮТУтверждения.Модуль(266)}:ПроверитьПредикат;\n"
+                        + "{YAXUNIT ОбщийМодуль.ОМ_Тест.Модуль(86)}:ЮТест.ОжидаетЧто(x)\n"
+                        + "{(1)}:Объект.МойТест()\n"
+                        + "{YAXUNIT ОбщийМодуль.ЮТМетодыСлужебный.Модуль(228)}:Выполнить;\n"
+                        + "{YAXUNIT ОбщийМодуль.ЮТИсполнительСлужебныйКлиентСервер.Модуль(330)}:Ошибка;\n"
+                        + "{YAXUNIT ОбщийМодуль.ЮТИсполнительСлужебныйВызовСервера.Модуль(46)}:Возврат;"
+                        + "</failure>"
+                        + "</testcase>"
+                        + "</testsuite>");
+
+        String md = JUnitMarkdownFormatter.format(r);
+
+        // YAXUnit-internal framework frames are stripped.
+        assertFalse(md.contains("ЮТУтверждения.Модуль"));
+        assertFalse(md.contains("ЮТМетодыСлужебный.Модуль"));
+        assertFalse(md.contains("ЮТИсполнительСлужебныйКлиентСервер.Модуль"));
+        assertFalse(md.contains("ЮТИсполнительСлужебныйВызовСервера.Модуль"));
+
+        // User frames (the test module and the object frame) are kept.
+        assertTrue(md.contains("ОМ_Тест.Модуль(86)"));
+        assertTrue(md.contains("{(1)}:Объект.МойТест()"));
+
+        // A collapse marker tells the model the trace was trimmed.
+        assertTrue(md.contains("internal YAXUnit frames hidden"));
+    }
+
+    private static int count(String haystack, String needle)
+    {
+        int n = 0;
+        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length()))
+        {
+            n++;
+        }
+        return n;
+    }
+
+    @Test
+    public void testHeadDroppedWhenMessageHasExtraPrefix() throws Exception
+    {
+        // Error reports restate the message as the first trace line, minus a
+        // leading "Исполнения: "-style prefix — so it is NOT an exact match.
+        JUnitTestResults r = parse(
+                "<testsuite name=\"S\" tests=\"1\" errors=\"1\">"
+                        + "<testcase classname=\"OM_a\" name=\"t\">"
+                        + "<error message=\"Исполнения: DUPME unique payload token\">"
+                        + "DUPME unique payload token\n"
+                        + "{(1)}:Объект.Тест()\n"
+                        + "{YAXUNIT ОбщийМодуль.ЮТМетодыСлужебный.Модуль(228)}:W;"
+                        + "</error>"
+                        + "</testcase>"
+                        + "</testsuite>");
+
+        String md = JUnitMarkdownFormatter.format(r);
+        // The restated head line is gone — the payload now appears only in **Message:**.
+        assertEquals(1, count(md, "DUPME unique payload token"));
+        assertTrue(md.contains("{(1)}:Объект.Тест()"));
+    }
+
+    @Test
+    public void testHeadDroppedWhenWrappedAsFailedMarker() throws Exception
+    {
+        // Assertion failures wrap the message as "[Failed] <message>".
+        JUnitTestResults r = parse(
+                "<testsuite name=\"S\" tests=\"1\" failures=\"1\">"
+                        + "<testcase classname=\"OM_a\" name=\"t\">"
+                        + "<failure message=\"ASSERT payload content token\">"
+                        + "[Failed] &lt;ASSERT payload content token&gt;\n"
+                        + "{(1)}:Объект.Тест()"
+                        + "</failure>"
+                        + "</testcase>"
+                        + "</testsuite>");
+
+        String md = JUnitMarkdownFormatter.format(r);
+        assertEquals(1, count(md, "ASSERT payload content token"));
+        assertFalse(md.contains("[Failed]"));
+        assertTrue(md.contains("{(1)}:Объект.Тест()"));
+    }
+
+    @Test
+    public void testUniqueHeadKept() throws Exception
+    {
+        // A head that does NOT restate the message must be preserved.
+        JUnitTestResults r = parse(
+                "<testsuite name=\"S\" tests=\"1\" failures=\"1\">"
+                        + "<testcase classname=\"OM_a\" name=\"t\">"
+                        + "<failure message=\"the assertion message text\">"
+                        + "completely different diagnostic head line\n"
+                        + "{(1)}:Объект.Тест()"
+                        + "</failure>"
+                        + "</testcase>"
+                        + "</testsuite>");
+
+        String md = JUnitMarkdownFormatter.format(r);
+        assertTrue(md.contains("completely different diagnostic head line"));
+        assertTrue(md.contains("{(1)}:Объект.Тест()"));
+    }
+
+    @Test
+    public void testLanguageIndependentOnEnglishPlatform() throws Exception
+    {
+        // On an English platform the metadata-kind words and the engine error
+        // category are localized (CommonModule/Module, EmbeddedLanguageRuntimeError),
+        // but the YAXUnit module names stay Cyrillic and the frame structure is
+        // unchanged — so trimming must still work.
+        JUnitTestResults r = parse(
+                "<testsuite name=\"S\" tests=\"1\" failures=\"1\">"
+                        + "<testcase classname=\"OM_a\" name=\"t\">"
+                        + "<failure message=\"msg\">"
+                        + "{YAXUNIT CommonModule.ЮТУтверждения.Module(2239)}:Raise;\n"
+                        + "{YAXUNIT CommonModule.ОМ_Тест.Module(86)}:Z\n"
+                        + "{(1)}:Object.MyTest()\n"
+                        + "{YAXUNIT CommonModule.ЮТИсполнительСлужебныйВызовСервера.Module(46)}:Return;\n"
+                        + "\n"
+                        + "[EmbeddedLanguageRuntimeError, ExceptionRaisedFromEmbeddedLanguage]{\n"
+                        + "\"#value\": \"ENGLISH_DUMP_PAYLOAD\"\n"
+                        + "}"
+                        + "</failure>"
+                        + "</testcase>"
+                        + "</testsuite>");
+
+        String md = JUnitMarkdownFormatter.format(r);
+
+        // Internal frames stripped despite the English metadata-kind words.
+        assertFalse(md.contains("ЮТУтверждения"));
+        assertFalse(md.contains("ЮТИсполнительСлужебныйВызовСервера"));
+        // English engine value-dump dropped (cut after the last frame).
+        assertFalse(md.contains("ENGLISH_DUMP_PAYLOAD"));
+        assertFalse(md.contains("EmbeddedLanguageRuntimeError"));
+        // User frames kept.
+        assertTrue(md.contains("ОМ_Тест.Module(86)"));
+        assertTrue(md.contains("{(1)}:Object.MyTest()"));
+        assertTrue(md.contains("internal YAXUnit frames hidden"));
+    }
+
+    @Test
+    public void testTrailingEngineValueDumpRemoved() throws Exception
+    {
+        JUnitTestResults r = parse(
+                "<testsuite name=\"S\" tests=\"1\" failures=\"1\">"
+                        + "<testcase classname=\"OM_a\" name=\"t\">"
+                        + "<failure message=\"msg\">"
+                        + "{(1)}:Объект.Тест()\n"
+                        + "\n"
+                        + "[ОшибкаВоВремяВыполненияВстроенногоЯзыка, ИсключениеВызванноеИзВстроенногоЯзыка]{\n"
+                        + "\"#value\": \"DUPLICATE_VALUE_PAYLOAD\"\n"
+                        + "}"
+                        + "</failure>"
+                        + "</testcase>"
+                        + "</testsuite>");
+
+        String md = JUnitMarkdownFormatter.format(r);
+
+        // The trailing engine value-dump (duplicating the message) is gone.
+        assertFalse(md.contains("DUPLICATE_VALUE_PAYLOAD"));
+        assertFalse(md.contains("ОшибкаВоВремяВыполненияВстроенногоЯзыка"));
+
+        // The meaningful user frame survives.
+        assertTrue(md.contains("{(1)}:Объект.Тест()"));
+    }
+
+    @Test
+    public void testTrailingEngineMarkerWithoutValueBlockRemoved() throws Exception
+    {
+        // Variant seen in error reports: the marker appears as a bare line with no { } block.
+        JUnitTestResults r = parse(
+                "<testsuite name=\"S\" tests=\"1\" errors=\"1\">"
+                        + "<testcase classname=\"OM_a\" name=\"t\">"
+                        + "<error message=\"msg\">"
+                        + "{(1)}:Объект.Тест()\n"
+                        + "\n"
+                        + "[ОшибкаВоВремяВыполненияВстроенногоЯзыка, ИсключениеВызванноеИзВстроенногоЯзыка]"
+                        + "</error>"
+                        + "</testcase>"
+                        + "</testsuite>");
+
+        String md = JUnitMarkdownFormatter.format(r);
+        assertFalse(md.contains("ОшибкаВоВремяВыполненияВстроенногоЯзыка"));
+        assertTrue(md.contains("{(1)}:Объект.Тест()"));
+    }
+
+    @Test
+    public void testMessageEmbeddedFramesNotTouched() throws Exception
+    {
+        // Frames embedded inside the message text are NOT YAXUNIT framework frames
+        // (no "YAXUNIT" prefix) and must be preserved as part of the error description.
+        JUnitTestResults r = parse(
+                "<testsuite name=\"S\" tests=\"1\" failures=\"1\">"
+                        + "<testcase classname=\"OM_a\" name=\"t\">"
+                        + "<failure message=\"msg\">"
+                        + "{ОбщийМодуль.APIВебСервисыСлужебный.Модуль(275)}:ВызватьИсключение;\n"
+                        + "{(1)}:Объект.Тест()"
+                        + "</failure>"
+                        + "</testcase>"
+                        + "</testsuite>");
+
+        String md = JUnitMarkdownFormatter.format(r);
+        assertTrue(md.contains("APIВебСервисыСлужебный.Модуль(275)"));
+        assertTrue(md.contains("{(1)}:Объект.Тест()"));
+        assertFalse(md.contains("скрыто служебных кадров YAXUnit"));
     }
 }


### PR DESCRIPTION
The Markdown report duplicated huge stack traces, blowing up MCP context. Trim each failure/error trace in JUnitMarkdownFormatter (raw junit.xml stays untouched on disk):

- collapse runs of YAXUnit-internal framework frames (assertion engine, executor, server-call plumbing) into a single "{… N internal YAXUnit frames hidden …}" marker;
- drop the trailing engine value-dump that merely repeats the message (cut everything after the last stack frame);
- drop the head when it just restates the message — the "[Failed] <…>" wrapper or a bare copy carrying an extra prefix (e.g. "Исполнения: ").

Matching keys on language-independent signals (YAXUnit module identifiers and stack-frame structure), so it works on RU and EN platforms alike. On a sample report this cut the output ~58% (18171 → 7569 chars).

Add JUnitMarkdownFormatterTest cases (RU/EN, head dedup, unique-head kept) and set UTF-8 encoding for the test project.