### PR TITLE
Fix SonarCloud bugs + safe duplicate-literal cleanup

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/doc/PlatformDocumentationService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/doc/PlatformDocumentationService.java
@@ -401,9 +401,10 @@ public class PlatformDocumentationService
             IV8ProjectManager v8pm = Activator.getDefault().getV8ProjectManager();
             if (v8pm != null)
             {
-                for (IV8Project project : v8pm.getProjects())
+                java.util.Iterator<IV8Project> it = v8pm.getProjects().iterator();
+                if (it.hasNext())
                 {
-                    return project.getVersion();
+                    return it.next().getVersion();
                 }
             }
             return null;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CleanProjectTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CleanProjectTool.java
@@ -39,7 +39,7 @@ public class CleanProjectTool implements IMcpTool
     public static final String NAME = "clean_project"; //$NON-NLS-1$
     
     /** Default timeout for waiting project lifecycle restart (3 minutes) */
-    private static final long DEFAULT_LIFECYCLE_TIMEOUT_MS = 3 * 60 * 1000;
+    private static final long DEFAULT_LIFECYCLE_TIMEOUT_MS = 3L * 60 * 1000;
     
     @Override
     public String getName()

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
@@ -1065,7 +1065,7 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         int dot = normFqn.lastIndexOf('.');
         String leaf = dot >= 0 ? normFqn.substring(dot + 1) : normFqn;
         String normalizedLeaf = normReport.apply("name", leaf); //$NON-NLS-1$
-        if (normalizedLeaf == leaf)
+        if (leaf.equals(normalizedLeaf))
         {
             return normFqn;
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetFormScreenshotTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetFormScreenshotTool.java
@@ -290,6 +290,10 @@ public class GetFormScreenshotTool implements IMcpTool
         }
         catch (Exception e)
         {
+            if (e instanceof InterruptedException)
+            {
+                Thread.currentThread().interrupt();
+            }
             Activator.logError("Failed to capture form screenshot", e); //$NON-NLS-1$
             return CaptureResult.error(
                 ToolResult.error("Failed to capture form screenshot: " + e.getMessage()).toJson()); //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadMethodSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadMethodSourceTool.java
@@ -269,7 +269,7 @@ public class ReadMethodSourceTool implements IMcpTool
                     if (closeParen >= 0)
                     {
                         String afterParen = afterMethod.substring(closeParen + 1);
-                        isExport = afterParen.matches("(?i)\\s*(?:\u042d\u043a\u0441\u043f\u043e\u0440\u0442|Export)\\s*"); //$NON-NLS-1$
+                        isExport = afterParen.matches("(?iu)\\s*(?:\u042d\u043a\u0441\u043f\u043e\u0440\u0442|Export)\\s*"); //$NON-NLS-1$
                     }
                     break;
                 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadMethodSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadMethodSourceTool.java
@@ -38,6 +38,14 @@ public class ReadMethodSourceTool implements IMcpTool
 {
     public static final String NAME = "read_method_source"; //$NON-NLS-1$
 
+    private static final String KEY_MODULE = "module"; //$NON-NLS-1$
+    private static final String KEY_METHOD = "method"; //$NON-NLS-1$
+    private static final String KEY_EXPORT = "export"; //$NON-NLS-1$
+    private static final String KEY_START_LINE = "startLine"; //$NON-NLS-1$
+    private static final String KEY_END_LINE = "endLine"; //$NON-NLS-1$
+    private static final String TYPE_PROCEDURE = "Procedure"; //$NON-NLS-1$
+    private static final String TYPE_FUNCTION = "Function"; //$NON-NLS-1$
+
     @Override
     public String getName()
     {
@@ -174,7 +182,7 @@ public class ReadMethodSourceTool implements IMcpTool
         int to = Math.min(allLines.size(), endLine);
 
         // Build signature info
-        String typeStr = method instanceof Function ? "Function" : "Procedure"; //$NON-NLS-1$ //$NON-NLS-2$
+        String typeStr = method instanceof Function ? TYPE_FUNCTION : TYPE_PROCEDURE; //$NON-NLS-1$ //$NON-NLS-2$
 
         // Find containing region
         String region = BslModuleUtils.findRegionForLine(allLines, startLine);
@@ -187,16 +195,16 @@ public class ReadMethodSourceTool implements IMcpTool
 
         FrontMatter fm = FrontMatter.create()
             .put("projectName", projectName) //$NON-NLS-1$
-            .put("module", modulePath); //$NON-NLS-1$
+            .put(KEY_MODULE, modulePath); //$NON-NLS-1$
         if (contentHash != null)
         {
             fm.put("contentHash", contentHash); //$NON-NLS-1$
         }
-        fm.put("method", method.getName()) //$NON-NLS-1$
+        fm.put(KEY_METHOD, method.getName()) //$NON-NLS-1$
             .put("type", typeStr) //$NON-NLS-1$
-            .put("export", method.isExport()) //$NON-NLS-1$
-            .put("startLine", from) //$NON-NLS-1$
-            .put("endLine", to) //$NON-NLS-1$
+            .put(KEY_EXPORT, method.isExport()) //$NON-NLS-1$
+            .put(KEY_START_LINE, from) //$NON-NLS-1$
+            .put(KEY_END_LINE, to) //$NON-NLS-1$
             .put("totalLines", allLines.size()); //$NON-NLS-1$
 
         if (region != null)
@@ -255,7 +263,7 @@ public class ReadMethodSourceTool implements IMcpTool
 
             int methodStart = tm.startLine;
             int methodEnd = tm.endLine;
-            String typeStr = tm.isFunction ? "Function" : "Procedure"; //$NON-NLS-1$ //$NON-NLS-2$
+            String typeStr = tm.isFunction ? TYPE_FUNCTION : TYPE_PROCEDURE; //$NON-NLS-1$ //$NON-NLS-2$
 
             // Detect export flag
             boolean isExport = false;
@@ -284,16 +292,16 @@ public class ReadMethodSourceTool implements IMcpTool
 
             FrontMatter fm = FrontMatter.create()
                 .put("projectName", projectName) //$NON-NLS-1$
-                .put("module", modulePath); //$NON-NLS-1$
+                .put(KEY_MODULE, modulePath); //$NON-NLS-1$
             if (contentHash != null)
             {
                 fm.put("contentHash", contentHash); //$NON-NLS-1$
             }
-            fm.put("method", methodName) //$NON-NLS-1$
+            fm.put(KEY_METHOD, methodName) //$NON-NLS-1$
                 .put("type", typeStr) //$NON-NLS-1$
-                .put("export", isExport) //$NON-NLS-1$
-                .put("startLine", methodStart + 1) //$NON-NLS-1$
-                .put("endLine", methodEnd + 1) //$NON-NLS-1$
+                .put(KEY_EXPORT, isExport) //$NON-NLS-1$
+                .put(KEY_START_LINE, methodStart + 1) //$NON-NLS-1$
+                .put(KEY_END_LINE, methodEnd + 1) //$NON-NLS-1$
                 .put("totalLines", allLines.size()); //$NON-NLS-1$
 
             if (region != null)
@@ -351,16 +359,16 @@ public class ReadMethodSourceTool implements IMcpTool
         int startLine, int endLine)
     {
         String sourceText = BslModuleUtils.getSourceText(method);
-        String typeStr = method instanceof Function ? "Function" : "Procedure"; //$NON-NLS-1$ //$NON-NLS-2$
+        String typeStr = method instanceof Function ? TYPE_FUNCTION : TYPE_PROCEDURE; //$NON-NLS-1$ //$NON-NLS-2$
 
         FrontMatter fm = FrontMatter.create()
             .put("projectName", projectName) //$NON-NLS-1$
-            .put("module", modulePath) //$NON-NLS-1$
-            .put("method", method.getName()) //$NON-NLS-1$
+            .put(KEY_MODULE, modulePath) //$NON-NLS-1$
+            .put(KEY_METHOD, method.getName()) //$NON-NLS-1$
             .put("type", typeStr) //$NON-NLS-1$
-            .put("export", method.isExport()) //$NON-NLS-1$
-            .put("startLine", startLine) //$NON-NLS-1$
-            .put("endLine", endLine); //$NON-NLS-1$
+            .put(KEY_EXPORT, method.isExport()) //$NON-NLS-1$
+            .put(KEY_START_LINE, startLine) //$NON-NLS-1$
+            .put(KEY_END_LINE, endLine); //$NON-NLS-1$
 
         StringBuilder sb = new StringBuilder();
         if (sourceText != null)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/reference/MetadataReferenceService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/reference/MetadataReferenceService.java
@@ -685,8 +685,9 @@ public class MetadataReferenceService
                 Activator.logError("Error extracting line number from URI: " + sourceUri, e); //$NON-NLS-1$
             }
 
-            // Fallback: try to parse line from fragment
-            return extractLineNumberFromFragment(sourceUri.fragment());
+            // The URI fragment carries a method index, not a line number, so the line
+            // cannot be derived here; 0 signals "unknown line".
+            return 0;
         }
 
         /**
@@ -715,46 +716,6 @@ public class MetadataReferenceService
                 lineResolveResourceSet = rs;
             }
             return lineResolveResourceSet;
-        }
-
-        /**
-         * Fallback method to extract approximate line number from URI fragment.
-         */
-        private int extractLineNumberFromFragment(String fragment)
-        {
-            if (fragment == null || fragment.isEmpty())
-            {
-                return 0;
-            }
-
-            // Fragment format may contain method index info, e.g. "//@methods.5"
-            // This is not accurate but better than nothing
-            try
-            {
-                // Look for method index - methods typically correlate with lines
-                if (fragment.contains("@methods.")) //$NON-NLS-1$
-                {
-                    int idx = fragment.indexOf("@methods."); //$NON-NLS-1$
-                    String rest = fragment.substring(idx + 9);
-                    int endIdx = rest.indexOf('/');
-                    if (endIdx > 0)
-                    {
-                        rest = rest.substring(0, endIdx);
-                    }
-                    endIdx = rest.indexOf('@');
-                    if (endIdx > 0)
-                    {
-                        rest = rest.substring(0, endIdx);
-                    }
-                    // Method index is not line number, return 0 for now
-                }
-            }
-            catch (Exception e)
-            {
-                // Ignore
-            }
-
-            return 0;
         }
 
         private boolean isInternalReference(IBmCrossReference ref)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/ui/McpStatusContribution.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/ui/McpStatusContribution.java
@@ -198,7 +198,9 @@ public class McpStatusContribution extends WorkbenchWindowControlContribution
         {
             for (int x = 0; x < size; x++)
             {
-                double distance = Math.sqrt((x - centerX) * (x - centerX) + (y - centerY) * (y - centerY));
+                double dx = (double)x - centerX;
+                double dy = (double)y - centerY;
+                double distance = Math.sqrt(dx * dx + dy * dy);
                 if (distance <= radius - 0.5)
                 {
                     // Inside circle - fill color

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BuildUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BuildUtils.java
@@ -24,7 +24,7 @@ import com.ditrix.edt.mcp.server.Activator;
 public final class BuildUtils
 {
     /** Default timeout for waiting derived data computations (5 minutes) */
-    private static final long DEFAULT_DD_TIMEOUT_MS = 5 * 60 * 1000;
+    private static final long DEFAULT_DD_TIMEOUT_MS = 5L * 60 * 1000;
     
     private BuildUtils()
     {


### PR DESCRIPTION
Addresses issues surfaced by the new SonarCloud analysis. Scoped to **correctness** and **safe, behaviour-preserving** cleanups — no churn in the BM-write "think twice" tools.

## Bugs fixed (7 + 1 blocker)
- **S5866** `ReadMethodSourceTool` — the export-keyword regex used `(?i)` without the unicode flag, so case-insensitive matching did not fold the Cyrillic `Экспорт` (e.g. `ЭКСПОРТ` would not match). Now `(?iu)`. *(real bug for 1C BSL)*
- **S2142** `GetFormScreenshotTool` — re-interrupt the thread when the caught exception is an `InterruptedException`.
- **S4973** `CreateMetadataTool` — compare the normalized leaf name with `equals()` instead of reference `==`.
- **S1751** `PlatformDocumentationService` — take the first project explicitly instead of a loop that always returns on the first iteration.
- **S2184** ×3 (`BuildUtils`, `CleanProjectTool`, `McpStatusContribution`) — do the arithmetic in `long`/`double` before widening.
- **S3516 (blocker)** `MetadataReferenceService` — removed `extractLineNumberFromFragment`, which parsed the fragment into a discarded local and always returned 0; inlined `0` at its single call site.

## Duplicated literals (S1192)
- `ReadMethodSourceTool` — extracted the repeated JSON output keys + method-type tokens to constants. The input-parameter name literals are intentionally left inline (the `SchemaExecuteParamParityTest` ratchet requires them verbatim in both schema and `execute()`), which is why this rule is only partially addressable here.

## Deliberately NOT changed (false positives / out of scope)
- **S1872** (`FormLayoutSnapshotService`) and **S3077** ×6 (`McpServer`, `Log`, `GroupServiceImpl`, `McpProtocolHandler`) — false positives: the `V8Border` check is a runtime type with no compile-time `instanceof`, and the `volatile` fields publish references to already-thread-safe / immutable objects. Converting them adds no safety and would churn a "think twice" god-class.
- The bulk of the remaining smells (S3776 cognitive-complexity ×149, S135 ×56, S107 ×24, S3011 reflection ×24) are genuine refactors, not quick wins, and are left for a separate, focused pass.

Local `compile.sh` (full Tycho build + 2099 unit tests) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
