### PR TITLE
Throw specific exceptions instead of generic RuntimeException (S112, 25) + S1168

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
@@ -670,7 +670,7 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
                         bind, titleLanguage, titleText, russianAutoNames, createdKind);
                     if (err != null)
                     {
-                        throw new RuntimeException(err);
+                        throw new IllegalStateException(err);
                     }
                 });
         }
@@ -950,7 +950,7 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
                     EObject container = FormElementWriter.resolveHandlerContainer(formModel, ref);
                     if (container == null)
                     {
-                        throw new RuntimeException(commandOwner
+                        throw new IllegalStateException(commandOwner
                             ? "Form command not found: " + ref.itemName //$NON-NLS-1$
                                 + ". Create the command first, then add the handler." //$NON-NLS-1$
                             : "Form item not found: " + ref.itemName //$NON-NLS-1$
@@ -960,7 +960,7 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
                         langCode, fCallType, createdKind);
                     if (err != null)
                     {
-                        throw new RuntimeException(err);
+                        throw new IllegalStateException(err);
                     }
                 });
         }
@@ -1103,7 +1103,7 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         Object value = owner.eGet(feature);
         if (!(value instanceof EList))
         {
-            throw new RuntimeException("Containment feature '" + feature.getName() + "' is not a list"); //$NON-NLS-1$ //$NON-NLS-2$
+            throw new IllegalStateException("Containment feature '" + feature.getName() + "' is not a list"); //$NON-NLS-1$ //$NON-NLS-2$
         }
         ((EList<EObject>)value).add(child);
     }
@@ -1114,7 +1114,7 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         Object collection = cfg.eGet(cfg.eClass().getEStructuralFeature(refName));
         if (!(collection instanceof EList))
         {
-            throw new RuntimeException("Configuration feature '" + refName + "' is not a list"); //$NON-NLS-1$ //$NON-NLS-2$
+            throw new IllegalStateException("Configuration feature '" + refName + "' is not a list"); //$NON-NLS-1$ //$NON-NLS-2$
         }
         ((EList<MdObject>)collection).add(newObject);
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -1170,7 +1170,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                     Object map = target.eGet(feature);
                     if (!(map instanceof EMap))
                     {
-                        throw new RuntimeException("Localized feature '" + feature.getName() //$NON-NLS-1$
+                        throw new IllegalStateException("Localized feature '" + feature.getName() //$NON-NLS-1$
                             + "' is not a map"); //$NON-NLS-1$
                     }
                     ((EMap<String, String>)map).put(localizedLanguage, localizedValue);
@@ -1218,7 +1218,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             EObject t = (EObject)tx.getObjectById(bmId);
             if (t == null)
             {
-                throw new RuntimeException("Reference target is no longer in the transaction"); //$NON-NLS-1$
+                throw new IllegalStateException("Reference target is no longer in the transaction"); //$NON-NLS-1$
             }
             return t;
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -659,7 +659,7 @@ public final class FormElementWriter
         EObject txMdForm = (EObject)tx.getObjectById(ctx.mdFormBmId);
         if (txMdForm == null)
         {
-            throw new RuntimeException("Form object not found in transaction"); //$NON-NLS-1$
+            throw new IllegalStateException("Form object not found in transaction"); //$NON-NLS-1$
         }
         return txMdForm;
     }
@@ -763,12 +763,12 @@ public final class FormElementWriter
         EStructuralFeature formsFeature = owner.eClass().getEStructuralFeature(KEY_FORMS);
         if (formsFeature == null || !(formsFeature.getEType() instanceof EClass))
         {
-            throw new RuntimeException("Object type '" + owner.eClass().getName() //$NON-NLS-1$
+            throw new IllegalArgumentException("Object type '" + owner.eClass().getName() //$NON-NLS-1$
                 + "' does not support forms."); //$NON-NLS-1$
         }
         if (findOwnedFormByName(owner, formsFeature, formName) != null)
         {
-            throw new RuntimeException("Form already exists: " + formName); //$NON-NLS-1$
+            throw new IllegalStateException("Form already exists: " + formName); //$NON-NLS-1$
         }
         EClass mdFormEClass = (EClass)formsFeature.getEType();
 
@@ -776,7 +776,7 @@ public final class FormElementWriter
         BasicForm mdForm = (BasicForm)mdFactory.create(mdFormEClass, version);
         if (mdForm == null)
         {
-            throw new RuntimeException("Factory returned null for form type: " + mdFormEClass.getName()); //$NON-NLS-1$
+            throw new IllegalStateException("Factory returned null for form type: " + mdFormEClass.getName()); //$NON-NLS-1$
         }
         mdForm.setName(formName);
         mdForm.setUuid(UUID.randomUUID());
@@ -807,7 +807,7 @@ public final class FormElementWriter
             MdClassPackage.Literals.BASIC_FORM__FORM);
         if (contentFqn == null || contentFqn.isEmpty())
         {
-            throw new RuntimeException("Could not generate the content-form FQN for: " + formName); //$NON-NLS-1$
+            throw new IllegalStateException("Could not generate the content-form FQN for: " + formName); //$NON-NLS-1$
         }
         tx.attachTopObject((IBmObject)content, contentFqn);
 
@@ -879,7 +879,7 @@ public final class FormElementWriter
         EClassifier concrete = formPkg != null ? formPkg.getEClassifier("Form") : null; //$NON-NLS-1$
         if (!(concrete instanceof EClass))
         {
-            throw new RuntimeException("The form model EPackage (" + FORM_PACKAGE_NS_URI //$NON-NLS-1$
+            throw new IllegalStateException("The form model EPackage (" + FORM_PACKAGE_NS_URI //$NON-NLS-1$
                 + ") is not available in this platform."); //$NON-NLS-1$
         }
         return (EClass)concrete;
@@ -1004,11 +1004,11 @@ public final class FormElementWriter
                 }
                 catch (ReflectiveOperationException e)
                 {
-                    throw new RuntimeException("Failed to set default object form", e); //$NON-NLS-1$
+                    throw new IllegalStateException("Failed to set default object form", e); //$NON-NLS-1$
                 }
             }
         }
-        throw new RuntimeException("Owner type '" + owner.eClass().getName() //$NON-NLS-1$
+        throw new IllegalArgumentException("Owner type '" + owner.eClass().getName() //$NON-NLS-1$
             + "' has no compatible setDefaultObjectForm(...) method; create the form without " //$NON-NLS-1$
             + "setAsDefault and assign it manually."); //$NON-NLS-1$
     }
@@ -1222,7 +1222,7 @@ public final class FormElementWriter
         EObject item = findUniqueItem(formModel, itemName);
         if (item == null)
         {
-            throw new RuntimeException("Form item not found: '" + itemName //$NON-NLS-1$
+            throw new IllegalArgumentException("Form item not found: '" + itemName //$NON-NLS-1$
                 + "'. Use get_metadata_details on the form to inspect its items."); //$NON-NLS-1$
         }
         String err;
@@ -1232,7 +1232,7 @@ public final class FormElementWriter
             EObject container = item.eContainer();
             if (container == null)
             {
-                throw new RuntimeException("Form item '" + itemName //$NON-NLS-1$
+                throw new IllegalStateException("Form item '" + itemName //$NON-NLS-1$
                     + "' has no parent container and cannot be moved."); //$NON-NLS-1$
             }
             err = moveItemInto(formModel, item, container, containerLabel(formModel, container),
@@ -1244,7 +1244,7 @@ public final class FormElementWriter
         }
         if (err != null)
         {
-            throw new RuntimeException(err);
+            throw new IllegalArgumentException(err);
         }
         return destinationOf(formModel, item);
     }
@@ -1365,14 +1365,14 @@ public final class FormElementWriter
             int idx = Integer.parseInt(position.trim());
             if (idx < 0)
             {
-                throw new RuntimeException("Invalid position index '" + position //$NON-NLS-1$
+                throw new IllegalArgumentException("Invalid position index '" + position //$NON-NLS-1$
                     + "': must be zero or positive."); //$NON-NLS-1$
             }
             return idx;
         }
         catch (NumberFormatException e)
         {
-            throw new RuntimeException("Invalid position '" + position //$NON-NLS-1$
+            throw new IllegalArgumentException("Invalid position '" + position //$NON-NLS-1$
                 + "'. Expected an integer index, 'first', 'last', 'before:<name>' or 'after:<name>'."); //$NON-NLS-1$
         }
     }
@@ -1382,12 +1382,12 @@ public final class FormElementWriter
     {
         if (sibling.isEmpty())
         {
-            throw new RuntimeException("Position reference is missing a sibling name " //$NON-NLS-1$
+            throw new IllegalArgumentException("Position reference is missing a sibling name " //$NON-NLS-1$
                 + "(use 'before:<name>' or 'after:<name>')."); //$NON-NLS-1$
         }
         if (sibling.equalsIgnoreCase(movedName))
         {
-            throw new RuntimeException("Position cannot reference the moved item itself: '" //$NON-NLS-1$
+            throw new IllegalArgumentException("Position cannot reference the moved item itself: '" //$NON-NLS-1$
                 + sibling + "'."); //$NON-NLS-1$
         }
         for (int i = 0; i < destNames.size(); i++)
@@ -1397,7 +1397,7 @@ public final class FormElementWriter
                 return i;
             }
         }
-        throw new RuntimeException("Sibling '" + sibling //$NON-NLS-1$
+        throw new IllegalArgumentException("Sibling '" + sibling //$NON-NLS-1$
             + "' not found in the destination container."); //$NON-NLS-1$
     }
 
@@ -1442,7 +1442,7 @@ public final class FormElementWriter
         collectItemsByName(formModel, name, (EClass)formItem, matches);
         if (matches.size() > 1)
         {
-            throw new RuntimeException("Form item name '" + name //$NON-NLS-1$
+            throw new IllegalArgumentException("Form item name '" + name //$NON-NLS-1$
                 + "' is ambiguous (it matches more than one item)."); //$NON-NLS-1$
         }
         return matches.isEmpty() ? null : matches.get(0);
@@ -2863,7 +2863,7 @@ public final class FormElementWriter
         EStructuralFeature feature = container.eClass().getEStructuralFeature(featureName);
         if (!(feature instanceof EReference) || !feature.isMany())
         {
-            throw new RuntimeException("Form feature '" + featureName + "' is not a list"); //$NON-NLS-1$ //$NON-NLS-2$
+            throw new IllegalArgumentException("Form feature '" + featureName + "' is not a list"); //$NON-NLS-1$ //$NON-NLS-2$
         }
         ((EList<EObject>)container.eGet(feature)).add(element);
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataPropertyIntrospector.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataPropertyIntrospector.java
@@ -381,7 +381,7 @@ public final class MetadataPropertyIntrospector
             String target = referenceTargetTypeName(feature);
             return target != null ? Collections.singletonList(target) : null;
         }
-        return null;
+        return Collections.emptyList();
     }
 
     private static List<String> enumLiterals(EStructuralFeature feature)


### PR DESCRIPTION
Tier-B of the SonarCloud **code-smell** cleanup (#164): **specific exceptions (S112) + one return-empty (S1168).**

## Fixed (26)
- **S112 (25)** — `throw new RuntimeException(...)` → a **specific unchecked** JDK exception: `IllegalStateException` (invalid/impossible internal state or a wrapped "should not happen" failure) or `IllegalArgumentException` (invalid argument). Both extend `RuntimeException`, so existing `catch (RuntimeException ...)` / broad `catch (Exception ...)` paths still catch them — **behaviour preserved**; message + cause kept verbatim. (FormElementWriter ×18, CreateMetadataTool ×5, ModifyMetadataTool ×2.)
- **S1168 (1)** — `MetadataPropertyIntrospector.allowedValuesFor` returns `Collections.emptyList()` instead of `null` (both callers already normalise null→empty via the `PropertyInfo` ctor).

## Deliberately NOT changed (correct as-is)
- **S112 checked `throws Exception` (12)** — these are reflection helpers (`ReflectionUtils.invokeMethod`, the standalone-server `ssInvoke`, etc.) that propagate genuine checked exceptions; narrowing the `throws` clause cascades through all callers → left alone.
- **S1168 (18) / S2447 (9) / S2696 (4) — assessed, found intentional / false-positive, recommend *Won't Fix* in SonarCloud:** the `null` returns are meaningful signals (omit-from-snapshot in form rendering; a "malformed FQN" sentinel the caller null-checks before indexing `[0]`; methods with explicit `assertNull` unit tests); the `Boolean` returns are intentional **tri-state** (`null` ≠ `false`, callers depend on it); the static-field writes are the standard **Eclipse Activator / singleton / IWorkbenchAdapter-cache** patterns where the method can't be static. "Fixing" any of these would break behaviour.

mvn clean verify green (2202 tests). Smells don't affect the quality gate (maintainability already A). Follows #166, #167, #168.
