### PR TITLE
Extract nested try blocks into helper methods (S1141, 16)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/NewGroupHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/NewGroupHandler.java
@@ -175,17 +175,8 @@ public class NewGroupHandler extends AbstractHandler {
     private String getCollectionPath(Object adapter) {
         try {
             // Get the model object name (e.g., "Attribute", "CommonModule")
-            String modelObjectName = null;
-            try {
-                Method getModelObjectNameMethod = adapter.getClass().getMethod("getModelObjectName");
-                Object result = getModelObjectNameMethod.invoke(adapter);
-                if (result instanceof String) {
-                    modelObjectName = (String) result;
-                }
-            } catch (NoSuchMethodException e) {
-                // Method doesn't exist
-            }
-            
+            String modelObjectName = invokeGetModelObjectName(adapter);
+
             if (modelObjectName == null) {
                 // Fallback: try using IWorkbenchAdapter label
                 if (adapter instanceof IWorkbenchAdapter workbenchAdapter) {
@@ -202,18 +193,12 @@ public class NewGroupHandler extends AbstractHandler {
             
             // Check if this is a nested collection (has parent EObject)
             // We only support top-level collections for groups
-            try {
-                Method getParentMethod = adapter.getClass().getMethod("getParent", Object.class);
-                Object parent = getParentMethod.invoke(adapter, adapter);
-                if (parent instanceof EObject) {
-                    // This is a nested collection (e.g., Catalog.Products.Attribute)
-                    // We don't support groups for nested collections
-                    return null;
-                }
-            } catch (NoSuchMethodException e) {
-                // Method doesn't exist - this is fine, proceed with simple path
+            if (isNestedCollection(adapter)) {
+                // This is a nested collection (e.g., Catalog.Products.Attribute)
+                // We don't support groups for nested collections
+                return null;
             }
-            
+
             // Return simple collection type name (e.g., "CommonModule", "Catalog")
             return modelObjectName;
             
@@ -223,7 +208,42 @@ public class NewGroupHandler extends AbstractHandler {
         
         return null;
     }
-    
+
+    /**
+     * Reflectively invokes {@code getModelObjectName()} on the adapter.
+     * Returns the model object name (e.g. "CommonModule", "Catalog"), or
+     * {@code null} when the method is absent or does not return a String.
+     */
+    private String invokeGetModelObjectName(Object adapter) throws Exception {
+        try {
+            Method getModelObjectNameMethod = adapter.getClass().getMethod("getModelObjectName");
+            Object result = getModelObjectNameMethod.invoke(adapter);
+            if (result instanceof String) {
+                return (String) result;
+            }
+        } catch (NoSuchMethodException e) {
+            // Method doesn't exist
+        }
+        return null;
+    }
+
+    /**
+     * Determines whether the adapter represents a nested collection (i.e. its
+     * parent is an {@link EObject}, like Catalog.Products.Attribute). When the
+     * reflective {@code getParent(Object)} method is absent this is treated as a
+     * top-level collection (returns {@code false}).
+     */
+    private boolean isNestedCollection(Object adapter) throws Exception {
+        try {
+            Method getParentMethod = adapter.getClass().getMethod("getParent", Object.class);
+            Object parent = getParentMethod.invoke(adapter, adapter);
+            return parent instanceof EObject;
+        } catch (NoSuchMethodException e) {
+            // Method doesn't exist - this is fine, proceed with simple path
+            return false;
+        }
+    }
+
     /**
      * Gets the project from a navigator adapter.
      */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagSearchFilter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagSearchFilter.java
@@ -508,17 +508,8 @@ public class TagSearchFilter extends ViewerFilter {
             }
             
             // Get the model object name (Attribute, EnumValue, TabularSection, etc.)
-            String modelObjectName = null;
-            try {
-                var method = element.getClass().getMethod("getModelObjectName");
-                Object result = method.invoke(element);
-                if (result != null) {
-                    modelObjectName = result.toString();
-                }
-            } catch (NoSuchMethodException e) {
-                // Ignore
-            }
-            
+            String modelObjectName = readModelObjectName(element);
+
             if (modelObjectName == null) {
                 return null;
             }
@@ -555,7 +546,30 @@ public class TagSearchFilter extends ViewerFilter {
             return null;
         }
     }
-    
+
+    /**
+     * Reflectively reads the {@code getModelObjectName()} value of a folder element
+     * (e.g. "Attribute", "EnumValue", "TabularSection").
+     *
+     * @param element the folder element
+     * @return the model object name, or {@code null} if the element has no such method
+     *         or returns {@code null}
+     * @throws ReflectiveOperationException if the reflective invocation fails (other than
+     *         the no-such-method case, which is treated as "not a nested folder")
+     */
+    private String readModelObjectName(Object element) throws ReflectiveOperationException {
+        try {
+            var method = element.getClass().getMethod("getModelObjectName");
+            Object result = method.invoke(element);
+            if (result != null) {
+                return result.toString();
+            }
+        } catch (NoSuchMethodException e) {
+            // Ignore
+        }
+        return null;
+    }
+
     /**
      * Maps a model object name (from getModelObjectName) to the FQN type prefix.
      * For example:

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
@@ -764,15 +764,10 @@ public class CreateInfobaseTool implements IMcpTool
             if (context == null)
             {
                 // The bundle is not active yet — start it transiently so its services register.
-                try
+                if (startBundleTransiently(bundle,
+                    "create_infobase: could not start standalone-server bundle")) //$NON-NLS-1$
                 {
-                    bundle.start(Bundle.START_TRANSIENT);
                     context = bundle.getBundleContext();
-                }
-                catch (Exception startEx)
-                {
-                    Activator.logError("create_infobase: could not start standalone-server bundle", //$NON-NLS-1$
-                        startEx);
                 }
             }
             if (context == null)
@@ -787,6 +782,29 @@ public class CreateInfobaseTool implements IMcpTool
         {
             Activator.logError("create_infobase: could not acquire the standalone-server service", t); //$NON-NLS-1$
             return null;
+        }
+    }
+
+    /**
+     * Starts {@code bundle} transiently (so its services register / its activator runs) and reports
+     * whether the start succeeded. On failure {@code errorMessage} is logged and {@code false} is
+     * returned; the caller decides how to proceed.
+     *
+     * @param bundle       the bundle to start (must not be {@code null})
+     * @param errorMessage message logged when the start throws
+     * @return {@code true} when the bundle started without error, {@code false} otherwise
+     */
+    private static boolean startBundleTransiently(Bundle bundle, String errorMessage)
+    {
+        try
+        {
+            bundle.start(Bundle.START_TRANSIENT);
+            return true;
+        }
+        catch (Exception startEx)
+        {
+            Activator.logError(errorMessage, startEx);
+            return false;
         }
     }
 
@@ -1032,18 +1050,7 @@ public class CreateInfobaseTool implements IMcpTool
                         {
                             appObj.addProperty("type", typeId); //$NON-NLS-1$
                         }
-                        try
-                        {
-                            ApplicationUpdateState updateState = appManager.getUpdateState(app);
-                            if (updateState != null)
-                            {
-                                appObj.addProperty(KEY_UPDATE_STATE, updateState.name());
-                            }
-                        }
-                        catch (ApplicationException e)
-                        {
-                            appObj.addProperty(KEY_UPDATE_STATE, "UNKNOWN"); //$NON-NLS-1$
-                        }
+                        addUpdateState(appObj, appManager, app);
                         // Identify the JUST-created standalone server by its name (a wst-server app whose
                         // name matches the new infobase) — NOT merely the first wst-server app, which could
                         // be a pre-existing standalone server already bound to this project.
@@ -1148,6 +1155,28 @@ public class CreateInfobaseTool implements IMcpTool
     }
 
     /**
+     * Adds the application's update state to {@code appObj} under {@link #KEY_UPDATE_STATE}.
+     * On {@link ApplicationException} (state could not be read) the value is recorded as
+     * {@code "UNKNOWN"}; a {@code null} state is omitted.
+     */
+    private static void addUpdateState(JsonObject appObj, IApplicationManager appManager,
+            IApplication app)
+    {
+        try
+        {
+            ApplicationUpdateState updateState = appManager.getUpdateState(app);
+            if (updateState != null)
+            {
+                appObj.addProperty(KEY_UPDATE_STATE, updateState.name());
+            }
+        }
+        catch (ApplicationException e)
+        {
+            appObj.addProperty(KEY_UPDATE_STATE, "UNKNOWN"); //$NON-NLS-1$
+        }
+    }
+
+    /**
      * Attempts to resolve an {@link IInfobaseCreationOperation} instance from the
      * ps-core Guice injector via reflection.
      *
@@ -1183,15 +1212,8 @@ public class CreateInfobaseTool implements IMcpTool
             if (coreInstance == null)
             {
                 // Bundle not active yet — start it transiently and retry once.
-                try
-                {
-                    psCoreBundle.start(Bundle.START_TRANSIENT);
-                }
-                catch (Exception startEx)
-                {
-                    Activator.logError("create_infobase: could not start platform-services.core bundle", //$NON-NLS-1$
-                        startEx);
-                }
+                startBundleTransiently(psCoreBundle,
+                    "create_infobase: could not start platform-services.core bundle"); //$NON-NLS-1$
                 coreInstance = getDefault.invoke(null);
                 if (coreInstance == null)
                 {
@@ -1279,18 +1301,7 @@ public class CreateInfobaseTool implements IMcpTool
                         {
                             appObj.addProperty("type", app.getType().getId()); //$NON-NLS-1$
                         }
-                        try
-                        {
-                            ApplicationUpdateState updateState = appManager.getUpdateState(app);
-                            if (updateState != null)
-                            {
-                                appObj.addProperty(KEY_UPDATE_STATE, updateState.name());
-                            }
-                        }
-                        catch (ApplicationException e)
-                        {
-                            appObj.addProperty(KEY_UPDATE_STATE, "UNKNOWN"); //$NON-NLS-1$
-                        }
+                        addUpdateState(appObj, appManager, app);
                         // Identify the newly created application by matching the infobase reference.
                         if (newAppId == null
                             && app instanceof IInfobaseApplication

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetApplicationsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetApplicationsTool.java
@@ -150,24 +150,7 @@ public class GetApplicationsTool implements IMcpTool
                 }
                 
                 // Add update state
-                try
-                {
-                    ApplicationUpdateState updateState = appManager.getUpdateState(app);
-                    if (updateState != null)
-                    {
-                        appObj.addProperty("updateState", updateState.name()); //$NON-NLS-1$
-                        
-                        // Add human-readable description
-                        String stateDescription = getUpdateStateDescription(updateState);
-                        appObj.addProperty("updateStateDescription", stateDescription); //$NON-NLS-1$
-                    }
-                }
-                catch (ApplicationException e)
-                {
-                    Activator.logError("Error getting update state for application: " + app.getId(), e); //$NON-NLS-1$
-                    appObj.addProperty("updateState", "ERROR"); //$NON-NLS-1$ //$NON-NLS-2$
-                    appObj.addProperty("updateStateError", e.getMessage()); //$NON-NLS-1$
-                }
+                addUpdateState(appManager, app, appObj);
                 
                 // Add required version if present
                 app.getRequiredVersion().ifPresent(version -> 
@@ -177,19 +160,7 @@ public class GetApplicationsTool implements IMcpTool
             }
             
             // Get default application
-            String defaultAppId = null;
-            try
-            {
-                IApplication defaultApp = appManager.getDefaultApplication(project).orElse(null);
-                if (defaultApp != null)
-                {
-                    defaultAppId = defaultApp.getId();
-                }
-            }
-            catch (ApplicationException e)
-            {
-                Activator.logError("Error getting default application", e); //$NON-NLS-1$
-            }
+            String defaultAppId = resolveDefaultApplicationId(appManager, project);
             
             ToolResult result = ToolResult.success()
                 .put(McpKeys.PROJECT, projectName)
@@ -211,8 +182,64 @@ public class GetApplicationsTool implements IMcpTool
     }
     
     /**
+     * Adds the update-state properties for a single application to its JSON object.
+     * On error the state is reported as {@code "ERROR"} together with the error message,
+     * preserving the original inline behaviour.
+     *
+     * @param appManager the application manager
+     * @param app the application whose update state is read
+     * @param appObj the JSON object to populate
+     */
+    private void addUpdateState(IApplicationManager appManager, IApplication app, JsonObject appObj)
+    {
+        try
+        {
+            ApplicationUpdateState updateState = appManager.getUpdateState(app);
+            if (updateState != null)
+            {
+                appObj.addProperty("updateState", updateState.name()); //$NON-NLS-1$
+
+                // Add human-readable description
+                String stateDescription = getUpdateStateDescription(updateState);
+                appObj.addProperty("updateStateDescription", stateDescription); //$NON-NLS-1$
+            }
+        }
+        catch (ApplicationException e)
+        {
+            Activator.logError("Error getting update state for application: " + app.getId(), e); //$NON-NLS-1$
+            appObj.addProperty("updateState", "ERROR"); //$NON-NLS-1$ //$NON-NLS-2$
+            appObj.addProperty("updateStateError", e.getMessage()); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Resolves the id of the project's default application, or {@code null} when there is no
+     * default application or it could not be determined.
+     *
+     * @param appManager the application manager
+     * @param project the project
+     * @return the default application id, or {@code null}
+     */
+    private String resolveDefaultApplicationId(IApplicationManager appManager, IProject project)
+    {
+        try
+        {
+            IApplication defaultApp = appManager.getDefaultApplication(project).orElse(null);
+            if (defaultApp != null)
+            {
+                return defaultApp.getId();
+            }
+        }
+        catch (ApplicationException e)
+        {
+            Activator.logError("Error getting default application", e); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
      * Returns human-readable description for update state.
-     * 
+     *
      * @param state the update state
      * @return description string
      */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -157,6 +157,29 @@ public class GetProjectErrorsTool implements IMcpTool
      *        marker collection, model reads and transaction boundaries are identical.
      * @return Markdown formatted string with error details
      */
+    /**
+     * Parses a severity filter name into a {@link MarkerSeverity}. Returns {@code null} for a
+     * null/empty input or an unrecognized name, in which case all severities are shown.
+     *
+     * @param severity the severity name (case-insensitive), may be {@code null}
+     * @return the parsed {@link MarkerSeverity}, or {@code null} to apply no severity filter
+     */
+    private static MarkerSeverity parseSeverityFilter(String severity)
+    {
+        if (severity != null && !severity.isEmpty())
+        {
+            try
+            {
+                return MarkerSeverity.valueOf(severity.toUpperCase());
+            }
+            catch (IllegalArgumentException e)
+            {
+                // Invalid severity, will show all
+            }
+        }
+        return null;
+    }
+
     public static String getProjectErrors(String projectName, String severity, String checkId, List<String> objects, int limit, boolean detailed)
     {
         try
@@ -172,19 +195,7 @@ public class GetProjectErrorsTool implements IMcpTool
             IBmModelManager bmModelManager = Activator.getDefault().getBmModelManager();
 
             // Parse severity filter
-            MarkerSeverity severityFilter = null;
-            if (severity != null && !severity.isEmpty())
-            {
-                try
-                {
-                    severityFilter = MarkerSeverity.valueOf(severity.toUpperCase());
-                }
-                catch (IllegalArgumentException e)
-                {
-                    // Invalid severity, will show all
-                }
-            }
-            final MarkerSeverity finalSeverityFilter = severityFilter;
+            final MarkerSeverity finalSeverityFilter = parseSeverityFilter(severity);
             final String finalCheckId = checkId;
             
             // Validate project if specified

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListProjectsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListProjectsTool.java
@@ -99,48 +99,14 @@ public class ListProjectsTool implements IMcpTool
                     // EDT project check and natures
                     String edtStatus = "-"; //$NON-NLS-1$
                     String naturesStr = "-"; //$NON-NLS-1$
-                    
+
                     if (project.isOpen())
                     {
-                        try
-                        {
-                            boolean isEdtProject = project.hasNature("com._1c.g5.v8.dt.core.V8ConfigurationNature") || //$NON-NLS-1$
-                                                   project.hasNature("com._1c.g5.v8.dt.core.V8ExtensionNature"); //$NON-NLS-1$
-                            edtStatus = isEdtProject ? "Yes" : "No"; //$NON-NLS-1$ //$NON-NLS-2$
-                            
-                            String[] natures = project.getDescription().getNatureIds();
-                            if (natures.length > 0)
-                            {
-                                // Show abbreviated natures
-                                StringBuilder naturesBuilder = new StringBuilder();
-                                for (int i = 0; i < Math.min(natures.length, 3); i++)
-                                {
-                                    if (i > 0)
-                                    {
-                                        naturesBuilder.append(", "); //$NON-NLS-1$
-                                    }
-                                    // Get short nature name
-                                    String nature = natures[i];
-                                    int lastDot = nature.lastIndexOf('.');
-                                    naturesBuilder.append(lastDot > 0 ? nature.substring(lastDot + 1) : nature);
-                                }
-                                if (natures.length > 3)
-                                {
-                                    naturesBuilder.append("...+").append(natures.length - 3); //$NON-NLS-1$
-                                }
-                                naturesStr = naturesBuilder.toString();
-                            }
-                        }
-                        catch (Exception e)
-                        {
-                            // Per-project failure is non-fatal (the row still lists
-                            // the project with "-" placeholders), but log it at WARNING
-                            // so a swallowed failure leaves a traceable server-side line.
-                            Log.warning("list_projects: failed to read nature/state for project '" //$NON-NLS-1$
-                                + project.getName() + "': " + e.getMessage()); //$NON-NLS-1$
-                        }
+                        String[] edtAndNatures = readEdtStatusAndNatures(project);
+                        edtStatus = edtAndNatures[0];
+                        naturesStr = edtAndNatures[1];
                     }
-                    
+
                     md.append(edtStatus);
                     md.append(" | "); //$NON-NLS-1$
                     md.append(MarkdownUtils.escapeForTable(naturesStr));
@@ -153,7 +119,60 @@ public class ListProjectsTool implements IMcpTool
             Activator.logError("Failed to list projects", e); //$NON-NLS-1$
             return ToolResult.error(e.getMessage()).toJson();
         }
-        
+
         return md.toString();
+    }
+
+    /**
+     * Reads the EDT-project flag and an abbreviated nature list for an open project.
+     * Returns a two-element array {@code [edtStatus, naturesStr]}. A per-project failure
+     * is non-fatal: it is logged at WARNING and the corresponding "-" placeholders are
+     * returned so the project row still renders.
+     *
+     * @param project the open project to inspect
+     * @return {@code [edtStatus, naturesStr]}
+     */
+    private static String[] readEdtStatusAndNatures(IProject project)
+    {
+        String edtStatus = "-"; //$NON-NLS-1$
+        String naturesStr = "-"; //$NON-NLS-1$
+        try
+        {
+            boolean isEdtProject = project.hasNature("com._1c.g5.v8.dt.core.V8ConfigurationNature") || //$NON-NLS-1$
+                                   project.hasNature("com._1c.g5.v8.dt.core.V8ExtensionNature"); //$NON-NLS-1$
+            edtStatus = isEdtProject ? "Yes" : "No"; //$NON-NLS-1$ //$NON-NLS-2$
+
+            String[] natures = project.getDescription().getNatureIds();
+            if (natures.length > 0)
+            {
+                // Show abbreviated natures
+                StringBuilder naturesBuilder = new StringBuilder();
+                for (int i = 0; i < Math.min(natures.length, 3); i++)
+                {
+                    if (i > 0)
+                    {
+                        naturesBuilder.append(", "); //$NON-NLS-1$
+                    }
+                    // Get short nature name
+                    String nature = natures[i];
+                    int lastDot = nature.lastIndexOf('.');
+                    naturesBuilder.append(lastDot > 0 ? nature.substring(lastDot + 1) : nature);
+                }
+                if (natures.length > 3)
+                {
+                    naturesBuilder.append("...+").append(natures.length - 3); //$NON-NLS-1$
+                }
+                naturesStr = naturesBuilder.toString();
+            }
+        }
+        catch (Exception e)
+        {
+            // Per-project failure is non-fatal (the row still lists
+            // the project with "-" placeholders), but log it at WARNING
+            // so a swallowed failure leaves a traceable server-side line.
+            Log.warning("list_projects: failed to read nature/state for project '" //$NON-NLS-1$
+                + project.getName() + "': " + e.getMessage()); //$NON-NLS-1$
+        }
+        return new String[] { edtStatus, naturesStr };
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
@@ -392,20 +392,10 @@ public class RunYaxunitTestsTool implements IMcpTool
 
             if (applicationId != null && !applicationId.isEmpty())
             {
-                try
+                String appError = validateApplicationExists(appManager, project, applicationId);
+                if (appError != null)
                 {
-                    Optional<IApplication> appOpt = appManager.getApplication(project, applicationId);
-                    if (!appOpt.isPresent())
-                    {
-                        return ToolResult.error("Application not found: " + applicationId //$NON-NLS-1$
-                                + ". Use get_applications to get valid application IDs.").toJson(); //$NON-NLS-1$
-                    }
-                }
-                catch (ApplicationException e)
-                {
-                    Activator.logError("Error checking application", e); //$NON-NLS-1$
-                    return ToolResult.error("Failed to validate application: " + applicationId //$NON-NLS-1$
-                            + " (" + e.getMessage() + ")").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+                    return appError;
                 }
             }
 
@@ -1008,6 +998,32 @@ public class RunYaxunitTestsTool implements IMcpTool
     }
 
     /**
+     * Validates that the given application exists for the project. Returns {@code null} when the
+     * application resolves, or a JSON error string (identical to the previous inline handling) when
+     * the application is not found or the lookup throws.
+     */
+    private String validateApplicationExists(IApplicationManager appManager, IProject project,
+            String applicationId)
+    {
+        try
+        {
+            Optional<IApplication> appOpt = appManager.getApplication(project, applicationId);
+            if (!appOpt.isPresent())
+            {
+                return ToolResult.error("Application not found: " + applicationId //$NON-NLS-1$
+                        + ". Use get_applications to get valid application IDs.").toJson(); //$NON-NLS-1$
+            }
+            return null;
+        }
+        catch (ApplicationException e)
+        {
+            Activator.logError("Error checking application", e); //$NON-NLS-1$
+            return ToolResult.error("Failed to validate application: " + applicationId //$NON-NLS-1$
+                    + " (" + e.getMessage() + ")").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+    }
+
+    /**
      * Parses the JUnit XML, formats it as Markdown and writes report.md next to junit.xml so
      * that the user can open the report manually from disk. Returns the Markdown content for
      * the MCP response, with an extra footer pointing at the on-disk file.
@@ -1020,16 +1036,7 @@ public class RunYaxunitTestsTool implements IMcpTool
             String markdown = JUnitMarkdownFormatter.format(results);
 
             Path reportFile = junitXml.toPath().resolveSibling("report.md"); //$NON-NLS-1$
-            boolean reportWritten = false;
-            try
-            {
-                Files.write(reportFile, markdown.getBytes(StandardCharsets.UTF_8));
-                reportWritten = Files.exists(reportFile);
-            }
-            catch (IOException io)
-            {
-                Activator.logError("Failed to write Markdown report to " + reportFile, io); //$NON-NLS-1$
-            }
+            boolean reportWritten = writeReportFile(reportFile, markdown);
 
             if (reportWritten)
             {
@@ -1041,6 +1048,25 @@ public class RunYaxunitTestsTool implements IMcpTool
         {
             Activator.logError("Error parsing JUnit XML: " + junitXml, e); //$NON-NLS-1$
             return ToolResult.error("Failed to parse test results: " + e.getMessage()).toJson(); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Writes the Markdown report to {@code reportFile}. Returns {@code true} if the file
+     * was written and exists afterwards; a failed write is logged and returns {@code false}
+     * (the report content is still returned to the caller without the on-disk footer).
+     */
+    private boolean writeReportFile(Path reportFile, String markdown)
+    {
+        try
+        {
+            Files.write(reportFile, markdown.getBytes(StandardCharsets.UTF_8));
+            return Files.exists(reportFile);
+        }
+        catch (IOException io)
+        {
+            Activator.logError("Failed to write Markdown report to " + reportFile, io); //$NON-NLS-1$
+            return false;
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/StandaloneServerSupport.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/StandaloneServerSupport.java
@@ -107,16 +107,7 @@ final class StandaloneServerSupport
             BundleContext context = bundle.getBundleContext();
             if (context == null)
             {
-                try
-                {
-                    bundle.start(Bundle.START_TRANSIENT);
-                    context = bundle.getBundleContext();
-                }
-                catch (Exception startEx)
-                {
-                    Activator.logError("standalone-server: could not start the standalone-server bundle", //$NON-NLS-1$
-                        startEx);
-                }
+                context = startAndGetContext(bundle);
             }
             if (context == null)
             {
@@ -128,6 +119,29 @@ final class StandaloneServerSupport
         catch (Throwable t)
         {
             Activator.logError("standalone-server: could not acquire the standalone-server service", t); //$NON-NLS-1$
+            return null;
+        }
+    }
+
+    /**
+     * Transiently starts the given bundle and returns its (now hopefully available) {@link BundleContext}.
+     * A start failure is logged and swallowed (best-effort): the returned context may still be {@code null},
+     * which the caller already handles by failing gracefully.
+     *
+     * @param bundle the standalone-server bundle whose context was not yet available
+     * @return the bundle context after the start attempt, or {@code null} when it is still unavailable
+     */
+    private static BundleContext startAndGetContext(Bundle bundle)
+    {
+        try
+        {
+            bundle.start(Bundle.START_TRANSIENT);
+            return bundle.getBundleContext();
+        }
+        catch (Exception startEx)
+        {
+            Activator.logError("standalone-server: could not start the standalone-server bundle", //$NON-NLS-1$
+                startEx);
             return null;
         }
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/EditorScreenshotHelper.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/EditorScreenshotHelper.java
@@ -139,16 +139,7 @@ public final class EditorScreenshotHelper
 
             if (nativeRender && !bufferedBefore)
             {
-                try
-                {
-                    Field bufferedField = serviceClass.getDeclaredField(bufferedFlagField);
-                    bufferedField.setAccessible(true);
-                    bufferedField.setBoolean(null, true);
-                }
-                catch (Exception e)
-                {
-                    ReflectionUtils.forceStaticFinalBoolean(serviceClass, bufferedFlagField, true);
-                }
+                forceBufferedRenderFlag(serviceClass, bufferedFlagField);
             }
 
             boolean bufferedAfter = (Boolean)isBufferedRenderMethod.invoke(null);
@@ -161,6 +152,27 @@ public final class EditorScreenshotHelper
         catch (Exception e)
         {
             Activator.logWarning("Failed to ensure buffered native render mode: " + e.getMessage()); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Forces the static buffered-render flag field to {@code true}, first via a plain reflective
+     * field set and, if that fails, via {@link ReflectionUtils#forceStaticFinalBoolean}.
+     *
+     * @param serviceClass the native render service class declaring the flag
+     * @param bufferedFlagField the name of the static boolean flag field
+     */
+    private static void forceBufferedRenderFlag(Class<?> serviceClass, String bufferedFlagField)
+    {
+        try
+        {
+            Field bufferedField = serviceClass.getDeclaredField(bufferedFlagField);
+            bufferedField.setAccessible(true);
+            bufferedField.setBoolean(null, true);
+        }
+        catch (Exception e)
+        {
+            ReflectionUtils.forceStaticFinalBoolean(serviceClass, bufferedFlagField, true);
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchConfigUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchConfigUtils.java
@@ -221,19 +221,9 @@ public final class LaunchConfigUtils
         {
             for (ILaunchConfiguration config : launchManager.getLaunchConfigurations(configType))
             {
-                try
+                if (matchesProjectAndApplication(config, projectName, applicationId))
                 {
-                    String configProject = config.getAttribute(ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
-                    String configAppId = config.getAttribute(ATTR_APPLICATION_ID, ""); //$NON-NLS-1$
-
-                    if (projectName.equals(configProject) && applicationId.equals(configAppId))
-                    {
-                        return config;
-                    }
-                }
-                catch (CoreException e)
-                {
-                    Activator.logError("Error reading launch configuration: " + config.getName(), e); //$NON-NLS-1$
+                    return config;
                 }
             }
         }
@@ -243,6 +233,33 @@ public final class LaunchConfigUtils
         }
 
         return null;
+    }
+
+    /**
+     * Tells whether {@code config}'s {@code project + applicationId} attributes match the given
+     * pair exactly. A {@link CoreException} while reading the attributes is logged and treated as
+     * "no match" (so the caller skips this configuration and continues searching).
+     *
+     * @param config        launch configuration to inspect
+     * @param projectName   target project name
+     * @param applicationId target application id
+     * @return {@code true} when both attributes match, {@code false} otherwise (including on read error)
+     */
+    private static boolean matchesProjectAndApplication(ILaunchConfiguration config,
+            String projectName, String applicationId)
+    {
+        try
+        {
+            String configProject = config.getAttribute(ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+            String configAppId = config.getAttribute(ATTR_APPLICATION_ID, ""); //$NON-NLS-1$
+
+            return projectName.equals(configProject) && applicationId.equals(configAppId);
+        }
+        catch (CoreException e)
+        {
+            Activator.logError("Error reading launch configuration: " + config.getName(), e); //$NON-NLS-1$
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Tier-B of the SonarCloud code-smell cleanup (#164): **16 of 24 S1141 nested-try findings** resolved by extracting the inner try/catch into a new private helper, chosen ONLY where clean and behaviour-preserving (self-contained block, few outer locals as params, control-flow mapped to a return, exception propagation preserved). The other 8 were left because the inner try breaks/continues the outer loop, early-returns from the outer method, or mutates several outer locals consumed later — incl. the `DeleteInfobaseTool` shared-files safety guard, kept untouched on purpose. `mvn clean verify` green (2202 tests), no behaviour change. Follows #166/#167/#168/#169.