### PR TITLE
Extract duplicated string literals into constants (S1192, 85 fixes)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/AddToGroupHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/AddToGroupHandler.java
@@ -34,7 +34,9 @@ import com.ditrix.edt.mcp.server.tags.TagUtils;
  * Only enabled for top-level metadata objects (with FQN like Type.Name).
  */
 public class AddToGroupHandler extends AbstractHandler {
-    
+
+    private static final String ADD_TO_GROUP = "Add to Group";
+
     @Override
     public void setEnabled(Object evaluationContext) {
         // Check if selection contains at least one top-level object
@@ -97,7 +99,7 @@ public class AddToGroupHandler extends AbstractHandler {
         }
         
         if (selectedObjects.isEmpty() || project == null || objectType == null) {
-            MessageDialog.openWarning(shell, "Add to Group", 
+            MessageDialog.openWarning(shell, ADD_TO_GROUP,
                 "Please select one or more top-level metadata objects to add to a group.");
             return null;
         }
@@ -110,7 +112,7 @@ public class AddToGroupHandler extends AbstractHandler {
             .toList();
         
         if (matchingGroups.isEmpty()) {
-            MessageDialog.openInformation(shell, "Add to Group", 
+            MessageDialog.openInformation(shell, ADD_TO_GROUP,
                 "No groups exist for " + objectType + ".\n" +
                 "Create a group first using 'New Group...' on the " + objectType + " folder.");
             return null;
@@ -126,7 +128,7 @@ public class AddToGroupHandler extends AbstractHandler {
                 return super.getText(element);
             }
         });
-        dialog.setTitle("Add to Group");
+        dialog.setTitle(ADD_TO_GROUP);
         dialog.setMessage("Select target group for " + objectType + ":");
         dialog.setElements(matchingGroups.toArray());
         dialog.setMultipleSelection(false);
@@ -163,10 +165,10 @@ public class AddToGroupHandler extends AbstractHandler {
         
         // Show result
         if (successCount > 0) {
-            MessageDialog.openInformation(shell, "Add to Group", 
+            MessageDialog.openInformation(shell, ADD_TO_GROUP,
                 "Added " + successCount + " object(s) to group '" + targetGroup.getName() + "'.");
         } else if (failCount > 0) {
-            MessageDialog.openWarning(shell, "Add to Group", 
+            MessageDialog.openWarning(shell, ADD_TO_GROUP,
                 "Failed to add objects. They may already be in the group.");
         }
         

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/RemoveFromGroupHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/RemoveFromGroupHandler.java
@@ -31,7 +31,9 @@ import com.ditrix.edt.mcp.server.tags.TagUtils;
  * Works on EObjects that are currently in a group.
  */
 public class RemoveFromGroupHandler extends AbstractHandler {
-    
+
+    private static final String REMOVE_FROM_GROUP = "Remove from Group";
+
     @Override
     public void setEnabled(Object evaluationContext) {
         // Check if selection contains objects that are in groups
@@ -102,7 +104,7 @@ public class RemoveFromGroupHandler extends AbstractHandler {
             ? "Remove this object from its group?"
             : "Remove " + objectsToRemove.size() + " objects from their groups?";
         
-        if (!MessageDialog.openConfirm(shell, "Remove from Group", message)) {
+        if (!MessageDialog.openConfirm(shell, REMOVE_FROM_GROUP, message)) {
             return null;
         }
         
@@ -126,10 +128,10 @@ public class RemoveFromGroupHandler extends AbstractHandler {
         
         // Show result
         if (successCount > 0 && failCount == 0) {
-            MessageDialog.openInformation(shell, "Remove from Group", 
+            MessageDialog.openInformation(shell, REMOVE_FROM_GROUP,
                 "Removed " + successCount + " object(s) from their groups.");
         } else if (failCount > 0) {
-            MessageDialog.openWarning(shell, "Remove from Group", 
+            MessageDialog.openWarning(shell, REMOVE_FROM_GROUP,
                 "Removed " + successCount + " object(s), failed to remove " + failCount + " object(s).");
         }
         

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolParameterSettings.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolParameterSettings.java
@@ -27,6 +27,11 @@ public final class ToolParameterSettings
     /** Preference key prefix for tool parameters */
     private static final String KEY_PREFIX = "tool."; //$NON-NLS-1$
 
+    /** Common "limit" result-cap parameter name shared by several tools. */
+    private static final String LIMIT = "limit"; //$NON-NLS-1$
+    /** Display name for the shared "limit" parameter. */
+    private static final String RESULT_LIMIT = "Result limit"; //$NON-NLS-1$
+
     private static final ToolParameterSettings INSTANCE = new ToolParameterSettings();
 
     /**
@@ -91,23 +96,23 @@ public final class ToolParameterSettings
         Map<String, List<ParameterDef>> map = new LinkedHashMap<>();
 
         map.put("get_project_errors", Collections.singletonList( //$NON-NLS-1$
-            new ParameterDef("limit", "Result limit", //$NON-NLS-1$ //$NON-NLS-2$
+            new ParameterDef(LIMIT, RESULT_LIMIT,
                 "Default number of errors to return", 100, 1, 1000))); //$NON-NLS-1$
 
         map.put("get_markers", Collections.singletonList( //$NON-NLS-1$
-            new ParameterDef("limit", "Result limit", //$NON-NLS-1$ //$NON-NLS-2$
+            new ParameterDef(LIMIT, RESULT_LIMIT,
                 "Default number of markers to return", 100, 1, 1000))); //$NON-NLS-1$
 
         map.put("get_metadata_objects", Collections.singletonList( //$NON-NLS-1$
-            new ParameterDef("limit", "Result limit", //$NON-NLS-1$ //$NON-NLS-2$
+            new ParameterDef(LIMIT, RESULT_LIMIT,
                 "Default number of metadata objects to return", 100, 1, 1000))); //$NON-NLS-1$
 
         map.put("list_subsystems", Collections.singletonList( //$NON-NLS-1$
-            new ParameterDef("limit", "Result limit", //$NON-NLS-1$ //$NON-NLS-2$
+            new ParameterDef(LIMIT, RESULT_LIMIT,
                 "Default number of subsystems to return", 100, 1, 1000))); //$NON-NLS-1$
 
         map.put("get_content_assist", Collections.singletonList( //$NON-NLS-1$
-            new ParameterDef("limit", "Result limit", //$NON-NLS-1$ //$NON-NLS-2$
+            new ParameterDef(LIMIT, RESULT_LIMIT,
                 "Default number of content assist proposals to return", 100, 1, 1000))); //$NON-NLS-1$
 
         map.put("search_in_code", Arrays.asList( //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/model/Tag.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/model/Tag.java
@@ -12,7 +12,10 @@ import java.util.Objects;
  * Represents a single tag that can be applied to metadata objects.
  */
 public class Tag {
-    
+
+    /** Default tag color (medium gray) used when none is supplied. */
+    private static final String DEFAULT_COLOR = "#808080";
+
     private String name;
     private String color;
     private String description;
@@ -23,7 +26,7 @@ public class Tag {
      * @param name the tag name
      */
     public Tag(String name) {
-        this(name, "#808080", "");
+        this(name, DEFAULT_COLOR, "");
     }
     
     /**
@@ -45,7 +48,7 @@ public class Tag {
      */
     public Tag(String name, String color, String description) {
         this.name = Objects.requireNonNull(name, "Tag name cannot be null");
-        this.color = color != null ? color : "#808080";
+        this.color = color != null ? color : DEFAULT_COLOR;
         this.description = description != null ? description : "";
     }
     
@@ -54,7 +57,7 @@ public class Tag {
      */
     public Tag() {
         this.name = "";
-        this.color = "#808080";
+        this.color = DEFAULT_COLOR;
         this.description = "";
     }
     

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagFilterView.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagFilterView.java
@@ -72,6 +72,9 @@ public class TagFilterView extends ViewPart implements ITagChangeListener {
     
     /** Size of color icons for tags */
     private static final int COLOR_ICON_SIZE = 16;
+
+    /** Placeholder/tooltip text for the search field */
+    private static final String SEARCH_REGEX_HINT = "Search (regex)...";
     
     private TagService tagService;
     private IV8ProjectManager v8ProjectManager;
@@ -470,7 +473,7 @@ public class TagFilterView extends ViewPart implements ITagChangeListener {
         
         // Search field
         searchText = new Text(group, SWT.BORDER | SWT.SEARCH | SWT.ICON_SEARCH | SWT.ICON_CANCEL);
-        searchText.setMessage("Search (regex)...");
+        searchText.setMessage(SEARCH_REGEX_HINT);
         GridData searchData = new GridData(SWT.FILL, SWT.CENTER, true, false);
         searchText.setLayoutData(searchData);
         searchText.addModifyListener(e -> {
@@ -692,11 +695,11 @@ public class TagFilterView extends ViewPart implements ITagChangeListener {
         String text = searchText.getText().trim();
         if (text.isEmpty()) {
             searchPattern = null;
-            searchText.setToolTipText("Search (regex)...");
+            searchText.setToolTipText(SEARCH_REGEX_HINT);
         } else {
             try {
                 searchPattern = Pattern.compile(text, Pattern.CASE_INSENSITIVE);
-                searchText.setToolTipText("Search (regex)...");
+                searchText.setToolTipText(SEARCH_REGEX_HINT);
             } catch (PatternSyntaxException e) {
                 // Invalid regex - show error in tooltip
                 searchText.setToolTipText("Invalid regex: " + e.getDescription());

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugStatusTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugStatusTool.java
@@ -39,6 +39,8 @@ public class DebugStatusTool implements IMcpTool
 {
     public static final String NAME = "debug_status"; //$NON-NLS-1$
 
+    private static final String APPLICATION_ID = "applicationId"; //$NON-NLS-1$
+
     @Override
     public String getName()
     {
@@ -60,7 +62,7 @@ public class DebugStatusTool implements IMcpTool
     public String getInputSchema()
     {
         return JsonSchemaBuilder.object()
-            .stringProperty("applicationId", "Optional application id filter") //$NON-NLS-1$ //$NON-NLS-2$
+            .stringProperty(APPLICATION_ID, "Optional application id filter") //$NON-NLS-1$
             .build();
     }
 
@@ -87,7 +89,7 @@ public class DebugStatusTool implements IMcpTool
     @Override
     public String execute(Map<String, String> params)
     {
-        String filterAppId = JsonUtils.extractStringArgument(params, "applicationId"); //$NON-NLS-1$
+        String filterAppId = JsonUtils.extractStringArgument(params, APPLICATION_ID);
 
         DebugSessionRegistry.get().ensureListenerRegistered();
 
@@ -119,7 +121,7 @@ public class DebugStatusTool implements IMcpTool
                 }
 
                 Map<String, Object> entry = new LinkedHashMap<>();
-                entry.put("applicationId", appId); //$NON-NLS-1$
+                entry.put(APPLICATION_ID, appId);
                 entry.put("mode", launch.getLaunchMode()); //$NON-NLS-1$
                 entry.put("debug", ILaunchManager.DEBUG_MODE.equals(launch.getLaunchMode())); //$NON-NLS-1$
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GenerateTranslationStringsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GenerateTranslationStringsTool.java
@@ -58,6 +58,13 @@ public class GenerateTranslationStringsTool implements IMcpTool
     private static final String FILL_UP_FROM_PROVIDER = "FROM_PROVIDER"; //$NON-NLS-1$
     private static final String V8_CONFIGURATION_NATURE = "com._1c.g5.v8.dt.core.V8ConfigurationNature"; //$NON-NLS-1$
 
+    private static final String TARGET_LANGUAGES = "targetLanguages"; //$NON-NLS-1$
+    private static final String STORAGE_ID = "storageId"; //$NON-NLS-1$
+    private static final String COLLECT_INTERFACE = "collectInterface"; //$NON-NLS-1$
+    private static final String COLLECT_MODEL = "collectModel"; //$NON-NLS-1$
+    private static final String COLLECT_MODEL_TYPE = "collectModelType"; //$NON-NLS-1$
+    private static final String FILL_UP_TYPE = "fillUpType"; //$NON-NLS-1$
+
     @Override
     public String getName()
     {
@@ -82,17 +89,17 @@ public class GenerateTranslationStringsTool implements IMcpTool
             .stringProperty(McpKeys.PROJECT_NAME,
                 "Configuration project name (V8ConfigurationNature), not a dictionary storage project. Required.", //$NON-NLS-1$
                 true)
-            .stringArrayProperty("targetLanguages", //$NON-NLS-1$
+            .stringArrayProperty(TARGET_LANGUAGES,
                 "Target language codes to generate, e.g. [\"en\"]. Required.", true) //$NON-NLS-1$
-            .stringProperty("storageId", //$NON-NLS-1$
+            .stringProperty(STORAGE_ID,
                 "Storage ID to write keys into (see get_translation_project_info). Default: \"edit:default\".") //$NON-NLS-1$
-            .booleanProperty("collectInterface", //$NON-NLS-1$
+            .booleanProperty(COLLECT_INTERFACE,
                 "Generate interface (.lstr) keys. Default: true.") //$NON-NLS-1$
-            .booleanProperty("collectModel", //$NON-NLS-1$
+            .booleanProperty(COLLECT_MODEL,
                 "Generate model (.trans) keys. Default: true.") //$NON-NLS-1$
-            .stringProperty("collectModelType", //$NON-NLS-1$
+            .stringProperty(COLLECT_MODEL_TYPE,
                 "Model mode: ANY | NONE | COMPUTED_ONLY | UNKNOWN_ONLY | TAGS_ONLY. Default: ANY.") //$NON-NLS-1$
-            .stringProperty("fillUpType", //$NON-NLS-1$
+            .stringProperty(FILL_UP_TYPE,
                 "Pre-fill source: NOT_FILLUP | FROM_SOURCE_LANGUAGE | FROM_PROVIDER. Default: NOT_FILLUP.") //$NON-NLS-1$
             .stringProperty("providerId", //$NON-NLS-1$
                 "Translation provider ID; required only when fillUpType=FROM_PROVIDER (see get_translation_project_info).") //$NON-NLS-1$
@@ -109,12 +116,12 @@ public class GenerateTranslationStringsTool implements IMcpTool
     public String execute(Map<String, String> params)
     {
         String projectName = JsonUtils.extractStringArgument(params, McpKeys.PROJECT_NAME);
-        List<String> targetLanguages = JsonUtils.extractArrayArgument(params, "targetLanguages"); //$NON-NLS-1$
-        String storageId = JsonUtils.extractStringArgument(params, "storageId"); //$NON-NLS-1$
-        boolean collectInterface = JsonUtils.extractBooleanArgument(params, "collectInterface", true); //$NON-NLS-1$
-        boolean collectModel = JsonUtils.extractBooleanArgument(params, "collectModel", true); //$NON-NLS-1$
-        String collectModelType = JsonUtils.extractStringArgument(params, "collectModelType"); //$NON-NLS-1$
-        String fillUpType = JsonUtils.extractStringArgument(params, "fillUpType"); //$NON-NLS-1$
+        List<String> targetLanguages = JsonUtils.extractArrayArgument(params, TARGET_LANGUAGES);
+        String storageId = JsonUtils.extractStringArgument(params, STORAGE_ID);
+        boolean collectInterface = JsonUtils.extractBooleanArgument(params, COLLECT_INTERFACE, true);
+        boolean collectModel = JsonUtils.extractBooleanArgument(params, COLLECT_MODEL, true);
+        String collectModelType = JsonUtils.extractStringArgument(params, COLLECT_MODEL_TYPE);
+        String fillUpType = JsonUtils.extractStringArgument(params, FILL_UP_TYPE);
         String providerId = JsonUtils.extractStringArgument(params, "providerId"); //$NON-NLS-1$
 
         String err = JsonUtils.requireArgument(params, McpKeys.PROJECT_NAME);
@@ -236,12 +243,12 @@ public class GenerateTranslationStringsTool implements IMcpTool
             return FrontMatter.create()
                 .put("tool", NAME) //$NON-NLS-1$
                 .put(McpKeys.PROJECT, projectName)
-                .put("targetLanguages", String.join(", ", targetLanguages)) //$NON-NLS-1$ //$NON-NLS-2$
-                .put("storageId", storageId) //$NON-NLS-1$
-                .put("collectInterface", collectInterface) //$NON-NLS-1$
-                .put("collectModel", collectModel) //$NON-NLS-1$
-                .put("collectModelType", collectModelType) //$NON-NLS-1$
-                .put("fillUpType", fillUpType) //$NON-NLS-1$
+                .put(TARGET_LANGUAGES, String.join(", ", targetLanguages)) //$NON-NLS-1$
+                .put(STORAGE_ID, storageId)
+                .put(COLLECT_INTERFACE, collectInterface)
+                .put(COLLECT_MODEL, collectModel)
+                .put(COLLECT_MODEL_TYPE, collectModelType)
+                .put(FILL_UP_TYPE, fillUpType)
                 .put("status", "success") //$NON-NLS-1$ //$NON-NLS-2$
                 .wrapContent("Translation strings generated."); //$NON-NLS-1$
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetFormScreenshotTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetFormScreenshotTool.java
@@ -28,6 +28,9 @@ public class GetFormScreenshotTool implements IMcpTool
     public static final String NAME = "get_form_screenshot"; //$NON-NLS-1$
     private static final String WYSIWYG_VIEWER_FIELD = "wysiwygViewer"; //$NON-NLS-1$
 
+    /** Input param: form FQN to open and capture. */
+    private static final String KEY_FORM_PATH = "formPath"; //$NON-NLS-1$
+
     @Override
     public String getName()
     {
@@ -49,7 +52,7 @@ public class GetFormScreenshotTool implements IMcpTool
         return JsonSchemaBuilder.object()
             .stringProperty("projectName", //$NON-NLS-1$
                 "EDT project name. Required when formPath is specified.") //$NON-NLS-1$
-            .stringProperty("formPath", //$NON-NLS-1$
+            .stringProperty(KEY_FORM_PATH,
                 "Form FQN (e.g. 'Catalog.Products.Forms.ItemForm' or 'CommonForm.MyForm'); " + //$NON-NLS-1$
                 "if omitted, captures the active form editor.") //$NON-NLS-1$
             .booleanProperty("refresh", //$NON-NLS-1$
@@ -67,7 +70,7 @@ public class GetFormScreenshotTool implements IMcpTool
     @Override
     public String getResultFileName(Map<String, String> params)
     {
-        String formPath = params.get("formPath"); //$NON-NLS-1$
+        String formPath = params.get(KEY_FORM_PATH);
         if (formPath != null && !formPath.isEmpty())
         {
             String[] parts = formPath.split("\\."); //$NON-NLS-1$
@@ -83,7 +86,7 @@ public class GetFormScreenshotTool implements IMcpTool
     public String execute(Map<String, String> params)
     {
         String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
-        String formPath = JsonUtils.extractStringArgument(params, "formPath"); //$NON-NLS-1$
+        String formPath = JsonUtils.extractStringArgument(params, KEY_FORM_PATH);
         boolean refresh = "true".equalsIgnoreCase(JsonUtils.extractStringArgument(params, "refresh")); //$NON-NLS-1$ //$NON-NLS-2$
 
         if (formPath != null && !formPath.isEmpty()

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataObjectsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataObjectsTool.java
@@ -72,7 +72,9 @@ public class GetMetadataObjectsTool implements IMcpTool
     private static final String TYPE_COMMON_ATTRIBUTES = "commonattributes"; //$NON-NLS-1$
     private static final String TYPE_EVENT_SUBSCRIPTIONS = "eventsubscriptions"; //$NON-NLS-1$
     private static final String TYPE_SCHEDULED_JOBS = "scheduledjobs"; //$NON-NLS-1$
-    
+
+    private static final String LIMIT = "limit"; //$NON-NLS-1$
+
     @Override
     public String getName()
     {
@@ -102,7 +104,7 @@ public class GetMetadataObjectsTool implements IMcpTool
                 "eventSubscriptions, scheduledJobs") //$NON-NLS-1$
             .stringProperty("nameFilter", //$NON-NLS-1$
                 "Case-insensitive substring matched against Name only (not Synonym)") //$NON-NLS-1$
-            .integerProperty("limit", //$NON-NLS-1$
+            .integerProperty(LIMIT,
                 "Max rows (default from preferences: 100, max 1000)") //$NON-NLS-1$
             .stringProperty("language", //$NON-NLS-1$
                 "Synonym language code, e.g. 'en'/'ru' (default: configuration default)") //$NON-NLS-1$
@@ -149,8 +151,8 @@ public class GetMetadataObjectsTool implements IMcpTool
         // Note: language will be resolved from configuration default if null/empty
 
         int defaultLimit = ToolParameterSettings.getInstance()
-            .getParameterValue(NAME, "limit", 100); //$NON-NLS-1$
-        int limit = JsonUtils.extractIntArgument(params, "limit", defaultLimit); //$NON-NLS-1$
+            .getParameterValue(NAME, LIMIT, 100);
+        int limit = JsonUtils.extractIntArgument(params, LIMIT, defaultLimit);
         limit = Pagination.clampLimit(limit, 1000);
 
         // Execute on UI thread

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GoToDefinitionTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GoToDefinitionTool.java
@@ -50,6 +50,12 @@ public class GoToDefinitionTool implements IMcpTool
     /** Input param: the symbol to resolve (qualified method, bare method, or metadata FQN). */
     private static final String KEY_SYMBOL = "symbol"; //$NON-NLS-1$
 
+    /** Opening fence for a BSL code block. */
+    private static final String BSL_CODE_FENCE_OPEN = "```bsl\n"; //$NON-NLS-1$
+
+    /** Closing fence for a code block. */
+    private static final String CODE_FENCE_CLOSE = "```\n"; //$NON-NLS-1$
+
     @Override
     public String getName()
     {
@@ -329,12 +335,12 @@ public class GoToDefinitionTool implements IMcpTool
         {
             if (allLines != null)
             {
-                sb.append("```bsl\n"); //$NON-NLS-1$
+                sb.append(BSL_CODE_FENCE_OPEN);
                 for (int i = from - 1; i < to; i++)
                 {
                     sb.append(allLines.get(i)).append('\n');
                 }
-                sb.append("```\n"); //$NON-NLS-1$
+                sb.append(CODE_FENCE_CLOSE);
             }
             else
             {
@@ -342,13 +348,13 @@ public class GoToDefinitionTool implements IMcpTool
                 String sourceText = BslModuleUtils.getSourceText(method);
                 if (sourceText != null)
                 {
-                    sb.append("```bsl\n"); //$NON-NLS-1$
+                    sb.append(BSL_CODE_FENCE_OPEN);
                     sb.append(sourceText);
                     if (!sourceText.endsWith("\n")) //$NON-NLS-1$
                     {
                         sb.append('\n');
                     }
-                    sb.append("```\n"); //$NON-NLS-1$
+                    sb.append(CODE_FENCE_CLOSE);
                 }
             }
         }
@@ -410,12 +416,12 @@ public class GoToDefinitionTool implements IMcpTool
             StringBuilder sb = new StringBuilder();
             if (includeSource)
             {
-                sb.append("```bsl\n"); //$NON-NLS-1$
+                sb.append(BSL_CODE_FENCE_OPEN);
                 for (int i = methodStart; i <= methodEnd; i++)
                 {
                     sb.append(allLines.get(i)).append('\n');
                 }
-                sb.append("```\n"); //$NON-NLS-1$
+                sb.append(CODE_FENCE_CLOSE);
             }
 
             return fm.wrapContent(sb.toString());

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListModulesTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListModulesTool.java
@@ -58,6 +58,10 @@ public class ListModulesTool implements IMcpTool
 
     private static final int MAX_RECURSION_DEPTH = 20;
 
+    private static final String MODULE_BSL = "Module.bsl"; //$NON-NLS-1$
+    private static final String MODULE = "Module"; //$NON-NLS-1$
+    private static final String CONFIGURATION = "Configuration"; //$NON-NLS-1$
+
     @Override
     public String getName()
     {
@@ -189,7 +193,7 @@ public class ListModulesTool implements IMcpTool
             case "commonmodules": //$NON-NLS-1$
                 collectSingleModuleType(project, modules, objectName, nameFilter,
                     config.getCommonModules(), CommonModule::getName,
-                    "CommonModules", "Module.bsl", "Module", "CommonModule"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+                    "CommonModules", MODULE_BSL, MODULE, "CommonModule"); //$NON-NLS-1$ //$NON-NLS-2$
                 break;
             case "documents": //$NON-NLS-1$
                 collectMultiModuleType(project, modules, objectName, nameFilter,
@@ -244,17 +248,17 @@ public class ListModulesTool implements IMcpTool
             case "commonforms": //$NON-NLS-1$
                 collectSingleModuleType(project, modules, objectName, nameFilter,
                     config.getCommonForms(), CommonForm::getName,
-                    "CommonForms", "Module.bsl", "FormModule", "CommonForm"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+                    "CommonForms", MODULE_BSL, "FormModule", "CommonForm"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
                 break;
             case "webservices": //$NON-NLS-1$
                 collectSingleModuleType(project, modules, objectName, nameFilter,
                     config.getWebServices(), WebService::getName,
-                    "WebServices", "Module.bsl", "Module", "WebService"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+                    "WebServices", MODULE_BSL, MODULE, "WebService"); //$NON-NLS-1$ //$NON-NLS-2$
                 break;
             case "httpservices": //$NON-NLS-1$
                 collectSingleModuleType(project, modules, objectName, nameFilter,
                     config.getHttpServices(), HTTPService::getName,
-                    "HTTPServices", "Module.bsl", "Module", "HTTPService"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+                    "HTTPServices", MODULE_BSL, MODULE, "HTTPService"); //$NON-NLS-1$ //$NON-NLS-2$
                 break;
             default:
                 return ToolResult.error("Unknown metadata type: " + metadataType + //$NON-NLS-1$
@@ -386,10 +390,10 @@ public class ListModulesTool implements IMcpTool
                     String parentName;
                     String parentType;
 
-                    if ("Configuration".equals(collectionName)) //$NON-NLS-1$
+                    if (CONFIGURATION.equals(collectionName))
                     {
-                        parentName = "Configuration"; //$NON-NLS-1$
-                        parentType = "Configuration"; //$NON-NLS-1$
+                        parentName = CONFIGURATION;
+                        parentType = CONFIGURATION;
                     }
                     else
                     {
@@ -409,7 +413,7 @@ public class ListModulesTool implements IMcpTool
                         continue;
                     }
 
-                    String basePath = "Configuration".equals(collectionName) //$NON-NLS-1$
+                    String basePath = CONFIGURATION.equals(collectionName)
                         ? collectionName : collectionName + "/" + parentName; //$NON-NLS-1$
                     String moduleType = determineModuleType(modulePath, basePath);
 
@@ -529,13 +533,13 @@ public class ListModulesTool implements IMcpTool
             : fileName;
 
         // "Module.bsl" in Forms subfolder → FormModule
-        if ("Module".equals(baseName)) //$NON-NLS-1$
+        if (MODULE.equals(baseName))
         {
             if (relativePath.startsWith("Forms/")) //$NON-NLS-1$
             {
                 return "FormModule"; //$NON-NLS-1$
             }
-            return "Module"; //$NON-NLS-1$
+            return MODULE;
         }
 
         return baseName;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadMethodSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadMethodSourceTool.java
@@ -48,6 +48,8 @@ public class ReadMethodSourceTool implements IMcpTool
     private static final String KEY_END_LINE = "endLine"; //$NON-NLS-1$
     private static final String TYPE_PROCEDURE = "Procedure"; //$NON-NLS-1$
     private static final String TYPE_FUNCTION = "Function"; //$NON-NLS-1$
+    private static final String BSL_FENCE_OPEN = "```bsl\n"; //$NON-NLS-1$
+    private static final String FENCE_CLOSE = "```\n"; //$NON-NLS-1$
 
     @Override
     public String getName()
@@ -216,12 +218,12 @@ public class ReadMethodSourceTool implements IMcpTool
         }
 
         StringBuilder sb = new StringBuilder();
-        sb.append("```bsl\n"); //$NON-NLS-1$
+        sb.append(BSL_FENCE_OPEN);
         for (int i = from - 1; i < to; i++)
         {
             sb.append(allLines.get(i)).append('\n');
         }
-        sb.append("```\n"); //$NON-NLS-1$
+        sb.append(FENCE_CLOSE);
 
         // Extension interception: if this is a core method intercepted by an extension
         // (or an extension method that intercepts a core one), note it below the code.
@@ -313,12 +315,12 @@ public class ReadMethodSourceTool implements IMcpTool
             }
 
             StringBuilder sb = new StringBuilder();
-            sb.append("```bsl\n"); //$NON-NLS-1$
+            sb.append(BSL_FENCE_OPEN);
             for (int i = methodStart; i <= methodEnd; i++)
             {
                 sb.append(allLines.get(i)).append('\n');
             }
-            sb.append("```\n"); //$NON-NLS-1$
+            sb.append(FENCE_CLOSE);
 
             return fm.wrapContent(sb.toString());
         }
@@ -376,13 +378,13 @@ public class ReadMethodSourceTool implements IMcpTool
         StringBuilder sb = new StringBuilder();
         if (sourceText != null)
         {
-            sb.append("```bsl\n"); //$NON-NLS-1$
+            sb.append(BSL_FENCE_OPEN);
             sb.append(sourceText);
             if (!sourceText.endsWith("\n")) //$NON-NLS-1$
             {
                 sb.append('\n');
             }
-            sb.append("```\n"); //$NON-NLS-1$
+            sb.append(FENCE_CLOSE);
         }
 
         return fm.wrapContent(sb.toString());

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceTool.java
@@ -39,6 +39,9 @@ public class ReadModuleSourceTool implements IMcpTool
 {
     public static final String NAME = "read_module_source"; //$NON-NLS-1$
 
+    private static final String START_LINE = "startLine"; //$NON-NLS-1$
+    private static final String END_LINE = "endLine"; //$NON-NLS-1$
+
     /** Fallback when the {@code maxLines} tool parameter is not configured */
     private static final int DEFAULT_MAX_LINES = 500;
 
@@ -66,9 +69,9 @@ public class ReadModuleSourceTool implements IMcpTool
                 "EDT project name (required)", true) //$NON-NLS-1$
             .stringProperty(McpKeys.MODULE_PATH,
                 "Path from src/, e.g. 'CommonModules/MyModule/Module.bsl' (required)", true) //$NON-NLS-1$
-            .integerProperty("startLine", //$NON-NLS-1$
+            .integerProperty(START_LINE,
                 "First line, 1-based inclusive; omit to read from the start.") //$NON-NLS-1$
-            .integerProperty("endLine", //$NON-NLS-1$
+            .integerProperty(END_LINE,
                 "Last line, 1-based inclusive; omit to read to the end.") //$NON-NLS-1$
             .build();
     }
@@ -103,8 +106,8 @@ public class ReadModuleSourceTool implements IMcpTool
 
         String projectName = JsonUtils.extractStringArgument(params, McpKeys.PROJECT_NAME);
         String modulePath = JsonUtils.extractStringArgument(params, McpKeys.MODULE_PATH);
-        int startLine = JsonUtils.extractIntArgument(params, "startLine", -1); //$NON-NLS-1$
-        int endLine = JsonUtils.extractIntArgument(params, "endLine", -1); //$NON-NLS-1$
+        int startLine = JsonUtils.extractIntArgument(params, START_LINE, -1);
+        int endLine = JsonUtils.extractIntArgument(params, END_LINE, -1);
 
         err = JsonUtils.requireArgument(params, McpKeys.MODULE_PATH, ". Example: 'CommonModules/MyModule/Module.bsl'"); //$NON-NLS-1$
         if (err != null)
@@ -216,8 +219,8 @@ public class ReadModuleSourceTool implements IMcpTool
 
         if (totalLines > 0)
         {
-            fm.put("startLine", from) //$NON-NLS-1$
-                .put("endLine", to); //$NON-NLS-1$
+            fm.put(START_LINE, from)
+                .put(END_LINE, to);
         }
 
         fm.put("totalLines", totalLines); //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SearchInCodeTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SearchInCodeTool.java
@@ -58,6 +58,15 @@ public class SearchInCodeTool implements IMcpTool
     private static final String MODE_COUNT = "count"; //$NON-NLS-1$
     private static final String MODE_FILES = "files"; //$NON-NLS-1$
 
+    /** Input param: lines of context before/after each match. */
+    private static final String KEY_CONTEXT_LINES = "contextLines"; //$NON-NLS-1$
+
+    /** Closing quote of a heading echoing the query, followed by a blank line. */
+    private static final String QUOTE_NEWLINES = "\"\n\n"; //$NON-NLS-1$
+
+    /** Markdown prefix for inline warnings in the rendered output. */
+    private static final String WARNING_PREFIX = "**Warning:** "; //$NON-NLS-1$
+
     @Override
     public String getName()
     {
@@ -92,7 +101,7 @@ public class SearchInCodeTool implements IMcpTool
                 "Max matches returned with context. Default: 100, max: 500") //$NON-NLS-1$
             .integerProperty(KEY_MAX_RESULTS,
                 "Deprecated alias for 'limit'. Default: 100, max: 500") //$NON-NLS-1$
-            .integerProperty("contextLines", //$NON-NLS-1$
+            .integerProperty(KEY_CONTEXT_LINES,
                 "Lines of context before/after each match. Default: 2, max: 5") //$NON-NLS-1$
             .stringProperty("fileMask", //$NON-NLS-1$
                 "Filter by module path substring (e.g. 'CommonModules' or 'Documents/SalesOrder')") //$NON-NLS-1$
@@ -138,12 +147,12 @@ public class SearchInCodeTool implements IMcpTool
         int configuredMaxResults = ToolParameterSettings.getInstance()
             .getParameterValue(NAME, KEY_MAX_RESULTS, DEFAULT_MAX_RESULTS);
         int configuredContextLines = ToolParameterSettings.getInstance()
-            .getParameterValue(NAME, "contextLines", DEFAULT_CONTEXT_LINES); //$NON-NLS-1$
+            .getParameterValue(NAME, KEY_CONTEXT_LINES, DEFAULT_CONTEXT_LINES);
         // Canonical param is "limit" (consistent with other paginated tools);
         // "maxResults" is kept as a deprecated alias (precedence: limit, then maxResults).
         int maxResultsAlias = JsonUtils.extractIntArgument(params, KEY_MAX_RESULTS, configuredMaxResults);
         int maxResults = JsonUtils.extractIntArgument(params, "limit", maxResultsAlias); //$NON-NLS-1$
-        int contextLines = JsonUtils.extractIntArgument(params, "contextLines", configuredContextLines); //$NON-NLS-1$
+        int contextLines = JsonUtils.extractIntArgument(params, KEY_CONTEXT_LINES, configuredContextLines);
         String fileMask = JsonUtils.extractStringArgument(params, "fileMask"); //$NON-NLS-1$
         String metadataType = JsonUtils.extractStringArgument(params, "metadataType"); //$NON-NLS-1$
         String outputMode = JsonUtils.extractStringArgument(params, "outputMode"); //$NON-NLS-1$
@@ -252,13 +261,13 @@ public class SearchInCodeTool implements IMcpTool
     private String formatCountOutput(String query, SearchCollector collector)
     {
         StringBuilder sb = new StringBuilder();
-        sb.append("## Search Count for \"").append(query).append("\"\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("## Search Count for \"").append(query).append(QUOTE_NEWLINES); //$NON-NLS-1$
         sb.append("**Total matches:** ").append(collector.totalMatches); //$NON-NLS-1$
         sb.append(" in **").append(collector.totalMatchedFiles).append("** files\n"); //$NON-NLS-1$ //$NON-NLS-2$
 
         if (collector.skippedFiles > 0)
         {
-            sb.append("**Warning:** ").append(collector.skippedFiles) //$NON-NLS-1$
+            sb.append(WARNING_PREFIX).append(collector.skippedFiles)
               .append(" file(s) could not be read\n"); //$NON-NLS-1$
         }
         if (collector.wasInterrupted())
@@ -274,13 +283,13 @@ public class SearchInCodeTool implements IMcpTool
     private String formatFilesOutput(String query, SearchCollector collector)
     {
         StringBuilder sb = new StringBuilder();
-        sb.append("## Search Files for \"").append(query).append("\"\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("## Search Files for \"").append(query).append(QUOTE_NEWLINES); //$NON-NLS-1$
         sb.append("**Total matches:** ").append(collector.totalMatches); //$NON-NLS-1$
         sb.append(" in **").append(collector.totalMatchedFiles).append("** files\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
 
         if (collector.skippedFiles > 0)
         {
-            sb.append("**Warning:** ").append(collector.skippedFiles) //$NON-NLS-1$
+            sb.append(WARNING_PREFIX).append(collector.skippedFiles)
               .append(" file(s) could not be read\n\n"); //$NON-NLS-1$
         }
         if (collector.wasInterrupted())
@@ -310,7 +319,7 @@ public class SearchInCodeTool implements IMcpTool
     private String formatFullOutput(String query, SearchCollector collector)
     {
         StringBuilder sb = new StringBuilder();
-        sb.append("## Search Results for \"").append(query).append("\"\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("## Search Results for \"").append(query).append(QUOTE_NEWLINES); //$NON-NLS-1$
 
         int totalMatches = collector.totalMatches;
         int totalFiles = collector.totalMatchedFiles;
@@ -323,7 +332,7 @@ public class SearchInCodeTool implements IMcpTool
 
         if (collector.skippedFiles > 0)
         {
-            sb.append("**Warning:** ").append(collector.skippedFiles) //$NON-NLS-1$
+            sb.append(WARNING_PREFIX).append(collector.skippedFiles)
               .append(" file(s) could not be read (check EDT Error Log)\n"); //$NON-NLS-1$
         }
         if (collector.wasInterrupted())

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchTool.java
@@ -82,6 +82,18 @@ public class TerminateLaunchTool implements IMcpTool
     /** Input key: deprecated alias of the 'timeout' wait window in seconds. */
     private static final String KEY_TIMEOUT_SECONDS = "timeoutSeconds"; //$NON-NLS-1$
 
+    /** Input key: exact launch configuration name (single-launch mode). */
+    private static final String KEY_LAUNCH_CONFIGURATION_NAME = "launchConfigurationName"; //$NON-NLS-1$
+
+    /** Input key: EDT project name. */
+    private static final String KEY_PROJECT_NAME = "projectName"; //$NON-NLS-1$
+
+    /** Input key: application ID from get_applications. */
+    private static final String KEY_APPLICATION_ID = "applicationId"; //$NON-NLS-1$
+
+    /** Sanitization pattern: any char outside [a-zA-Z0-9._-] for safe file names. */
+    private static final String UNSAFE_FILENAME_CHARS = "[^a-zA-Z0-9._-]"; //$NON-NLS-1$
+
     @Override
     public String getName()
     {
@@ -101,11 +113,11 @@ public class TerminateLaunchTool implements IMcpTool
     public String getInputSchema()
     {
         return JsonSchemaBuilder.object()
-            .stringProperty("launchConfigurationName", //$NON-NLS-1$
+            .stringProperty(KEY_LAUNCH_CONFIGURATION_NAME,
                 "Exact launch configuration name from list_configurations (single-launch mode).") //$NON-NLS-1$
-            .stringProperty("projectName", //$NON-NLS-1$
+            .stringProperty(KEY_PROJECT_NAME,
                 "EDT project name; pair with applicationId for one launch, or with all=true.") //$NON-NLS-1$
-            .stringProperty("applicationId", //$NON-NLS-1$
+            .stringProperty(KEY_APPLICATION_ID,
                 "Application ID from get_applications; requires projectName.") //$NON-NLS-1$
             .booleanProperty("all", //$NON-NLS-1$
                 "Terminate every live EDT launch (optionally narrowed by projectName); " //$NON-NLS-1$
@@ -135,19 +147,19 @@ public class TerminateLaunchTool implements IMcpTool
     @Override
     public String getResultFileName(Map<String, String> params)
     {
-        String name = JsonUtils.extractStringArgument(params, "launchConfigurationName"); //$NON-NLS-1$
+        String name = JsonUtils.extractStringArgument(params, KEY_LAUNCH_CONFIGURATION_NAME);
         if (name != null && !name.isEmpty())
         {
-            String safe = name.replaceAll("[^a-zA-Z0-9._-]", "-").toLowerCase(); //$NON-NLS-1$ //$NON-NLS-2$
+            String safe = name.replaceAll(UNSAFE_FILENAME_CHARS, "-").toLowerCase(); //$NON-NLS-1$
             return "terminate-" + safe + ".md"; //$NON-NLS-1$ //$NON-NLS-2$
         }
         boolean all = JsonUtils.extractBooleanArgument(params, "all", false); //$NON-NLS-1$
         if (all)
         {
-            String project = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
+            String project = JsonUtils.extractStringArgument(params, KEY_PROJECT_NAME);
             if (project != null && !project.isEmpty())
             {
-                String safe = project.replaceAll("[^a-zA-Z0-9._-]", "-").toLowerCase(); //$NON-NLS-1$ //$NON-NLS-2$
+                String safe = project.replaceAll(UNSAFE_FILENAME_CHARS, "-").toLowerCase(); //$NON-NLS-1$
                 return "terminate-all-" + safe + ".md"; //$NON-NLS-1$ //$NON-NLS-2$
             }
             return "terminate-all.md"; //$NON-NLS-1$
@@ -155,12 +167,12 @@ public class TerminateLaunchTool implements IMcpTool
         // projectName + applicationId mode — include both in the filename so
         // parallel calls against different IBs don't overwrite each other's
         // result file.
-        String project = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
-        String appId = JsonUtils.extractStringArgument(params, "applicationId"); //$NON-NLS-1$
+        String project = JsonUtils.extractStringArgument(params, KEY_PROJECT_NAME);
+        String appId = JsonUtils.extractStringArgument(params, KEY_APPLICATION_ID);
         if (project != null && !project.isEmpty() && appId != null && !appId.isEmpty())
         {
-            String safeProject = project.replaceAll("[^a-zA-Z0-9._-]", "-").toLowerCase(); //$NON-NLS-1$ //$NON-NLS-2$
-            String safeAppId = appId.replaceAll("[^a-zA-Z0-9._-]", "-").toLowerCase(); //$NON-NLS-1$ //$NON-NLS-2$
+            String safeProject = project.replaceAll(UNSAFE_FILENAME_CHARS, "-").toLowerCase(); //$NON-NLS-1$
+            String safeAppId = appId.replaceAll(UNSAFE_FILENAME_CHARS, "-").toLowerCase(); //$NON-NLS-1$
             // Truncate to keep the path short — agents sometimes pass long UUIDs.
             if (safeAppId.length() > 16)
             {
@@ -174,9 +186,9 @@ public class TerminateLaunchTool implements IMcpTool
     @Override
     public String execute(Map<String, String> params)
     {
-        String configName = JsonUtils.extractStringArgument(params, "launchConfigurationName"); //$NON-NLS-1$
-        String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
-        String applicationId = JsonUtils.extractStringArgument(params, "applicationId"); //$NON-NLS-1$
+        String configName = JsonUtils.extractStringArgument(params, KEY_LAUNCH_CONFIGURATION_NAME);
+        String projectName = JsonUtils.extractStringArgument(params, KEY_PROJECT_NAME);
+        String applicationId = JsonUtils.extractStringArgument(params, KEY_APPLICATION_ID);
         boolean all = JsonUtils.extractBooleanArgument(params, "all", false); //$NON-NLS-1$
         boolean confirm = JsonUtils.extractBooleanArgument(params, "confirm", false); //$NON-NLS-1$
         boolean force = JsonUtils.extractBooleanArgument(params, "force", false); //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/TranslateConfigurationTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/TranslateConfigurationTool.java
@@ -53,6 +53,8 @@ public class TranslateConfigurationTool implements IMcpTool
 {
     public static final String NAME = "translate_configuration"; //$NON-NLS-1$
 
+    private static final String TARGET_LANGUAGES = "targetLanguages"; //$NON-NLS-1$
+
     @Override
     public String getName()
     {
@@ -76,7 +78,7 @@ public class TranslateConfigurationTool implements IMcpTool
     {
         return JsonSchemaBuilder.object()
             .stringProperty(McpKeys.PROJECT_NAME, "Project name (typically the source, e.g. the ru project). Required.", true) //$NON-NLS-1$
-            .stringArrayProperty("targetLanguages", //$NON-NLS-1$
+            .stringArrayProperty(TARGET_LANGUAGES,
                 "Target language codes to synchronize (e.g. [\"en\"]). Required.", true) //$NON-NLS-1$
             .build();
     }
@@ -91,7 +93,7 @@ public class TranslateConfigurationTool implements IMcpTool
     public String execute(Map<String, String> params)
     {
         String projectName = JsonUtils.extractStringArgument(params, McpKeys.PROJECT_NAME);
-        List<String> targetLanguages = JsonUtils.extractArrayArgument(params, "targetLanguages"); //$NON-NLS-1$
+        List<String> targetLanguages = JsonUtils.extractArrayArgument(params, TARGET_LANGUAGES);
 
         String err = JsonUtils.requireArgument(params, McpKeys.PROJECT_NAME);
         if (err != null)
@@ -153,7 +155,7 @@ public class TranslateConfigurationTool implements IMcpTool
             return FrontMatter.create()
                 .put("tool", NAME) //$NON-NLS-1$
                 .put(McpKeys.PROJECT, projectName)
-                .put("targetLanguages", String.join(", ", targetLanguages)) //$NON-NLS-1$ //$NON-NLS-2$
+                .put(TARGET_LANGUAGES, String.join(", ", targetLanguages)) //$NON-NLS-1$
                 .put("status", "success") //$NON-NLS-1$ //$NON-NLS-2$
                 .wrapContent("Translate configuration completed."); //$NON-NLS-1$
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ValidateQueryTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ValidateQueryTool.java
@@ -49,7 +49,13 @@ public class ValidateQueryTool implements IMcpTool
     
     /** URI used to look up the QlDcs language IResourceServiceProvider */
     private static final URI QLDCS_LOOKUP_URI = URI.createURI("/nopr/querywizard_validate.qldcs"); //$NON-NLS-1$
-    
+
+    private static final String PROJECT_NAME = "projectName"; //$NON-NLS-1$
+    private static final String QUERY_TEXT = "queryText"; //$NON-NLS-1$
+    private static final String DCS_MODE = "dcsMode"; //$NON-NLS-1$
+    private static final String ERROR = "ERROR"; //$NON-NLS-1$
+    private static final String WARNING = "WARNING"; //$NON-NLS-1$
+
     @Override
     public String getName()
     {
@@ -69,12 +75,12 @@ public class ValidateQueryTool implements IMcpTool
     public String getInputSchema()
     {
         return JsonSchemaBuilder.object()
-            .stringProperty("projectName", //$NON-NLS-1$
+            .stringProperty(PROJECT_NAME,
                 "EDT project name (required).", true) //$NON-NLS-1$
-            .stringProperty("queryText", //$NON-NLS-1$
+            .stringProperty(QUERY_TEXT,
                 "Full 1C query text to validate (required), e.g. 'SELECT Ref FROM Catalog.Products'.", //$NON-NLS-1$
                 true)
-            .booleanProperty("dcsMode", //$NON-NLS-1$
+            .booleanProperty(DCS_MODE,
                 "true for Data Composition System queries (allows DCS-specific syntax). Default: false.") //$NON-NLS-1$
             .build();
     }
@@ -85,7 +91,7 @@ public class ValidateQueryTool implements IMcpTool
         return JsonSchemaBuilder.object()
             .booleanProperty("success", "Whether the operation succeeded", true) //$NON-NLS-1$ //$NON-NLS-2$
             .booleanProperty("valid", "true when the query has zero issues") //$NON-NLS-1$ //$NON-NLS-2$
-            .booleanProperty("dcsMode", "Whether DCS validation mode was used") //$NON-NLS-1$ //$NON-NLS-2$
+            .booleanProperty(DCS_MODE, "Whether DCS validation mode was used") //$NON-NLS-1$
             .integerProperty("errorCount", "Number of ERROR-severity issues") //$NON-NLS-1$ //$NON-NLS-2$
             .integerProperty("warningCount", "Number of WARNING-severity issues") //$NON-NLS-1$ //$NON-NLS-2$
             .integerProperty("infoCount", "Number of INFO-severity issues") //$NON-NLS-1$ //$NON-NLS-2$
@@ -103,11 +109,11 @@ public class ValidateQueryTool implements IMcpTool
     @Override
     public String execute(Map<String, String> params)
     {
-        String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
-        String queryText = JsonUtils.extractStringArgument(params, "queryText"); //$NON-NLS-1$
-        boolean dcsMode = JsonUtils.extractBooleanArgument(params, "dcsMode", false); //$NON-NLS-1$
-        
-        String err = JsonUtils.requireArguments(params, "projectName", "queryText"); //$NON-NLS-1$ //$NON-NLS-2$
+        String projectName = JsonUtils.extractStringArgument(params, PROJECT_NAME);
+        String queryText = JsonUtils.extractStringArgument(params, QUERY_TEXT);
+        boolean dcsMode = JsonUtils.extractBooleanArgument(params, DCS_MODE, false);
+
+        String err = JsonUtils.requireArguments(params, PROJECT_NAME, QUERY_TEXT);
         if (err != null)
         {
             return err;
@@ -225,7 +231,7 @@ public class ValidateQueryTool implements IMcpTool
             for (Resource.Diagnostic error : resource.getErrors())
             {
                 issues.add(new QueryIssue(
-                    "ERROR", //$NON-NLS-1$
+                    ERROR,
                     error.getMessage(),
                     error.getLine(),
                     error.getColumn(),
@@ -236,7 +242,7 @@ public class ValidateQueryTool implements IMcpTool
             for (Resource.Diagnostic warning : resource.getWarnings())
             {
                 issues.add(new QueryIssue(
-                    "WARNING", //$NON-NLS-1$
+                    WARNING,
                     warning.getMessage(),
                     warning.getLine(),
                     warning.getColumn(),
@@ -253,16 +259,16 @@ public class ValidateQueryTool implements IMcpTool
                 switch (issue.getSeverity())
                 {
                     case ERROR:
-                        severity = "ERROR"; //$NON-NLS-1$
+                        severity = ERROR;
                         break;
                     case WARNING:
-                        severity = "WARNING"; //$NON-NLS-1$
+                        severity = WARNING;
                         break;
                     case INFO:
                         severity = "INFO"; //$NON-NLS-1$
                         break;
                     default:
-                        severity = "WARNING"; //$NON-NLS-1$
+                        severity = WARNING;
                         break;
                 }
                 
@@ -345,11 +351,11 @@ public class ValidateQueryTool implements IMcpTool
 
         return ToolResult.success()
             .put("valid", issues.isEmpty()) //$NON-NLS-1$
-            .put("dcsMode", dcsMode) //$NON-NLS-1$
+            .put(DCS_MODE, dcsMode)
             .put("errorCount", //$NON-NLS-1$
-                issues.stream().filter(i -> "ERROR".equals(i.severity)).count()) //$NON-NLS-1$
+                issues.stream().filter(i -> ERROR.equals(i.severity)).count())
             .put("warningCount", //$NON-NLS-1$
-                issues.stream().filter(i -> "WARNING".equals(i.severity)).count()) //$NON-NLS-1$
+                issues.stream().filter(i -> WARNING.equals(i.severity)).count())
             .put("infoCount", //$NON-NLS-1$
                 issues.stream().filter(i -> "INFO".equals(i.severity)).count()) //$NON-NLS-1$
             .put("issues", issueList) //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
@@ -44,6 +44,15 @@ public class WriteModuleSourceTool implements IMcpTool
     private static final String MODE_APPEND = "append"; //$NON-NLS-1$
     private static final String MODE_SEARCH_REPLACE = "searchReplace"; //$NON-NLS-1$
 
+    private static final String PROJECT_NAME = "projectName"; //$NON-NLS-1$
+    private static final String MODULE_PATH = "modulePath"; //$NON-NLS-1$
+
+    private static final String MODULE_TYPE_MODULE = "Module"; //$NON-NLS-1$
+    private static final String MODULE_TYPE_OBJECT_MODULE = "ObjectModule"; //$NON-NLS-1$
+    private static final String MODULE_TYPE_COMMAND_MODULE = "CommandModule"; //$NON-NLS-1$
+
+    private static final String MODULE_FILE_SUFFIX = "/Module.bsl"; //$NON-NLS-1$
+
     /** Maximum source length to prevent accidental huge writes */
     private static final int MAX_SOURCE_LENGTH = 500_000;
 
@@ -71,9 +80,9 @@ public class WriteModuleSourceTool implements IMcpTool
     public String getInputSchema()
     {
         return JsonSchemaBuilder.object()
-            .stringProperty("projectName", //$NON-NLS-1$
+            .stringProperty(PROJECT_NAME,
                 "EDT project name (required)", true) //$NON-NLS-1$
-            .stringProperty("modulePath", //$NON-NLS-1$
+            .stringProperty(MODULE_PATH,
                 "src/-relative module path, e.g. 'CommonModules/MyModule/Module.bsl'. " + //$NON-NLS-1$
                 "Alternative to objectName (pass exactly one).") //$NON-NLS-1$
             .stringProperty("objectName", //$NON-NLS-1$
@@ -81,7 +90,7 @@ public class WriteModuleSourceTool implements IMcpTool
                 "Resolved with moduleType. Alternative to modulePath.") //$NON-NLS-1$
             .enumProperty("moduleType", //$NON-NLS-1$
                 "Module type for objectName resolution (default ObjectModule).", //$NON-NLS-1$
-                "ObjectModule", "ManagerModule", "FormModule", "CommandModule", "RecordSetModule", "Module") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+                MODULE_TYPE_OBJECT_MODULE, "ManagerModule", "FormModule", MODULE_TYPE_COMMAND_MODULE, "RecordSetModule", MODULE_TYPE_MODULE) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             .stringProperty("source", //$NON-NLS-1$
                 "BSL source to write (required): full file for replace, new fragment for " + //$NON-NLS-1$
                 "searchReplace, text to add for append.", true) //$NON-NLS-1$
@@ -89,7 +98,7 @@ public class WriteModuleSourceTool implements IMcpTool
                 "Fragment to find and replace; required for searchReplace, must match exactly once.") //$NON-NLS-1$
             .enumProperty("mode", //$NON-NLS-1$
                 "Write mode (default searchReplace).", //$NON-NLS-1$
-                "searchReplace", "replace", "append") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                MODE_SEARCH_REPLACE, MODE_REPLACE, MODE_APPEND)
             .stringProperty("formName", //$NON-NLS-1$
                 "Form name; required when moduleType=FormModule (e.g. 'ItemForm').") //$NON-NLS-1$
             .stringProperty("commandName", //$NON-NLS-1$
@@ -114,7 +123,7 @@ public class WriteModuleSourceTool implements IMcpTool
     @Override
     public String getResultFileName(Map<String, String> params)
     {
-        String modulePath = JsonUtils.extractStringArgument(params, "modulePath"); //$NON-NLS-1$
+        String modulePath = JsonUtils.extractStringArgument(params, MODULE_PATH);
         if (modulePath != null && !modulePath.isEmpty())
         {
             String safeName = modulePath.replace("/", "-").replace("\\", "-").toLowerCase(); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -127,8 +136,8 @@ public class WriteModuleSourceTool implements IMcpTool
     public String execute(Map<String, String> params)
     {
         // 1. Extract parameters
-        String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
-        String modulePath = JsonUtils.extractStringArgument(params, "modulePath"); //$NON-NLS-1$
+        String projectName = JsonUtils.extractStringArgument(params, PROJECT_NAME);
+        String modulePath = JsonUtils.extractStringArgument(params, MODULE_PATH);
         String objectName = JsonUtils.extractStringArgument(params, "objectName"); //$NON-NLS-1$
         String moduleType = JsonUtils.extractStringArgument(params, "moduleType"); //$NON-NLS-1$
         String source = JsonUtils.extractStringArgument(params, "source"); //$NON-NLS-1$
@@ -142,7 +151,7 @@ public class WriteModuleSourceTool implements IMcpTool
         String expectedHash = JsonUtils.extractStringArgument(params, "expectedHash"); //$NON-NLS-1$
 
         // 2. Validate required parameters
-        String err = JsonUtils.requireArgument(params, "projectName"); //$NON-NLS-1$
+        String err = JsonUtils.requireArgument(params, PROJECT_NAME);
         if (err != null)
         {
             return err;
@@ -374,8 +383,8 @@ public class WriteModuleSourceTool implements IMcpTool
             // 10. Build frontmatter
             FrontMatter fm = FrontMatter.create()
                 .put("tool", NAME) //$NON-NLS-1$
-                .put("projectName", projectName) //$NON-NLS-1$
-                .put("modulePath", modulePath) //$NON-NLS-1$
+                .put(PROJECT_NAME, projectName)
+                .put(MODULE_PATH, modulePath)
                 .put("mode", mode) //$NON-NLS-1$
                 .put("status", "success") //$NON-NLS-1$ //$NON-NLS-2$
                 .put("linesAfter", newLines.size()) //$NON-NLS-1$
@@ -616,25 +625,25 @@ public class WriteModuleSourceTool implements IMcpTool
                 || "WebService".equals(englishType) //$NON-NLS-1$
                 || "HTTPService".equals(englishType)) //$NON-NLS-1$
             {
-                moduleType = "Module"; //$NON-NLS-1$
+                moduleType = MODULE_TYPE_MODULE;
             }
             else if ("CommonCommand".equals(englishType)) //$NON-NLS-1$
             {
-                moduleType = "CommandModule"; //$NON-NLS-1$
+                moduleType = MODULE_TYPE_COMMAND_MODULE;
             }
             else
             {
-                moduleType = "ObjectModule"; //$NON-NLS-1$
+                moduleType = MODULE_TYPE_OBJECT_MODULE;
             }
         }
 
         // Build path based on moduleType
         switch (moduleType)
         {
-            case "Module": //$NON-NLS-1$
-                return dirName + "/" + namePart + "/Module.bsl"; //$NON-NLS-1$ //$NON-NLS-2$
+            case MODULE_TYPE_MODULE:
+                return dirName + "/" + namePart + MODULE_FILE_SUFFIX; //$NON-NLS-1$
 
-            case "ObjectModule": //$NON-NLS-1$
+            case MODULE_TYPE_OBJECT_MODULE:
                 return dirName + "/" + namePart + "/ObjectModule.bsl"; //$NON-NLS-1$ //$NON-NLS-2$
 
             case "ManagerModule": //$NON-NLS-1$
@@ -647,15 +656,15 @@ public class WriteModuleSourceTool implements IMcpTool
                 // CommonForms don't need formName — path is always Module.bsl
                 if ("CommonForm".equals(englishType)) //$NON-NLS-1$
                 {
-                    return dirName + "/" + namePart + "/Module.bsl"; //$NON-NLS-1$ //$NON-NLS-2$
+                    return dirName + "/" + namePart + MODULE_FILE_SUFFIX; //$NON-NLS-1$
                 }
                 if (formName == null || formName.isEmpty())
                 {
                     return ToolResult.error("formName is required when moduleType=FormModule").toJson(); //$NON-NLS-1$
                 }
-                return dirName + "/" + namePart + "/Forms/" + formName + "/Module.bsl"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                return dirName + "/" + namePart + "/Forms/" + formName + MODULE_FILE_SUFFIX; //$NON-NLS-1$ //$NON-NLS-2$
 
-            case "CommandModule": //$NON-NLS-1$
+            case MODULE_TYPE_COMMAND_MODULE:
                 // CommonCommands don't need commandName — path is always CommandModule.bsl
                 if ("CommonCommand".equals(englishType)) //$NON-NLS-1$
                 {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/AbstractMetadataFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/AbstractMetadataFormatter.java
@@ -32,6 +32,9 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
     protected static final String YES = "Yes"; //$NON-NLS-1$
     protected static final String NO = "No"; //$NON-NLS-1$
     protected static final String DASH = "-"; //$NON-NLS-1$
+    private static final String PROPERTY = "Property"; //$NON-NLS-1$
+    private static final String VALUE = "Value"; //$NON-NLS-1$
+    private static final String SYNONYM = "Synonym"; //$NON-NLS-1$
 
     /**
      * Per-section row cap for the unbounded EMF-reflection dumps
@@ -212,9 +215,9 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
     protected void formatBasicProperties(StringBuilder sb, MdObject mdObject, String language)
     {
         addSectionHeader(sb, "Basic Properties"); //$NON-NLS-1$
-        startTable(sb, "Property", "Value"); //$NON-NLS-1$ //$NON-NLS-2$
+        startTable(sb, PROPERTY, VALUE);
         addPropertyRow(sb, "Name", mdObject.getName()); //$NON-NLS-1$
-        addPropertyRow(sb, "Synonym", getSynonym(mdObject.getSynonym(), language)); //$NON-NLS-1$
+        addPropertyRow(sb, SYNONYM, getSynonym(mdObject.getSynonym(), language));
         
         String comment = mdObject.getComment();
         if (comment != null && !comment.isEmpty())
@@ -244,7 +247,7 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
             if (standardAttributes != null && !standardAttributes.isEmpty())
             {
                 addSectionHeader(sb, "StandardAttributes"); //$NON-NLS-1$
-                startTable(sb, "Name", "Synonym", "Fill Checking", "Full Text Search", "Password Mode", "Multi Line", "Quick Choice", "Create On Input", "Data History"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$
+                startTable(sb, "Name", SYNONYM, "Fill Checking", "Full Text Search", "Password Mode", "Multi Line", "Quick Choice", "Create On Input", "Data History"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$
                 
                 for (StandardAttribute attr : standardAttributes)
                 {
@@ -292,7 +295,7 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
     protected void formatAllDynamicProperties(StringBuilder sb, EObject eObject, String language, String sectionTitle)
     {
         addSectionHeader(sb, sectionTitle);
-        startTable(sb, "Property", "Value"); //$NON-NLS-1$ //$NON-NLS-2$
+        startTable(sb, PROPERTY, VALUE);
 
         List<EStructuralFeature> features = eObject.eClass().getEAllStructuralFeatures();
 
@@ -414,7 +417,7 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
         if (!simpleAttributes.isEmpty())
         {
             addSectionHeader(sb, "Properties"); //$NON-NLS-1$
-            startTable(sb, "Property", "Value"); //$NON-NLS-1$ //$NON-NLS-2$
+            startTable(sb, PROPERTY, VALUE);
             for (EAttribute attr : simpleAttributes)
             {
                 Object value = eObject.eGet(attr);
@@ -430,7 +433,7 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
         if (!singleReferences.isEmpty())
         {
             addSectionHeader(sb, "References"); //$NON-NLS-1$
-            startTable(sb, "Property", "Value"); //$NON-NLS-1$ //$NON-NLS-2$
+            startTable(sb, PROPERTY, VALUE);
             for (EReference ref : singleReferences)
             {
                 Object value = eObject.eGet(ref);
@@ -470,7 +473,7 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
         {
             // For EMap collections like Synonym, ObjectPresentation - format as key-value table
             addSectionHeader(sb, formatFeatureName(name) + " (" + collection.size() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
-            startTable(sb, "Language", "Value"); //$NON-NLS-1$ //$NON-NLS-2$
+            startTable(sb, "Language", VALUE); //$NON-NLS-1$
             for (Object item : collection)
             {
                 java.util.Map.Entry entry = (java.util.Map.Entry) item;
@@ -497,7 +500,7 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
                 MdObject mdObj = (MdObject) item;
                 if (first)
                 {
-                    startTable(sb, "FQN", "Synonym"); //$NON-NLS-1$ //$NON-NLS-2$
+                    startTable(sb, "FQN", SYNONYM); //$NON-NLS-1$
                     first = false;
                 }
                 if (mdRendered >= MAX_DYNAMIC_ROWS)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
@@ -42,6 +42,12 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
     /** Table column / property label for a value cell. */
     private static final String VALUE_TOKEN = "Value"; //$NON-NLS-1$
 
+    /** Table column / property label for a synonym cell. */
+    private static final String SYNONYM_TOKEN = "Synonym"; //$NON-NLS-1$
+
+    /** Table column label for an origin cell. */
+    private static final String ORIGIN_TOKEN = "Origin"; //$NON-NLS-1$
+
     /**
      * Gets the singleton instance.
      */
@@ -243,11 +249,11 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
         boolean showOrigin = anyAdopted(forms);
         if (showOrigin)
         {
-            startTable(sb, "Name", "Synonym", "Form Type", "Origin"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            startTable(sb, "Name", SYNONYM_TOKEN, "Form Type", ORIGIN_TOKEN); //$NON-NLS-1$ //$NON-NLS-2$
         }
         else
         {
-            startTable(sb, "Name", "Synonym", "Form Type"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            startTable(sb, "Name", SYNONYM_TOKEN, "Form Type"); //$NON-NLS-1$ //$NON-NLS-2$
         }
 
         for (Object item : forms)
@@ -307,7 +313,7 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
     private void formatCommandsCollection(StringBuilder sb, String name, Collection<?> commands, String language)
     {
         addSectionHeader(sb, name);
-        startTable(sb, "Name", "Synonym", "Group"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        startTable(sb, "Name", SYNONYM_TOKEN, "Group"); //$NON-NLS-1$ //$NON-NLS-2$
         
         for (Object item : commands)
         {
@@ -345,10 +351,10 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
         {
             // Extended format with 10 columns (+ Origin when adopted attributes are present)
             java.util.List<String> headers = new java.util.ArrayList<>(java.util.Arrays.asList(
-                "Name", "Synonym", "Type", "Indexing", "Fill Checking", "Full Text Search", "Password Mode", "Multi Line", "Quick Choice", "Create On Input")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$ //$NON-NLS-10$
+                "Name", SYNONYM_TOKEN, "Type", "Indexing", "Fill Checking", "Full Text Search", "Password Mode", "Multi Line", "Quick Choice", "Create On Input")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$
             if (showOrigin)
             {
-                headers.add("Origin"); //$NON-NLS-1$
+                headers.add(ORIGIN_TOKEN);
             }
             startTable(sb, headers.toArray(new String[0]));
 
@@ -422,11 +428,11 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
             // Compact format - Name, Synonym, Type (+ Origin when adopted attributes are present)
             if (showOrigin)
             {
-                startTable(sb, "Name", "Synonym", "Type", "Origin"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+                startTable(sb, "Name", SYNONYM_TOKEN, "Type", ORIGIN_TOKEN); //$NON-NLS-1$ //$NON-NLS-2$
             }
             else
             {
-                startTable(sb, "Name", "Synonym", "Type"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                startTable(sb, "Name", SYNONYM_TOKEN, "Type"); //$NON-NLS-1$ //$NON-NLS-2$
             }
 
             for (Object item : items)
@@ -477,7 +483,7 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
                 // Properties table for the TS itself
                 startTable(sb, "Property", VALUE_TOKEN);
                 addPropertyRow(sb, "Name", ts.getName());
-                addPropertyRow(sb, "Synonym", getSynonym(ts.getSynonym(), language));
+                addPropertyRow(sb, SYNONYM_TOKEN, getSynonym(ts.getSynonym(), language));
                 
                 String comment = ts.getComment();
                 if (comment != null && !comment.isEmpty())
@@ -682,11 +688,11 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
                     // Build table headers based on first item
                     if (full)
                     {
-                        startTable(sb, "Name", "Synonym", "Type"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                        startTable(sb, "Name", SYNONYM_TOKEN, "Type"); //$NON-NLS-1$ //$NON-NLS-2$
                     }
                     else
                     {
-                        startTable(sb, "Name", "Synonym"); //$NON-NLS-1$ //$NON-NLS-2$
+                        startTable(sb, "Name", SYNONYM_TOKEN); //$NON-NLS-1$
                     }
                     first = false;
                 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
@@ -64,6 +64,25 @@ import com.ditrix.edt.mcp.server.utils.ProjectContext;
  */
 public class MetadataRenameService
 {
+    /** Em dash placeholder rendered in markdown table cells with no value. */
+    private static final String DASH = "\u2014"; //$NON-NLS-1$
+
+    /** Change-point type tag for BSL reference changes. */
+    private static final String BSL_REF = "bslRef"; //$NON-NLS-1$
+
+    /** Reflective method name: Guice injector instance lookup. */
+    private static final String GET_INSTANCE = "getInstance"; //$NON-NLS-1$
+
+    /** Reflective method name: file accessor on a modified element / search match. */
+    private static final String GET_FILE = "getFile"; //$NON-NLS-1$
+
+    /** Xtext rename element context interface class name. */
+    private static final String IRENAME_ELEMENT_CONTEXT_CLASS =
+        "org.eclipse.xtext.ui.refactoring.ui.IRenameElementContext"; //$NON-NLS-1$
+
+    /** EDT search-core SearchIn enum class name. */
+    private static final String SEARCH_IN_CLASS = "com._1c.g5.v8.dt.search.core.SearchIn"; //$NON-NLS-1$
+
     public String rename(String projectName, String objectFqn, String newName,
         boolean confirm, java.util.Set<Integer> disableIndices, int maxResults)
     {
@@ -234,11 +253,11 @@ public class MetadataRenameService
             ChangePoint cp = allChanges.get(i);
             String enabledMark = cp.enabled ? "\u2705" : "\u274c"; //$NON-NLS-1$ //$NON-NLS-2$
             String optionalMark = cp.optional ? "yes" : "no"; //$NON-NLS-1$ //$NON-NLS-2$
-            String fqnCell = cp.fqn != null ? escapeMarkdownCell(cp.fqn) : "\u2014"; //$NON-NLS-1$
-            String projectCell = cp.project != null ? escapeMarkdownCell(cp.project) : "\u2014"; //$NON-NLS-1$
-            String line = cp.lineNumber > 0 ? String.valueOf(cp.lineNumber) : "\u2014"; //$NON-NLS-1$
-                        String column = cp.columnNumber > 0 ? String.valueOf(cp.columnNumber) : "\u2014"; //$NON-NLS-1$
-            String description = cp.description != null ? escapeMarkdownCell(cp.description) : "\u2014"; //$NON-NLS-1$
+            String fqnCell = cp.fqn != null ? escapeMarkdownCell(cp.fqn) : DASH;
+            String projectCell = cp.project != null ? escapeMarkdownCell(cp.project) : DASH;
+            String line = cp.lineNumber > 0 ? String.valueOf(cp.lineNumber) : DASH;
+                        String column = cp.columnNumber > 0 ? String.valueOf(cp.columnNumber) : DASH;
+            String description = cp.description != null ? escapeMarkdownCell(cp.description) : DASH;
             sb.append("| ").append(cp.index) //$NON-NLS-1$
               .append(" | ").append(cp.type) //$NON-NLS-1$
               .append(" | ").append(description) //$NON-NLS-1$
@@ -429,7 +448,7 @@ public class MetadataRenameService
                     String exactFqn = exactMatch.fqn != null ? exactMatch.fqn : fqn;
                     String exactProject = exactMatch.project != null ? exactMatch.project : project;
                     result.add(new ChangePoint(
-                        leafIndex, "bslRef", exactFqn, exactProject, //$NON-NLS-1$
+                        leafIndex, BSL_REF, exactFqn, exactProject,
                         change.getName(), optional, change.isEnabled(), refactoringTitle,
                         exactMatch.lineNumber, exactMatch.columnNumber, exactMatch.codeContext, exactMatch.methodName));
                 }
@@ -468,7 +487,7 @@ public class MetadataRenameService
                                     matchedMethodName = findContainingMethodText(content, matchedLineNumber);
                                 }
                                 result.add(new ChangePoint(
-                                    leafIndex, "bslRef", fqn, project, //$NON-NLS-1$
+                                    leafIndex, BSL_REF, fqn, project,
                                     change.getName(), optional, change.isEnabled(), refactoringTitle,
                                     matchedLineNumber, matchedColumnNumber, matchedCodeContext, matchedMethodName));
                             }
@@ -517,7 +536,7 @@ public class MetadataRenameService
                                         matchedMethodName = findContainingMethodText(content, matchedLineNumber);
                                     }
                                     result.add(new ChangePoint(
-                                        leafIndex, "bslRef", fqn, project, //$NON-NLS-1$
+                                        leafIndex, BSL_REF, fqn, project,
                                         change.getName(), optional, change.isEnabled(), refactoringTitle,
                                         matchedLineNumber, matchedColumnNumber, matchedCodeContext, matchedMethodName));
                                 }
@@ -543,7 +562,7 @@ public class MetadataRenameService
             }
 
             result.add(new ChangePoint(
-                indexCounter[0]++, "bslRef", fqn, project, //$NON-NLS-1$
+                indexCounter[0]++, BSL_REF, fqn, project,
                 change.getName(), optional, change.isEnabled(), refactoringTitle,
                 lineNumber, columnNumber, codeContext, methodName));
         }
@@ -554,16 +573,16 @@ public class MetadataRenameService
         try
         {
             Object bslInjector = getBslInjector();
-            Object renameProvider = invokeMethod(bslInjector, "getInstance", new Class<?>[] {Class.class}, //$NON-NLS-1$
+            Object renameProvider = invokeMethod(bslInjector, GET_INSTANCE, new Class<?>[] {Class.class},
                 getClassOrThrow("com._1c.g5.v8.dt.bsl.bm.ui.refactoring.BslBmRenameRefactoringProvider")); //$NON-NLS-1$
             Object renameContext = createRenameElementContext(targetObject);
             Object refactoring = invokeMethod(renameProvider, "getRenameRefactoring", new Class<?>[] { //$NON-NLS-1$
-                getClassOrThrow("org.eclipse.xtext.ui.refactoring.ui.IRenameElementContext")}, renameContext); //$NON-NLS-1$
+                getClassOrThrow(IRENAME_ELEMENT_CONTEXT_CLASS)}, renameContext);
             Object processor = refactoring != null ? invokeNoArg(refactoring, "getProcessor") : null; //$NON-NLS-1$
             if (processor == null)
             {
                 processor = invokeMethod(renameProvider, "getRenameProcessor", new Class<?>[] { //$NON-NLS-1$
-                getClassOrThrow("org.eclipse.xtext.ui.refactoring.ui.IRenameElementContext")}, renameContext); //$NON-NLS-1$
+                getClassOrThrow(IRENAME_ELEMENT_CONTEXT_CLASS)}, renameContext);
             }
             if (processor == null)
             {
@@ -584,11 +603,11 @@ public class MetadataRenameService
                 return Map.of();
             }
 
-            Object supplier = invokeMethod(bslInjector, "getInstance", new Class<?>[] {Class.class}, //$NON-NLS-1$
+            Object supplier = invokeMethod(bslInjector, GET_INSTANCE, new Class<?>[] {Class.class},
                 getClassOrThrow("com._1c.g5.v8.dt.bsl.bm.ui.refactoring.BslTextSearchRefactoringSupplier")); //$NON-NLS-1$
 
             Object searchInjector = getSearchCoreInjector();
-            Object factory = invokeMethod(searchInjector, "getInstance", new Class<?>[] {Class.class}, //$NON-NLS-1$
+            Object factory = invokeMethod(searchInjector, GET_INSTANCE, new Class<?>[] {Class.class},
                 getClassOrThrow("com._1c.g5.v8.dt.search.core.refactoring.TextSearchRefactoringParticipantFactory")); //$NON-NLS-1$
             Object participant = invokeMethod(factory, "create", new Class<?>[] {String.class, EObject.class, //$NON-NLS-1$
                 getClassOrThrow("com._1c.g5.v8.dt.search.core.refactoring.ITextSearchRefactoringSupplier")}, //$NON-NLS-1$
@@ -600,9 +619,9 @@ public class MetadataRenameService
             Object searchScopeSettings = getClassOrThrow("com._1c.g5.v8.dt.search.core.TextSearchScopeSettings") //$NON-NLS-1$
                 .getConstructor()
                 .newInstance();
-            Object modules = getEnumConstant("com._1c.g5.v8.dt.search.core.SearchIn", "MODULES"); //$NON-NLS-1$ //$NON-NLS-2$
-            Object dcs = getEnumConstant("com._1c.g5.v8.dt.search.core.SearchIn", "DCS"); //$NON-NLS-1$ //$NON-NLS-2$
-            Object dynamicListQuery = getEnumConstant("com._1c.g5.v8.dt.search.core.SearchIn", "DYNAMIC_LIST_QUERY"); //$NON-NLS-1$ //$NON-NLS-2$
+            Object modules = getEnumConstant(SEARCH_IN_CLASS, "MODULES"); //$NON-NLS-1$
+            Object dcs = getEnumConstant(SEARCH_IN_CLASS, "DCS"); //$NON-NLS-1$
+            Object dynamicListQuery = getEnumConstant(SEARCH_IN_CLASS, "DYNAMIC_LIST_QUERY"); //$NON-NLS-1$
             invokeMethod(searchScopeSettings, "addSearchIn", new Class<?>[] {modules.getClass().arrayType()}, //$NON-NLS-1$
                 (Object) arrayOf(modules.getClass(), modules, dcs, dynamicListQuery));
             @SuppressWarnings("unchecked")
@@ -654,11 +673,11 @@ public class MetadataRenameService
         try
         {
             Object bslInjector = getBslInjector();
-            Object renameProvider = invokeMethod(bslInjector, "getInstance", new Class<?>[] {Class.class}, //$NON-NLS-1$
+            Object renameProvider = invokeMethod(bslInjector, GET_INSTANCE, new Class<?>[] {Class.class},
                 getClassOrThrow("com._1c.g5.v8.dt.bsl.bm.ui.refactoring.BslBmRenameRefactoringProvider")); //$NON-NLS-1$
             Object renameContext = createRenameElementContext(targetObject);
             Object refactoring = invokeMethod(renameProvider, "getRenameRefactoring", new Class<?>[] { //$NON-NLS-1$
-                getClassOrThrow("org.eclipse.xtext.ui.refactoring.ui.IRenameElementContext")}, renameContext); //$NON-NLS-1$
+                getClassOrThrow(IRENAME_ELEMENT_CONTEXT_CLASS)}, renameContext);
             if (refactoring == null)
             {
                 return List.of();
@@ -717,7 +736,7 @@ public class MetadataRenameService
         List<Integer> bslIndices = new ArrayList<>();
         for (int i = 0; i < allChanges.size(); i++)
         {
-            if ("bslRef".equals(allChanges.get(i).type)) //$NON-NLS-1$
+            if (BSL_REF.equals(allChanges.get(i).type))
             {
                 bslIndices.add(Integer.valueOf(i));
             }
@@ -757,7 +776,7 @@ public class MetadataRenameService
                 ExactMatchInfo info = createFileExactMatchInfo(match);
                 if (info != null)
                 {
-                    IFile file = (IFile) invokeNoArg(match, "getFile"); //$NON-NLS-1$
+                    IFile file = (IFile) invokeNoArg(match, GET_FILE);
                     int fileOffset = ((Number) invokeNoArg(match, "getFileOffset")).intValue(); //$NON-NLS-1$
                     int textLength = ((Number) invokeNoArg(match, "getTextLength")).intValue(); //$NON-NLS-1$
                     result.put(getFileMatchKey(file, fileOffset, textLength), info);
@@ -783,7 +802,7 @@ public class MetadataRenameService
     {
         try
         {
-            IFile file = (IFile) invokeNoArg(match, "getFile"); //$NON-NLS-1$
+            IFile file = (IFile) invokeNoArg(match, GET_FILE);
             if (file == null)
             {
                 return null;
@@ -1157,7 +1176,7 @@ public class MetadataRenameService
     private static Object getBslInjector() throws Exception
     {
         Class<?> activatorClass = getClassOrThrow("com._1c.g5.v8.dt.bsl.ui.internal.BslActivator"); //$NON-NLS-1$
-        Object activator = activatorClass.getMethod("getInstance").invoke(null); //$NON-NLS-1$
+        Object activator = activatorClass.getMethod(GET_INSTANCE).invoke(null);
         return activatorClass.getMethod("getInjector", String.class).invoke(activator, //$NON-NLS-1$
             "com._1c.g5.v8.dt.bsl.Bsl"); //$NON-NLS-1$
     }
@@ -1204,7 +1223,7 @@ public class MetadataRenameService
         {
             return null;
         }
-        Object fileObject = invokeNoArg(modifiedElement, "getFile"); //$NON-NLS-1$
+        Object fileObject = invokeNoArg(modifiedElement, GET_FILE);
         return fileObject instanceof IFile file ? file : null;
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/symbol/SymbolInfoService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/symbol/SymbolInfoService.java
@@ -67,6 +67,12 @@ public class SymbolInfoService
     // the same one) rather than re-declaring a local copy.
     private static final URI BSL_LOOKUP_URI = BslModuleUtils.BSL_LOOKUP_URI;
 
+    private static final String PROPERTY = "Property"; //$NON-NLS-1$
+    private static final String VALUE = "Value"; //$NON-NLS-1$
+    private static final String SYMBOL = "Symbol"; //$NON-NLS-1$
+    private static final String IN_METHOD = "In method"; //$NON-NLS-1$
+    private static final String EMF_TYPE = "EMF type"; //$NON-NLS-1$
+
     // Lazy-initialized CopyDown instance for HTML-to-Markdown conversion (thread-confined to UI thread)
     private CopyDown copyDown; //$NON-NLS-1$
 
@@ -476,7 +482,7 @@ public class SymbolInfoService
 
                     // Return at least token info
                     StringBuilder sb = new StringBuilder();
-                    sb.append(MarkdownUtils.tableHeader("Property", "Value")); //$NON-NLS-1$ //$NON-NLS-2$
+                    sb.append(MarkdownUtils.tableHeader(PROPERTY, VALUE));
                     sb.append(codeCell("Token", leafNode.getText())); //$NON-NLS-1$
                     String grammar = leafNode.getGrammarElement() != null
                         ? leafNode.getGrammarElement().eClass().getName() : "-"; //$NON-NLS-1$
@@ -522,14 +528,14 @@ public class SymbolInfoService
     private String buildEObjectInfo(EObject element)
     {
         StringBuilder sb = new StringBuilder();
-        sb.append(MarkdownUtils.tableHeader("Property", "Value")); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append(MarkdownUtils.tableHeader(PROPERTY, VALUE));
 
         if (element instanceof Method)
         {
             Method method = (Method) element;
             boolean isFunction = element instanceof Function;
 
-            sb.append(codeCell("Symbol", method.getName())); //$NON-NLS-1$
+            sb.append(codeCell(SYMBOL, method.getName()));
             sb.append("| **Kind** | ").append(isFunction ? "Function" : "Procedure").append(" |\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             sb.append(codeCell("Signature", BslModuleUtils.buildSignature(method))); //$NON-NLS-1$
             sb.append("| **Export** | ").append(method.isExport() ? "Yes" : "No").append(" |\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
@@ -556,7 +562,7 @@ public class SymbolInfoService
         else if (element instanceof FormalParam)
         {
             FormalParam param = (FormalParam) element;
-            sb.append(codeCell("Symbol", param.getName())); //$NON-NLS-1$
+            sb.append(codeCell(SYMBOL, param.getName()));
             sb.append("| **Kind** | Parameter |\n"); //$NON-NLS-1$
             sb.append("| **ByValue** | ").append(param.isByValue() ? "Yes" : "No").append(" |\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
@@ -564,58 +570,58 @@ public class SymbolInfoService
             EObject container = param.eContainer();
             if (container instanceof Method)
             {
-                sb.append(codeCell("In method", ((Method) container).getName())); //$NON-NLS-1$
+                sb.append(codeCell(IN_METHOD, ((Method) container).getName()));
             }
         }
         else if (element instanceof StaticFeatureAccess)
         {
             StaticFeatureAccess sfa = (StaticFeatureAccess) element;
-            sb.append(codeCell("Symbol", sfa.getName())); //$NON-NLS-1$
+            sb.append(codeCell(SYMBOL, sfa.getName()));
             sb.append("| **Kind** | StaticFeatureAccess |\n"); //$NON-NLS-1$
-            sb.append(cell("EMF type", sfa.eClass().getName())); //$NON-NLS-1$
+            sb.append(cell(EMF_TYPE, sfa.eClass().getName()));
 
             // Show containing method
             EObject container = findContainingMethod(sfa);
             if (container instanceof Method)
             {
-                sb.append(codeCell("In method", ((Method) container).getName())); //$NON-NLS-1$
+                sb.append(codeCell(IN_METHOD, ((Method) container).getName()));
             }
         }
         else if (element instanceof DynamicFeatureAccess)
         {
             DynamicFeatureAccess dfa = (DynamicFeatureAccess) element;
-            sb.append(codeCell("Symbol", dfa.getName())); //$NON-NLS-1$
+            sb.append(codeCell(SYMBOL, dfa.getName()));
             sb.append("| **Kind** | DynamicFeatureAccess |\n"); //$NON-NLS-1$
-            sb.append(cell("EMF type", dfa.eClass().getName())); //$NON-NLS-1$
+            sb.append(cell(EMF_TYPE, dfa.eClass().getName()));
 
             // Show containing method
             EObject container = findContainingMethod(dfa);
             if (container instanceof Method)
             {
-                sb.append(codeCell("In method", ((Method) container).getName())); //$NON-NLS-1$
+                sb.append(codeCell(IN_METHOD, ((Method) container).getName()));
             }
         }
         else if (element instanceof Invocation)
         {
             Invocation invocation = (Invocation) element;
             sb.append("| **Kind** | Invocation |\n"); //$NON-NLS-1$
-            sb.append(cell("EMF type", invocation.eClass().getName())); //$NON-NLS-1$
+            sb.append(cell(EMF_TYPE, invocation.eClass().getName()));
 
             // Try to get the method name from the feature access
             EObject methodAccess = invocation.getMethodAccess();
             if (methodAccess instanceof StaticFeatureAccess)
             {
-                sb.append(codeCell("Symbol", ((StaticFeatureAccess) methodAccess).getName())); //$NON-NLS-1$
+                sb.append(codeCell(SYMBOL, ((StaticFeatureAccess) methodAccess).getName()));
             }
             else if (methodAccess instanceof DynamicFeatureAccess)
             {
-                sb.append(codeCell("Symbol", ((DynamicFeatureAccess) methodAccess).getName())); //$NON-NLS-1$
+                sb.append(codeCell(SYMBOL, ((DynamicFeatureAccess) methodAccess).getName()));
             }
         }
         else if (element instanceof Module)
         {
             sb.append("| **Kind** | Module |\n"); //$NON-NLS-1$
-            sb.append(cell("EMF type", element.eClass().getName())); //$NON-NLS-1$
+            sb.append(cell(EMF_TYPE, element.eClass().getName()));
         }
         else
         {
@@ -628,7 +634,7 @@ public class SymbolInfoService
                 Object name = ReflectionUtils.invokeMethod(element, "getName"); //$NON-NLS-1$
                 if (name instanceof String && !((String) name).isEmpty())
                 {
-                    sb.append(codeCell("Symbol", (String) name)); //$NON-NLS-1$
+                    sb.append(codeCell(SYMBOL, (String) name));
                 }
             }
             catch (Exception e)
@@ -640,7 +646,7 @@ public class SymbolInfoService
             EObject container = findContainingMethod(element);
             if (container instanceof Method)
             {
-                sb.append(codeCell("In method", ((Method) container).getName())); //$NON-NLS-1$
+                sb.append(codeCell(IN_METHOD, ((Method) container).getName()));
             }
 
             int startLine = BslModuleUtils.getStartLine(element);
@@ -856,7 +862,7 @@ public class SymbolInfoService
             }
 
             StringBuilder sb = new StringBuilder();
-            sb.append(MarkdownUtils.tableHeader("Property", "Value")); //$NON-NLS-1$ //$NON-NLS-2$
+            sb.append(MarkdownUtils.tableHeader(PROPERTY, VALUE));
             sb.append(codeCell("Token", leafNode.getText())); //$NON-NLS-1$
             return sb.toString();
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/transport/McpHttpHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/transport/McpHttpHandler.java
@@ -40,6 +40,11 @@ import com.sun.net.httpserver.HttpHandler;
  */
 public class McpHttpHandler implements HttpHandler
 {
+    private static final String CONTENT_TYPE = "Content-Type"; //$NON-NLS-1$
+    private static final String TEXT_EVENT_STREAM = "text/event-stream"; //$NON-NLS-1$
+    private static final String CONNECTION = "Connection"; //$NON-NLS-1$
+    private static final String KEEP_ALIVE = "keep-alive"; //$NON-NLS-1$
+
     /** Event ID counter for SSE - AtomicLong for thread safety across concurrent SSE streams */
     private final AtomicLong eventIdCounter = new AtomicLong(0);
 
@@ -324,7 +329,7 @@ public class McpHttpHandler implements HttpHandler
 
         // Check if client accepts SSE
         String acceptHeader = exchange.getRequestHeaders().getFirst("Accept"); //$NON-NLS-1$
-        boolean acceptsSse = acceptHeader != null && acceptHeader.contains("text/event-stream"); //$NON-NLS-1$
+        boolean acceptsSse = acceptHeader != null && acceptHeader.contains(TEXT_EVENT_STREAM);
 
         if (acceptsSse)
         {
@@ -338,8 +343,8 @@ public class McpHttpHandler implements HttpHandler
             {
                 exchange.getResponseHeaders().add(McpConstants.HEADER_SESSION_ID, generateSessionId());
             }
-            exchange.getResponseHeaders().add("Content-Type", "application/json"); //$NON-NLS-1$ //$NON-NLS-2$
-            exchange.getResponseHeaders().add("Connection", "keep-alive"); //$NON-NLS-1$ //$NON-NLS-2$
+            exchange.getResponseHeaders().add(CONTENT_TYPE, "application/json"); //$NON-NLS-1$
+            exchange.getResponseHeaders().add(CONNECTION, KEEP_ALIVE);
             HttpTransport.sendResponse(exchange, 200, response);
         }
     }
@@ -358,9 +363,9 @@ public class McpHttpHandler implements HttpHandler
      */
     private void sendSseResponse(HttpExchange exchange, String response, boolean isInitialize) throws IOException
     {
-        exchange.getResponseHeaders().add("Content-Type", "text/event-stream"); //$NON-NLS-1$ //$NON-NLS-2$
+        exchange.getResponseHeaders().add(CONTENT_TYPE, TEXT_EVENT_STREAM);
         exchange.getResponseHeaders().add("Cache-Control", "no-cache"); //$NON-NLS-1$ //$NON-NLS-2$
-        exchange.getResponseHeaders().add("Connection", "keep-alive"); //$NON-NLS-1$ //$NON-NLS-2$
+        exchange.getResponseHeaders().add(CONNECTION, KEEP_ALIVE);
 
         // Add session ID for initialize response
         if (isInitialize)
@@ -395,13 +400,13 @@ public class McpHttpHandler implements HttpHandler
     {
         String acceptHeader = exchange.getRequestHeaders().getFirst("Accept"); //$NON-NLS-1$
 
-        if (acceptHeader != null && acceptHeader.contains("text/event-stream")) //$NON-NLS-1$
+        if (acceptHeader != null && acceptHeader.contains(TEXT_EVENT_STREAM))
         {
             Activator.logInfo("SSE GET request received - opening SSE stream"); //$NON-NLS-1$
 
-            exchange.getResponseHeaders().add("Content-Type", "text/event-stream"); //$NON-NLS-1$ //$NON-NLS-2$
+            exchange.getResponseHeaders().add(CONTENT_TYPE, TEXT_EVENT_STREAM);
             exchange.getResponseHeaders().add("Cache-Control", "no-cache"); //$NON-NLS-1$ //$NON-NLS-2$
-            exchange.getResponseHeaders().add("Connection", "keep-alive"); //$NON-NLS-1$ //$NON-NLS-2$
+            exchange.getResponseHeaders().add(CONNECTION, KEEP_ALIVE);
             exchange.sendResponseHeaders(200, 0);
 
             // Register the stream so the server can PUSH notifications to it (e.g.
@@ -453,7 +458,7 @@ public class McpHttpHandler implements HttpHandler
                 McpConstants.PLUGIN_VERSION,
                 GetEdtVersionTool.getEdtVersion(),
                 McpConstants.PROTOCOL_VERSION);
-            exchange.getResponseHeaders().add("Content-Type", "application/json"); //$NON-NLS-1$ //$NON-NLS-2$
+            exchange.getResponseHeaders().add(CONTENT_TYPE, "application/json"); //$NON-NLS-1$
             HttpTransport.sendResponse(exchange, 200, response);
         }
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
@@ -89,6 +89,9 @@ public final class BslModuleUtils
      */
     public static final String SOURCE_FOLDER = "src"; //$NON-NLS-1$
 
+    /** Default charset for BSL files in EDT (always UTF-8). */
+    private static final String UTF_8 = "UTF-8"; //$NON-NLS-1$
+
     /**
      * Resolves a module path (relative to the project's source folder) to an IFile.
      * Centralizes the source-folder assumption that every module tool previously
@@ -437,7 +440,7 @@ public final class BslModuleUtils
                 input.reset();
             }
             // BSL files in EDT are always UTF-8
-            String charset = "UTF-8"; //$NON-NLS-1$
+            String charset = UTF_8;
             if (!isUtf8Bom)
             {
                 try
@@ -446,7 +449,7 @@ public final class BslModuleUtils
                 }
                 catch (Exception ce)
                 {
-                    charset = "UTF-8"; //$NON-NLS-1$
+                    charset = UTF_8;
                 }
             }
             try (BufferedReader reader = new BufferedReader(
@@ -502,7 +505,7 @@ public final class BslModuleUtils
             {
                 input.reset();
             }
-            String charset = "UTF-8"; //$NON-NLS-1$
+            String charset = UTF_8;
             if (!isUtf8Bom)
             {
                 try
@@ -511,7 +514,7 @@ public final class BslModuleUtils
                 }
                 catch (Exception ce)
                 {
-                    charset = "UTF-8"; //$NON-NLS-1$
+                    charset = UTF_8;
                 }
             }
             try (InputStreamReader reader = new InputStreamReader(input, charset))

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -101,6 +101,7 @@ public final class FormElementWriter
     private static final String ECLASS_FORM_GROUP = "FormGroup"; //$NON-NLS-1$
     private static final String ECLASS_DECORATION = "Decoration"; //$NON-NLS-1$
     private static final String ECLASS_FORM_ITEM = "FormItem"; //$NON-NLS-1$
+    private static final String ECLASS_FORM_FIELD = "FormField"; //$NON-NLS-1$
     private static final String ECLASS_USUAL_GROUP_EXT_INFO = "UsualGroupExtInfo"; //$NON-NLS-1$
     private static final String ECLASS_LABEL_DECORATION_EXT_INFO = "LabelDecorationExtInfo"; //$NON-NLS-1$
     private static final String ECLASS_FORM_COMMAND = "FormCommand"; //$NON-NLS-1$
@@ -155,6 +156,10 @@ public final class FormElementWriter
     private static final String ELEM_BUTTON = "Button"; //$NON-NLS-1$
     /** The leading fragment of the "invalid event" error message. */
     private static final String ERR_EVENT_PREFIX = "Event '"; //$NON-NLS-1$
+    /** The leading fragment of the "item already exists" error message. */
+    private static final String ERR_ITEM_EXISTS = "Form item already exists: "; //$NON-NLS-1$
+    /** The legacy managed-form platform type name (swapped with {@code ClientApplicationForm}). */
+    private static final String TYPE_MANAGED_FORM = "ManagedForm"; //$NON-NLS-1$
 
     /** A supported form-element kind, resolved from a (bilingual) FQN kind token. */
     public enum Kind { ATTRIBUTE, COMMAND, GROUP, DECORATION, FIELD, BUTTON }
@@ -390,7 +395,7 @@ public final class FormElementWriter
             return false;
         }
         String t = token.trim().toLowerCase();
-        return "handler".equals(t) || RU_HANDLER.equals(t); //$NON-NLS-1$
+        return FEATURE_HANDLER.equals(t) || RU_HANDLER.equals(t);
     }
 
     public static Kind kindForToken(String token)
@@ -400,7 +405,7 @@ public final class FormElementWriter
             return null;
         }
         String t = token.trim().toLowerCase();
-        if ("attribute".equals(t) || "attributes".equals(t) || RU_ATTRIBUTE.equals(t)) //$NON-NLS-1$ //$NON-NLS-2$
+        if ("attribute".equals(t) || FEATURE_ATTRIBUTES.equals(t) || RU_ATTRIBUTE.equals(t)) //$NON-NLS-1$
         {
             return Kind.ATTRIBUTE;
         }
@@ -408,7 +413,7 @@ public final class FormElementWriter
         {
             return Kind.COMMAND;
         }
-        if ("group".equals(t) || RU_GROUP.equals(t)) //$NON-NLS-1$
+        if (FEATURE_GROUP.equals(t) || RU_GROUP.equals(t))
         {
             return Kind.GROUP;
         }
@@ -1099,7 +1104,7 @@ public final class FormElementWriter
     {
         if (findItem(formModel, name) != null)
         {
-            return "Form item already exists: " + name; //$NON-NLS-1$
+            return ERR_ITEM_EXISTS + name;
         }
         EObject container = containerFor(formModel, parentName);
         if (container == null)
@@ -1538,14 +1543,14 @@ public final class FormElementWriter
         }
         if (findItem(formModel, name) != null)
         {
-            return "Form item already exists: " + name; //$NON-NLS-1$
+            return ERR_ITEM_EXISTS + name;
         }
         EObject container = containerFor(formModel, parentName);
         if (container == null)
         {
             return parentNotFound(parentName);
         }
-        EObject item = createFromClassifier(formModel, "FormField"); //$NON-NLS-1$
+        EObject item = createFromClassifier(formModel, ECLASS_FORM_FIELD);
         if (item == null)
         {
             return "Cannot create a form field for this form model."; //$NON-NLS-1$
@@ -1614,7 +1619,7 @@ public final class FormElementWriter
         }
         if (findItem(formModel, name) != null)
         {
-            return "Form item already exists: " + name; //$NON-NLS-1$
+            return ERR_ITEM_EXISTS + name;
         }
         EObject container = containerFor(formModel, parentName);
         if (container == null)
@@ -2258,13 +2263,13 @@ public final class FormElementWriter
             return null;
         }
         EObject type = resolveType(provider, context, typeName);
-        if (type == null && "ManagedForm".equals(typeName)) //$NON-NLS-1$
+        if (type == null && TYPE_MANAGED_FORM.equals(typeName))
         {
             type = resolveType(provider, context, "ClientApplicationForm"); //$NON-NLS-1$
         }
         else if (type == null && "ClientApplicationForm".equals(typeName)) //$NON-NLS-1$
         {
-            type = resolveType(provider, context, "ManagedForm"); //$NON-NLS-1$
+            type = resolveType(provider, context, TYPE_MANAGED_FORM);
         }
         return type;
     }
@@ -2301,12 +2306,12 @@ public final class FormElementWriter
     {
         Map<String, String> m = new HashMap<>();
         // Element base types.
-        m.put("Form", "ManagedForm"); // modern: ClientApplicationForm (resolveTypeName swaps) //$NON-NLS-1$ //$NON-NLS-2$
-        m.put("Table", "FormTable"); //$NON-NLS-1$ //$NON-NLS-2$
-        m.put("Decoration", "FormDecoration"); //$NON-NLS-1$ //$NON-NLS-2$
-        m.put("FormField", "FormField"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.put("Form", TYPE_MANAGED_FORM); // modern: ClientApplicationForm (resolveTypeName swaps) //$NON-NLS-1$
+        m.put(ECLASS_TABLE, "FormTable"); //$NON-NLS-1$
+        m.put(ECLASS_DECORATION, "FormDecoration"); //$NON-NLS-1$
+        m.put(ECLASS_FORM_FIELD, ECLASS_FORM_FIELD);
         m.put(ELEM_BUTTON, "FormButton"); //$NON-NLS-1$
-        m.put("FormGroup", "FormGroup"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.put(ECLASS_FORM_GROUP, ECLASS_FORM_GROUP);
         m.put("Addition", "FormItemAddition"); //$NON-NLS-1$ //$NON-NLS-2$
         // Form ext-infos.
         m.put("CatalogFormExtInfo", "ManagedFormExtensionForCatalogs"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -2328,7 +2333,7 @@ public final class FormElementWriter
         m.put("CubeRecordSetFormExtInfo", "ManagedFormExtensionForExternalDataSourceCubeRecordSet"); //$NON-NLS-1$ //$NON-NLS-2$
         // Table / decoration ext-infos.
         m.put("DynamicListTableExtInfo", "FormTableExtensionForDynamicList"); //$NON-NLS-1$ //$NON-NLS-2$
-        m.put("LabelDecorationExtInfo", "FormDecorationExtensionForALabel"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.put(ECLASS_LABEL_DECORATION_EXT_INFO, "FormDecorationExtensionForALabel"); //$NON-NLS-1$
         m.put("PictureDecorationExtInfo", "FormDecorationExtensionForAPicture"); //$NON-NLS-1$ //$NON-NLS-2$
         // Field ext-infos.
         m.put("LabelFieldExtInfo", "FormFieldExtensionForALabelField"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -2357,7 +2362,7 @@ public final class FormElementWriter
         m.put("PageGroupExtInfo", "FormGroupExtensionForAPage"); //$NON-NLS-1$ //$NON-NLS-2$
         m.put("PopupGroupExtInfo", "FormGroupExtensionForAPopup"); //$NON-NLS-1$ //$NON-NLS-2$
         m.put("CommandBarExtInfo", "FormGroupExtensionForACommandBar"); //$NON-NLS-1$ //$NON-NLS-2$
-        m.put("UsualGroupExtInfo", "FormGroupExtensionForAUsualGroup"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.put(ECLASS_USUAL_GROUP_EXT_INFO, "FormGroupExtensionForAUsualGroup"); //$NON-NLS-1$
         // Addition ext-infos.
         m.put("SearchStringAdditionExtInfo", "FormItemAdditionExtensionForSearchString"); //$NON-NLS-1$ //$NON-NLS-2$
         m.put("ViewStatusAdditionExtInfo", "FormItemAdditionExtensionForViewStatus"); //$NON-NLS-1$ //$NON-NLS-2$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/GuideRenderer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/GuideRenderer.java
@@ -31,6 +31,10 @@ import com.google.gson.JsonParser;
  */
 public final class GuideRenderer
 {
+    private static final String PROPERTIES = "properties"; //$NON-NLS-1$
+    private static final String REQUIRED = "required"; //$NON-NLS-1$
+    private static final String DESCRIPTION = "description"; //$NON-NLS-1$
+
     private GuideRenderer()
     {
         // Utility class - no instantiation
@@ -118,13 +122,13 @@ public final class GuideRenderer
                 if (parsed != null && parsed.isJsonObject())
                 {
                     JsonObject root = parsed.getAsJsonObject();
-                    if (root.has("properties") && root.get("properties").isJsonObject()) //$NON-NLS-1$ //$NON-NLS-2$
+                    if (root.has(PROPERTIES) && root.get(PROPERTIES).isJsonObject())
                     {
-                        properties = root.getAsJsonObject("properties"); //$NON-NLS-1$
+                        properties = root.getAsJsonObject(PROPERTIES);
                     }
-                    if (root.has("required") && root.get("required").isJsonArray()) //$NON-NLS-1$ //$NON-NLS-2$
+                    if (root.has(REQUIRED) && root.get(REQUIRED).isJsonArray())
                     {
-                        required = root.getAsJsonArray("required"); //$NON-NLS-1$
+                        required = root.getAsJsonArray(REQUIRED);
                     }
                 }
             }
@@ -152,8 +156,8 @@ public final class GuideRenderer
             String type = prop.has("type") && prop.get("type").isJsonPrimitive() //$NON-NLS-1$ //$NON-NLS-2$
                 ? prop.get("type").getAsString() : ""; //$NON-NLS-1$ //$NON-NLS-2$
             String typeCell = appendEnum(type, prop);
-            String descriptionCell = prop.has("description") && prop.get("description").isJsonPrimitive() //$NON-NLS-1$ //$NON-NLS-2$
-                ? prop.get("description").getAsString() : ""; //$NON-NLS-1$ //$NON-NLS-2$
+            String descriptionCell = prop.has(DESCRIPTION) && prop.get(DESCRIPTION).isJsonPrimitive()
+                ? prop.get(DESCRIPTION).getAsString() : ""; //$NON-NLS-1$
 
             sb.append(MarkdownUtils.tableRow(name, requiredCell, typeCell, descriptionCell));
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/InterceptionUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/InterceptionUtils.java
@@ -46,6 +46,8 @@ import com.ditrix.edt.mcp.server.Activator;
  */
 public final class InterceptionUtils
 {
+    private static final String VIA_SEPARATOR = "` via `"; //$NON-NLS-1$
+
     private InterceptionUtils()
     {
         // Utility class
@@ -138,7 +140,7 @@ public final class InterceptionUtils
                         Method baseMethod = entry.getValue();
                         String baseName = baseMethod != null ? baseMethod.getName() : pragmaTarget(entry.getKey());
                         lines.add("`" + safeName(method) + "` -> intercepts core method `" + baseName //$NON-NLS-1$ //$NON-NLS-2$
-                            + "` via `" + annotation(entry.getKey()) + "`"); //$NON-NLS-1$ //$NON-NLS-2$
+                            + VIA_SEPARATOR + annotation(entry.getKey()) + "`"); //$NON-NLS-1$
                     }
                 }
             }
@@ -164,7 +166,7 @@ public final class InterceptionUtils
                                 Method baseMethod = entry.getValue();
                                 String baseName = baseMethod != null ? baseMethod.getName() : pragmaTarget(entry.getKey());
                                 lines.add("`" + baseName + "` <- intercepted by extension `" + extProject //$NON-NLS-1$ //$NON-NLS-2$
-                                    + "`: `" + safeName(extMethod) + "` via `" + annotation(entry.getKey()) + "`"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                                    + "`: `" + safeName(extMethod) + VIA_SEPARATOR + annotation(entry.getKey()) + "`"); //$NON-NLS-1$ //$NON-NLS-2$
                             }
                         }
                     }
@@ -205,7 +207,7 @@ public final class InterceptionUtils
             Method baseMethod = entry.getValue();
             String baseName = baseMethod != null ? baseMethod.getName() : pragmaTarget(entry.getKey());
             lines.add("**Extension interception** — `" + safeName(extensionMethod) //$NON-NLS-1$
-                + "` intercepts core method `" + baseName + "` via `" + annotation(entry.getKey()) + "`"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                + "` intercepts core method `" + baseName + VIA_SEPARATOR + annotation(entry.getKey()) + "`"); //$NON-NLS-1$ //$NON-NLS-2$
         }
     }
 
@@ -232,7 +234,7 @@ public final class InterceptionUtils
             for (Map.Entry<Pragma, Method> entry : hits.entrySet())
             {
                 lines.add("**Intercepted by extension** `" + extProject + "`: `" + safeName(entry.getValue()) //$NON-NLS-1$ //$NON-NLS-2$
-                    + "` via `" + annotation(entry.getKey()) + "`"); //$NON-NLS-1$ //$NON-NLS-2$
+                    + VIA_SEPARATOR + annotation(entry.getKey()) + "`"); //$NON-NLS-1$
             }
         }
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/JUnitXmlParser.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/JUnitXmlParser.java
@@ -26,6 +26,8 @@ import org.w3c.dom.NodeList;
  */
 public final class JUnitXmlParser
 {
+    private static final String MESSAGE = "message"; //$NON-NLS-1$
+
     private JUnitXmlParser()
     {
         // utility class
@@ -89,7 +91,7 @@ public final class JUnitXmlParser
                     nodeFailures++;
                     Element failure = (Element) failureNodes.item(0);
                     results.addFailure(new JUnitTestResults.TestCase(fullName,
-                            failure.getAttribute("message"), //$NON-NLS-1$
+                            failure.getAttribute(MESSAGE),
                             failure.getTextContent()));
                 }
 
@@ -99,7 +101,7 @@ public final class JUnitXmlParser
                     nodeErrors++;
                     Element error = (Element) errorNodes.item(0);
                     results.addError(new JUnitTestResults.TestCase(fullName,
-                            error.getAttribute("message"), //$NON-NLS-1$
+                            error.getAttribute(MESSAGE),
                             error.getTextContent()));
                 }
 
@@ -109,7 +111,7 @@ public final class JUnitXmlParser
                     nodeSkipped++;
                     Element skip = (Element) skippedNodes.item(0);
                     results.addSkipped(new JUnitTestResults.TestCase(fullName,
-                            skip.getAttribute("message"), //$NON-NLS-1$
+                            skip.getAttribute(MESSAGE),
                             null));
                 }
             }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/VariableSerializer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/VariableSerializer.java
@@ -29,6 +29,12 @@ public final class VariableSerializer
     /** Hard cap for serialised string values to keep MCP responses sane. */
     public static final int MAX_VALUE_LENGTH = 500;
 
+    /** DTO key: the variable's serialised value. */
+    private static final String KEY_VALUE = "value"; //$NON-NLS-1$
+
+    /** DTO key: whether the value can be expanded into child variables. */
+    private static final String KEY_HAS_CHILDREN = "hasChildren"; //$NON-NLS-1$
+
     private VariableSerializer()
     {
     }
@@ -108,16 +114,16 @@ public final class VariableSerializer
         catch (Exception ex)
         {
             dto.put("type", "<unknown>"); //$NON-NLS-1$ //$NON-NLS-2$
-            dto.put("value", "<error: " + ex.getMessage() + ">"); //$NON-NLS-1$ //$NON-NLS-2$
-            dto.put("hasChildren", false); //$NON-NLS-1$
+            dto.put(KEY_VALUE, "<error: " + ex.getMessage() + ">"); //$NON-NLS-1$
+            dto.put(KEY_HAS_CHILDREN, false);
             return dto;
         }
 
         if (value == null)
         {
             dto.put("type", "Undefined"); //$NON-NLS-1$ //$NON-NLS-2$
-            dto.put("value", null); //$NON-NLS-1$
-            dto.put("hasChildren", false); //$NON-NLS-1$
+            dto.put(KEY_VALUE, null);
+            dto.put(KEY_HAS_CHILDREN, false);
             return dto;
         }
 
@@ -135,13 +141,13 @@ public final class VariableSerializer
         }
         if (stringValue != null && stringValue.length() > MAX_VALUE_LENGTH)
         {
-            dto.put("value", stringValue.substring(0, MAX_VALUE_LENGTH)); //$NON-NLS-1$
+            dto.put(KEY_VALUE, stringValue.substring(0, MAX_VALUE_LENGTH));
             dto.put("truncated", true); //$NON-NLS-1$
             dto.put("fullLength", stringValue.length()); //$NON-NLS-1$
         }
         else
         {
-            dto.put("value", stringValue); //$NON-NLS-1$
+            dto.put(KEY_VALUE, stringValue);
         }
 
         boolean hasChildren;
@@ -153,7 +159,7 @@ public final class VariableSerializer
         {
             hasChildren = false;
         }
-        dto.put("hasChildren", hasChildren); //$NON-NLS-1$
+        dto.put(KEY_HAS_CHILDREN, hasChildren);
         if (hasChildren)
         {
             // Hint for the caller: pass this name as expandPath (or append it


### PR DESCRIPTION
Tier-B of the SonarCloud **code-smell** cleanup (#164): **S1192 — 85 duplicated string literals → constants.**

Each literal duplicated 3+ times is hoisted to a `private static final String` constant; where Sonar pointed at an **already-defined** constant, the literal is replaced by that constant. **Behaviour-preserving** — every constant value is byte-identical to the literal it replaced, and the `//$NON-NLS-N$` markers were moved onto the declarations / renumbered on multi-literal lines (the subtle part).

29 files, done via a fan-out of 8 parallel agents over **disjoint files** (no merge conflicts), integrated with a single **`mvn clean verify` — 2202 tests green** (the build also proves the constants are valid compile-time constants, e.g. as `case` labels, and the tests prove the values are unchanged).

No skips. Code smells don't affect the quality gate (maintainability is already A) — pure hygiene.

Follows #166 (9 reliability bugs) and #167 (Tier-A: 40 mechanical smells).
