### PR TITLE
fix(shutdown): never block on UI thread from bundle stop — EDT hung as background process (#135)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/McpServer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/McpServer.java
@@ -14,6 +14,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.ditrix.edt.mcp.server.preferences.PreferenceConstants;
@@ -136,9 +137,17 @@ public class McpServer
         //      the queue before executor rejection can occur.
         // SSE (the only infinite-duration request type) is handled by the dedicated
         // sseExecutor and never enters this pool.
+        // Daemon threads: a worker still handling a request at EDT shutdown
+        // must not keep the JVM alive after the workbench has closed (#135).
+        AtomicInteger mainThreadCounter = new AtomicInteger();
         mainExecutor = new ThreadPoolExecutor(
             8, 8, 60L, TimeUnit.SECONDS,
-            new LinkedBlockingQueue<>(200));
+            new LinkedBlockingQueue<>(200),
+            r -> {
+                Thread t = new Thread(r, "MCP-Main-" + mainThreadCounter.incrementAndGet()); //$NON-NLS-1$
+                t.setDaemon(true);
+                return t;
+            });
         mainExecutor.allowCoreThreadTimeOut(true);
         server.setExecutor(mainExecutor);
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/StartupOrchestrator.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/StartupOrchestrator.java
@@ -25,7 +25,7 @@ import com.ditrix.edt.mcp.server.groups.internal.GroupServiceImpl;
  *       via {@code Display.asyncExec}.</li>
  * </ol>
  * Teardown reverses these on {@link #stop()}: dispose the navigator toolbar
- * customizer (non-headless, on the UI thread via {@code syncExec}), deactivate
+ * customizer (non-headless, only when already on a live UI thread), deactivate
  * the group service, then stop the {@code UpdateChecker} scheduler.
  * <p>
  * This class owns the {@link IGroupService} reference; {@link Activator}
@@ -74,30 +74,28 @@ public class StartupOrchestrator
      */
     public void stop(boolean headless)
     {
-        // Dispose UI components only in non-headless mode
+        // Dispose UI components only in non-headless mode.
+        // Never block on the UI thread from here: stop() runs on the OSGi
+        // framework shutdown thread after the workbench event loop has exited,
+        // so a syncExec never returns and pins the JVM — EDT keeps running as
+        // a background process (#135). Display.getDefault() is also forbidden
+        // here: with the display already disposed it would CREATE a new one on
+        // the shutdown thread. Listener teardown is best-effort — widgets die
+        // with the display — so run it inline only when already on a live UI
+        // thread and skip it otherwise.
         if (!headless)
         {
-            // Dispose navigator toolbar customizer
-            try
+            org.eclipse.swt.widgets.Display display = org.eclipse.swt.widgets.Display.getCurrent();
+            if (display != null && !display.isDisposed())
             {
-                org.eclipse.swt.widgets.Display display = org.eclipse.swt.widgets.Display.getDefault();
-                if (display != null && !display.isDisposed())
+                try
                 {
-                    display.syncExec(() -> {
-                        try
-                        {
-                            com.ditrix.edt.mcp.server.ui.NavigatorToolbarCustomizer.getInstance().dispose();
-                        }
-                        catch (Exception e)
-                        {
-                            // Ignore - workbench may be closing
-                        }
-                    });
+                    com.ditrix.edt.mcp.server.ui.NavigatorToolbarCustomizer.getInstance().dispose();
                 }
-            }
-            catch (Exception e)
-            {
-                // Ignore - display may be disposed
+                catch (Exception e)
+                {
+                    // Ignore - workbench may be closing
+                }
             }
         }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/transport/InterruptibleToolExecutor.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/transport/InterruptibleToolExecutor.java
@@ -81,6 +81,9 @@ public class InterruptibleToolExecutor
             }
         }, "MCP-Tool-Executor"); //$NON-NLS-1$
 
+        // Daemon: a tool call still running (or stuck) at EDT shutdown must
+        // not keep the JVM alive after the workbench has closed (#135).
+        executionThread.setDaemon(true);
         executionThread.start();
 
         // Wait for completion or user signal


### PR DESCRIPTION
Fixes #135.

## Problem

Closing EDT with the MCP server enabled left the EDT process alive as a background process. With the server stopped before closing, EDT exited normally.

## Root cause

The reporter's logs pin it down: `MCP Server stopped` (the last line of `McpServer.stop()`) is the **last line ever written** to the .log — the `GroupService deactivated` and `EDT MCP Server plugin stopped` lines that must follow within milliseconds in `Activator.stop()` never appear. So the server itself shut down fine; `Activator.stop()` hung right after it.

`Activator.stop()` runs on the Equinox **"Framework stop"** thread. `StartupOrchestrator.stop()` then called `Display.getDefault()` + `display.syncExec(...)` to dispose `NavigatorToolbarCustomizer`. At that point the workbench event loop has already exited but the `Display` is not yet disposed, so the `!display.isDisposed()` guard passes and `syncExec` enqueues into a queue nobody pumps — it never returns. The blocked non-daemon framework-stop thread keeps the JVM alive forever: window closed, process hanging.

Why "stop MCP first" worked around it: with the server running, `HttpServer.stop(1)` spends ~1.3 s draining connections before the `syncExec`, pushing it past the point where the UI thread stops dispatching.

## Fix

- **`StartupOrchestrator.stop()`** — never block on the UI thread from the bundle-stop path. Use `Display.getCurrent()` and dispose inline only when already on a live UI thread; otherwise skip teardown (listeners die with the display, nothing to leak in a dying JVM). `Display.getDefault()` is banned here: with the display already disposed it would *create a new one* on the shutdown thread.
- **`InterruptibleToolExecutor`** — the per-call `MCP-Tool-Executor` thread is now a daemon, so an in-flight/stuck tool call cannot pin the JVM at shutdown (defensive, same failure family).
- **`McpServer`** — `mainExecutor` now uses a daemon thread factory (`MCP-Main-N`), consistent with the existing `sseExecutor`.

## Verification

- Tier 1: `compile.sh` — BUILD SUCCESS, 1607 unit tests, 0 failures.
- Adversarial review traced the whole shutdown path (`Activator.stop` → `EdtServices.dispose` → `StartupOrchestrator.stop`) — no remaining unbounded blocking calls (everything else is `join(2000)` / `stop(1)` / `shutdownNow`). No reliance anywhere on these threads being non-daemon.
- The hang never reproduced on the maintainer's machine, so final confirmation needs the reporter: a `jstack <PID>` of a hung process on the old build should show the "Framework stop" thread parked in `Display.syncExec` via `StartupOrchestrator.stop`, and the fixed build should exit cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)