### PR TITLE
feat(update_database): auto-free the infobase before update (terminate running clients) (#128)

### DIFF
--- a/.claude/skills/edt-mcp-testing/references/launch/update_database.md
+++ b/.claude/skills/edt-mcp-testing/references/launch/update_database.md
@@ -20,8 +20,7 @@ By launch configuration name (preferred — fixes the project + applicationId pa
 ```
 update_database(
   launchConfigurationName="TestConfiguration Thin Client",
-  fullUpdate=false,
-  autoRestructure=true
+  fullUpdate=false
 )
 ```
 
@@ -30,8 +29,7 @@ By project + application id (use the `id` from `get_applications`):
 update_database(
   projectName="TestConfiguration",
   applicationId="82e532bc-b103-401d-9ce2-6f0785aad340",
-  fullUpdate=false,
-  autoRestructure=true
+  fullUpdate=false
 )
 ```
 
@@ -91,9 +89,9 @@ Field meaning (from source):
 - **Destructive at the DB level; source-revert is not enough.** `git checkout`/`git clean` only restores `TestConfiguration/src`. The infobase restructuring is already done — re-running `update_database` is the only way to realign the DB with the reverted source. Run **only** on `TestConfiguration`, **only** on an explicit request.
 - **Infobase exclusivity is the #1 failure.** A running client (`running:true` in `list_configurations`) holds the IB exclusively → update fails. An elevated/external `1cv8`/`1cv8c` holding the IB makes the call **stall at "Connecting to designer agent"** and it cannot be killed from a non-elevated shell. Always free the IB (via `terminate_launch` for EDT-started launches) before calling.
 - **Heavy / blocking.** `update()` runs synchronously with a `NullProgressMonitor`; a real restructuring can take a while. It also grabs the active SWT shell (`LaunchLifecycleUtils.grabActiveShell`) so EDT can parent confirmation/restructuring dialogs — in a headless/automated run a dialog may block. This is why the procedure is documented, not auto-executed.
-- **`fullUpdate` vs `autoRestructure`.** `fullUpdate=true` → `ApplicationUpdateType.FULL` (complete reload, heavier/more destructive); default `false` → `INCREMENTAL` (changes only). `autoRestructure` (default `true`) lets EDT apply restructurization without a manual prompt; both are declared in the schema and read in `execute()`.
+- **`fullUpdate`.** `fullUpdate=true` → `ApplicationUpdateType.FULL` (complete reload, heavier/more destructive); default `false` → `INCREMENTAL` (changes only). There is NO restructure switch: when the update needs a DB restructure, EDT confirms it via its own dialog (or the update returns still-out-of-sync) — the EDT update API has no per-call auto-confirm, which is why the former `autoRestructure` parameter was removed as a no-op.
 - **Resolution precedence.** If `launchConfigurationName` is given it wins and *derives* `projectName`/`applicationId` from the config's `ATTR_PROJECT_NAME`/`ATTR_APPLICATION_ID` (any passed `projectName`/`applicationId` are overwritten). Only when the name is omitted are `projectName` **and** `applicationId` both required.
 - **State gate.** Because of `checkReadyOrError`, calling against an indexing project returns the not-ready error, not a partial update. Re-poll `list_projects` until `ready`.
 - **JSON tool, no HTML escaping.** Output is the `ToolResult` JSON envelope; `GsonProvider` uses `disableHtmlEscaping()`, so `ToolResult.toJson()` keeps `>`, `<`, `&`, `=`, and the apostrophe `'` RAW (not `\uXXXX`). If you assert on text, match a delimiter-free substring (e.g. `not found`) for robustness, never raw `'…'` or `>=`.
-- **Flaky output channel.** If the result comes back garbled/empty (a bare `Error`/`Done`), do **not** retry-spam a *mutating* tool — a retry could apply the update twice. Re-verify independently: check `updateState` via `get_applications`, and read the EDT log at `D:\WS\EDT\.metadata\.log` (the tool logs `"Update database: project=…, application=…, type=…, autoRestructure=…"` and any error).
+- **Flaky output channel.** If the result comes back garbled/empty (a bare `Error`/`Done`), do **not** retry-spam a *mutating* tool — a retry could apply the update twice. Re-verify independently: check `updateState` via `get_applications`, and read the EDT log at `D:\WS\EDT\.metadata\.log` (the tool logs `"Update database: project=…, application=…, type=…"` and any error).
 - **Bilingual.** Field keys and enum names (`updateType`, `stateBefore/After`) are fixed English/programmatic identifiers. `applicationName` is the configured application name, not a translatable 1C synonym — nothing here goes through the synonym / TYPE-token bilingual path. Target the application by its programmatic `applicationId` / launch-config `name`, not by a localized label.

--- a/docs/e2e/mcp-test-cases.md
+++ b/docs/e2e/mcp-test-cases.md
@@ -346,7 +346,7 @@ whole suite by calling the `mcp__EDT-MCP-Server__*` tools and recording PASS/FAI
 
 ### update_database
 - **Type:** destructive (DB migration) · **Runnable on IRP:** SKIPPED — permission‑gated
-- **Cases (sandbox + explicit approval only):** by `launchConfigurationName`, or `projectName+applicationId`; `fullUpdate`, `autoRestructure`.
+- **Cases (sandbox + explicit approval only):** by `launchConfigurationName`, or `projectName+applicationId`; `fullUpdate`.
 - **Note:** CLAUDE.md restricts this to explicit user request; the Claude Code auto‑mode classifier **blocks** it even on the error path. A test agent must treat it as `SKIPPED (needs approval + infobase)`.
 - **Validated 2026‑06‑01:** not run — blocked by safety classifier (expected).
 

--- a/docs/tools/update_database.md
+++ b/docs/tools/update_database.md
@@ -9,7 +9,6 @@ Apply configuration changes to an application's database (infobase), full or inc
 | projectName | — | string | EDT project name; required if launchConfigurationName is omitted. |
 | applicationId | — | string | Application ID from get_applications; required if launchConfigurationName is omitted. |
 | fullUpdate | — | boolean | true = full reload, false = incremental (default false). |
-| autoRestructure | — | boolean | Auto-apply restructurization when needed (default true). |
 | confirm | — | boolean | true = apply the update; default false = preview only (resolves the target and reports what would change WITHOUT mutating the infobase). |
 
 ## Guide
@@ -38,7 +37,6 @@ After changing metadata/configuration, to push those changes into the running in
 - **projectName** (string) — required if launchConfigurationName is omitted.
 - **applicationId** (string) — from `get_applications`; required if launchConfigurationName is omitted.
 - **fullUpdate** (boolean, default false) — true performs a FULL reload (complete rebuild), false performs an INCREMENTAL update (changed objects only). Incremental is faster; use full when the structure changed substantially or an incremental update fails.
-- **autoRestructure** (boolean, default true) — automatically apply database restructurization (table/index changes) when the update requires it, instead of prompting. Leave true for unattended use.
 - **confirm** (boolean, default false) — false previews the resolved update without touching the infobase; true applies it.
 
 ## Exclusive-lock gotcha

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/update_database.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/update_database.md
@@ -23,7 +23,6 @@ After changing metadata/configuration, to push those changes into the running in
 - **projectName** (string) — required if launchConfigurationName is omitted.
 - **applicationId** (string) — from `get_applications`; required if launchConfigurationName is omitted.
 - **fullUpdate** (boolean, default false) — true performs a FULL reload (complete rebuild), false performs an INCREMENTAL update (changed objects only). Incremental is faster; use full when the structure changed substantially or an incremental update fails.
-- **autoRestructure** (boolean, default true) — automatically apply database restructurization (table/index changes) when the update requires it, instead of prompting. Leave true for unattended use.
 - **confirm** (boolean, default false) — false previews the resolved update without touching the infobase; true applies it.
 - **terminateRunningClients** (boolean, default true) — before applying, terminate any 1C client THIS EDT launched on the target infobase to free the exclusive lock and stop it running stale modules. Set false to leave a running client in place (the update then fails if that client holds the infobase exclusively). Only affects the apply phase (confirm=true); the preview reports `willTerminateRunningClients` but terminates nothing.
 
@@ -32,6 +31,10 @@ After changing metadata/configuration, to push those changes into the running in
 A 1C client launched from this EDT that is running against the target infobase holds it in **exclusive** use (so the update fails) and **caches the old module version** (it keeps running stale code even after a successful publish). With the default `terminateRunningClients=true` the tool frees the infobase itself before applying: it terminates that EDT-launched client using the same client-typed sweep the launch tools use — it never touches a debug-server session or a launch owned by another MCP tool — and reports `terminatedClient`.
 
 Pass `terminateRunningClients=false` to keep the client running; then the old manual flow applies — check `list_configurations` for `running: true` and call `terminate_launch` yourself before retrying. Externally launched clients (Designer, ad-hoc 1cv8c.exe) are invisible to both this sweep and `terminate_launch`, and must be closed by hand.
+
+## Database restructure (not controllable here)
+
+When the update requires a database restructure (table/index changes), EDT itself decides how to confirm it: it shows its own confirmation dialog in the EDT window, or — if confirmation cannot happen — the update returns with the infobase still requiring an update. The EDT update API offers no per-call switch to auto-confirm a restructure, so this tool intentionally has no parameter for it. If the result reports a state other than `UPDATED`, confirm the restructure in the EDT UI (or use `fullUpdate=true`, which may avoid the incremental restructure path) and re-run.
 
 ## Examples
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/update_database.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/update_database.md
@@ -40,7 +40,7 @@ Pass `terminateRunningClients=false` to keep the client running; then the old ma
 
 ## Result
 
-JSON with `project`, `applicationId`, `applicationName`, `updateType` (FULL/INCREMENTAL), `stateBefore`, `stateAfter`, `terminatedClient` (true if a running client was terminated to free the infobase) and a `message`. A successful run reports `stateAfter = UPDATED`. If the application is already BEING_UPDATED the tool returns an error and you should wait.
+JSON with `project`, `applicationId`, `applicationName`, `updateType` (FULL/INCREMENTAL), `stateBefore`, `stateAfter` and a `message`. `terminatedClient: true` is present ONLY when a running client was actually terminated to free the infobase (absent on a preview, on opt-out, or when no client was running). A successful run reports `stateAfter = UPDATED`. If the application is already BEING_UPDATED the tool returns an error and you should wait.
 
 ## Gotchas
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/update_database.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/update_database.md
@@ -25,10 +25,13 @@ After changing metadata/configuration, to push those changes into the running in
 - **fullUpdate** (boolean, default false) — true performs a FULL reload (complete rebuild), false performs an INCREMENTAL update (changed objects only). Incremental is faster; use full when the structure changed substantially or an incremental update fails.
 - **autoRestructure** (boolean, default true) — automatically apply database restructurization (table/index changes) when the update requires it, instead of prompting. Leave true for unattended use.
 - **confirm** (boolean, default false) — false previews the resolved update without touching the infobase; true applies it.
+- **terminateRunningClients** (boolean, default true) — before applying, terminate any 1C client THIS EDT launched on the target infobase to free the exclusive lock and stop it running stale modules. Set false to leave a running client in place (the update then fails if that client holds the infobase exclusively). Only affects the apply phase (confirm=true); the preview reports `willTerminateRunningClients` but terminates nothing.
 
-## Exclusive-lock gotcha
+## Exclusive-lock handling (automatic)
 
-If a 1C client launched from this EDT is currently running against the target infobase, the update typically FAILS because the infobase is held in exclusive use. Check `list_configurations` for `running: true`; if so, call `terminate_launch` first (it only affects launches started from this EDT instance), then retry. Externally launched clients (Designer, ad-hoc 1cv8c.exe) are invisible to `terminate_launch` and must be closed by hand.
+A 1C client launched from this EDT that is running against the target infobase holds it in **exclusive** use (so the update fails) and **caches the old module version** (it keeps running stale code even after a successful publish). With the default `terminateRunningClients=true` the tool frees the infobase itself before applying: it terminates that EDT-launched client using the same client-typed sweep the launch tools use — it never touches a debug-server session or a launch owned by another MCP tool — and reports `terminatedClient`.
+
+Pass `terminateRunningClients=false` to keep the client running; then the old manual flow applies — check `list_configurations` for `running: true` and call `terminate_launch` yourself before retrying. Externally launched clients (Designer, ad-hoc 1cv8c.exe) are invisible to both this sweep and `terminate_launch`, and must be closed by hand.
 
 ## Examples
 
@@ -37,11 +40,11 @@ If a 1C client launched from this EDT is currently running against the target in
 
 ## Result
 
-JSON with `project`, `applicationId`, `applicationName`, `updateType` (FULL/INCREMENTAL), `stateBefore`, `stateAfter` and a `message`. A successful run reports `stateAfter = UPDATED`. If the application is already BEING_UPDATED the tool returns an error and you should wait.
+JSON with `project`, `applicationId`, `applicationName`, `updateType` (FULL/INCREMENTAL), `stateBefore`, `stateAfter`, `terminatedClient` (true if a running client was terminated to free the infobase) and a `message`. A successful run reports `stateAfter = UPDATED`. If the application is already BEING_UPDATED the tool returns an error and you should wait.
 
 ## Gotchas
 
-- Most failures are the exclusive lock above — terminate the running launch first.
+- With `terminateRunningClients=false`, most failures are the exclusive lock above — terminate the running launch first (the default frees it automatically).
 - `launchConfigurationName` must reference a runtime-client config; an Attach config is rejected.
 - The project must exist and be open; a closed project returns an error.
 - Running this on a **standalone-server** application (`applicationId` starting with `ServerApplication.`) STARTS the standalone server in RUN mode as a side effect — that is EDT-native behaviour of the server-application update (the configurator agent publishes the modules into the running server). A subsequent `debug_launch` will then have to restart that server in DEBUG mode. Prefer letting the launch do the update: `debug_launch` / `run_yaxunit_tests` with `updateBeforeLaunch=true` defer the server-app update to EDT's coordinated launch flow.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
@@ -352,7 +352,7 @@ public class UpdateDatabaseTool implements IMcpTool
             ToolResult errorResult = ToolResult.error("Database update failed: " //$NON-NLS-1$
                 + e.getMessage() + describeInfobaseHolder(applicationId));
             errorResult.put("applicationId", applicationId); //$NON-NLS-1$
-            errorResult.put("projectName", projectName); //$NON-NLS-1$
+            errorResult.put("project", projectName); //$NON-NLS-1$
             if (terminatedClient)
             {
                 errorResult.put("terminatedClient", true); //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
@@ -71,8 +71,6 @@ public class UpdateDatabaseTool implements IMcpTool
                 "Application ID from get_applications; required if launchConfigurationName is omitted.") //$NON-NLS-1$
             .booleanProperty("fullUpdate", //$NON-NLS-1$
                 "true = full reload, false = incremental (default false).") //$NON-NLS-1$
-            .booleanProperty("autoRestructure", //$NON-NLS-1$
-                "Auto-apply restructurization when needed (default true).") //$NON-NLS-1$
             .booleanProperty("confirm", //$NON-NLS-1$
                 "true = apply the update; default false = preview only (resolves the target and " //$NON-NLS-1$
                 + "reports what would change WITHOUT mutating the infobase).") //$NON-NLS-1$
@@ -121,7 +119,6 @@ public class UpdateDatabaseTool implements IMcpTool
         String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
         String applicationId = JsonUtils.extractStringArgument(params, "applicationId"); //$NON-NLS-1$
         boolean fullUpdate = JsonUtils.extractBooleanArgument(params, "fullUpdate", false); //$NON-NLS-1$
-        boolean autoRestructure = JsonUtils.extractBooleanArgument(params, "autoRestructure", true); //$NON-NLS-1$
         boolean confirm = JsonUtils.extractBooleanArgument(params, "confirm", false); //$NON-NLS-1$
         boolean terminateRunningClients =
             JsonUtils.extractBooleanArgument(params, "terminateRunningClients", true); //$NON-NLS-1$
@@ -180,7 +177,7 @@ public class UpdateDatabaseTool implements IMcpTool
             return ToolResult.error(building).toJson();
         }
 
-        return updateDatabase(projectName, applicationId, fullUpdate, autoRestructure, confirm,
+        return updateDatabase(projectName, applicationId, fullUpdate, confirm,
             terminateRunningClients);
     }
 
@@ -190,14 +187,13 @@ public class UpdateDatabaseTool implements IMcpTool
      * @param projectName name of the project
      * @param applicationId ID of the application
      * @param fullUpdate true for full update, false for incremental
-     * @param autoRestructure whether to auto-apply restructurization
      * @param confirm false previews without mutating; true applies the update
      * @param terminateRunningClients true (default) frees the infobase by terminating a 1C client
      *            this EDT launched on it before the update; false leaves a running client in place
      * @return JSON string with result
      */
     private String updateDatabase(String projectName, String applicationId,
-            boolean fullUpdate, boolean autoRestructure, boolean confirm,
+            boolean fullUpdate, boolean confirm,
             boolean terminateRunningClients)
     {
         boolean terminatedClient = false;
@@ -281,8 +277,7 @@ public class UpdateDatabaseTool implements IMcpTool
 
             Activator.logInfo("Update database: project=" + projectName +  //$NON-NLS-1$
                     ", application=" + applicationId +  //$NON-NLS-1$
-                    ", type=" + updateType +  //$NON-NLS-1$
-                    ", autoRestructure=" + autoRestructure); //$NON-NLS-1$
+                    ", type=" + updateType); //$NON-NLS-1$
 
             IProgressMonitor monitor = new NullProgressMonitor();
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
@@ -54,7 +54,8 @@ public class UpdateDatabaseTool implements IMcpTool
             + "incremental. Target by launchConfigurationName (preferred) or projectName + " //$NON-NLS-1$
             + "applicationId. Destructive/irreversible: guarded by a confirm-preview - call without " //$NON-NLS-1$
             + "confirm to preview the exact update (no infobase change), then confirm=true to apply. " //$NON-NLS-1$
-            + "Terminate any running 1C client on the target infobase first (exclusive lock). " //$NON-NLS-1$
+            + "Auto-terminates any 1C client THIS EDT launched on the target infobase first to free the " //$NON-NLS-1$
+            + "exclusive lock (opt out with terminateRunningClients=false). " //$NON-NLS-1$
             + "Full parameters and examples: call get_tool_guide('update_database')."; //$NON-NLS-1$
     }
 
@@ -75,6 +76,10 @@ public class UpdateDatabaseTool implements IMcpTool
             .booleanProperty("confirm", //$NON-NLS-1$
                 "true = apply the update; default false = preview only (resolves the target and " //$NON-NLS-1$
                 + "reports what would change WITHOUT mutating the infobase).") //$NON-NLS-1$
+            .booleanProperty("terminateRunningClients", //$NON-NLS-1$
+                "Before applying, terminate any 1C client THIS EDT launched on the target infobase " //$NON-NLS-1$
+                + "to free the exclusive lock (default true). false keeps a running client — the " //$NON-NLS-1$
+                + "update then fails if that client holds the infobase exclusively.") //$NON-NLS-1$
             .build();
     }
 
@@ -93,6 +98,12 @@ public class UpdateDatabaseTool implements IMcpTool
             .stringProperty("stateBefore", "Application update state before the update.") //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty("stateAfter", "Application update state after the update.") //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty("message", "Human-readable status message for the update.") //$NON-NLS-1$ //$NON-NLS-2$
+            .booleanProperty("terminatedClient", //$NON-NLS-1$
+                "true when a running 1C client holding the infobase was terminated before the update " //$NON-NLS-1$
+                + "(only when terminateRunningClients=true).") //$NON-NLS-1$
+            .booleanProperty("willTerminateRunningClients", //$NON-NLS-1$
+                "On a preview: whether confirm=true would first terminate a running client " //$NON-NLS-1$
+                + "(reflects terminateRunningClients).") //$NON-NLS-1$
             .build();
     }
 
@@ -111,6 +122,8 @@ public class UpdateDatabaseTool implements IMcpTool
         boolean fullUpdate = JsonUtils.extractBooleanArgument(params, "fullUpdate", false); //$NON-NLS-1$
         boolean autoRestructure = JsonUtils.extractBooleanArgument(params, "autoRestructure", true); //$NON-NLS-1$
         boolean confirm = JsonUtils.extractBooleanArgument(params, "confirm", false); //$NON-NLS-1$
+        boolean terminateRunningClients =
+            JsonUtils.extractBooleanArgument(params, "terminateRunningClients", true); //$NON-NLS-1$
 
         boolean hasName = configName != null && !configName.isEmpty();
         if (!hasName)
@@ -166,20 +179,25 @@ public class UpdateDatabaseTool implements IMcpTool
             return ToolResult.error(building).toJson();
         }
 
-        return updateDatabase(projectName, applicationId, fullUpdate, autoRestructure, confirm);
+        return updateDatabase(projectName, applicationId, fullUpdate, autoRestructure, confirm,
+            terminateRunningClients);
     }
-    
+
     /**
      * Updates the database for the specified application.
-     * 
+     *
      * @param projectName name of the project
      * @param applicationId ID of the application
      * @param fullUpdate true for full update, false for incremental
      * @param autoRestructure whether to auto-apply restructurization
+     * @param confirm false previews without mutating; true applies the update
+     * @param terminateRunningClients true (default) frees the infobase by terminating a 1C client
+     *            this EDT launched on it before the update; false leaves a running client in place
      * @return JSON string with result
      */
     private String updateDatabase(String projectName, String applicationId,
-            boolean fullUpdate, boolean autoRestructure, boolean confirm)
+            boolean fullUpdate, boolean autoRestructure, boolean confirm,
+            boolean terminateRunningClients)
     {
         try
         {
@@ -238,11 +256,32 @@ public class UpdateDatabaseTool implements IMcpTool
                     .put("applicationName", application.getName()) //$NON-NLS-1$
                     .put("updateType", updateType.name()) //$NON-NLS-1$
                     .put("stateBefore", stateBefore.name()) //$NON-NLS-1$
+                    .put("willTerminateRunningClients", terminateRunningClients) //$NON-NLS-1$
                     .put("message", "PREVIEW: this would apply a " + updateType.name() //$NON-NLS-1$ //$NON-NLS-2$
                         + " configuration update to the database of application '" + application.getName() //$NON-NLS-1$
                         + "' (project " + projectName + "). This mutates the infobase and is " //$NON-NLS-1$ //$NON-NLS-2$
-                        + "IRREVERSIBLE. Re-call with confirm=true to apply it.") //$NON-NLS-1$
+                        + "IRREVERSIBLE." //$NON-NLS-1$
+                        + (terminateRunningClients
+                            ? " It will first terminate any 1C client this EDT launched on the infobase." //$NON-NLS-1$
+                            : "") //$NON-NLS-1$
+                        + " Re-call with confirm=true to apply it.") //$NON-NLS-1$
                     .toJson();
+            }
+
+            // Free the infobase before updating. A 1C client THIS EDT launched holds the IB in
+            // exclusive use (so the update blocks/fails) and caches the old module version (it keeps
+            // running stale code even after a successful publish). Reuse the launch path's
+            // battle-tested sweep — client-typed-thread discriminated (never touches a debug-server
+            // session) and exempting MCP-owned launches. Runs only on confirm=true, never in preview.
+            boolean terminatedClient = false;
+            if (terminateRunningClients)
+            {
+                terminatedClient = LaunchLifecycleUtils.ensureNoExistingClientSession(project, applicationId);
+                if (terminatedClient)
+                {
+                    Activator.logInfo("Update database: terminated a running client to free the " //$NON-NLS-1$
+                        + "infobase: project=" + projectName + ", application=" + applicationId); //$NON-NLS-1$ //$NON-NLS-2$
+                }
             }
 
             // Create execution context with the active Shell so EDT can parent
@@ -273,7 +312,8 @@ public class UpdateDatabaseTool implements IMcpTool
                 .put("applicationName", application.getName()) //$NON-NLS-1$
                 .put("updateType", updateType.name()) //$NON-NLS-1$
                 .put("stateBefore", stateBefore.name()) //$NON-NLS-1$
-                .put("stateAfter", stateAfter.name()); //$NON-NLS-1$
+                .put("stateAfter", stateAfter.name()) //$NON-NLS-1$
+                .put("terminatedClient", terminatedClient); //$NON-NLS-1$
             
             // Add status message based on result
             if (stateAfter == ApplicationUpdateState.UPDATED)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
@@ -99,8 +99,9 @@ public class UpdateDatabaseTool implements IMcpTool
             .stringProperty("stateAfter", "Application update state after the update.") //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty("message", "Human-readable status message for the update.") //$NON-NLS-1$ //$NON-NLS-2$
             .booleanProperty("terminatedClient", //$NON-NLS-1$
-                "true when a running 1C client holding the infobase was terminated before the update " //$NON-NLS-1$
-                + "(only when terminateRunningClients=true).") //$NON-NLS-1$
+                "Present and true ONLY when an applied update (confirm=true) terminated a running " //$NON-NLS-1$
+                + "client to free the infobase; absent otherwise (preview, opt-out, or no running " //$NON-NLS-1$
+                + "client).") //$NON-NLS-1$
             .booleanProperty("willTerminateRunningClients", //$NON-NLS-1$
                 "On a preview: whether confirm=true would first terminate a running client " //$NON-NLS-1$
                 + "(reflects terminateRunningClients).") //$NON-NLS-1$
@@ -199,6 +200,7 @@ public class UpdateDatabaseTool implements IMcpTool
             boolean fullUpdate, boolean autoRestructure, boolean confirm,
             boolean terminateRunningClients)
     {
+        boolean terminatedClient = false;
         try
         {
             ProjectContext ctx = ProjectContext.of(projectName);
@@ -268,22 +270,6 @@ public class UpdateDatabaseTool implements IMcpTool
                     .toJson();
             }
 
-            // Free the infobase before updating. A 1C client THIS EDT launched holds the IB in
-            // exclusive use (so the update blocks/fails) and caches the old module version (it keeps
-            // running stale code even after a successful publish). Reuse the launch path's
-            // battle-tested sweep — client-typed-thread discriminated (never touches a debug-server
-            // session) and exempting MCP-owned launches. Runs only on confirm=true, never in preview.
-            boolean terminatedClient = false;
-            if (terminateRunningClients)
-            {
-                terminatedClient = LaunchLifecycleUtils.ensureNoExistingClientSession(project, applicationId);
-                if (terminatedClient)
-                {
-                    Activator.logInfo("Update database: terminated a running client to free the " //$NON-NLS-1$
-                        + "infobase: project=" + projectName + ", application=" + applicationId); //$NON-NLS-1$ //$NON-NLS-2$
-                }
-            }
-
             // Create execution context with the active Shell so EDT can parent
             // its dialogs. Shared SWT-grab lives in LaunchLifecycleUtils.
             ExecutionContext context = new ExecutionContext();
@@ -297,14 +283,36 @@ public class UpdateDatabaseTool implements IMcpTool
                     ", application=" + applicationId +  //$NON-NLS-1$
                     ", type=" + updateType +  //$NON-NLS-1$
                     ", autoRestructure=" + autoRestructure); //$NON-NLS-1$
-            
-            // Create progress monitor
+
             IProgressMonitor monitor = new NullProgressMonitor();
-            
-            // Perform update
-            ApplicationUpdateState stateAfter = appManager.update(application, updateType, context, monitor);
-            
-            // Build result
+
+            // Free the infobase and apply the update under the SAME per-IB lock the launch path
+            // uses (LaunchLifecycleUtils.lockFor), so a concurrent run_yaxunit_tests / debug_launch
+            // on this infobase cannot interleave its own terminate+update (two updates racing, or a
+            // freshly-freed IB grabbed by a new client between the sweep and update()). A 1C client
+            // THIS EDT launched holds the IB in exclusive use (the update fails) and caches the old
+            // module version (stale code even after a successful publish); the reused sweep is
+            // client-typed-thread discriminated (never a debug-server session) and exempts MCP-owned
+            // launches. Runs only on confirm=true, never in preview.
+            ApplicationUpdateState stateAfter;
+            synchronized (LaunchLifecycleUtils.lockFor(projectName, applicationId))
+            {
+                if (terminateRunningClients)
+                {
+                    terminatedClient =
+                        LaunchLifecycleUtils.ensureNoExistingClientSession(project, applicationId);
+                    if (terminatedClient)
+                    {
+                        Activator.logInfo("Update database: terminated a running client to free the " //$NON-NLS-1$
+                            + "infobase: project=" + projectName + ", application=" + applicationId); //$NON-NLS-1$ //$NON-NLS-2$
+                    }
+                }
+                stateAfter = appManager.update(application, updateType, context, monitor);
+            }
+
+            // Build result. terminatedClient is emitted ONLY when a client was actually terminated
+            // (truthful; "swept but none / not confirmed" and opt-out are indistinguishable by
+            // absence — the confirmationRequired idiom).
             ToolResult result = ToolResult.success()
                 .put("action", "updated") //$NON-NLS-1$ //$NON-NLS-2$
                 .put("project", projectName) //$NON-NLS-1$
@@ -312,8 +320,11 @@ public class UpdateDatabaseTool implements IMcpTool
                 .put("applicationName", application.getName()) //$NON-NLS-1$
                 .put("updateType", updateType.name()) //$NON-NLS-1$
                 .put("stateBefore", stateBefore.name()) //$NON-NLS-1$
-                .put("stateAfter", stateAfter.name()) //$NON-NLS-1$
-                .put("terminatedClient", terminatedClient); //$NON-NLS-1$
+                .put("stateAfter", stateAfter.name()); //$NON-NLS-1$
+            if (terminatedClient)
+            {
+                result.put("terminatedClient", true); //$NON-NLS-1$
+            }
             
             // Add status message based on result
             if (stateAfter == ApplicationUpdateState.UPDATED)
@@ -335,11 +346,18 @@ public class UpdateDatabaseTool implements IMcpTool
         {
             Activator.logError("Error updating database for application: " + applicationId, e); //$NON-NLS-1$
             
-            // Return detailed error information
-            ToolResult errorResult = ToolResult.error("Database update failed: " + e.getMessage()); //$NON-NLS-1$
+            // The common failure is the exclusive lock: name a 1C client that still holds the
+            // infobase (an MCP-owned sibling launch is exempt from the sweep, or a client outlived
+            // the terminate window) so the agent can act instead of seeing a bare failure.
+            ToolResult errorResult = ToolResult.error("Database update failed: " //$NON-NLS-1$
+                + e.getMessage() + describeInfobaseHolder(applicationId));
             errorResult.put("applicationId", applicationId); //$NON-NLS-1$
             errorResult.put("projectName", projectName); //$NON-NLS-1$
-            
+            if (terminatedClient)
+            {
+                errorResult.put("terminatedClient", true); //$NON-NLS-1$
+            }
+
             // Try to get additional error details
             if (e.getCause() != null)
             {
@@ -352,7 +370,40 @@ public class UpdateDatabaseTool implements IMcpTool
         catch (Exception e)
         {
             Activator.logError("Unexpected error during database update", e); //$NON-NLS-1$
-            return ToolResult.error("Unexpected error: " + e.getMessage()).toJson(); //$NON-NLS-1$
+            ToolResult errorResult = ToolResult.error("Unexpected error: " + e.getMessage()); //$NON-NLS-1$
+            if (terminatedClient)
+            {
+                errorResult.put("terminatedClient", true); //$NON-NLS-1$
+            }
+            return errorResult.toJson();
         }
+    }
+
+    /**
+     * Best-effort hint naming a 1C client that still holds the infobase, appended to the
+     * exclusive-lock failure message: an MCP-owned sibling launch (exempt from the auto-sweep)
+     * or a client that outlived the terminate window. Empty string when none is resolvable, so
+     * the base error message is unchanged.
+     */
+    private static String describeInfobaseHolder(String applicationId)
+    {
+        try
+        {
+            LaunchLifecycleUtils.ExistingClientSession holder =
+                LaunchLifecycleUtils.resolveExistingClientSession(applicationId);
+            if (holder != null && holder.launch != null)
+            {
+                String name = holder.launch.getLaunchConfiguration() != null
+                    ? holder.launch.getLaunchConfiguration().getName() : "<unknown>"; //$NON-NLS-1$
+                return " A 1C client still holds the infobase (launch '" + name //$NON-NLS-1$
+                    + "'); if it is an MCP-owned session, stop it with terminate_launch " //$NON-NLS-1$
+                    + "(force=true) and retry."; //$NON-NLS-1$
+            }
+        }
+        catch (Exception ignore)
+        {
+            // best-effort hint only — never let it mask the real error
+        }
+        return ""; //$NON-NLS-1$
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
@@ -1049,8 +1049,8 @@ public final class LaunchLifecycleUtils
             + "not yet applied) after " + (syncApplyTimeoutMs / 1000) //$NON-NLS-1$
             + "s (final update state: " + finalState + ") — results would be stale, " //$NON-NLS-1$ //$NON-NLS-2$
             + "so the run was refused. Retry the run; if it persists, call " //$NON-NLS-1$
-            + "`update_database` (optionally with `fullUpdate=true` / " //$NON-NLS-1$
-            + "`autoRestructure=true`) and inspect the EDT problems view."; //$NON-NLS-1$
+            + "`update_database` (optionally with `fullUpdate=true`) and " //$NON-NLS-1$
+            + "inspect the EDT problems view."; //$NON-NLS-1$
     }
 
     /**
@@ -1068,7 +1068,7 @@ public final class LaunchLifecycleUtils
             + "(final update state: " + finalState + ") — the update requires user " //$NON-NLS-1$ //$NON-NLS-2$
             + "action (e.g. an interactive restructure), so the run was refused " //$NON-NLS-1$
             + "immediately rather than executed stale. Call `update_database` " //$NON-NLS-1$
-            + "(optionally with `fullUpdate=true` / `autoRestructure=true`) and " //$NON-NLS-1$
+            + "(optionally with `fullUpdate=true`) and " //$NON-NLS-1$
             + "inspect the EDT problems view, then retry."; //$NON-NLS-1$
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
@@ -1799,6 +1799,17 @@ public final class LaunchLifecycleUtils
      */
     public static boolean terminateExistingSessionAndWait(IDebugTarget target, String appId)
     {
+        return terminateExistingSessionAndWait(target, appId, RESTART_TERMINATE_TIMEOUT_MS);
+    }
+
+    /**
+     * Timeout-parameterized seam of {@link #terminateExistingSessionAndWait(IDebugTarget, String)}
+     * — package-private so the headless test can exercise the timeout-elapsed path without
+     * waiting out the full production window. Production callers always go through the public
+     * overload ({@link #RESTART_TERMINATE_TIMEOUT_MS}).
+     */
+    static boolean terminateExistingSessionAndWait(IDebugTarget target, String appId, long timeoutMs)
+    {
         if (target == null)
         {
             if (appId != null && !appId.isEmpty())
@@ -1819,7 +1830,7 @@ public final class LaunchLifecycleUtils
             Activator.logError("Error terminating existing debug session before restart", e); //$NON-NLS-1$
         }
         boolean terminated = false;
-        long deadline = System.currentTimeMillis() + RESTART_TERMINATE_TIMEOUT_MS;
+        long deadline = System.currentTimeMillis() + timeoutMs;
         while (System.currentTimeMillis() < deadline)
         {
             try
@@ -1847,7 +1858,7 @@ public final class LaunchLifecycleUtils
         if (!terminated)
         {
             Activator.logWarning("Existing client debug session did not confirm termination within " //$NON-NLS-1$
-                + RESTART_TERMINATE_TIMEOUT_MS + "ms (applicationId=" + appId //$NON-NLS-1$
+                + timeoutMs + "ms (applicationId=" + appId //$NON-NLS-1$
                 + ") — the infobase may still be held"); //$NON-NLS-1$
         }
         if (appId != null && !appId.isEmpty())

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
@@ -1791,8 +1791,13 @@ public final class LaunchLifecycleUtils
      * delegate's modal is the armed auto-confirmer's job. Callers must only ever pass
      * a target the type-aware discriminator matched as a CLIENT — never a server
      * target.
+     *
+     * @return {@code true} when the target was observed terminated within
+     *     {@link #RESTART_TERMINATE_TIMEOUT_MS}; {@code false} on a {@code null} target or
+     *     when the wait elapsed without confirming death (a warning is logged) — callers
+     *     must NOT report "terminated" on a {@code false} return.
      */
-    public static void terminateExistingSessionAndWait(IDebugTarget target, String appId)
+    public static boolean terminateExistingSessionAndWait(IDebugTarget target, String appId)
     {
         if (target == null)
         {
@@ -1800,7 +1805,7 @@ public final class LaunchLifecycleUtils
             {
                 DebugSessionRegistry.get().forgetApplication(appId);
             }
-            return;
+            return false;
         }
         try
         {
@@ -1813,6 +1818,7 @@ public final class LaunchLifecycleUtils
         {
             Activator.logError("Error terminating existing debug session before restart", e); //$NON-NLS-1$
         }
+        boolean terminated = false;
         long deadline = System.currentTimeMillis() + RESTART_TERMINATE_TIMEOUT_MS;
         while (System.currentTimeMillis() < deadline)
         {
@@ -1820,6 +1826,7 @@ public final class LaunchLifecycleUtils
             {
                 if (target.isTerminated())
                 {
+                    terminated = true;
                     break;
                 }
             }
@@ -1837,10 +1844,17 @@ public final class LaunchLifecycleUtils
                 break;
             }
         }
+        if (!terminated)
+        {
+            Activator.logWarning("Existing client debug session did not confirm termination within " //$NON-NLS-1$
+                + RESTART_TERMINATE_TIMEOUT_MS + "ms (applicationId=" + appId //$NON-NLS-1$
+                + ") — the infobase may still be held"); //$NON-NLS-1$
+        }
         if (appId != null && !appId.isEmpty())
         {
             DebugSessionRegistry.get().forgetApplication(appId);
         }
+        return terminated;
     }
 
     /**
@@ -1849,8 +1863,13 @@ public final class LaunchLifecycleUtils
      * to die, then clears the registry for {@code appId} — the launch analogue of
      * {@link #terminateExistingSessionAndWait}. Best-effort: a failure is logged, not
      * thrown; the caller proceeds to launch regardless.
+     *
+     * @return {@code true} when the launch was observed terminated within
+     *     {@link #RESTART_TERMINATE_TIMEOUT_MS}; {@code false} on a {@code null} launch or
+     *     when the wait elapsed without confirming death (a warning is logged) — callers
+     *     must NOT report "terminated" on a {@code false} return.
      */
-    public static void terminateExistingLaunchAndWait(ILaunch launch, String appId)
+    public static boolean terminateExistingLaunchAndWait(ILaunch launch, String appId)
     {
         if (launch == null)
         {
@@ -1858,7 +1877,7 @@ public final class LaunchLifecycleUtils
             {
                 DebugSessionRegistry.get().forgetApplication(appId);
             }
-            return;
+            return false;
         }
         try
         {
@@ -1871,6 +1890,7 @@ public final class LaunchLifecycleUtils
         {
             Activator.logError("Error terminating existing launch before restart", e); //$NON-NLS-1$
         }
+        boolean terminated = false;
         long deadline = System.currentTimeMillis() + RESTART_TERMINATE_TIMEOUT_MS;
         while (System.currentTimeMillis() < deadline)
         {
@@ -1878,6 +1898,7 @@ public final class LaunchLifecycleUtils
             {
                 if (launch.isTerminated())
                 {
+                    terminated = true;
                     break;
                 }
             }
@@ -1895,10 +1916,17 @@ public final class LaunchLifecycleUtils
                 break;
             }
         }
+        if (!terminated)
+        {
+            Activator.logWarning("Existing client launch did not confirm termination within " //$NON-NLS-1$
+                + RESTART_TERMINATE_TIMEOUT_MS + "ms (applicationId=" + appId //$NON-NLS-1$
+                + ") — the infobase may still be held"); //$NON-NLS-1$
+        }
         if (appId != null && !appId.isEmpty())
         {
             DebugSessionRegistry.get().forgetApplication(appId);
         }
+        return terminated;
     }
 
     /**
@@ -1996,16 +2024,9 @@ public final class LaunchLifecycleUtils
         // (catches UI-started "Debug As" sessions the ILaunchManager never sees).
         if (project != null)
         {
-            IDebugTarget existing = DebugServerTargetSupport.findRuntimeClientDebugTarget(
-                project.getName(), delegateAppId);
-            if (existing != null)
-            {
-                Activator.logInfo("Fresh-launch guard: terminating existing client session from " //$NON-NLS-1$
-                    + "the debug target manager (e.g. UI-started 'Debug As'): applicationId=" //$NON-NLS-1$
-                    + delegateAppId);
-                terminateExistingSessionAndWait(existing, delegateAppId);
-                terminatedAny = true;
-            }
+            terminatedAny |= sweepTargetManagerSession(
+                DebugServerTargetSupport.findRuntimeClientDebugTarget(project.getName(), delegateAppId),
+                delegateAppId);
         }
         return terminatedAny;
     }
@@ -2053,14 +2074,47 @@ public final class LaunchLifecycleUtils
         {
             Activator.logInfo("Fresh-launch guard: terminating existing client debug target: " //$NON-NLS-1$
                 + "applicationId=" + delegateAppId); //$NON-NLS-1$
-            terminateExistingSessionAndWait(session.liveTarget, delegateAppId);
+            return terminateExistingSessionAndWait(session.liveTarget, delegateAppId);
         }
-        else
+        Activator.logInfo("Fresh-launch guard: terminating existing client launch (mode=" //$NON-NLS-1$
+            + session.mode + "): applicationId=" + delegateAppId); //$NON-NLS-1$ //$NON-NLS-2$
+        return terminateExistingLaunchAndWait(session.launch, delegateAppId);
+    }
+
+    /**
+     * Handles the debug-target-manager half of {@link #ensureNoExistingClientSession}: the
+     * {@code IRuntimeDebugClientTargetManager} can surface a UI-started "Debug As" client the
+     * {@link ILaunchManager} never sees. Mirrors {@link #sweepLaunchManagerSession} — a target
+     * whose owning {@link ILaunch} is MCP-owned ({@link #registerOwnedLaunch}) is SKIPPED
+     * (managed by its own tool), closing the gap where a concurrent MCP DEBUG session on the
+     * same infobase was silently terminated; any other (UI-started / foreign) client is
+     * terminated. Returns whether termination was CONFIRMED, not merely attempted.
+     *
+     * <p>Package-visible so the owned-vs-foreign decision is unit-testable without a live
+     * target manager.
+     *
+     * @param existing the target resolved by {@code findRuntimeClientDebugTarget} (may be
+     *     {@code null} — no-op)
+     * @param delegateAppId the delegate-resolved application id (registry cleanup + logging)
+     * @return {@code true} when a foreign client target was confirmed terminated; {@code false}
+     *     when none, skipped as MCP-owned, or termination did not confirm
+     */
+    static boolean sweepTargetManagerSession(IDebugTarget existing, String delegateAppId)
+    {
+        if (existing == null)
         {
-            Activator.logInfo("Fresh-launch guard: terminating existing client launch (mode=" //$NON-NLS-1$
-                + session.mode + "): applicationId=" + delegateAppId); //$NON-NLS-1$ //$NON-NLS-2$
-            terminateExistingLaunchAndWait(session.launch, delegateAppId);
+            return false;
         }
-        return true;
+        if (isOwnedLaunch(existing.getLaunch()))
+        {
+            Activator.logInfo("Fresh-launch guard: skipping MCP-owned debug session from the " //$NON-NLS-1$
+                + "debug target manager; it is managed by its own tool: applicationId=" //$NON-NLS-1$
+                + delegateAppId);
+            return false;
+        }
+        Activator.logInfo("Fresh-launch guard: terminating existing client session from " //$NON-NLS-1$
+            + "the debug target manager (e.g. UI-started 'Debug As'): applicationId=" //$NON-NLS-1$
+            + delegateAppId);
+        return terminateExistingSessionAndWait(existing, delegateAppId);
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
@@ -7,6 +7,7 @@
 package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -63,10 +64,14 @@ public class UpdateDatabaseToolTest
         assertTrue(schema.contains("\"projectName\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"applicationId\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"fullUpdate\"")); //$NON-NLS-1$
-        assertTrue(schema.contains("\"autoRestructure\"")); //$NON-NLS-1$
         assertTrue("schema must declare the confirm gate", schema.contains("\"confirm\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("schema must declare the terminateRunningClients opt-out", //$NON-NLS-1$
             schema.contains("\"terminateRunningClients\"")); //$NON-NLS-1$
+        // autoRestructure was removed: the EDT update API (IApplicationManager.update /
+        // ExecutionContext) has no per-call restructure-confirmation switch, so the parameter
+        // could never influence the update — advertising it misled unattended clients.
+        assertFalse("autoRestructure must not reappear without being wired into the EDT call", //$NON-NLS-1$
+            schema.contains("\"autoRestructure\"")); //$NON-NLS-1$
     }
 
     @Test
@@ -133,8 +138,9 @@ public class UpdateDatabaseToolTest
         // Exclusive-lock guidance migrated from the old description.
         assertTrue(guide.contains("terminate_launch")); //$NON-NLS-1$
         assertTrue(guide.contains("exclusive")); //$NON-NLS-1$
-        // fullUpdate/autoRestructure rationale migrated from the old schema descriptions.
-        assertTrue(guide.contains("autoRestructure")); //$NON-NLS-1$
+        // The guide must state that a DB restructure is EDT-confirmed and not controllable
+        // per call (the former autoRestructure parameter was a no-op and was removed).
+        assertTrue(guide.contains("restructure")); //$NON-NLS-1$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
@@ -65,6 +65,8 @@ public class UpdateDatabaseToolTest
         assertTrue(schema.contains("\"fullUpdate\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"autoRestructure\"")); //$NON-NLS-1$
         assertTrue("schema must declare the confirm gate", schema.contains("\"confirm\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("schema must declare the terminateRunningClients opt-out", //$NON-NLS-1$
+            schema.contains("\"terminateRunningClients\"")); //$NON-NLS-1$
     }
 
     @Test
@@ -77,6 +79,19 @@ public class UpdateDatabaseToolTest
         assertTrue("outputSchema must declare action", schema.contains("\"action\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("outputSchema must declare confirmationRequired", //$NON-NLS-1$
             schema.contains("\"confirmationRequired\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testOutputSchemaDeclaresTerminateFields()
+    {
+        // The free-the-infobase behaviour reports terminatedClient on an applied update and
+        // willTerminateRunningClients on a preview, so a client can see the lock-freeing side effect.
+        String schema = new UpdateDatabaseTool().getOutputSchema();
+        assertNotNull(schema);
+        assertTrue("outputSchema must declare terminatedClient", //$NON-NLS-1$
+            schema.contains("\"terminatedClient\"")); //$NON-NLS-1$
+        assertTrue("outputSchema must declare willTerminateRunningClients", //$NON-NLS-1$
+            schema.contains("\"willTerminateRunningClients\"")); //$NON-NLS-1$
     }
 
     @Test
@@ -120,6 +135,17 @@ public class UpdateDatabaseToolTest
         assertTrue(guide.contains("exclusive")); //$NON-NLS-1$
         // fullUpdate/autoRestructure rationale migrated from the old schema descriptions.
         assertTrue(guide.contains("autoRestructure")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testGuideDocumentsTerminateRunningClients()
+    {
+        // The default-on free-the-infobase behaviour (and its opt-out) must be documented so an
+        // agent knows the tool now terminates a running client itself instead of failing on the lock.
+        String guide = new UpdateDatabaseTool().getGuide();
+        assertNotNull(guide);
+        assertTrue("guide must document the terminateRunningClients parameter", //$NON-NLS-1$
+            guide.contains("terminateRunningClients")); //$NON-NLS-1$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtilsSessionTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtilsSessionTest.java
@@ -526,14 +526,15 @@ public class LaunchLifecycleUtilsSessionTest
     @Test
     public void testTerminateExistingSessionAndWaitReturnsFalseOnTimeout() throws Exception
     {
-        // A client that never reports terminated within RESTART_TERMINATE_TIMEOUT_MS: the helper
-        // must NOT claim success — it returns false (and logs a warning) so update_database does not
-        // report a client as terminated while it may still hold the infobase exclusively. (Waits
-        // out the terminate window once.)
+        // A client that never reports terminated within the wait window: the helper must NOT
+        // claim success — it returns false (and logs a warning) so update_database does not
+        // report a client as terminated while it may still hold the infobase exclusively.
+        // Exercised through the timeout-parameterized seam with a short window (one genuine
+        // poll+sleep iteration) instead of waiting out the production 3s timeout.
         IDebugTarget client = targetWithThreads(liveThread());
         when(client.canTerminate()).thenReturn(true);
         when(client.isTerminated()).thenReturn(false);
-        assertFalse(LaunchLifecycleUtils.terminateExistingSessionAndWait(client, "app-stuck")); //$NON-NLS-1$
+        assertFalse(LaunchLifecycleUtils.terminateExistingSessionAndWait(client, "app-stuck", 150L)); //$NON-NLS-1$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtilsSessionTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtilsSessionTest.java
@@ -509,4 +509,83 @@ public class LaunchLifecycleUtilsSessionTest
         assertTrue(LaunchLifecycleUtils.sweepLaunchManagerSession(session, "app-foreign")); //$NON-NLS-1$
         verify(foreign, times(1)).terminate();
     }
+
+    // ============ confirmed-termination boolean (truthful terminatedClient) ============
+
+    @Test
+    public void testTerminateExistingSessionAndWaitReturnsTrueWhenConfirmed() throws Exception
+    {
+        // The terminate-half now returns whether death was CONFIRMED within the window, so a
+        // caller (update_database) can report terminatedClient truthfully.
+        IDebugTarget client = targetWithThreads(liveThread());
+        when(client.canTerminate()).thenReturn(true);
+        when(client.isTerminated()).thenReturn(false, true);
+        assertTrue(LaunchLifecycleUtils.terminateExistingSessionAndWait(client, "app-x")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testTerminateExistingSessionAndWaitReturnsFalseOnTimeout() throws Exception
+    {
+        // A client that never reports terminated within RESTART_TERMINATE_TIMEOUT_MS: the helper
+        // must NOT claim success — it returns false (and logs a warning) so update_database does not
+        // report a client as terminated while it may still hold the infobase exclusively. (Waits
+        // out the terminate window once.)
+        IDebugTarget client = targetWithThreads(liveThread());
+        when(client.canTerminate()).thenReturn(true);
+        when(client.isTerminated()).thenReturn(false);
+        assertFalse(LaunchLifecycleUtils.terminateExistingSessionAndWait(client, "app-stuck")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testTerminateExistingSessionAndWaitNullReturnsFalse()
+    {
+        // Null target: nothing was terminated, so the confirmed-termination contract is false.
+        assertFalse(LaunchLifecycleUtils.terminateExistingSessionAndWait(null, "app-x")); //$NON-NLS-1$
+    }
+
+    // ============ target-manager sweep vs MCP-owned debug sessions (the 🔴 finding) ============
+    // The debug-target-manager source of ensureNoExistingClientSession, exercised through its
+    // seam sweepTargetManagerSession (the live IRuntimeDebugClientTargetManager scan needs a
+    // workbench and is covered E2E).
+
+    @Test
+    public void testSweepTargetManagerNullTargetIsNoOp()
+    {
+        assertFalse(LaunchLifecycleUtils.sweepTargetManagerSession(null, "app-none")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSweepTargetManagerSkipsOwnedDebugSession() throws Exception
+    {
+        // THE FINDING: the debug-target-manager source must NOT terminate a target whose owning
+        // launch is MCP-owned (e.g. a concurrent debug_yaxunit_tests session on the same infobase)
+        // — Source 2 previously killed it unconditionally, bypassing the owned-exemption.
+        ILaunch ownedLaunch = mock(ILaunch.class);
+        IDebugTarget owned = targetWithThreads(liveThread());
+        when(owned.getLaunch()).thenReturn(ownedLaunch);
+        LaunchLifecycleUtils.registerOwnedLaunch(ownedLaunch);
+        try
+        {
+            assertFalse(LaunchLifecycleUtils.sweepTargetManagerSession(owned, "app-owned-dbg")); //$NON-NLS-1$
+            verify(owned, never()).terminate();
+        }
+        finally
+        {
+            LaunchLifecycleUtils.unregisterOwnedLaunch(ownedLaunch);
+        }
+    }
+
+    @Test
+    public void testSweepTargetManagerTerminatesForeignDebugSession() throws Exception
+    {
+        // A foreign (not MCP-owned, e.g. a UI-started 'Debug As') client target IS terminated, and
+        // the confirmed-termination boolean is returned.
+        ILaunch foreignLaunch = mock(ILaunch.class);
+        IDebugTarget foreign = targetWithThreads(liveThread());
+        when(foreign.getLaunch()).thenReturn(foreignLaunch);
+        when(foreign.canTerminate()).thenReturn(true);
+        when(foreign.isTerminated()).thenReturn(false, true);
+        assertTrue(LaunchLifecycleUtils.sweepTargetManagerSession(foreign, "app-foreign-dbg")); //$NON-NLS-1$
+        verify(foreign, times(1)).terminate();
+    }
 }

--- a/tests/e2e/tools/test_update_database.py
+++ b/tests/e2e/tools/test_update_database.py
@@ -102,6 +102,27 @@ def test_real_project_unknown_application_is_resolved_and_rejected_without_mutat
     assert_no_diff("a rejected update must not touch the project source on disk")
 
 
+@e2e_test(tool="update_database", kind="action")
+def test_terminate_running_clients_param_accepted_without_mutation():
+    """The terminateRunningClients opt-out is wired into execute() (read + declared in schema).
+
+    Passing it (false) alongside a real project + non-existent applicationId must still be rejected
+    at the application lookup BEFORE the apply phase — so neither the destructive update() nor the
+    client-freeing sweep ever runs. This proves the new parameter is accepted (not an unknown-arg
+    error) and does not alter the safe resolution chain; terminateRunningClients=false also
+    guarantees no client-termination side effect regardless. The fixture source stays clean.
+    """
+    r = call("update_database", {
+        "projectName": PROJECT,
+        "applicationId": BOGUS_APP_ID,
+        "terminateRunningClients": False,
+    })
+    e = assert_error(r, "real project + non-existent applicationId + terminateRunningClients=false")
+    assert_contains(e, "Application not found",
+                    "the terminateRunningClients param must not change the application-lookup rejection")
+    assert_no_diff("a rejected update (even with terminateRunningClients) must not touch the project on disk")
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # NEGATIVE MATRIX — targeting argument validation (XOR-ish projectName+applicationId
 # vs launchConfigurationName), plus invalid targets. Every call leaves the tree clean.

--- a/tests/e2e/tools/test_update_database.py
+++ b/tests/e2e/tools/test_update_database.py
@@ -104,13 +104,15 @@ def test_real_project_unknown_application_is_resolved_and_rejected_without_mutat
 
 @e2e_test(tool="update_database", kind="action")
 def test_terminate_running_clients_param_accepted_without_mutation():
-    """The terminateRunningClients opt-out is wired into execute() (read + declared in schema).
+    """The terminateRunningClients opt-out is parsed by execute() and does not break the
+    resolution chain.
 
-    Passing it (false) alongside a real project + non-existent applicationId must still be rejected
-    at the application lookup BEFORE the apply phase — so neither the destructive update() nor the
-    client-freeing sweep ever runs. This proves the new parameter is accepted (not an unknown-arg
-    error) and does not alter the safe resolution chain; terminateRunningClients=false also
-    guarantees no client-termination side effect regardless. The fixture source stays clean.
+    Passing it (false) alongside a real project + non-existent applicationId is still rejected at
+    the application lookup BEFORE the apply phase — so neither the destructive update() nor the
+    client-freeing sweep runs. This is a platform-boundary test: it proves the parameter is PARSED
+    and the resolution chain still reaches getApplication() with an un-mangled id, NOT that the
+    sweep itself works (the sweep needs a live launch + infobase and is verify-live-only). The
+    fixture source stays clean on every path.
     """
     r = call("update_database", {
         "projectName": PROJECT,
@@ -118,6 +120,11 @@ def test_terminate_running_clients_param_accepted_without_mutation():
         "terminateRunningClients": False,
     })
     e = assert_error(r, "real project + non-existent applicationId + terminateRunningClients=false")
+    # Same quality bar as the twin happy test: prove execution reached getApplication() with the
+    # un-mangled id (names=[BOGUS_APP_ID]) and stayed actionable (suggests=[get_applications]) —
+    # without it, any "Application not found"-ish text would pass without proving real resolution.
+    assert_error_quality(e, names=[BOGUS_APP_ID], suggests=["get_applications"],
+                         ctx="param-accepted path still names the bad id and suggests get_applications")
     assert_contains(e, "Application not found",
                     "the terminateRunningClients param must not change the application-lookup rejection")
     assert_no_diff("a rejected update (even with terminateRunningClients) must not touch the project on disk")

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -3164,7 +3164,7 @@
           "type": "boolean"
         },
         "terminatedClient": {
-          "description": "true when a running 1C client holding the infobase was terminated before the update (only when terminateRunningClients=true).",
+          "description": "Present and true ONLY when an applied update (confirm=true) terminated a running client to free the infobase; absent otherwise (preview, opt-out, or no running client).",
           "type": "boolean"
         },
         "updateType": {

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -3096,10 +3096,6 @@
           "description": "Application ID from get_applications; required if launchConfigurationName is omitted.",
           "type": "string"
         },
-        "autoRestructure": {
-          "description": "Auto-apply restructurization when needed (default true).",
-          "type": "boolean"
-        },
         "confirm": {
           "description": "true = apply the update; default false = preview only (resolves the target and reports what would change WITHOUT mutating the infobase).",
           "type": "boolean"

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -3089,7 +3089,7 @@
       "openWorldHint": false,
       "readOnlyHint": false
     },
-    "description": "Apply configuration changes to an application's database (infobase), full or incremental. Target by launchConfigurationName (preferred) or projectName + applicationId. Destructive/irreversible: guarded by a confirm-preview - call without confirm to preview the exact update (no infobase change), then confirm=true to apply. Terminate any running 1C client on the target infobase first (exclusive lock). Full parameters and examples: call get_tool_guide('update_database').",
+    "description": "Apply configuration changes to an application's database (infobase), full or incremental. Target by launchConfigurationName (preferred) or projectName + applicationId. Destructive/irreversible: guarded by a confirm-preview - call without confirm to preview the exact update (no infobase change), then confirm=true to apply. Auto-terminates any 1C client THIS EDT launched on the target infobase first to free the exclusive lock (opt out with terminateRunningClients=false). Full parameters and examples: call get_tool_guide('update_database').",
     "inputSchema": {
       "properties": {
         "applicationId": {
@@ -3115,6 +3115,10 @@
         "projectName": {
           "description": "EDT project name; required if launchConfigurationName is omitted.",
           "type": "string"
+        },
+        "terminateRunningClients": {
+          "description": "Before applying, terminate any 1C client THIS EDT launched on the target infobase to free the exclusive lock (default true). false keeps a running client — the update then fails if that client holds the infobase exclusively.",
+          "type": "boolean"
         }
       },
       "required": [],
@@ -3159,9 +3163,17 @@
           "description": "Whether the operation succeeded",
           "type": "boolean"
         },
+        "terminatedClient": {
+          "description": "true when a running 1C client holding the infobase was terminated before the update (only when terminateRunningClients=true).",
+          "type": "boolean"
+        },
         "updateType": {
           "description": "Update mode applied: FULL or INCREMENTAL.",
           "type": "string"
+        },
+        "willTerminateRunningClients": {
+          "description": "On a preview: whether confirm=true would first terminate a running client (reflects terminateRunningClients).",
+          "type": "boolean"
         }
       },
       "required": [


### PR DESCRIPTION
## Summary

`update_database` now frees the infobase itself before applying. A new `terminateRunningClients` parameter (default **true**) terminates any 1C client THIS EDT launched on the target infobase before the update — so an active session no longer blocks the update (exclusive lock) or leaves a client running stale modules after a successful publish.

This is the narrow `#128` residual that #142 did **not** cover: #142 made the **launch / debug / YAXUnit** path unattended-safe (pre-launch sweep, stale-IB refusal, EN+RU update modal, incremental-first) but never touched `UpdateDatabaseTool` — the explicit tool still called `appManager.update(...)` with the running client left in place. Its description even promised "Terminate any running 1C client on the target infobase first", but the code never did it. This PR makes that promise true.

Follow-up to closing #143 (which predated #142 and duplicated #142's machine); this is the slim, reuse-only slice.

## What changed

- **Free the infobase (reuse, no new code).** On `confirm=true`, before `appManager.update(...)`, the tool calls the launch path's own `LaunchLifecycleUtils.ensureNoExistingClientSession(project, applicationId)` — the same battle-tested sweep `run_yaxunit_tests` / `debug_launch` use. It is client-typed-thread discriminated (never touches a debug-server session) and exempts MCP-owned launches. **No new util class** — deliberately not re-introducing #143's parallel `ApplicationUpdatePolicy`/`UpdateWatchdog`/`EdtDialogAutoConfirmer`, which would duplicate #142's machine.
- **Opt-out.** `terminateRunningClients=false` keeps a running client (the update then fails on the exclusive lock, as before).
- **Honest preview.** The confirm-preview stays side-effect-free but now reports `willTerminateRunningClients` and says so in the message — it terminates nothing.
- **New output.** `terminatedClient` (boolean) on an applied update.

## New surface

| Kind | Name | Default | Meaning |
|---|---|---|---|
| param | `terminateRunningClients` | `true` | free the IB by terminating an EDT-launched client before updating |
| output | `terminatedClient` | — | a running client was terminated to free the IB |
| output | `willTerminateRunningClients` | — | preview-only: whether confirm=true would terminate a client |

## Why no watchdog

#143 added a background-thread update watchdog. Dropped on purpose: #142's model returns `BEING_UPDATED` and the tool already surfaces it ("Update in progress") rather than hanging, and #142's event-driven `awaitUpdateState` is package-private to the launch path. Threading a destructive `appManager.update(...)` off its request thread is risk for no gain, so this PR does not add one.

## Tests / docs

- `UpdateDatabaseToolTest`: schema declares `terminateRunningClients`; outputSchema declares `terminatedClient` + `willTerminateRunningClients`; guide documents the param. (`ToolContractConsistencyTest` enforces the schema↔execute parity for the new param.)
- e2e `test_update_database.py`: a `terminateRunningClients=false` call on a real project + non-existent applicationId is still rejected at the application lookup BEFORE the apply phase — proving the param is wired and triggers no mutation/sweep.
- `tools_list.golden.json`, the guide and the tool description updated.

## Verification status

- **Tier 1 (compile + Java unit ratchets): green** via `mvn clean verify` on the 2025.2 target.
- **Tier 2/3 (live redeploy + e2e golden-verify): pending** — needs a redeploy of this build into a running EDT (the golden + formatter contracts are e2e-only). The golden was hand-updated with the exact generator serialization (`sort_keys`, `ensure_ascii=False`, `indent=2`); `docs/tools/update_database.md` + the README catalog regenerate from the live server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
