### PR TITLE
Fix: always set id=-1 on a created form's autoCommandBar

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -850,10 +850,18 @@ public final class FormElementWriter
         }
         // Guard: the factory may not run in this environment (its injector may be absent), or a future
         // change may stop seeding the command bar. Ensure the render-critical element is present.
-        if (singleReference(content, FEATURE_AUTO_COMMAND_BAR) == null)
+        EObject autoCommandBar = singleReference(content, FEATURE_AUTO_COMMAND_BAR);
+        if (autoCommandBar == null)
         {
-            setSingleReference(content, FEATURE_AUTO_COMMAND_BAR,
-                createDefaultAutoCommandBar(content, russianAutoNames));
+            autoCommandBar = createDefaultAutoCommandBar(content, russianAutoNames);
+            setSingleReference(content, FEATURE_AUTO_COMMAND_BAR, autoCommandBar);
+        }
+        // The FormObjectFactory-built bar does NOT carry the id=-1 sentinel a form's own predefined
+        // command bar requires, so EDT validation flags it (form-invalid-item-id). Enforce id=-1 on
+        // the bar regardless of who created it (the fallback bar already set it; this is idempotent).
+        if (autoCommandBar != null)
+        {
+            setIntFeature(autoCommandBar, FEATURE_ID, -1);
         }
         applyFormDefaults(content, version);
         return content;


### PR DESCRIPTION
create_metadata for a form object (createContentForm) seeded the render-critical autoCommandBar's id=-1 sentinel only inside the fallback helper createDefaultAutoCommandBar, which runs solely when the factory did NOT create the bar (the `if (autoCommandBar == null)` branch).

In a real EDT runtime the FormObjectFactory creates the autoCommandBar itself, so that branch is skipped and the bar is persisted without an id. EDT validation then flags every such form with form-invalid-item-id ("Некорректное значение идентификатора элемента формы").

Enforce id=-1 on the autoCommandBar unconditionally after it is obtained or created, regardless of which path produced it (the fallback already set it, so the call is idempotent).

Note: the existing headless FormElementWriterTest exercises the fallback path (formFactory=null), where id=-1 was already applied, so it did not catch the factory path. A factory-path regression test would need the EDT runtime.