### PR TITLE
feat(update_database): auto-terminate sessions, incremental-first publish

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/update_database.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/update_database.md
@@ -5,42 +5,59 @@ Applies the EDT configuration to an application's database (infobase) — the eq
 This tool mutates the infobase and is **irreversible**. Run it ONLY on an explicit user request. A full update can drop/recreate database structures; back up or be sure the infobase is disposable.
 
 It is guarded by a two-phase workflow (mirroring delete_metadata):
-1. **Preview** (`confirm` omitted / false, the default): resolves the target and returns `action='preview'`, `confirmationRequired=true`, the resolved project/applicationId/applicationName, the `updateType` (FULL/INCREMENTAL) and `stateBefore` - WITHOUT touching the infobase.
-2. **Apply** (`confirm=true`): performs the update; the result reports `action='updated'`.
+1. **Preview** (`confirm` omitted / false, the default): resolves the target and returns `action='preview'`, `confirmationRequired=true`, the resolved project/applicationId/applicationName, the `updateType` (FULL/INCREMENTAL) and `stateBefore` - WITHOUT touching the infobase and WITHOUT terminating any client.
+2. **Apply** (`confirm=true`): terminates running clients (see below), then performs the update; the result reports `action='updated'`.
 
 ## When to use
 
-After changing metadata/configuration, to push those changes into the running infobase so a launched client sees them. Typically: edit metadata -> `update_database` -> launch/restart the client.
+After changing metadata/configuration (or an extension's BSL/metadata), to push those changes into the running infobase so a launched client sees them. Typically: edit metadata -> `update_database` -> launch/restart the client. Extensions are handled exactly like the main configuration — the same incremental update publishes them.
 
 ## Targeting (choose ONE)
 
 1. **`launchConfigurationName`** (preferred) — exact runtime-client config name from `list_configurations`. It fixes the project + applicationId pair for you, so you cannot mismatch them. Must be a runtime-client config (not an Attach config).
 2. **`projectName` + `applicationId`** — used only when `launchConfigurationName` is omitted. Get `applicationId` from `get_applications`. Both are required in this mode.
 
+## Transparent session termination (default ON)
+
+On `confirm=true` the tool first terminates any 1C client **this EDT instance launched** against the target infobase (controlled by `terminateRunningClients`, default `true`). This removes the two reasons an update misbehaves with a live session:
+- the infobase is held in **exclusive** use, so the update would block/fail; and
+- a connected client caches the old module version, so even after a successful publish it would keep running stale code until it restarts.
+
+Termination is **polite** (no force-kill): if a client will not stop within the timeout the tool returns an actionable error suggesting `terminate_launch` with `force=true`. The response includes `terminatedClients` (how many were stopped).
+
+The tool also **auto-confirms** EDT's blocking "update the database?" modal that can pop during the update when a session is active, so the call does not hang waiting for a human click. As a backstop, a watchdog (`updateTimeoutSeconds`, default 120) bounds the wait: if the update does not finish in time it keeps running in the background and the tool returns `stateAfter=BEING_UPDATED` so you can poll `get_applications` (a full reload can take several minutes). The auto-confirm stays active for the **whole** life of the update, so even a long full reload that pops a restructurization dialog after the watchdog window is still confirmed in the background and does not hang.
+
+## Incremental vs full
+
+Incremental is the default and is almost always what you want — including for extensions. After an incremental update an extension-bearing configuration may still report `stateAfter=INCREMENTAL_UPDATE_REQUIRED`: this is a **cosmetic** EDT state (the changes ARE published) and is reported as **success**, so do NOT retry with a full update. Only a genuine `FULL_UPDATE_REQUIRED` (surfaced with `fullUpdateRequired=true`) means incremental is insufficient and you should re-call with `fullUpdate=true`. Full updates are rare, slow, and can drop/recreate structures — reach for one only when explicitly required.
+
 ## Parameter details
 
 - **launchConfigurationName** (string) — preferred target; see above.
 - **projectName** (string) — required if launchConfigurationName is omitted.
 - **applicationId** (string) — from `get_applications`; required if launchConfigurationName is omitted.
-- **fullUpdate** (boolean, default false) — true performs a FULL reload (complete rebuild), false performs an INCREMENTAL update (changed objects only). Incremental is faster; use full when the structure changed substantially or an incremental update fails.
+- **fullUpdate** (boolean, default false) — true performs a FULL reload (complete rebuild), false performs an INCREMENTAL update (changed objects only). Incremental is faster; use full only when `fullUpdateRequired=true` is returned or the structure changed substantially.
 - **autoRestructure** (boolean, default true) — automatically apply database restructurization (table/index changes) when the update requires it, instead of prompting. Leave true for unattended use.
 - **confirm** (boolean, default false) — false previews the resolved update without touching the infobase; true applies it.
+- **terminateRunningClients** (boolean, default true) — on `confirm=true`, terminate EDT-launched 1C clients on the target infobase before updating. Set false only if you have already stopped them yourself.
+- **updateTimeoutSeconds** (integer, default 120, clamped 5..600) — watchdog window for the update call; on timeout the update continues in the background and `stateAfter=BEING_UPDATED` is returned.
 
-## Exclusive-lock gotcha
+## Exclusive-lock gotcha (external clients)
 
-If a 1C client launched from this EDT is currently running against the target infobase, the update typically FAILS because the infobase is held in exclusive use. Check `list_configurations` for `running: true`; if so, call `terminate_launch` first (it only affects launches started from this EDT instance), then retry. Externally launched clients (Designer, ad-hoc 1cv8c.exe) are invisible to `terminate_launch` and must be closed by hand.
+The tool can only terminate clients **this EDT instance launched**. A 1C client started **externally** — Designer, an ad-hoc `1cv8c.exe`, another EDT instance, or a server session — is invisible to `terminate_launch` and still holds the infobase in exclusive use. If an update stalls or fails on a lock and `terminatedClients` is 0, close that external client by hand and retry.
 
 ## Examples
 
-- Preferred, incremental: `launchConfigurationName="MyApp / ThinClient"`.
-- Full reload via project + appId: `projectName="MyProject"`, `applicationId="<id from get_applications>"`, `fullUpdate=true`.
+- Preferred, incremental, transparent termination: `launchConfigurationName="MyApp / ThinClient"`, `confirm=true`.
+- Full reload via project + appId: `projectName="MyProject"`, `applicationId="<id from get_applications>"`, `fullUpdate=true`, `confirm=true`.
+- Skip termination (you stopped clients yourself): add `terminateRunningClients=false`.
 
 ## Result
 
-JSON with `project`, `applicationId`, `applicationName`, `updateType` (FULL/INCREMENTAL), `stateBefore`, `stateAfter` and a `message`. A successful run reports `stateAfter = UPDATED`. If the application is already BEING_UPDATED the tool returns an error and you should wait.
+JSON with `project`, `applicationId`, `applicationName`, `updateType` (FULL/INCREMENTAL), `stateBefore`, `stateAfter`, `terminatedClients` and a `message`. A successful run reports `stateAfter = UPDATED` (or `INCREMENTAL_UPDATE_REQUIRED` for an extension-bearing config — also a success). `fullUpdateRequired=true` with `success=false` means re-call with `fullUpdate=true`.
 
 ## Gotchas
 
-- Most failures are the exclusive lock above — terminate the running launch first.
+- Most remaining failures are an **external** client holding the lock — close it by hand (see above).
 - `launchConfigurationName` must reference a runtime-client config; an Attach config is rejected.
 - The project must exist and be open; a closed project returns an error.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
@@ -6,8 +6,6 @@
 
 package com.ditrix.edt.mcp.server.tools.impl;
 
-import java.util.Arrays;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 
@@ -28,6 +26,7 @@ import com.ditrix.edt.mcp.server.utils.ApplicationUpdatePolicy;
 import com.ditrix.edt.mcp.server.utils.EdtDialogAutoConfirmer;
 import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
 import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils;
+import com.ditrix.edt.mcp.server.utils.LaunchUpdateDialogAutoConfirmer;
 import com.ditrix.edt.mcp.server.utils.ProjectContext;
 import com.ditrix.edt.mcp.server.utils.ProjectStateChecker;
 import com.ditrix.edt.mcp.server.utils.UpdateWatchdog;
@@ -59,12 +58,12 @@ public class UpdateDatabaseTool implements IMcpTool
      * Auto-confirms a blocking update/restructurization modal during the
      * programmatic update only. {@code confirm=true} already authorised the
      * mutation, so pressing the dialog's default ("proceed") button is what a
-     * careful user would do. Seeded with the known launch-delegate title; add
-     * restructurization titles here once confirmed against a live EDT.
+     * careful user would do. Reuses the launch modal's localized titles; the EDT
+     * restructurization dialog title (for the FULL path) is still to be confirmed
+     * live and added to the shared set.
      */
     private static final EdtDialogAutoConfirmer UPDATE_DIALOG_CONFIRMER =
-        new EdtDialogAutoConfirmer(new LinkedHashSet<>(Arrays.asList(
-            "Application update"))); //$NON-NLS-1$
+        new EdtDialogAutoConfirmer(LaunchUpdateDialogAutoConfirmer.APPLICATION_UPDATE_TITLES);
 
     /** Appended when an update may be blocked by a client this EDT did not launch. */
     private static final String EXTERNAL_SESSION_NOTE =
@@ -324,6 +323,19 @@ public class UpdateDatabaseTool implements IMcpTool
                     }
                 }
 
+                // Re-check the state UNDER the lock: a concurrent confirm=true call or a
+                // pre-launch update on this IB could have started between the early stateBefore
+                // read and here (and the watchdog releases this lock on timeout while an update
+                // still runs in the background). Don't fire a second appManager.update against an
+                // IB that is already updating. This fresh value is also what we report.
+                ApplicationUpdateState stateBeforeLocked = appManager.getUpdateState(application);
+                if (stateBeforeLocked == ApplicationUpdateState.BEING_UPDATED)
+                {
+                    return ToolResult.error("Application is already being updated (a concurrent " //$NON-NLS-1$
+                        + "update is in progress). Poll get_applications until it settles, then " //$NON-NLS-1$
+                        + "retry.").toJson(); //$NON-NLS-1$
+                }
+
                 // Create execution context with the active Shell so EDT can parent its
                 // dialogs. Shared SWT-grab lives in LaunchLifecycleUtils.
                 ExecutionContext context = new ExecutionContext();
@@ -373,7 +385,7 @@ public class UpdateDatabaseTool implements IMcpTool
                     .put("applicationId", applicationId) //$NON-NLS-1$
                     .put("applicationName", application.getName()) //$NON-NLS-1$
                     .put("updateType", updateType.name()) //$NON-NLS-1$
-                    .put("stateBefore", stateBefore.name()) //$NON-NLS-1$
+                    .put("stateBefore", stateBeforeLocked.name()) //$NON-NLS-1$
                     .put("stateAfter", stateAfter.name()) //$NON-NLS-1$
                     .put("terminatedClients", terminatedClients) //$NON-NLS-1$
                     .put("message", message); //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
@@ -6,6 +6,8 @@
 
 package com.ditrix.edt.mcp.server.tools.impl;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 
@@ -22,10 +24,13 @@ import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
 import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.ApplicationUpdatePolicy;
+import com.ditrix.edt.mcp.server.utils.EdtDialogAutoConfirmer;
 import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
 import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils;
 import com.ditrix.edt.mcp.server.utils.ProjectContext;
 import com.ditrix.edt.mcp.server.utils.ProjectStateChecker;
+import com.ditrix.edt.mcp.server.utils.UpdateWatchdog;
 import com.e1c.g5.dt.applications.ApplicationException;
 import com.e1c.g5.dt.applications.ApplicationUpdateState;
 import com.e1c.g5.dt.applications.ApplicationUpdateType;
@@ -40,7 +45,33 @@ import com.e1c.g5.dt.applications.IApplicationManager;
 public class UpdateDatabaseTool implements IMcpTool
 {
     public static final String NAME = "update_database"; //$NON-NLS-1$
-    
+
+    /** Default watchdog window for the synchronous update() call, in seconds. */
+    private static final int DEFAULT_UPDATE_TIMEOUT_SECONDS = 120;
+
+    /** Lower clamp bound for the update watchdog window. */
+    private static final int MIN_UPDATE_TIMEOUT_SECONDS = 5;
+
+    /** Upper clamp bound for the update watchdog window. */
+    private static final int MAX_UPDATE_TIMEOUT_SECONDS = 600;
+
+    /**
+     * Auto-confirms a blocking update/restructurization modal during the
+     * programmatic update only. {@code confirm=true} already authorised the
+     * mutation, so pressing the dialog's default ("proceed") button is what a
+     * careful user would do. Seeded with the known launch-delegate title; add
+     * restructurization titles here once confirmed against a live EDT.
+     */
+    private static final EdtDialogAutoConfirmer UPDATE_DIALOG_CONFIRMER =
+        new EdtDialogAutoConfirmer(new LinkedHashSet<>(Arrays.asList(
+            "Application update"))); //$NON-NLS-1$
+
+    /** Appended when an update may be blocked by a client this EDT did not launch. */
+    private static final String EXTERNAL_SESSION_NOTE =
+        "If a 1C client started OUTSIDE this EDT (Designer, a standalone 1cv8c, another EDT " //$NON-NLS-1$
+            + "instance, or a server session) is holding the infobase, it is invisible to " //$NON-NLS-1$
+            + "terminate_launch and must be closed manually before the update can complete."; //$NON-NLS-1$
+
     @Override
     public String getName()
     {
@@ -54,7 +85,8 @@ public class UpdateDatabaseTool implements IMcpTool
             + "incremental. Target by launchConfigurationName (preferred) or projectName + " //$NON-NLS-1$
             + "applicationId. Destructive/irreversible: guarded by a confirm-preview - call without " //$NON-NLS-1$
             + "confirm to preview the exact update (no infobase change), then confirm=true to apply. " //$NON-NLS-1$
-            + "Terminate any running 1C client on the target infobase first (exclusive lock). " //$NON-NLS-1$
+            + "On confirm it transparently terminates EDT-launched 1C clients on the target " //$NON-NLS-1$
+            + "infobase first (external clients must be closed manually). " //$NON-NLS-1$
             + "Full parameters and examples: call get_tool_guide('update_database')."; //$NON-NLS-1$
     }
 
@@ -75,6 +107,15 @@ public class UpdateDatabaseTool implements IMcpTool
             .booleanProperty("confirm", //$NON-NLS-1$
                 "true = apply the update; default false = preview only (resolves the target and " //$NON-NLS-1$
                 + "reports what would change WITHOUT mutating the infobase).") //$NON-NLS-1$
+            .booleanProperty("terminateRunningClients", //$NON-NLS-1$
+                "Before updating (confirm=true), terminate any 1C client THIS EDT launched against " //$NON-NLS-1$
+                + "the target infobase so the update is not blocked by an exclusive lock and the new " //$NON-NLS-1$
+                + "code is not masked by a cached session (default true). External clients are not " //$NON-NLS-1$
+                + "affected.") //$NON-NLS-1$
+            .integerProperty("updateTimeoutSeconds", //$NON-NLS-1$
+                "Watchdog window for the update call in seconds (default 120, clamped 5..600). If the " //$NON-NLS-1$
+                + "update does not finish in time it keeps running in the background and the tool " //$NON-NLS-1$
+                + "returns stateAfter=BEING_UPDATED so you can poll get_applications.") //$NON-NLS-1$
             .build();
     }
 
@@ -93,6 +134,11 @@ public class UpdateDatabaseTool implements IMcpTool
             .stringProperty("stateBefore", "Application update state before the update.") //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty("stateAfter", "Application update state after the update.") //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty("message", "Human-readable status message for the update.") //$NON-NLS-1$ //$NON-NLS-2$
+            .integerProperty("terminatedClients", //$NON-NLS-1$
+                "Number of EDT-launched 1C clients terminated before the update.") //$NON-NLS-1$
+            .booleanProperty("fullUpdateRequired", //$NON-NLS-1$
+                "Present and true when the incremental update genuinely needs a full update " //$NON-NLS-1$
+                + "(state FULL_UPDATE_REQUIRED); re-call with fullUpdate=true.") //$NON-NLS-1$
             .build();
     }
 
@@ -111,6 +157,10 @@ public class UpdateDatabaseTool implements IMcpTool
         boolean fullUpdate = JsonUtils.extractBooleanArgument(params, "fullUpdate", false); //$NON-NLS-1$
         boolean autoRestructure = JsonUtils.extractBooleanArgument(params, "autoRestructure", true); //$NON-NLS-1$
         boolean confirm = JsonUtils.extractBooleanArgument(params, "confirm", false); //$NON-NLS-1$
+        boolean terminateRunningClients =
+            JsonUtils.extractBooleanArgument(params, "terminateRunningClients", true); //$NON-NLS-1$
+        int updateTimeoutSeconds = clampTimeout(
+            JsonUtils.extractIntArgument(params, "updateTimeoutSeconds", DEFAULT_UPDATE_TIMEOUT_SECONDS)); //$NON-NLS-1$
 
         boolean hasName = configName != null && !configName.isEmpty();
         if (!hasName)
@@ -166,7 +216,8 @@ public class UpdateDatabaseTool implements IMcpTool
             return ToolResult.error(building).toJson();
         }
 
-        return updateDatabase(projectName, applicationId, fullUpdate, autoRestructure, confirm);
+        return updateDatabase(projectName, applicationId, fullUpdate, autoRestructure, confirm,
+            terminateRunningClients, updateTimeoutSeconds);
     }
     
     /**
@@ -179,7 +230,8 @@ public class UpdateDatabaseTool implements IMcpTool
      * @return JSON string with result
      */
     private String updateDatabase(String projectName, String applicationId,
-            boolean fullUpdate, boolean autoRestructure, boolean confirm)
+            boolean fullUpdate, boolean autoRestructure, boolean confirm,
+            boolean terminateRunningClients, int updateTimeoutSeconds)
     {
         try
         {
@@ -245,51 +297,99 @@ public class UpdateDatabaseTool implements IMcpTool
                     .toJson();
             }
 
-            // Create execution context with the active Shell so EDT can parent
-            // its dialogs. Shared SWT-grab lives in LaunchLifecycleUtils.
-            ExecutionContext context = new ExecutionContext();
-            Shell shell = LaunchLifecycleUtils.grabActiveShell();
-            if (shell != null)
+            // confirm=true: serialise the terminate+update sequence with concurrent
+            // test runs on the same IB via the shared per-IB lock.
+            synchronized (LaunchLifecycleUtils.lockFor(projectName, applicationId))
             {
-                context.setProperty(ExecutionContext.ACTIVE_SHELL_NAME, shell);
-            }
+                // Free the infobase first: terminate any 1C client THIS EDT launched
+                // against it, so the update is not blocked by an exclusive lock and the
+                // new code is not masked by a cached session. External clients are
+                // invisible to us (flagged below if the update stalls).
+                int terminatedClients = 0;
+                if (terminateRunningClients)
+                {
+                    ILaunchManager lm = DebugPlugin.getDefault().getLaunchManager();
+                    if (lm != null)
+                    {
+                        int termTimeout = LaunchLifecycleUtils.getDefaultTerminateTimeoutSeconds();
+                        LaunchLifecycleUtils.PreLaunchResult term =
+                            LaunchLifecycleUtils.terminateLiveLaunchesForIb(lm, project,
+                                applicationId, termTimeout);
+                        if (!term.isOk())
+                        {
+                            return ToolResult.error(term.getError() + " " + EXTERNAL_SESSION_NOTE) //$NON-NLS-1$
+                                .toJson();
+                        }
+                        terminatedClients = term.getTerminatedCount();
+                    }
+                }
 
-            Activator.logInfo("Update database: project=" + projectName +  //$NON-NLS-1$
-                    ", application=" + applicationId +  //$NON-NLS-1$
-                    ", type=" + updateType +  //$NON-NLS-1$
-                    ", autoRestructure=" + autoRestructure); //$NON-NLS-1$
-            
-            // Create progress monitor
-            IProgressMonitor monitor = new NullProgressMonitor();
-            
-            // Perform update
-            ApplicationUpdateState stateAfter = appManager.update(application, updateType, context, monitor);
-            
-            // Build result
-            ToolResult result = ToolResult.success()
-                .put("action", "updated") //$NON-NLS-1$ //$NON-NLS-2$
-                .put("project", projectName) //$NON-NLS-1$
-                .put("applicationId", applicationId) //$NON-NLS-1$
-                .put("applicationName", application.getName()) //$NON-NLS-1$
-                .put("updateType", updateType.name()) //$NON-NLS-1$
-                .put("stateBefore", stateBefore.name()) //$NON-NLS-1$
-                .put("stateAfter", stateAfter.name()); //$NON-NLS-1$
-            
-            // Add status message based on result
-            if (stateAfter == ApplicationUpdateState.UPDATED)
-            {
-                result.put("message", "Database updated successfully"); //$NON-NLS-1$ //$NON-NLS-2$
+                // Create execution context with the active Shell so EDT can parent its
+                // dialogs. Shared SWT-grab lives in LaunchLifecycleUtils.
+                ExecutionContext context = new ExecutionContext();
+                Shell shell = LaunchLifecycleUtils.grabActiveShell();
+                if (shell != null)
+                {
+                    context.setProperty(ExecutionContext.ACTIVE_SHELL_NAME, shell);
+                }
+
+                Activator.logInfo("Update database: project=" + projectName //$NON-NLS-1$
+                    + ", application=" + applicationId //$NON-NLS-1$
+                    + ", type=" + updateType //$NON-NLS-1$
+                    + ", autoRestructure=" + autoRestructure //$NON-NLS-1$
+                    + ", terminatedClients=" + terminatedClients); //$NON-NLS-1$
+
+                IProgressMonitor monitor = new NullProgressMonitor();
+
+                // Auto-confirm a blocking update/restructurization modal for the ENTIRE life of
+                // the update (an active session can make appManager.update pop one that would
+                // otherwise hang the MCP call). The confirmer stays armed even after the watchdog
+                // times out, so a long full reload that pops a modal minutes later — after we
+                // already returned BEING_UPDATED — is still auto-confirmed in the background. The
+                // watchdog bounds the wait so a stuck update returns BEING_UPDATED, not a hang.
+                ApplicationUpdateState stateAfter = UpdateWatchdog.runWithTimeout(
+                    () -> appManager.update(application, updateType, context, monitor),
+                    updateTimeoutSeconds,
+                    UPDATE_DIALOG_CONFIRMER::arm, UPDATE_DIALOG_CONFIRMER::disarm);
+
+                // Single source of truth for "is this success?": INCREMENTAL_UPDATE_REQUIRED
+                // after an incremental update is the expected cosmetic state for an
+                // extension-bearing config (changes ARE published) and must NOT trigger a
+                // needless full update; only FULL_UPDATE_REQUIRED genuinely needs one.
+                ApplicationUpdatePolicy.Result verdict =
+                    ApplicationUpdatePolicy.classifyExplicitUpdate(updateType, stateAfter);
+                boolean ok = verdict.outcome() == ApplicationUpdatePolicy.Outcome.SUCCESS
+                    || verdict.outcome() == ApplicationUpdatePolicy.Outcome.IN_PROGRESS;
+                String message = verdict.outcome() == ApplicationUpdatePolicy.Outcome.IN_PROGRESS
+                    ? verdict.message() + " " + EXTERNAL_SESSION_NOTE //$NON-NLS-1$
+                    : verdict.message();
+
+                // message is in the structured body on EVERY outcome (the output schema
+                // declares it); ToolResult.error() additionally surfaces it in the error
+                // envelope, so a NEEDS_FULL_UPDATE/FAILED caller still gets the actionable text.
+                ToolResult result = ok ? ToolResult.success() : ToolResult.error(message);
+                result.put("action", "updated") //$NON-NLS-1$ //$NON-NLS-2$
+                    .put("project", projectName) //$NON-NLS-1$
+                    .put("applicationId", applicationId) //$NON-NLS-1$
+                    .put("applicationName", application.getName()) //$NON-NLS-1$
+                    .put("updateType", updateType.name()) //$NON-NLS-1$
+                    .put("stateBefore", stateBefore.name()) //$NON-NLS-1$
+                    .put("stateAfter", stateAfter.name()) //$NON-NLS-1$
+                    .put("terminatedClients", terminatedClients) //$NON-NLS-1$
+                    .put("message", message); //$NON-NLS-1$
+                if (verdict.outcome() == ApplicationUpdatePolicy.Outcome.NEEDS_FULL_UPDATE)
+                {
+                    result.put("fullUpdateRequired", true); //$NON-NLS-1$
+                }
+                return result.toJson();
             }
-            else if (stateAfter == ApplicationUpdateState.BEING_UPDATED)
-            {
-                result.put("message", "Update in progress"); //$NON-NLS-1$ //$NON-NLS-2$
-            }
-            else
-            {
-                result.put("message", "Update completed with state: " + stateAfter.name()); //$NON-NLS-1$ //$NON-NLS-2$
-            }
-            
-            return result.toJson();
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            return ToolResult.error("Database update was interrupted while waiting for it to " //$NON-NLS-1$
+                + "complete. It may still be running in the background — poll get_applications.") //$NON-NLS-1$
+                .toJson();
         }
         catch (ApplicationException e)
         {
@@ -314,5 +414,19 @@ public class UpdateDatabaseTool implements IMcpTool
             Activator.logError("Unexpected error during database update", e); //$NON-NLS-1$
             return ToolResult.error("Unexpected error: " + e.getMessage()).toJson(); //$NON-NLS-1$
         }
+    }
+
+    /** Clamps the watchdog window to a sane range. */
+    private static int clampTimeout(int seconds)
+    {
+        if (seconds < MIN_UPDATE_TIMEOUT_SECONDS)
+        {
+            return MIN_UPDATE_TIMEOUT_SECONDS;
+        }
+        if (seconds > MAX_UPDATE_TIMEOUT_SECONDS)
+        {
+            return MAX_UPDATE_TIMEOUT_SECONDS;
+        }
+        return seconds;
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ApplicationUpdatePolicy.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ApplicationUpdatePolicy.java
@@ -1,0 +1,162 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2026 Diversus23 (https://github.com/Diversus23)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import com.e1c.g5.dt.applications.ApplicationUpdateState;
+import com.e1c.g5.dt.applications.ApplicationUpdateType;
+
+/**
+ * Single canonical interpretation of an {@link ApplicationUpdateState} returned
+ * by {@code IApplicationManager.update(...)}. Both the explicit
+ * {@code update_database} tool and the pre-launch auto-chain
+ * ({@code LaunchLifecycleUtils.updateApplicationIfNeeded}) classify through this
+ * one place so the "is this success?" decision never diverges.
+ *
+ * <h2>Why {@code INCREMENTAL_UPDATE_REQUIRED} after an incremental update is a
+ * SUCCESS</h2>
+ * For a configuration that has a dependent extension (the classic case is a
+ * YAXUnit <em>test extension</em>), {@code InfobaseApplicationProvisionDelegate.getUpdateState}
+ * propagates the extension's {@code INCREMENTAL_UPDATE_REQUIRED} to the whole
+ * application — and a plain {@code IApplicationManager.update} publishes the
+ * configuration but does <b>not</b> durably clear that state; it reverts
+ * immediately. So observing {@code INCREMENTAL_UPDATE_REQUIRED} right after an
+ * incremental update does NOT mean the update failed — the changes ARE in the
+ * infobase. Treating it as a failure is what historically pushed callers into a
+ * needless (and often failing) FULL update. See
+ * {@code LaunchUpdateDialogAutoConfirmer} for the matching launch-time handling.
+ *
+ * <p>A genuine "incremental is not enough" signal is the distinct
+ * {@link ApplicationUpdateState#FULL_UPDATE_REQUIRED} value — only that one maps
+ * to {@link Outcome#NEEDS_FULL_UPDATE}.
+ */
+public final class ApplicationUpdatePolicy
+{
+    /** Classified outcome of a database update. */
+    public enum Outcome
+    {
+        /** The configuration is published; the caller may proceed. */
+        SUCCESS,
+        /** The update is still running (BEING_UPDATED); poll until it settles. */
+        IN_PROGRESS,
+        /** Incremental is genuinely insufficient — a FULL update is required. */
+        NEEDS_FULL_UPDATE,
+        /** Unexpected terminal state — surface it to the user. */
+        FAILED
+    }
+
+    /** Immutable {outcome + actionable message} pair. */
+    public static final class Result
+    {
+        private final Outcome outcome;
+        private final String message;
+
+        private Result(Outcome outcome, String message)
+        {
+            this.outcome = outcome;
+            this.message = message;
+        }
+
+        public Outcome outcome()
+        {
+            return outcome;
+        }
+
+        public String message()
+        {
+            return message;
+        }
+
+        public boolean isSuccess()
+        {
+            return outcome == Outcome.SUCCESS;
+        }
+    }
+
+    private ApplicationUpdatePolicy()
+    {
+        // Utility class
+    }
+
+    /**
+     * Classifies the state for the <b>pre-launch</b> path (the auto-chain only
+     * ever runs an INCREMENTAL update). {@code BEING_UPDATED} is expected to be
+     * polled to a settled state by the caller before classification, but it is
+     * handled here too for safety.
+     */
+    public static Result classifyPostUpdate(ApplicationUpdateState after)
+    {
+        return classifyExplicitUpdate(ApplicationUpdateType.INCREMENTAL, after);
+    }
+
+    /**
+     * Classifies the state for the <b>explicit</b> {@code update_database} path,
+     * where the caller may have requested a FULL or an INCREMENTAL update.
+     *
+     * @param requestedType the update type that was actually run
+     * @param after         the state returned by {@code update()} (or polled
+     *                      after a {@code BEING_UPDATED}); may be {@code null}
+     */
+    public static Result classifyExplicitUpdate(ApplicationUpdateType requestedType,
+            ApplicationUpdateState after)
+    {
+        if (after == null)
+        {
+            return new Result(Outcome.FAILED,
+                "Database update returned no state. Inspect the EDT '.log' / Problems view."); //$NON-NLS-1$
+        }
+        switch (after)
+        {
+            case UPDATED:
+                return new Result(Outcome.SUCCESS, "Database updated successfully."); //$NON-NLS-1$
+
+            case INCREMENTAL_UPDATE_REQUIRED:
+                if (requestedType == ApplicationUpdateType.FULL)
+                {
+                    // A FULL update should leave the IB UPDATED; still asking for an
+                    // incremental afterward means the full update did not settle.
+                    return new Result(Outcome.FAILED,
+                        "Full update finished but the database still reports " //$NON-NLS-1$
+                            + "INCREMENTAL_UPDATE_REQUIRED. Inspect the EDT '.log' / Problems " //$NON-NLS-1$
+                            + "view; the infobase may need manual restructurization."); //$NON-NLS-1$
+                }
+                // The expected cosmetic case for an extension-bearing configuration:
+                // the changes ARE published; do NOT escalate to a full update. The
+                // message keeps an honest escape hatch in case the rare genuine
+                // "needs full" is misreported as this state.
+                return new Result(Outcome.SUCCESS,
+                    "Database updated successfully (incremental). The application still reports " //$NON-NLS-1$
+                        + "INCREMENTAL_UPDATE_REQUIRED — normally the cosmetic state of a " //$NON-NLS-1$
+                        + "configuration with a dependent extension, so a full update is usually " //$NON-NLS-1$
+                        + "NOT needed. If a freshly launched client still runs stale code, re-call " //$NON-NLS-1$
+                        + "update_database with fullUpdate=true."); //$NON-NLS-1$
+
+            case FULL_UPDATE_REQUIRED:
+                if (requestedType == ApplicationUpdateType.FULL)
+                {
+                    return new Result(Outcome.FAILED,
+                        "Full update finished but the database still reports " //$NON-NLS-1$
+                            + "FULL_UPDATE_REQUIRED. Inspect the EDT '.log' / Problems view."); //$NON-NLS-1$
+                }
+                return new Result(Outcome.NEEDS_FULL_UPDATE,
+                    "Incremental update finished but the database genuinely requires a FULL " //$NON-NLS-1$
+                        + "update (state: FULL_UPDATE_REQUIRED) — the structural changes cannot be " //$NON-NLS-1$
+                        + "applied incrementally. Call update_database with fullUpdate=true to apply " //$NON-NLS-1$
+                        + "them, then retry."); //$NON-NLS-1$
+
+            case BEING_UPDATED:
+                return new Result(Outcome.IN_PROGRESS,
+                    "The update is still running in the background (BEING_UPDATED). Poll " //$NON-NLS-1$
+                        + "get_applications until the state becomes UPDATED before launching a client."); //$NON-NLS-1$
+
+            default:
+                // UNKNOWN or any future enum value.
+                return new Result(Outcome.FAILED,
+                    "Database update finished with an unexpected state: " + after.name() //$NON-NLS-1$
+                        + ". Inspect the EDT '.log' / Problems view."); //$NON-NLS-1$
+        }
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/EdtDialogAutoConfirmer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/EdtDialogAutoConfirmer.java
@@ -1,0 +1,232 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2026 Diversus23 (https://github.com/Diversus23)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTError;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Shell;
+
+import com.ditrix.edt.mcp.server.Activator;
+
+/**
+ * Auto-confirms a blocking EDT modal dialog (by exact title) while armed, by
+ * programmatically pressing its <em>default</em> button — the same choice a
+ * careful user would make. Each instance watches its own immutable set of
+ * titles, so different callers (a launch, a database update) can target
+ * different dialogs without interfering with each other.
+ *
+ * <h2>Why this is needed</h2>
+ * Several EDT operations (a runtime-client launch whose infobase is not
+ * byte-for-byte equal to the project, and {@code IApplicationManager.update}
+ * against an infobase that still has an active session) bring up an
+ * <b>application-modal</b> dialog and block the calling thread until a human
+ * answers it. In an unattended MCP run nobody clicks it, so the call hangs until
+ * the transport times out. While armed, a {@link Display} filter presses the
+ * dialog's default button so the operation proceeds.
+ *
+ * <h2>Scope &amp; safety</h2>
+ * <ul>
+ *   <li>The filter is installed only between {@link #arm()} and {@link #disarm()}
+ *       (use try/finally around the single blocking call), so manual EDT
+ *       operations outside that window still prompt normally.</li>
+ *   <li>{@link #arm()}/{@link #disarm()} are reentrant via a counter.</li>
+ *   <li>Only the exact configured titles are matched, so unrelated dialogs that
+ *       happen to appear during the window are left untouched.</li>
+ *   <li>Headless (no SWT {@link Display}) is a no-op — no dialog can appear
+ *       there anyway.</li>
+ * </ul>
+ */
+public final class EdtDialogAutoConfirmer
+{
+    private final Set<String> targetTitles;
+    private final Object lock = new Object();
+
+    private int armCount;
+    private Display filterDisplay;
+    private Listener filter;
+
+    /**
+     * @param targetTitles exact shell titles to auto-confirm (case-sensitive). A
+     *                     defensive immutable copy is taken.
+     */
+    public EdtDialogAutoConfirmer(Set<String> targetTitles)
+    {
+        this.targetTitles = Collections.unmodifiableSet(new LinkedHashSet<>(targetTitles));
+    }
+
+    /** True if {@code shellTitle} is one of the titles this instance confirms. */
+    public boolean isTargetTitle(String shellTitle)
+    {
+        return shellTitle != null && targetTitles.contains(shellTitle);
+    }
+
+    /**
+     * Arms the auto-confirmer. MUST be paired with {@link #disarm()} in a
+     * {@code finally} block around the blocking call. Reentrant: nested/concurrent
+     * uses of the same instance share a single filter.
+     *
+     * <p>No-op in a headless environment (no SWT display).
+     */
+    public void arm()
+    {
+        Display display = safeDisplay();
+        if (display == null)
+        {
+            return;
+        }
+        synchronized (lock)
+        {
+            armCount++;
+            if (filter != null)
+            {
+                return;
+            }
+            Listener listener = event -> {
+                if (!(event.widget instanceof Shell))
+                {
+                    return;
+                }
+                Shell shell = (Shell)event.widget;
+                String title;
+                try
+                {
+                    title = shell.getText();
+                }
+                catch (RuntimeException e)
+                {
+                    return;
+                }
+                if (!isTargetTitle(title))
+                {
+                    return;
+                }
+                // Defer so the modal finishes building its button bar and enters
+                // its event loop; the press then runs inside that loop.
+                shell.getDisplay().asyncExec(() -> pressDefaultButton(shell));
+            };
+            // Display filters must be (un)installed on the UI thread.
+            display.syncExec(() -> {
+                display.addFilter(SWT.Activate, listener);
+                display.addFilter(SWT.Show, listener);
+            });
+            filter = listener;
+            filterDisplay = display;
+        }
+    }
+
+    /**
+     * Disarms the auto-confirmer. The underlying {@link Display} filter is
+     * removed only once the last paired {@link #arm()} has been released.
+     */
+    public void disarm()
+    {
+        Listener toRemove;
+        Display display;
+        synchronized (lock)
+        {
+            if (armCount > 0)
+            {
+                armCount--;
+            }
+            if (armCount > 0 || filter == null)
+            {
+                return;
+            }
+            toRemove = filter;
+            display = filterDisplay;
+            filter = null;
+            filterDisplay = null;
+        }
+        if (display != null && !display.isDisposed())
+        {
+            display.syncExec(() -> {
+                display.removeFilter(SWT.Activate, toRemove);
+                display.removeFilter(SWT.Show, toRemove);
+            });
+        }
+    }
+
+    /**
+     * Presses the default button of the given dialog shell. Guarded against
+     * disposal and never throws onto the UI thread.
+     */
+    private void pressDefaultButton(Shell shell)
+    {
+        try
+        {
+            if (shell == null || shell.isDisposed())
+            {
+                return;
+            }
+            Button button = shell.getDefaultButton();
+            if (button == null || button.isDisposed())
+            {
+                return;
+            }
+            Activator.logInfo("Auto-confirming EDT dialog '" + safeTitle(shell) //$NON-NLS-1$
+                + "' via button '" + safeText(button) + "'"); //$NON-NLS-1$ //$NON-NLS-2$
+            Event event = new Event();
+            event.widget = button;
+            // Mirrors a user click: JFace dialog buttons fire buttonPressed() on
+            // SWT.Selection, which sets the return code and closes the dialog.
+            button.notifyListeners(SWT.Selection, event);
+        }
+        catch (RuntimeException e)
+        {
+            Activator.logError("Failed to auto-confirm an EDT dialog", e); //$NON-NLS-1$
+        }
+    }
+
+    private static String safeTitle(Shell shell)
+    {
+        try
+        {
+            return shell.getText();
+        }
+        catch (RuntimeException e)
+        {
+            return "<unknown>"; //$NON-NLS-1$
+        }
+    }
+
+    private static String safeText(Button button)
+    {
+        try
+        {
+            return button.getText();
+        }
+        catch (RuntimeException e)
+        {
+            return "<unknown>"; //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Returns the default {@link Display} or {@code null} when SWT cannot be
+     * initialised (headless CI / no UI).
+     */
+    private static Display safeDisplay()
+    {
+        try
+        {
+            Display display = Display.getDefault();
+            return display != null && !display.isDisposed() ? display : null;
+        }
+        catch (SWTError | UnsatisfiedLinkError e)
+        {
+            return null;
+        }
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
@@ -342,29 +342,21 @@ public final class LaunchLifecycleUtils
             ApplicationUpdateState after = appManager.update(application,
                 ApplicationUpdateType.INCREMENTAL, context, new NullProgressMonitor());
             Activator.logInfo("Pre-launch DB update completed: stateAfter=" + after); //$NON-NLS-1$
-            // Post-condition gate: the auto-chain promises the IB will be in
-            // UPDATED state before workingCopy.launch() runs, otherwise the
-            // launch delegate would still see "DB needs update" and pop its
-            // modal dialog — which is exactly what we are trying to avoid.
-            if (after == ApplicationUpdateState.UPDATED)
-            {
-                return Optional.empty();
-            }
+            // Settle an async update before classifying — never launch against a
+            // half-updated IB.
             if (after == ApplicationUpdateState.BEING_UPDATED)
             {
-                // appManager.update() returned but the state machine still
-                // reports an update in progress (async path). Wait for it.
                 long maxMillis = getDefaultTerminateTimeoutSeconds() * 1000L;
                 after = waitForUpdateSettled(appManager, application, maxMillis);
-                if (after == ApplicationUpdateState.UPDATED)
-                {
-                    return Optional.empty();
-                }
             }
-            return Optional.of("Database update finished with state " + after //$NON-NLS-1$
-                + " (expected UPDATED). Inspect the EDT problems view, " //$NON-NLS-1$
-                + "or call `update_database` with `fullUpdate=true` / " //$NON-NLS-1$
-                + "`autoRestructure=true` to handle restructurization, then retry."); //$NON-NLS-1$
+            // Defer the success/failure decision to the single ApplicationUpdatePolicy
+            // so this pre-launch path and update_database agree. INCREMENTAL_UPDATE_REQUIRED
+            // here is the expected cosmetic state for an extension-bearing app (the launch
+            // delegate's modal is auto-confirmed by LaunchUpdateDialogAutoConfirmer), so the
+            // policy treats it as success and we do NOT push the caller toward a needless
+            // full update.
+            ApplicationUpdatePolicy.Result verdict = ApplicationUpdatePolicy.classifyPostUpdate(after);
+            return verdict.isSuccess() ? Optional.empty() : Optional.of(verdict.message());
         }
         catch (ApplicationException e)
         {
@@ -413,6 +405,86 @@ public final class LaunchLifecycleUtils
     }
 
     /**
+     * Terminates every live EDT <b>runtime-client</b> launch on the given
+     * {@code project + applicationId} infobase, politely, waiting up to
+     * {@code terminateTimeoutSeconds} per launch.
+     *
+     * <p>This is the shared "free the infobase before mutating it" primitive used
+     * both by the pre-launch auto-chain ({@link #prepareForFreshLaunch}) and by
+     * {@code update_database}. It prunes the OWNED registry first, refuses to touch
+     * a launch another MCP tool owns (registered via {@link #registerOwnedLaunch})
+     * so concurrent test runs don't sabotage each other, and aborts ({@code ok=false})
+     * if a launch will not stop within the window — leaving the IB locked would
+     * defeat the purpose.
+     *
+     * <p>Only runtime-client launches are swept (they hold the infobase). Attach
+     * debug launches do not hold the lock and are handled separately by
+     * {@link #prepareForFreshLaunch}.
+     *
+     * <p>Acquires {@link #lockFor} for the pair; safe to call from a caller that
+     * already holds it ({@code synchronized} is reentrant).
+     *
+     * @param launchManager           Eclipse launch manager
+     * @param project                 target project
+     * @param applicationId           target {@code ATTR_APPLICATION_ID}
+     * @param terminateTimeoutSeconds polite-wait window per live launch
+     * @return {@code ok=true} + terminated count on success; {@code ok=false} with
+     *         an actionable error when a launch is owned or would not stop in time
+     */
+    public static PreLaunchResult terminateLiveLaunchesForIb(ILaunchManager launchManager,
+            IProject project, String applicationId, int terminateTimeoutSeconds)
+    {
+        if (launchManager == null)
+        {
+            return new PreLaunchResult(false, 0, "Launch manager is not available"); //$NON-NLS-1$
+        }
+        if (project == null)
+        {
+            return new PreLaunchResult(false, 0, "Project is null"); //$NON-NLS-1$
+        }
+        synchronized (lockFor(project.getName(), applicationId))
+        {
+            // Prune terminated entries so a stale registration cannot
+            // permanently block future auto-chains.
+            OWNED_LAUNCHES.removeIf(ILaunch::isTerminated);
+
+            int terminated = 0;
+            for (ILaunch live : LaunchConfigUtils.getAllLiveLaunches(launchManager,
+                project.getName()))
+            {
+                if (!applicationId.equals(LaunchConfigUtils.getApplicationIdFor(live)))
+                {
+                    continue;
+                }
+                String name = live.getLaunchConfiguration() != null
+                    ? live.getLaunchConfiguration().getName() : "<unknown>"; //$NON-NLS-1$
+                // Identity-equals lookup against the OWNED registry — relies on
+                // the invariant that callers pass the exact ILaunch instance
+                // returned by workingCopy.launch() to registerOwnedLaunch.
+                if (OWNED_LAUNCHES.contains(live))
+                {
+                    return new PreLaunchResult(false, terminated,
+                        "Another test run is already in progress for this IB " //$NON-NLS-1$
+                            + "(launch '" + name + "'). Wait for it to finish " //$NON-NLS-1$ //$NON-NLS-2$
+                            + "(call this tool again later with the same arguments), " //$NON-NLS-1$
+                            + "or call `terminate_launch` to stop it first."); //$NON-NLS-1$
+                }
+                boolean done = terminateAndWait(live, terminateTimeoutSeconds);
+                if (!done)
+                {
+                    return new PreLaunchResult(false, terminated,
+                        "Could not terminate previous launch '" + name //$NON-NLS-1$
+                            + "' within " + terminateTimeoutSeconds //$NON-NLS-1$
+                            + "s. Call `terminate_launch` with `force=true` to kill " //$NON-NLS-1$
+                            + "the stuck process, then retry."); //$NON-NLS-1$
+                }
+                terminated++;
+            }
+            return new PreLaunchResult(true, terminated, null);
+        }
+    }
+
+    /**
      * Auto-chain executed before {@code workingCopy.launch()} when the caller
      * wants to bypass EDT's interactive "Update database?" dialog:
      * <ol>
@@ -452,42 +524,16 @@ public final class LaunchLifecycleUtils
         // their full spawn+register sequence around the auto-chain.
         synchronized (lockFor(project.getName(), applicationId))
         {
-            // Prune terminated entries so a stale registration cannot
-            // permanently block future auto-chains.
-            OWNED_LAUNCHES.removeIf(ILaunch::isTerminated);
-
-            int terminated = 0;
-            for (ILaunch live : LaunchConfigUtils.getAllLiveLaunches(launchManager,
-                project.getName()))
+            // First pass: terminate live runtime-client launches holding this IB.
+            // Shared with update_database via terminateLiveLaunchesForIb, which prunes
+            // the OWNED registry and enforces the owned-launch protection.
+            PreLaunchResult termination = terminateLiveLaunchesForIb(launchManager, project,
+                applicationId, terminateTimeoutSeconds);
+            if (!termination.isOk())
             {
-                if (!applicationId.equals(LaunchConfigUtils.getApplicationIdFor(live)))
-                {
-                    continue;
-                }
-                String name = live.getLaunchConfiguration() != null
-                    ? live.getLaunchConfiguration().getName() : "<unknown>"; //$NON-NLS-1$
-                // Identity-equals lookup against the OWNED registry — relies on
-                // the invariant that callers pass the exact ILaunch instance
-                // returned by workingCopy.launch() to registerOwnedLaunch.
-                if (OWNED_LAUNCHES.contains(live))
-                {
-                    return new PreLaunchResult(false, terminated,
-                        "Another test run is already in progress for this IB " //$NON-NLS-1$
-                            + "(launch '" + name + "'). Wait for it to finish " //$NON-NLS-1$ //$NON-NLS-2$
-                            + "(call this tool again later with the same arguments), " //$NON-NLS-1$
-                            + "or call `terminate_launch` to stop it first."); //$NON-NLS-1$
-                }
-                boolean done = terminateAndWait(live, terminateTimeoutSeconds);
-                if (!done)
-                {
-                    return new PreLaunchResult(false, terminated,
-                        "Could not terminate previous launch '" + name //$NON-NLS-1$
-                            + "' within " + terminateTimeoutSeconds //$NON-NLS-1$
-                            + "s. Call `terminate_launch` with `force=true` to kill " //$NON-NLS-1$
-                            + "the stuck process, then retry."); //$NON-NLS-1$
-                }
-                terminated++;
+                return termination;
             }
+            int terminated = termination.getTerminatedCount();
 
             // Second pass: stale Attach launches on the same project. Attach
             // configs don't carry a real ATTR_APPLICATION_ID — getApplicationIdFor

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
@@ -6,17 +6,20 @@
 
 package com.ditrix.edt.mcp.server.utils;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * Auto-confirms EDT's blocking <em>"Application update"</em> launch modal while
  * a YAXUnit tool is spawning a launch via {@code workingCopy.launch()}.
  *
  * <p>This is a thin static facade over a shared {@link EdtDialogAutoConfirmer}
- * configured for the single {@link #APPLICATION_UPDATE_TITLE} dialog, kept for
- * the existing launch call sites. {@code update_database} uses its own
- * {@link EdtDialogAutoConfirmer} instance (it may face additional dialog
- * titles), so the two never share arm/disarm state.
+ * configured for the launch update modal's {@linkplain #APPLICATION_UPDATE_TITLES
+ * localized titles}, kept for the existing launch call sites. {@code update_database}
+ * reuses the same titles for its own {@link EdtDialogAutoConfirmer} instance, so
+ * the two never share arm/disarm state.
  *
  * <p>For YAXUnit runs the modal is structural: the dependent test extension
  * reports {@code INCREMENTAL_UPDATE_REQUIRED}, which
@@ -28,16 +31,29 @@ import java.util.Collections;
  */
 public final class LaunchUpdateDialogAutoConfirmer
 {
+    /** English EDT build title of the launch-delegate "update before launch?" modal. */
+    static final String APPLICATION_UPDATE_TITLE_EN = "Application update"; //$NON-NLS-1$
+
     /**
-     * Exact title of EDT's launch-delegate "update infobase before launch?"
-     * modal ({@code ApplicationUiSupport_Application_update}). The EDT-MCP
-     * surface is English-only and so is the target EDT build, so an exact-title
-     * match is sufficient and keeps the filter from touching other dialogs.
+     * The same modal in a Russian EDT build. The title is localized to the EDT
+     * UI language, so an exact-title match must enumerate each locale: a Russian
+     * EDT shows this title, which the English one never matched — the launch
+     * then hung on the modal. Justified Cyrillic per CLAUDE.md #7 (a real EDT UI
+     * string the code matches, not a regex; the Tycho build is UTF-8).
      */
-    static final String APPLICATION_UPDATE_TITLE = "Application update"; //$NON-NLS-1$
+    static final String APPLICATION_UPDATE_TITLE_RU = "Обновление приложения"; //$NON-NLS-1$
+
+    /**
+     * Known localized titles of the launch "update before launch?" modal. Add
+     * more here as other EDT UI locales are confirmed live. Shared with
+     * {@code update_database}'s confirmer so both honour the same locale set.
+     */
+    public static final Set<String> APPLICATION_UPDATE_TITLES =
+        Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(
+            APPLICATION_UPDATE_TITLE_EN, APPLICATION_UPDATE_TITLE_RU)));
 
     private static final EdtDialogAutoConfirmer CONFIRMER =
-        new EdtDialogAutoConfirmer(Collections.singleton(APPLICATION_UPDATE_TITLE));
+        new EdtDialogAutoConfirmer(APPLICATION_UPDATE_TITLES);
 
     private LaunchUpdateDialogAutoConfirmer()
     {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
@@ -6,64 +6,25 @@
 
 package com.ditrix.edt.mcp.server.utils;
 
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.SWTError;
-import org.eclipse.swt.widgets.Button;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Listener;
-import org.eclipse.swt.widgets.Shell;
-
-import com.ditrix.edt.mcp.server.Activator;
+import java.util.Collections;
 
 /**
- * Auto-confirms EDT's blocking <em>"Application update"</em> launch modal, but
- * ONLY while one of the YAXUnit tools is spawning a launch via
- * {@code workingCopy.launch()}.
+ * Auto-confirms EDT's blocking <em>"Application update"</em> launch modal while
+ * a YAXUnit tool is spawning a launch via {@code workingCopy.launch()}.
  *
- * <h2>Why this is needed</h2>
- * When a launch configuration's infobase is not byte-for-byte equal to the
- * project, EDT's runtime launch delegate routes through
- * {@code ApplicationUpdateStatusHandler} (status code {@code 1006}) which calls
- * {@code IApplicationUiSupport.ensureUpdated}. If
- * {@code IApplicationManager.getUpdateState(application)} is anything other than
- * {@code UPDATED}, that method pops an <b>application-modal</b> dialog titled
- * "Application update" with the choices "Update then run" / "Run without update"
- * / "Cancel" and blocks the launch thread until a human answers it.
+ * <p>This is a thin static facade over a shared {@link EdtDialogAutoConfirmer}
+ * configured for the single {@link #APPLICATION_UPDATE_TITLE} dialog, kept for
+ * the existing launch call sites. {@code update_database} uses its own
+ * {@link EdtDialogAutoConfirmer} instance (it may face additional dialog
+ * titles), so the two never share arm/disarm state.
  *
- * <p>For YAXUnit runs the blocker is structural: the dependent <em>test
- * extension</em> reports {@code INCREMENTAL_UPDATE_REQUIRED}, which
+ * <p>For YAXUnit runs the modal is structural: the dependent test extension
+ * reports {@code INCREMENTAL_UPDATE_REQUIRED}, which
  * {@code InfobaseApplicationProvisionDelegate.getUpdateState} propagates to the
- * whole application. A plain {@code IApplicationManager.update} (the same path
- * as {@code update_database} and the EDT "Update then run" button) publishes the
- * configuration but does <b>not</b> durably bring the extension to {@code EQUAL}
- * — the state reverts to {@code INCREMENTAL_UPDATE_REQUIRED} immediately — so the
- * modal returns on every launch and there is no launch-config attribute or
- * preference to suppress it. The MCP call then hangs until the user clicks
- * through, which defeats unattended runs.
- *
- * <h2>What it does</h2>
- * While armed, a {@link Display} filter watches for the activation of a shell
- * whose title is exactly {@link #APPLICATION_UPDATE_TITLE} and programmatically
- * presses its <em>default</em> button ("Update then run", the same choice a
- * careful user would pick), letting the launch proceed without human input. The
- * preceding pre-launch DB update (see {@code LaunchLifecycleUtils}) has already
- * published the configuration, so the auto-pressed update is a fast no-op and
- * does not cascade into a second structural-changes dialog.
- *
- * <h2>Scope &amp; safety</h2>
- * <ul>
- *   <li>The filter is installed only between {@link #arm()} and {@link #disarm()}
- *       (use try/finally around the single {@code launch()} call), so manual EDT
- *       launches outside an MCP tool still prompt normally.</li>
- *   <li>{@link #arm()}/{@link #disarm()} are reentrant via a counter; concurrent
- *       YAXUnit launches share one filter and the last {@code disarm()} removes
- *       it.</li>
- *   <li>Only the exact "Application update" title is matched, so unrelated
- *       dialogs that happen to appear during the window are left untouched.</li>
- *   <li>Headless (no SWT {@link Display}) is a no-op — no dialog can appear
- *       there anyway.</li>
- * </ul>
+ * whole application, and a plain {@code IApplicationManager.update} does not
+ * durably clear it — so the launch delegate pops "Application update" on every
+ * launch and there is no attribute/preference to suppress it. Pressing the
+ * default ("Update then run") button lets the launch proceed unattended.
  */
 public final class LaunchUpdateDialogAutoConfirmer
 {
@@ -75,11 +36,8 @@ public final class LaunchUpdateDialogAutoConfirmer
      */
     static final String APPLICATION_UPDATE_TITLE = "Application update"; //$NON-NLS-1$
 
-    private static final Object LOCK = new Object();
-
-    private static int armCount;
-    private static Display filterDisplay;
-    private static Listener filter;
+    private static final EdtDialogAutoConfirmer CONFIRMER =
+        new EdtDialogAutoConfirmer(Collections.singleton(APPLICATION_UPDATE_TITLE));
 
     private LaunchUpdateDialogAutoConfirmer()
     {
@@ -87,158 +45,29 @@ public final class LaunchUpdateDialogAutoConfirmer
     }
 
     /**
-     * Pure decision used by the {@link Display} filter (and by tests): is the
-     * given shell title the "Application update" modal we auto-confirm?
+     * Pure decision used by tests: is the given shell title the "Application
+     * update" modal this facade auto-confirms?
      */
     static boolean isTargetTitle(String shellTitle)
     {
-        return APPLICATION_UPDATE_TITLE.equals(shellTitle);
+        return CONFIRMER.isTargetTitle(shellTitle);
     }
 
     /**
      * Arms the auto-confirmer. MUST be paired with {@link #disarm()} in a
      * {@code finally} block around the {@code workingCopy.launch()} call.
-     * Reentrant: nested/concurrent launches share a single filter.
-     *
-     * <p>No-op in a headless environment (no SWT display).
+     * Reentrant. No-op in a headless environment.
      */
     public static void arm()
     {
-        Display display = safeDisplay();
-        if (display == null)
-        {
-            return;
-        }
-        synchronized (LOCK)
-        {
-            armCount++;
-            if (filter != null)
-            {
-                return;
-            }
-            Listener listener = event -> {
-                if (!(event.widget instanceof Shell))
-                {
-                    return;
-                }
-                Shell shell = (Shell)event.widget;
-                String title;
-                try
-                {
-                    title = shell.getText();
-                }
-                catch (RuntimeException e)
-                {
-                    return;
-                }
-                if (!isTargetTitle(title))
-                {
-                    return;
-                }
-                // Defer so the modal finishes building its button bar and enters
-                // its event loop; the press then runs inside that loop.
-                shell.getDisplay().asyncExec(() -> pressDefaultButton(shell));
-            };
-            // Display filters must be (un)installed on the UI thread.
-            display.syncExec(() -> {
-                display.addFilter(SWT.Activate, listener);
-                display.addFilter(SWT.Show, listener);
-            });
-            filter = listener;
-            filterDisplay = display;
-        }
+        CONFIRMER.arm();
     }
 
     /**
-     * Disarms the auto-confirmer. The underlying {@link Display} filter is
-     * removed only once the last paired {@link #arm()} has been released.
+     * Disarms the auto-confirmer once the last paired {@link #arm()} is released.
      */
     public static void disarm()
     {
-        Listener toRemove;
-        Display display;
-        synchronized (LOCK)
-        {
-            if (armCount > 0)
-            {
-                armCount--;
-            }
-            if (armCount > 0 || filter == null)
-            {
-                return;
-            }
-            toRemove = filter;
-            display = filterDisplay;
-            filter = null;
-            filterDisplay = null;
-        }
-        if (display != null && !display.isDisposed())
-        {
-            display.syncExec(() -> {
-                display.removeFilter(SWT.Activate, toRemove);
-                display.removeFilter(SWT.Show, toRemove);
-            });
-        }
-    }
-
-    /**
-     * Presses the default ("Update then run") button of the given dialog shell.
-     * Guarded against disposal and never throws onto the UI thread.
-     */
-    private static void pressDefaultButton(Shell shell)
-    {
-        try
-        {
-            if (shell == null || shell.isDisposed())
-            {
-                return;
-            }
-            Button button = shell.getDefaultButton();
-            if (button == null || button.isDisposed())
-            {
-                return;
-            }
-            Activator.logInfo("Auto-confirming launch dialog '" + APPLICATION_UPDATE_TITLE //$NON-NLS-1$
-                + "' via button '" + safeText(button) + "'"); //$NON-NLS-1$ //$NON-NLS-2$
-            Event event = new Event();
-            event.widget = button;
-            // Mirrors a user click: JFace dialog buttons fire buttonPressed() on
-            // SWT.Selection, which sets the return code and closes the dialog.
-            button.notifyListeners(SWT.Selection, event);
-        }
-        catch (RuntimeException e)
-        {
-            Activator.logError("Failed to auto-confirm the launch update dialog", e); //$NON-NLS-1$
-        }
-    }
-
-    private static String safeText(Button button)
-    {
-        try
-        {
-            return button.getText();
-        }
-        catch (RuntimeException e)
-        {
-            return "<unknown>"; //$NON-NLS-1$
-        }
-    }
-
-    /**
-     * Returns the default {@link Display} or {@code null} when SWT cannot be
-     * initialised (headless CI / no UI), mirroring
-     * {@code LaunchLifecycleUtils.grabActiveShell}.
-     */
-    private static Display safeDisplay()
-    {
-        try
-        {
-            Display display = Display.getDefault();
-            return display != null && !display.isDisposed() ? display : null;
-        }
-        catch (SWTError | UnsatisfiedLinkError e)
-        {
-            return null;
-        }
+        CONFIRMER.disarm();
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/UpdateWatchdog.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/UpdateWatchdog.java
@@ -1,0 +1,174 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2026 Diversus23 (https://github.com/Diversus23)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.ditrix.edt.mcp.server.Activator;
+import com.e1c.g5.dt.applications.ApplicationException;
+import com.e1c.g5.dt.applications.ApplicationUpdateState;
+
+/**
+ * Runs a synchronous {@code IApplicationManager.update(...)} call with a bounded
+ * wall-clock timeout so a stuck update cannot hang the MCP worker thread until
+ * the transport-level timeout severs the connection.
+ *
+ * <p>The update is not cancellable, so on timeout we do <b>not</b> interrupt it:
+ * the call keeps running on a daemon background thread (the infobase eventually
+ * settles), and the watchdog returns {@link ApplicationUpdateState#BEING_UPDATED}
+ * — which {@link ApplicationUpdatePolicy} maps to "poll get_applications". The
+ * MCP call therefore returns a clear, actionable result instead of blocking.
+ *
+ * <p>This is a backstop. The primary defences against a hanging update are
+ * terminating the sessions that hold the infobase and auto-confirming EDT's
+ * blocking "Application update" modal (see {@code LaunchLifecycleUtils} /
+ * {@code EdtDialogAutoConfirmer}).
+ */
+public final class UpdateWatchdog
+{
+    private static final ThreadFactory DAEMON_FACTORY = runnable -> {
+        Thread thread = new Thread(runnable, "edt-mcp-update-watchdog"); //$NON-NLS-1$
+        thread.setDaemon(true);
+        return thread;
+    };
+
+    private UpdateWatchdog()
+    {
+        // Utility class
+    }
+
+    /**
+     * Executes {@code updateCall} on a daemon thread, waiting at most
+     * {@code timeoutSeconds} for it to return.
+     *
+     * @param updateCall     the {@code appManager.update(...)} invocation wrapped
+     *                       as a {@link Callable} (decoupled from EDT so it is
+     *                       unit-testable)
+     * @param timeoutSeconds wall-clock limit; values below 1 are clamped to 1
+     * @return the state returned by the update, or
+     *         {@link ApplicationUpdateState#BEING_UPDATED} on timeout
+     * @throws ApplicationException if the update call itself failed with one
+     * @throws InterruptedException if the waiting thread was interrupted
+     */
+    public static ApplicationUpdateState runWithTimeout(Callable<ApplicationUpdateState> updateCall,
+            int timeoutSeconds) throws ApplicationException, InterruptedException
+    {
+        return runWithTimeout(updateCall, timeoutSeconds, null, null);
+    }
+
+    /**
+     * As {@link #runWithTimeout(Callable, int)}, but brackets the update with
+     * {@code onStart} / {@code onComplete} so a guard (e.g. a dialog
+     * auto-confirmer) stays active for the <b>entire</b> life of the update —
+     * including after a timeout, while the abandoned update keeps running in the
+     * background. This matters for a long full update (a multi-minute reload that
+     * pops a restructurization modal well after the watchdog already returned
+     * {@code BEING_UPDATED}): the guard must still be armed to auto-confirm it.
+     *
+     * <p>{@code onComplete} runs exactly once, on whichever thread finishes the
+     * update: the caller thread for a fast return, or the daemon thread after a
+     * timeout (i.e. AFTER this method returned {@code BEING_UPDATED}).
+     *
+     * @param updateCall     the {@code appManager.update(...)} invocation wrapped
+     *                       as a {@link Callable} (decoupled from EDT so it is
+     *                       unit-testable)
+     * @param timeoutSeconds wall-clock limit; values below 1 are clamped to 1
+     * @param onStart        run on the calling thread before the update starts
+     *                       (may be {@code null})
+     * @param onComplete     run when the update actually finishes, success or
+     *                       failure (may be {@code null})
+     * @return the state returned by the update, or
+     *         {@link ApplicationUpdateState#BEING_UPDATED} on timeout
+     * @throws ApplicationException if the update call itself failed with one
+     * @throws InterruptedException if the waiting thread was interrupted
+     */
+    public static ApplicationUpdateState runWithTimeout(Callable<ApplicationUpdateState> updateCall,
+            int timeoutSeconds, Runnable onStart, Runnable onComplete)
+            throws ApplicationException, InterruptedException
+    {
+        int seconds = Math.max(1, timeoutSeconds);
+        if (onStart != null)
+        {
+            onStart.run();
+        }
+        ExecutorService executor = Executors.newSingleThreadExecutor(DAEMON_FACTORY);
+        try
+        {
+            Future<ApplicationUpdateState> future = executor.submit(() -> {
+                try
+                {
+                    return updateCall.call();
+                }
+                finally
+                {
+                    // Runs when the update TRULY finishes. On a timeout this fires on
+                    // the daemon thread after runWithTimeout already returned
+                    // BEING_UPDATED, so the guard outlives the abandoned update.
+                    if (onComplete != null)
+                    {
+                        onComplete.run();
+                    }
+                }
+            });
+            try
+            {
+                return future.get(seconds, TimeUnit.SECONDS);
+            }
+            catch (TimeoutException e)
+            {
+                Activator.logInfo("update watchdog: appManager.update did not return within " //$NON-NLS-1$
+                    + seconds + "s — it continues in the background; reporting BEING_UPDATED so the " //$NON-NLS-1$
+                    + "caller can poll get_applications."); //$NON-NLS-1$
+                // Do NOT cancel: the update is not interruptible and cancelling would
+                // only abort the waiting thread, not the EDT operation.
+                return ApplicationUpdateState.BEING_UPDATED;
+            }
+            catch (ExecutionException e)
+            {
+                throw unwrap(e);
+            }
+        }
+        finally
+        {
+            // shutdown(), not shutdownNow(): let an abandoned (timed-out) update
+            // run to completion on its daemon thread (and fire onComplete there).
+            executor.shutdown();
+        }
+    }
+
+    /**
+     * Rethrows the real cause of an {@link ExecutionException}. The wrapped
+     * {@code update()} only declares {@link ApplicationException}; unchecked
+     * throwables are propagated as-is.
+     */
+    private static ApplicationException unwrap(ExecutionException e) throws ApplicationException
+    {
+        Throwable cause = e.getCause();
+        if (cause instanceof ApplicationException)
+        {
+            return (ApplicationException)cause;
+        }
+        if (cause instanceof RuntimeException)
+        {
+            throw (RuntimeException)cause;
+        }
+        if (cause instanceof Error)
+        {
+            throw (Error)cause;
+        }
+        // No other checked type is possible from update(); be defensive anyway.
+        throw new IllegalStateException("Database update failed", //$NON-NLS-1$
+            cause != null ? cause : e);
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
@@ -122,6 +122,35 @@ public class UpdateDatabaseToolTest
         assertTrue(guide.contains("autoRestructure")); //$NON-NLS-1$
     }
 
+    @Test
+    public void testSchemaDeclaresSessionTerminationParams()
+    {
+        // The transparent terminate-before-update behaviour is controllable per-call.
+        String schema = new UpdateDatabaseTool().getInputSchema();
+        assertTrue("schema must declare terminateRunningClients", //$NON-NLS-1$
+            schema.contains("\"terminateRunningClients\"")); //$NON-NLS-1$
+        assertTrue("schema must declare updateTimeoutSeconds", //$NON-NLS-1$
+            schema.contains("\"updateTimeoutSeconds\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testOutputSchemaDeclaresTerminatedClientsAndFullUpdateRequired()
+    {
+        String schema = new UpdateDatabaseTool().getOutputSchema();
+        assertTrue("outputSchema must declare terminatedClients", //$NON-NLS-1$
+            schema.contains("\"terminatedClients\"")); //$NON-NLS-1$
+        assertTrue("outputSchema must declare fullUpdateRequired", //$NON-NLS-1$
+            schema.contains("\"fullUpdateRequired\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testGuideDocumentsTransparentTermination()
+    {
+        String guide = new UpdateDatabaseTool().getGuide();
+        assertTrue("guide must document the auto-termination of clients", //$NON-NLS-1$
+            guide.contains("terminateRunningClients")); //$NON-NLS-1$
+    }
+
     // ==================== Argument validation (no live launch manager needed) ====================
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ApplicationUpdatePolicyTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ApplicationUpdatePolicyTest.java
@@ -1,0 +1,124 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2026 Diversus23 (https://github.com/Diversus23)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.utils.ApplicationUpdatePolicy.Outcome;
+import com.ditrix.edt.mcp.server.utils.ApplicationUpdatePolicy.Result;
+import com.e1c.g5.dt.applications.ApplicationUpdateState;
+import com.e1c.g5.dt.applications.ApplicationUpdateType;
+
+/**
+ * Tests the single canonical interpretation of {@link ApplicationUpdateState} in
+ * {@link ApplicationUpdatePolicy}. The crux is that
+ * {@code INCREMENTAL_UPDATE_REQUIRED} after an incremental update is a SUCCESS
+ * (the cosmetic extension state — the changes ARE published), while only
+ * {@code FULL_UPDATE_REQUIRED} genuinely needs a full update.
+ */
+public class ApplicationUpdatePolicyTest
+{
+    // ── Pre-launch path (classifyPostUpdate, always incremental) ──────────────
+
+    @Test
+    public void testPostUpdate_Updated_isSuccess()
+    {
+        Result r = ApplicationUpdatePolicy.classifyPostUpdate(ApplicationUpdateState.UPDATED);
+        assertEquals(Outcome.SUCCESS, r.outcome());
+        assertTrue(r.isSuccess());
+    }
+
+    @Test
+    public void testPostUpdate_IncrementalRequired_isSuccess()
+    {
+        // The fix: this is the cosmetic state for an extension-bearing config; the
+        // changes ARE published, so it must NOT be treated as a failure.
+        Result r = ApplicationUpdatePolicy.classifyPostUpdate(
+            ApplicationUpdateState.INCREMENTAL_UPDATE_REQUIRED);
+        assertEquals(Outcome.SUCCESS, r.outcome());
+        assertTrue(r.isSuccess());
+    }
+
+    @Test
+    public void testPostUpdate_FullRequired_needsFullAndIsActionable()
+    {
+        Result r = ApplicationUpdatePolicy.classifyPostUpdate(
+            ApplicationUpdateState.FULL_UPDATE_REQUIRED);
+        assertEquals(Outcome.NEEDS_FULL_UPDATE, r.outcome());
+        assertFalse(r.isSuccess());
+        // Existing LaunchLifecycleUtilsUpdateTest pins these tokens in the surfaced error.
+        assertTrue("must surface the state", r.message().contains("FULL_UPDATE_REQUIRED"));
+        assertTrue("must point at update_database", r.message().contains("update_database"));
+        assertTrue("must name the remedy", r.message().contains("fullUpdate=true"));
+    }
+
+    @Test
+    public void testPostUpdate_BeingUpdated_isInProgress()
+    {
+        Result r = ApplicationUpdatePolicy.classifyPostUpdate(
+            ApplicationUpdateState.BEING_UPDATED);
+        assertEquals(Outcome.IN_PROGRESS, r.outcome());
+        assertFalse(r.isSuccess());
+    }
+
+    @Test
+    public void testPostUpdate_Null_isFailed()
+    {
+        Result r = ApplicationUpdatePolicy.classifyPostUpdate(null);
+        assertEquals(Outcome.FAILED, r.outcome());
+        assertFalse(r.isSuccess());
+    }
+
+    // ── Explicit path (classifyExplicitUpdate, requested type matters) ─────────
+
+    @Test
+    public void testExplicitIncremental_IncrementalRequired_isSuccess()
+    {
+        Result r = ApplicationUpdatePolicy.classifyExplicitUpdate(
+            ApplicationUpdateType.INCREMENTAL, ApplicationUpdateState.INCREMENTAL_UPDATE_REQUIRED);
+        assertEquals(Outcome.SUCCESS, r.outcome());
+    }
+
+    @Test
+    public void testExplicitFull_IncrementalRequired_isFailed()
+    {
+        // A FULL update should leave the IB UPDATED; still asking for an incremental
+        // means the full update did not settle — that IS a failure.
+        Result r = ApplicationUpdatePolicy.classifyExplicitUpdate(
+            ApplicationUpdateType.FULL, ApplicationUpdateState.INCREMENTAL_UPDATE_REQUIRED);
+        assertEquals(Outcome.FAILED, r.outcome());
+    }
+
+    @Test
+    public void testExplicitIncremental_FullRequired_needsFull()
+    {
+        Result r = ApplicationUpdatePolicy.classifyExplicitUpdate(
+            ApplicationUpdateType.INCREMENTAL, ApplicationUpdateState.FULL_UPDATE_REQUIRED);
+        assertEquals(Outcome.NEEDS_FULL_UPDATE, r.outcome());
+        assertTrue(r.message().contains("fullUpdate=true"));
+    }
+
+    @Test
+    public void testExplicitFull_FullRequired_isFailed()
+    {
+        Result r = ApplicationUpdatePolicy.classifyExplicitUpdate(
+            ApplicationUpdateType.FULL, ApplicationUpdateState.FULL_UPDATE_REQUIRED);
+        assertEquals(Outcome.FAILED, r.outcome());
+    }
+
+    @Test
+    public void testExplicitFull_Updated_isSuccess()
+    {
+        Result r = ApplicationUpdatePolicy.classifyExplicitUpdate(
+            ApplicationUpdateType.FULL, ApplicationUpdateState.UPDATED);
+        assertEquals(Outcome.SUCCESS, r.outcome());
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/EdtDialogAutoConfirmerTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/EdtDialogAutoConfirmerTest.java
@@ -1,0 +1,78 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2026 Diversus23 (https://github.com/Diversus23)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+
+import org.junit.Test;
+
+/**
+ * Tests the pure title-matching decision of {@link EdtDialogAutoConfirmer} and
+ * the no-op safety of an unbalanced {@code disarm}. The SWT plumbing
+ * ({@code arm}/{@code disarm} + the {@code Display} filter) is exercised only
+ * live (it needs a real workbench).
+ */
+public class EdtDialogAutoConfirmerTest
+{
+    private static EdtDialogAutoConfirmer confirmer(String... titles)
+    {
+        return new EdtDialogAutoConfirmer(new LinkedHashSet<>(Arrays.asList(titles)));
+    }
+
+    @Test
+    public void testConfiguredTitlesMatch()
+    {
+        EdtDialogAutoConfirmer c = confirmer("Application update", "Database restructuring");
+        assertTrue(c.isTargetTitle("Application update"));
+        assertTrue(c.isTargetTitle("Database restructuring"));
+    }
+
+    @Test
+    public void testUnconfiguredTitleDoesNotMatch()
+    {
+        EdtDialogAutoConfirmer c = confirmer("Application update");
+        assertFalse(c.isTargetTitle("Save resources"));
+    }
+
+    @Test
+    public void testMatchIsCaseSensitive()
+    {
+        EdtDialogAutoConfirmer c = confirmer("Application update");
+        assertFalse(c.isTargetTitle("application update"));
+    }
+
+    @Test
+    public void testNullTitleDoesNotMatch()
+    {
+        EdtDialogAutoConfirmer c = confirmer("Application update");
+        assertFalse(c.isTargetTitle(null));
+    }
+
+    @Test
+    public void testInstancesAreIndependent()
+    {
+        EdtDialogAutoConfirmer a = confirmer("A");
+        EdtDialogAutoConfirmer b = confirmer("B");
+        assertTrue(a.isTargetTitle("A"));
+        assertFalse("each instance matches only its own titles", a.isTargetTitle("B"));
+        assertTrue(b.isTargetTitle("B"));
+        assertFalse(b.isTargetTitle("A"));
+    }
+
+    @Test
+    public void testUnbalancedDisarmIsNoOp()
+    {
+        // Releasing without a prior arm() must not throw or touch a Display.
+        EdtDialogAutoConfirmer c = confirmer("Application update");
+        c.disarm();
+        c.disarm();
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtilsUpdateTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtilsUpdateTest.java
@@ -166,6 +166,28 @@ public class LaunchLifecycleUtilsUpdateTest
     }
 
     @Test
+    public void testUpdateReturnsIncrementalRequiredIsSuccess() throws ApplicationException
+    {
+        // The fix for the extension-bearing case: appManager.update() leaves the app
+        // reporting INCREMENTAL_UPDATE_REQUIRED (the launch delegate's modal is handled
+        // by LaunchUpdateDialogAutoConfirmer). The changes ARE published, so this must
+        // be a success — NOT an error that pushes the caller toward a full update.
+        IApplication app = mock(IApplication.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplication(any(IProject.class), eq(APP_ID)))
+            .thenReturn(Optional.of(app));
+        when(mgr.getUpdateState(app)).thenReturn(ApplicationUpdateState.INCREMENTAL_UPDATE_REQUIRED);
+        when(mgr.update(eq(app), any(), any(), any()))
+            .thenReturn(ApplicationUpdateState.INCREMENTAL_UPDATE_REQUIRED);
+
+        Optional<String> result = LaunchLifecycleUtils.updateApplicationIfNeeded(
+            mockOpenProject(), APP_ID, mgr);
+        assertFalse("INCREMENTAL_UPDATE_REQUIRED post-update is the cosmetic extension " //$NON-NLS-1$
+            + "state and must be success", result.isPresent());
+        verify(mgr, times(1)).update(eq(app), any(), any(), any());
+    }
+
+    @Test
     public void testUpdateReturnsBeingUpdatedThenSettles() throws ApplicationException
     {
         IApplication app = mock(IApplication.class);

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmerTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmerTest.java
@@ -6,6 +6,7 @@
 
 package com.ditrix.edt.mcp.server.utils;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -64,5 +65,26 @@ public class LaunchUpdateDialogAutoConfirmerTest
         // with no filter installed it returns before any UI access.
         LaunchUpdateDialogAutoConfirmer.disarm();
         LaunchUpdateDialogAutoConfirmer.disarm();
+    }
+
+    @Test
+    public void testRussianTitleMatches()
+    {
+        // A Russian EDT build shows this localized title; the English-only match used
+        // to miss it, so the launch hung on the modal (a root cause of YAXUnit "dancing").
+        assertTrue("the Russian EDT modal title must match",
+            LaunchUpdateDialogAutoConfirmer.isTargetTitle(
+                LaunchUpdateDialogAutoConfirmer.APPLICATION_UPDATE_TITLE_RU));
+    }
+
+    @Test
+    public void testRussianTitleEncoding()
+    {
+        // Guard the exact codepoints so a re-encode can't silently break the match
+        // against the live "Обновление приложения" dialog (О=U+041E … я=U+044F, 21 chars).
+        String ru = LaunchUpdateDialogAutoConfirmer.APPLICATION_UPDATE_TITLE_RU;
+        assertEquals(21, ru.length());
+        assertEquals(0x041E, ru.charAt(0));
+        assertEquals(0x044F, ru.charAt(ru.length() - 1));
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/UpdateWatchdogTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/UpdateWatchdogTest.java
@@ -1,0 +1,119 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2026 Diversus23 (https://github.com/Diversus23)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import com.e1c.g5.dt.applications.ApplicationException;
+import com.e1c.g5.dt.applications.ApplicationUpdateState;
+
+/**
+ * Tests {@link UpdateWatchdog#runWithTimeout} via injected {@link java.util.concurrent.Callable}s,
+ * so the timing/unwrapping logic is verified without a live EDT.
+ */
+public class UpdateWatchdogTest
+{
+    @Test
+    public void testFastCallReturnsItsState() throws Exception
+    {
+        ApplicationUpdateState state = UpdateWatchdog.runWithTimeout(
+            () -> ApplicationUpdateState.UPDATED, 5);
+        assertEquals(ApplicationUpdateState.UPDATED, state);
+    }
+
+    @Test
+    public void testTimeoutReturnsBeingUpdated() throws Exception
+    {
+        // The callable blocks well past the 1s window; the watchdog must return
+        // BEING_UPDATED rather than wait for it. The abandoned daemon thread is
+        // harmless (it just sleeps out).
+        ApplicationUpdateState state = UpdateWatchdog.runWithTimeout(() -> {
+            Thread.sleep(5000L);
+            return ApplicationUpdateState.UPDATED;
+        }, 1);
+        assertEquals(ApplicationUpdateState.BEING_UPDATED, state);
+    }
+
+    @Test
+    public void testApplicationExceptionIsRethrown() throws Exception
+    {
+        ApplicationException boom = new ApplicationException("update boom");
+        try
+        {
+            UpdateWatchdog.runWithTimeout(() -> {
+                throw boom;
+            }, 5);
+            fail("expected the ApplicationException to propagate");
+        }
+        catch (ApplicationException e)
+        {
+            assertSame("the original ApplicationException must propagate unwrapped", boom, e);
+        }
+    }
+
+    @Test
+    public void testRuntimeExceptionIsRethrown() throws Exception
+    {
+        RuntimeException boom = new IllegalStateException("kaboom");
+        try
+        {
+            UpdateWatchdog.runWithTimeout(() -> {
+                throw boom;
+            }, 5);
+            fail("expected the RuntimeException to propagate");
+        }
+        catch (RuntimeException e)
+        {
+            assertSame("the original RuntimeException must propagate unwrapped", boom, e);
+        }
+    }
+
+    @Test
+    public void testOnCompleteRunsBeforeFastReturn() throws Exception
+    {
+        // On a fast update, onComplete (the guard's disarm) must have run by the time
+        // the value is returned — the task's finally executes before the future completes.
+        CountDownLatch completed = new CountDownLatch(1);
+        ApplicationUpdateState state = UpdateWatchdog.runWithTimeout(
+            () -> ApplicationUpdateState.UPDATED, 5, null, completed::countDown);
+        assertEquals(ApplicationUpdateState.UPDATED, state);
+        assertEquals("onComplete must have run by the time a fast update returns",
+            0, completed.getCount());
+    }
+
+    @Test
+    public void testOnCompleteRunsWhenUpdateFinishesEvenAfterTimeout() throws Exception
+    {
+        // The fix for finding #3: the guard must stay armed until the update TRULY
+        // finishes. onStart runs up front; runWithTimeout returns BEING_UPDATED at the
+        // 1s timeout while the 1.5s update is still running (onComplete not yet fired);
+        // onComplete fires only once the background update completes.
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch completed = new CountDownLatch(1);
+
+        ApplicationUpdateState state = UpdateWatchdog.runWithTimeout(() -> {
+            Thread.sleep(1500L);
+            return ApplicationUpdateState.UPDATED;
+        }, 1, started::countDown, completed::countDown);
+
+        assertEquals("a slow update must time out to BEING_UPDATED",
+            ApplicationUpdateState.BEING_UPDATED, state);
+        assertEquals("onStart must have run before the update started", 0, started.getCount());
+        assertEquals("onComplete must NOT have run yet — the update is still in the background",
+            1, completed.getCount());
+        assertTrue("onComplete must fire once the background update finishes",
+            completed.await(3, TimeUnit.SECONDS));
+    }
+}

--- a/tests/e2e/tools/test_update_database.py
+++ b/tests/e2e/tools/test_update_database.py
@@ -190,3 +190,21 @@ def test_nonexistent_project_is_rejected_without_mutating():
     assert_contains(e, "Project not found",
                     "a non-existent project must hit the value-naming not-found branch")
     assert_no_diff("a rejected update must not touch the project on disk")
+
+
+@e2e_test(tool="update_database", kind="action")
+def test_terminate_flag_does_not_change_resolution_or_mutate():
+    """The transparent session-termination flag (terminateRunningClients) must not alter
+    the resolution chain or mutate anything when the target is invalid. Session termination
+    only runs on confirm=true AFTER the application is resolved; a bogus applicationId is
+    rejected at the application lookup BEFORE any termination, regardless of the flag, and
+    the project tree stays clean. Proves the new param is inert on the rejection path."""
+    r = call("update_database", {
+        "projectName": PROJECT,
+        "applicationId": BOGUS_APP_ID,
+        "terminateRunningClients": False,
+    })
+    e = assert_error(r, "real project + bogus app + terminateRunningClients=false")
+    assert_contains(e, "Application not found",
+                    "must still be rejected at the real application lookup, flag is inert here")
+    assert_no_diff("the terminate flag must not touch the project source on disk")

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -2831,7 +2831,7 @@
       "openWorldHint": false,
       "readOnlyHint": false
     },
-    "description": "Apply configuration changes to an application's database (infobase), full or incremental. Target by launchConfigurationName (preferred) or projectName + applicationId. Destructive/irreversible: guarded by a confirm-preview - call without confirm to preview the exact update (no infobase change), then confirm=true to apply. Terminate any running 1C client on the target infobase first (exclusive lock). Full parameters and examples: call get_tool_guide('update_database').",
+    "description": "Apply configuration changes to an application's database (infobase), full or incremental. Target by launchConfigurationName (preferred) or projectName + applicationId. Destructive/irreversible: guarded by a confirm-preview - call without confirm to preview the exact update (no infobase change), then confirm=true to apply. On confirm it transparently terminates EDT-launched 1C clients on the target infobase first (external clients must be closed manually). Full parameters and examples: call get_tool_guide('update_database').",
     "inputSchema": {
       "properties": {
         "applicationId": {
@@ -2857,6 +2857,14 @@
         "projectName": {
           "description": "EDT project name; required if launchConfigurationName is omitted.",
           "type": "string"
+        },
+        "terminateRunningClients": {
+          "description": "Before updating (confirm=true), terminate any 1C client THIS EDT launched against the target infobase so the update is not blocked by an exclusive lock and the new code is not masked by a cached session (default true). External clients are not affected.",
+          "type": "boolean"
+        },
+        "updateTimeoutSeconds": {
+          "description": "Watchdog window for the update call in seconds (default 120, clamped 5..600). If the update does not finish in time it keeps running in the background and the tool returns stateAfter=BEING_UPDATED so you can poll get_applications.",
+          "type": "integer"
         }
       },
       "required": [],
@@ -2881,6 +2889,10 @@
           "description": "true on a preview (no infobase change made); absent/false once updated.",
           "type": "boolean"
         },
+        "fullUpdateRequired": {
+          "description": "Present and true when the incremental update genuinely needs a full update (state FULL_UPDATE_REQUIRED); re-call with fullUpdate=true.",
+          "type": "boolean"
+        },
         "message": {
           "description": "Human-readable status message for the update.",
           "type": "string"
@@ -2900,6 +2912,10 @@
         "success": {
           "description": "Whether the operation succeeded",
           "type": "boolean"
+        },
+        "terminatedClients": {
+          "description": "Number of EDT-launched 1C clients terminated before the update.",
+          "type": "integer"
         },
         "updateType": {
           "description": "Update mode applied: FULL or INCREMENTAL.",


### PR DESCRIPTION
## Summary

`update_database` (and the pre-launch update path) now transparently frees the infobase before updating: it terminates the 1C clients **this EDT instance launched**, auto-confirms EDT's blocking update modal, and runs the update under
a watchdog — so an active session no longer blocks the update or leaves a client running stale modules. It also stops escalating to a (slow, sometimes failing) FULL update when an incremental one already published the changes.

Closes #128.

## Why — root cause

The issue bundled several symptoms; tracing them gave four distinct causes:

1. **MCP never freed the infobase before updating.** There was no terminate step in the update path. A client launched from EDT keeps the infobase in **exclusive** use (the update blocks/fails) and **caches the old module version** (even after a successful publish it runs stale code until restart). That is the "clients run old code" complaint.

2. **`revalidate_objects` can't help here.** It only re-runs EDT's in-IDE validation; it never calls `IApplicationManager.update`, so it publishes nothing to the infobase. The hypothesis in the issue was correct.

3. **The launch auto-confirm never fired in a Russian EDT.** The "update before launch?" modal is localized: in a Russian build it is titled "Обновление приложения", but the confirmer matched only the English "Application update". So `run_yaxunit_tests` / `debug_launch` hung on the modal until the transport timeout — the likely real cause of the YAXUnit "dancing" /timeouts, and why a manual "Update then run" click "fixed" it.

4. **Spurious FULL updates.** After an incremental update, an extension-bearing configuration can still report `INCREMENTAL_UPDATE_REQUIRED`. That is a **cosmetic** EDT state — the changes ARE published — but it was read as failure and escalated to a FULL update, which is slow and can drop/recreate structures.

## What changed

- **Transparent termination.** On `confirm=true`, under a per-IB lock, politely terminate every EDT-launched 1C client on the target infobase (`terminateRunningClients`, default `true`). No force-kill; on timeout it returns an actionable error pointing at `terminate_launch force=true`.
- **Localized modal auto-confirm.** Match a locale set (`APPLICATION_UPDATE_TITLE_EN` + `_RU`), shared by the launch and `update_database` confirmers. The confirmer stays armed for the **whole** life of the update (even past the watchdog window), so a long full reload that pops a dialog minutes later is still confirmed in the background.
- **Watchdog.** The update runs under `updateTimeoutSeconds` (default 120, clamped 5..600). On timeout the update keeps running and the call returns `stateAfter=BEING_UPDATED` to poll `get_applications` instead of hanging.
- **Incremental-first policy.** New shared `ApplicationUpdatePolicy` treats post-incremental `INCREMENTAL_UPDATE_REQUIRED` as success and escalates only on a genuine `FULL_UPDATE_REQUIRED` (surfaced via `fullUpdateRequired=true` + an escape hatch in the success message). The same policy drives the pre-launch path,
  so `run_yaxunit_tests` / `debug_yaxunit_tests` / `debug_launch` stop pushing failing full updates.
- **Shared helpers, no new duplication.** Extracted `LaunchLifecycleUtils.terminateLiveLaunchesForIb` (reused by `prepareForFreshLaunch` and `update_database`); generalized the auto-confirm into `EdtDialogAutoConfirmer` (per-instance localized title set), leaving `LaunchUpdateDialogAutoConfirmer` a thin shim; new `ApplicationUpdatePolicy`,  `UpdateWatchdog`.

## New surface

| Kind | Name | Default | Meaning |
|---|---|---|---|
| param | `terminateRunningClients` | `true` | terminate EDT-launched clients before updating |
| param | `updateTimeoutSeconds` | `120` (5..600) | watchdog window; on timeout → `BEING_UPDATED` |
| output | `terminatedClients` | — | how many clients were stopped |
| output | `fullUpdateRequired` | — | `true` ⇒ re-call with `fullUpdate=true` |

## Follow-ups / known gaps

- The FULL-path **restructurization** dialog title is not yet captured (only the pre-update "Application update" modal is). Until confirmed live and added, a rare `fullUpdate=true` run may sit until the watchdog window and then return  `BEING_UPDATED` — soft degradation, not a hang.
- `autoRestructure` is read and logged but not yet wired into the EDT update call (pre-existing no-op); to be either wired via the EDT API or softened in the schema.
