### PR TITLE
Clean mechanical SonarCloud code smells (Tier A: 40 fixes)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/Activator.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/Activator.java
@@ -540,12 +540,7 @@ public class Activator extends AbstractUIPlugin
 
         // 3) Standard AWT headless flag (if provided by runtime)
         String awtHeadless = System.getProperty("java.awt.headless"); //$NON-NLS-1$
-        if ("true".equalsIgnoreCase(awtHeadless)) //$NON-NLS-1$
-        {
-            return true;
-        }
-
-        // Default to false (assume UI is available)
-        return false;
+        // Default to false (assume UI is available) unless the AWT headless flag is set.
+        return "true".equalsIgnoreCase(awtHeadless); //$NON-NLS-1$
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/repository/YamlGroupRepository.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/repository/YamlGroupRepository.java
@@ -86,7 +86,7 @@ public class YamlGroupRepository implements IGroupRepository {
             }
             
             // Cleanup orphaned FQNs (objects that might have been deleted)
-            cleanupOrphanedFqns(project, storage);
+            cleanupOrphanedFqns(storage);
             
             return storage;
             
@@ -149,7 +149,7 @@ public class YamlGroupRepository implements IGroupRepository {
             IFile groupsFile = project.getFile(GROUPS_PATH);
             
             // Use file locking for concurrent access protection
-            return saveWithLock(project, groupsFile, content);
+            return saveWithLock(groupsFile, content);
             
         } catch (CoreException e) {
             Activator.logError("Failed to save groups for project " + project.getName(), e);
@@ -171,7 +171,7 @@ public class YamlGroupRepository implements IGroupRepository {
     /**
      * Saves content with file lock for concurrent access protection.
      */
-    private boolean saveWithLock(IProject project, IFile groupsFile, byte[] content) {
+    private boolean saveWithLock(IFile groupsFile, byte[] content) {
         Path filePath = groupsFile.getLocation() != null 
             ? groupsFile.getLocation().toFile().toPath() 
             : null;
@@ -249,7 +249,7 @@ public class YamlGroupRepository implements IGroupRepository {
      * Cleans up orphaned FQNs (metadata objects that no longer exist).
      * This is called during load to ensure storage consistency.
      */
-    private void cleanupOrphanedFqns(IProject project, GroupStorage storage) {
+    private void cleanupOrphanedFqns(GroupStorage storage) {
         // Note: Full orphan detection requires BM access which should be done lazily
         // Here we just clean obviously invalid FQNs (empty, null)
         for (Group group : storage.getGroups()) {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolsTab.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolsTab.java
@@ -277,7 +277,10 @@ public class ToolsTab
         treeViewer.addTreeListener(new ITreeViewerListener()
         {
             @Override
-            public void treeCollapsed(TreeExpansionEvent event) { }
+            public void treeCollapsed(TreeExpansionEvent event)
+            {
+                // No action needed on collapse; check states are only set lazily on expand.
+            }
 
             @Override
             public void treeExpanded(TreeExpansionEvent event)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/FilterByTagDialog.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/FilterByTagDialog.java
@@ -608,10 +608,7 @@ public class FilterByTagDialog extends SelectionDialog {
                 return true;
             }
             String description = tag.getDescription();
-            if (description != null && description.toLowerCase().contains(searchPattern)) {
-                return true;
-            }
-            return false;
+            return description != null && description.toLowerCase().contains(searchPattern);
         }
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/FilterByTagManager.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/FilterByTagManager.java
@@ -61,9 +61,7 @@ public class FilterByTagManager {
      */
     private void resetToggleState() {
         // Delay execution to ensure command service is available
-        org.eclipse.swt.widgets.Display.getDefault().asyncExec(() -> {
-            updateToggleState(false);
-        });
+        org.eclipse.swt.widgets.Display.getDefault().asyncExec(() -> updateToggleState(false));
     }
     
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagColorIconFactory.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagColorIconFactory.java
@@ -202,11 +202,10 @@ public final class TagColorIconFactory {
                 }
                 
                 color.dispose();
-                
+
                 // Get the image data
-                ImageData result = image.getImageData();
-                return result;
-                
+                return image.getImageData();
+
             } finally {
                 gc.dispose();
                 image.dispose();
@@ -276,11 +275,10 @@ public final class TagColorIconFactory {
                 }
                 
                 color.dispose();
-                
+
                 // Get the image data
-                ImageData result = image.getImageData();
-                return result;
-                
+                return image.getImageData();
+
             } finally {
                 gc.dispose();
                 image.dispose();

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagFilterView.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagFilterView.java
@@ -973,9 +973,7 @@ public class TagFilterView extends ViewPart implements ITagChangeListener {
     
     @Override
     public void onTagsChanged(IProject project) {
-        Display.getDefault().asyncExec(() -> {
-            refreshTagsTree();
-        });
+        Display.getDefault().asyncExec(() -> refreshTagsTree());
     }
     
     @Override

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagLabelDecorator.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagLabelDecorator.java
@@ -120,9 +120,7 @@ public class TagLabelDecorator implements ILightweightLabelDecorator, ITagChange
         
         if (!refreshPending) {
             refreshPending = true;
-            org.eclipse.swt.widgets.Display.getDefault().timerExec((int) REFRESH_DEBOUNCE_MS, () -> {
-                executeRefresh();
-            });
+            org.eclipse.swt.widgets.Display.getDefault().timerExec((int) REFRESH_DEBOUNCE_MS, () -> executeRefresh());
         }
     }
     
@@ -136,9 +134,7 @@ public class TagLabelDecorator implements ILightweightLabelDecorator, ITagChange
         
         if (elapsed < REFRESH_DEBOUNCE_MS) {
             // More requests came in, reschedule
-            org.eclipse.swt.widgets.Display.getDefault().timerExec((int) (REFRESH_DEBOUNCE_MS - elapsed), () -> {
-                executeRefresh();
-            });
+            org.eclipse.swt.widgets.Display.getDefault().timerExec((int) (REFRESH_DEBOUNCE_MS - elapsed), () -> executeRefresh());
         } else {
             // Debounce period passed, execute refresh
             refreshPending = false;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagSearchFilter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagSearchFilter.java
@@ -102,6 +102,7 @@ public class TagSearchFilter extends ViewerFilter {
      * Default constructor for extension factory.
      */
     public TagSearchFilter() {
+        // No initialization needed; required by the extension factory.
     }
     
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagSearchFilter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagSearchFilter.java
@@ -220,13 +220,13 @@ public class TagSearchFilter extends ViewerFilter {
         }
         
         // Use the shared filtering logic
-        return selectByMatchingFqns(viewer, parentElement, element);
+        return selectByMatchingFqns(parentElement, element);
     }
     
     /**
      * Shared filtering logic - checks if element matches the current matching FQNs.
      */
-    private boolean selectByMatchingFqns(Viewer viewer, Object parentElement, Object element) {
+    private boolean selectByMatchingFqns(Object parentElement, Object element) {
         // If no matching FQNs, show everything
         if (matchingFqns.isEmpty() && matchingFqnsByProject.isEmpty()) {
             return true;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetConfigurationPropertiesTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetConfigurationPropertiesTool.java
@@ -108,9 +108,7 @@ public class GetConfigurationPropertiesTool implements IMcpTool
         {
             // Execute in UI thread
             Activator.logInfo("getConfigurationProperties: Switching to UI thread..."); //$NON-NLS-1$
-            display.syncExec(() -> {
-                result[0] = getConfigurationPropertiesInternal(projectName);
-            });
+            display.syncExec(() -> result[0] = getConfigurationPropertiesInternal(projectName));
         }
         
         return result[0];

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
@@ -265,7 +265,7 @@ public class GetMethodCallHierarchyTool implements IMcpTool
             }
         }
 
-        return formatCallersOutput(modulePath, methodName, callers, limit, totalReferences);
+        return formatCallersOutput(modulePath, methodName, callers, totalReferences);
     }
 
     /**
@@ -522,7 +522,7 @@ public class GetMethodCallHierarchyTool implements IMcpTool
             }
         }
 
-        return formatCalleesOutput(modulePath, methodName, callees, limit, totalInvocations);
+        return formatCalleesOutput(modulePath, methodName, callees, totalInvocations);
     }
 
     // ========== Helper methods ==========
@@ -574,7 +574,7 @@ public class GetMethodCallHierarchyTool implements IMcpTool
     }
 
     private String formatCallersOutput(String modulePath, String methodName,
-                                        List<CallerInfo> callers, int limit, int totalReferences)
+                                        List<CallerInfo> callers, int totalReferences)
     {
         StringBuilder sb = new StringBuilder();
         sb.append("## Call Hierarchy: ").append(modulePath).append(" :: ").append(methodName).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
@@ -609,7 +609,7 @@ public class GetMethodCallHierarchyTool implements IMcpTool
     }
 
     private String formatCalleesOutput(String modulePath, String methodName,
-                                        List<CalleeInfo> callees, int limit, int totalInvocations)
+                                        List<CalleeInfo> callees, int totalInvocations)
     {
         StringBuilder sb = new StringBuilder();
         sb.append("## Call Hierarchy: ").append(modulePath).append(" :: ").append(methodName).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -514,11 +514,7 @@ public class GetProjectErrorsTool implements IMcpTool
         {
             return true;
         }
-        if (symbolicCheckId != null && symbolicCheckId.toLowerCase().contains(needle))
-        {
-            return true;
-        }
-        return false;
+        return symbolicCheckId != null && symbolicCheckId.toLowerCase().contains(needle);
     }
     
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GoToDefinitionTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GoToDefinitionTool.java
@@ -214,11 +214,11 @@ public class GoToDefinitionTool implements IMcpTool
         MdObject mdObject = findMdObjectByFqn(config, firstPart, secondPart);
         if (mdObject != null)
         {
-            return formatMetadataDefinition(project, projectName, config, mdObject, firstPart, secondPart);
+            return formatMetadataDefinition(project, projectName, mdObject, firstPart);
         }
 
         // 3. Nothing found — provide suggestions
-        return buildNotFoundResponse(project, config, firstPart, secondPart);
+        return buildNotFoundResponse(config, firstPart, secondPart);
     }
 
     /**
@@ -463,8 +463,8 @@ public class GoToDefinitionTool implements IMcpTool
      * Formats a metadata object definition result.
      * Includes the object type, available modules, and module paths.
      */
-    private String formatMetadataDefinition(IProject project, String projectName, Configuration config,
-                                             MdObject mdObject, String typeName, String objectName)
+    private String formatMetadataDefinition(IProject project, String projectName,
+                                             MdObject mdObject, String typeName)
     {
         String collectionFolder = getCollectionFolder(typeName);
 
@@ -565,7 +565,7 @@ public class GoToDefinitionTool implements IMcpTool
      * If firstPart is a recognized metadata type, shows similar objects of that type.
      * Otherwise, shows similar common modules.
      */
-    private String buildNotFoundResponse(IProject project, Configuration config,
+    private String buildNotFoundResponse(Configuration config,
                                           String firstPart, String secondPart)
     {
         StringBuilder sb = new StringBuilder();

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/AbstractMetadataFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/AbstractMetadataFormatter.java
@@ -316,7 +316,7 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
             }
 
             Object value = eObject.eGet(feature);
-            String valueStr = formatDynamicValue(value, feature, language);
+            String valueStr = formatDynamicValue(value, language);
 
             // Show all properties, even empty ones - use empty string for null/empty values
             if (valueStr == null || valueStr.equals(DASH))
@@ -418,7 +418,7 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
             for (EAttribute attr : simpleAttributes)
             {
                 Object value = eObject.eGet(attr);
-                String valueStr = formatDynamicValue(value, attr, language);
+                String valueStr = formatDynamicValue(value, language);
                 if (valueStr != null && !valueStr.isEmpty() && !valueStr.equals(DASH))
                 {
                     addPropertyRow(sb, formatFeatureName(attr.getName()), valueStr);
@@ -434,7 +434,7 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
             for (EReference ref : singleReferences)
             {
                 Object value = eObject.eGet(ref);
-                String valueStr = formatDynamicValue(value, ref, language);
+                String valueStr = formatDynamicValue(value, language);
                 if (valueStr != null && !valueStr.isEmpty() && !valueStr.equals(DASH))
                 {
                     addPropertyRow(sb, formatFeatureName(ref.getName()), valueStr);
@@ -550,7 +550,7 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
     /**
      * Format a dynamic value based on its type.
      */
-    protected String formatDynamicValue(Object value, EStructuralFeature feature, String language)
+    protected String formatDynamicValue(Object value, String language)
     {
         if (value == null)
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
@@ -198,7 +198,6 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
             {
                 // StandardAttributes are now formatted via formatStandardAttributes() method
                 // Skip them here to avoid duplication
-                continue;
             }
             else if (firstItem instanceof CharacteristicsDescription)
             {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
@@ -201,7 +201,7 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
             }
             else if (firstItem instanceof CharacteristicsDescription)
             {
-                formatCharacteristicsCollection(sb, collectionName, collection, language);
+                formatCharacteristicsCollection(sb, collectionName, collection);
             }
             else if (firstItem instanceof BasicTabularSection)
             {
@@ -216,7 +216,7 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
             else if (firstItem instanceof java.util.Map.Entry)
             {
                 // Handle EMap collections like Synonym, ObjectPresentation
-                formatMapEntryCollection(sb, collectionName, collection, language);
+                formatMapEntryCollection(sb, collectionName, collection);
             }
             else if (firstItem instanceof MdObject)
             {
@@ -224,7 +224,7 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
             }
             else if (firstItem instanceof EObject)
             {
-                formatEObjectCollection(sb, collectionName, collection, full, language);
+                formatEObjectCollection(sb, collectionName, collection);
             }
         }
     }
@@ -555,7 +555,7 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
      * Format a collection of characteristics descriptions as a single table.
      * Shows all properties of each CharacteristicsDescription using EMF reflection.
      */
-    private void formatCharacteristicsCollection(StringBuilder sb, String name, Collection<?> items, String language)
+    private void formatCharacteristicsCollection(StringBuilder sb, String name, Collection<?> items)
     {
         addSectionHeader(sb, name);
         startTable(sb, "Index", "Characteristic Types", "Key Field", "Types Filter Field", "Types Filter Value", "Characteristic Values", "Object Field", "Type Field", "Value Field"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$
@@ -623,7 +623,7 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
      * Displays as Language/Value table.
      */
     @SuppressWarnings("rawtypes")
-    private void formatMapEntryCollection(StringBuilder sb, String name, Collection<?> items, String language)
+    private void formatMapEntryCollection(StringBuilder sb, String name, Collection<?> items)
     {
         addSectionHeader(sb, name);
         startTable(sb, "Language", VALUE_TOKEN); //$NON-NLS-1$
@@ -706,11 +706,10 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
     /**
      * Format a collection of EObjects that are not MdObjects.
      */
-    private void formatEObjectCollection(StringBuilder sb, String name, Collection<?> items, 
-            boolean full, String language)
+    private void formatEObjectCollection(StringBuilder sb, String name, Collection<?> items)
     {
         addSectionHeader(sb, name);
-        
+
         boolean first = true;
         for (Object item : items)
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/reference/MetadataReferenceService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/reference/MetadataReferenceService.java
@@ -734,12 +734,7 @@ public class MetadataReferenceService
             }
 
             // Skip derived command interface (cmi/deriveddata package)
-            if (packageUri.contains("cmi") && packageUri.contains("deriveddata")) //$NON-NLS-1$ //$NON-NLS-2$
-            {
-                return true;
-            }
-
-            return false;
+            return packageUri.contains("cmi") && packageUri.contains("deriveddata"); //$NON-NLS-1$ //$NON-NLS-2$
         }
 
         private String getCategoryFromObject(IBmObject object)
@@ -833,13 +828,8 @@ public class MetadataReferenceService
             }
 
             // Skip paths starting with technical features
-            if (path.startsWith("Value types") || path.startsWith("Form context") //$NON-NLS-1$ //$NON-NLS-2$
-                || path.startsWith("Db view defs") || path.startsWith("Standard commands")) //$NON-NLS-1$ //$NON-NLS-2$
-            {
-                return true;
-            }
-
-            return false;
+            return path.startsWith("Value types") || path.startsWith("Form context") //$NON-NLS-1$ //$NON-NLS-2$
+                || path.startsWith("Db view defs") || path.startsWith("Standard commands"); //$NON-NLS-1$ //$NON-NLS-2$
         }
 
         /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/reference/MetadataReferenceService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/reference/MetadataReferenceService.java
@@ -799,7 +799,7 @@ public class MetadataReferenceService
             }
 
             // Build the inner path EDT-style: FeatureLabel.ObjectName.FeatureLabel...
-            String innerPath = buildInnerPathEdtStyle(sourceObject, topObject, ref.getFeature());
+            String innerPath = buildInnerPathEdtStyle(sourceObject, ref.getFeature());
 
             // Filter out internal/technical paths that EDT doesn't show
             if (innerPath != null && isInternalPath(innerPath))
@@ -865,11 +865,10 @@ public class MetadataReferenceService
          * Following EDT's TableItemsFactory algorithm.
          *
          * @param sourceObject the source object where reference is located
-         * @param topObject the top-level container
          * @param referenceFeature the feature that contains the reference
          * @return path string like "Items.List.Items.Owner.Data path"
          */
-        private String buildInnerPathEdtStyle(IBmObject sourceObject, IBmObject topObject, EStructuralFeature referenceFeature)
+        private String buildInnerPathEdtStyle(IBmObject sourceObject, EStructuralFeature referenceFeature)
         {
             // Build path exactly like EDT's TableItemsFactory.getTopObjectPathToReference
             // Path is built from source up to topObject: Deque<Pair<EObject, EStructuralFeature>>

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
@@ -638,8 +638,7 @@ public class MetadataRenameService
             Collection<?> matches = (Collection<?>) invokeMethod(supplier, "getMatches", //$NON-NLS-1$
                 new Class<?>[] {Change.class, getClassOrThrow("com._1c.g5.v8.dt.search.core.SimpleSearchResultCollector")}, //$NON-NLS-1$
                 normalChange, collector);
-            Map<String, ExactMatchInfo> exactMatchMap = toExactMatchMap(matches);
-            return exactMatchMap;
+            return toExactMatchMap(matches);
         }
         catch (Exception e)
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
@@ -126,7 +126,7 @@ public class MetadataRenameService
         Collection<IRefactoring> refactorings, int maxResults)
     {
         Map<String, ExactMatchInfo> exactMatches = buildExactMatchInfo(project, targetObject, newName);
-        List<ChangePoint> edtBslPreviewChanges = buildEdtBslPreviewChanges(project, targetObject, newName, exactMatches);
+        List<ChangePoint> edtBslPreviewChanges = buildEdtBslPreviewChanges(targetObject, newName, exactMatches);
         String oldName = targetObject.getName();
 
         // Phase 1: collect all changes and problems
@@ -647,7 +647,7 @@ public class MetadataRenameService
         }
     }
 
-    private List<ChangePoint> buildEdtBslPreviewChanges(IProject project, MdObject targetObject, String newName,
+    private List<ChangePoint> buildEdtBslPreviewChanges(MdObject targetObject, String newName,
         Map<String, ExactMatchInfo> exactMatches)
     {
         try

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/symbol/SymbolInfoService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/symbol/SymbolInfoService.java
@@ -103,7 +103,6 @@ public class SymbolInfoService
         final IFile targetFile = file;
         final int targetLine = line;
         final int targetColumn = column;
-        final String targetFilePath = filePath;
 
         AtomicReference<String> resultRef = new AtomicReference<>();
 
@@ -112,7 +111,7 @@ public class SymbolInfoService
         display.syncExec(() -> {
             try
             {
-                String result = executeOnUiThread(targetFile, targetLine, targetColumn, targetFilePath);
+                String result = executeOnUiThread(targetFile, targetLine, targetColumn);
                 resultRef.set(result);
             }
             catch (Exception e)
@@ -163,7 +162,7 @@ public class SymbolInfoService
     /**
      * Executes symbol info retrieval on UI thread.
      */
-    private String executeOnUiThread(IFile file, int line, int column, String filePath) throws Exception
+    private String executeOnUiThread(IFile file, int line, int column) throws Exception
     {
         IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
         if (window == null)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/ui/NavigatorToolbarCustomizer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/ui/NavigatorToolbarCustomizer.java
@@ -78,26 +78,32 @@ public class NavigatorToolbarCustomizer {
 
             @Override
             public void partBroughtToTop(IWorkbenchPartReference partRef) {
+                // Intentionally empty: IPartListener2 hook not needed here
             }
 
             @Override
             public void partClosed(IWorkbenchPartReference partRef) {
+                // Intentionally empty: IPartListener2 hook not needed here
             }
 
             @Override
             public void partDeactivated(IWorkbenchPartReference partRef) {
+                // Intentionally empty: IPartListener2 hook not needed here
             }
 
             @Override
             public void partHidden(IWorkbenchPartReference partRef) {
+                // Intentionally empty: IPartListener2 hook not needed here
             }
 
             @Override
             public void partVisible(IWorkbenchPartReference partRef) {
+                // Intentionally empty: IPartListener2 hook not needed here
             }
 
             @Override
             public void partInputChanged(IWorkbenchPartReference partRef) {
+                // Intentionally empty: IPartListener2 hook not needed here
             }
         };
 
@@ -121,10 +127,12 @@ public class NavigatorToolbarCustomizer {
 
             @Override
             public void windowActivated(IWorkbenchWindow window) {
+                // Intentionally empty: IWindowListener hook not needed here
             }
 
             @Override
             public void windowDeactivated(IWorkbenchWindow window) {
+                // Intentionally empty: IWindowListener hook not needed here
             }
         };
         PlatformUI.getWorkbench().addWindowListener(windowListener);
@@ -157,6 +165,7 @@ public class NavigatorToolbarCustomizer {
 
             @Override
             public void pageActivated(IWorkbenchPage page) {
+                // Intentionally empty: IPageListener hook not needed here
             }
         };
         window.addPageListener(pageListener);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslSyntaxChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslSyntaxChecker.java
@@ -210,7 +210,6 @@ public final class BslSyntaxChecker
             if (TRY_START.matcher(trimmed).find())
             {
                 stack.push(new String[] { TAG_TRY, String.valueOf(lineNum) });
-                continue;
             }
         }
 


### PR DESCRIPTION
SonarCloud **code-smell** cleanup requested in #164. Tier A = mechanical, **no behaviour change**; verified with `mvn clean verify` (2202 unit tests green). **40 smells fixed.**

## Fixed (40)

**Mechanical, file-local (26)**
- **S1186 (11)** — empty listener/contribution-manager callback stubs now carry a short intentional-empty comment (no `throw`, no logic, `@Override`/signature untouched).
- **S1126 (4)** — `if (c) { return true; } else { return false; }` collapsed to `return c;`.
- **S1602 (4)** — useless braces removed from single-statement lambdas.
- **S1488 (3)** — immediately-returned temporary variables inlined.
- **S3626 (2)** — redundant trailing `continue;` removed.

**S1172 unused method parameters (14)** — each confirmed unused, non-`@Override`, and file-local (all callers in the same file); the parameter was removed from the declaration and every in-file call site (the compiler enforces no call site was missed). Methods incl. `selectByMatchingFqns(viewer)`, `saveWithLock/cleanupOrphanedFqns(project)`, `executeOnUiThread(filePath)`, `formatCallers/CalleesOutput(limit)`, `formatMetadataDefinition(config,objectName)`, `format{Characteristics,MapEntry,EObject}Collection(language,full)`, `formatDynamicValue(feature)` (verified the one subclass does not override it), `buildInnerPathEdtStyle(topObject)`, etc.

Done via a fan-out of parallel agents over **disjoint files** (no merge conflicts by construction), integrated and built once per batch.

## Deliberately NOT "fixed" — false positives (recommend *Won't Fix* in SonarCloud)

Studying each before touching it mattered — these would **break** things if auto-fixed:

- **`Messages.java` — S1444 (×11) + S3008 (×11) = 22.** Eclipse **NLS** pattern: `public static String` fields are assigned **reflectively** by `NLS.initializeMessages(...)`, and the names must match the `.properties` keys. `final` breaks init; renaming breaks i18n.
- **S125 "commented-out code" (20).** On inspection every one is a genuine **explanatory comment** (security rationale, transaction semantics, BOM-detection note, …), not dead code — kept.

These 42 are best resolved as *Won't Fix / False Positive* in the SonarCloud UI (admin-only) rather than polluting the code with 42 suppressions.

## Skipped here (a later, careful cross-file pass)

- **VariableSerializer.serializeVariable(registry)** — `public static`, called from tests + other tools (cross-file signature change).
- **ChangePoint(... ignored ...)** — a constructor-chain placeholder; removing it cascades through two constructors + callers.

## Out of scope for this PR

Medium tier (S1192 duplicate-string→constant, S1168 null→empty-collection) and the complexity refactors (S3776/S6541) are later, separate PRs.

Note: code smells do **not** affect the quality gate (maintainability is already A) — this is pure hygiene.
