### PR TITLE
Reduce cognitive complexity via Extract Method, part 2 (S3776 cc 19-22, 29 methods)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/RenameGroupHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/RenameGroupHandler.java
@@ -8,6 +8,7 @@ package com.ditrix.edt.mcp.server.groups.handlers;
 
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.window.Window;
 
 import com.ditrix.edt.mcp.server.Activator;
@@ -32,27 +33,8 @@ public class RenameGroupHandler extends AbstractGroupHandler {
         String parentPath = group.getPath();
         
         // Show dialog for editing name and description
-        EditGroupDialog dialog = new EditGroupDialog(sel.shell, group, name -> {
-            if (name == null || name.trim().isEmpty()) {
-                return "Group name cannot be empty";
-            }
-            String trimmed = name.trim();
-            if (trimmed.contains("/") || trimmed.contains("\\")) {
-                return "Group name cannot contain path separators";
-            }
-            // Check if same as current name
-            if (trimmed.equals(group.getName())) {
-                return null; // Same name is OK
-            }
-            // Check for existing group with new name
-            String newFullPath = (parentPath == null || parentPath.isEmpty()) 
-                ? trimmed 
-                : parentPath + "/" + trimmed;
-            if (getGroupService().getGroupStorage(sel.project).getGroupByFullPath(newFullPath) != null) {
-                return "A group with this name already exists";
-            }
-            return null;
-        });
+        EditGroupDialog dialog = new EditGroupDialog(sel.shell, group,
+            name -> validateNewGroupName(name, group, parentPath, sel.project));
         
         if (dialog.open() == Window.OK) {
             String newName = dialog.getGroupName();
@@ -72,6 +54,39 @@ public class RenameGroupHandler extends AbstractGroupHandler {
             }
         }
         
+        return null;
+    }
+
+    /**
+     * Validates a proposed new group name for an in-place rename. Returns an
+     * error message to surface in the dialog, or {@code null} when the name is
+     * acceptable (including when it is unchanged).
+     *
+     * @param name the proposed name as entered (may be {@code null})
+     * @param group the group being renamed
+     * @param parentPath the path of the group's parent (may be {@code null} or empty for a root group)
+     * @param project the project owning the group, used to look up name collisions
+     * @return an error message, or {@code null} when the name is valid
+     */
+    private String validateNewGroupName(String name, Group group, String parentPath, IProject project) {
+        if (name == null || name.trim().isEmpty()) {
+            return "Group name cannot be empty";
+        }
+        String trimmed = name.trim();
+        if (trimmed.contains("/") || trimmed.contains("\\")) {
+            return "Group name cannot contain path separators";
+        }
+        // Check if same as current name
+        if (trimmed.equals(group.getName())) {
+            return null; // Same name is OK
+        }
+        // Check for existing group with new name
+        String newFullPath = (parentPath == null || parentPath.isEmpty())
+            ? trimmed
+            : parentPath + "/" + trimmed;
+        if (getGroupService().getGroupStorage(project).getGroupByFullPath(newFullPath) != null) {
+            return "A group with this name already exists";
+        }
         return null;
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolsTab.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolsTab.java
@@ -238,34 +238,7 @@ public class ToolsTab
                 {
                     return;
                 }
-                Object element = event.getElement();
-                boolean checked = event.getChecked();
-
-                if (element instanceof ToolGroup group)
-                {
-                    for (String toolName : group.getToolNames())
-                    {
-                        if (checked)
-                        {
-                            disabledTools.remove(toolName);
-                        }
-                        else
-                        {
-                            disabledTools.add(toolName);
-                        }
-                    }
-                }
-                else if (element instanceof String toolName)
-                {
-                    if (checked)
-                    {
-                        disabledTools.remove(toolName);
-                    }
-                    else
-                    {
-                        disabledTools.add(toolName);
-                    }
-                }
+                applyCheckChange(event.getElement(), event.getChecked());
 
                 refreshCheckStates();
                 selectMatchingPreset();
@@ -309,6 +282,44 @@ public class ToolsTab
                 showDetailsForElement(selection.getFirstElement());
             }
         });
+    }
+
+    /**
+     * Applies a single checkbox change to {@link #disabledTools}: a checked element
+     * enables (removes from disabled) and an unchecked element disables (adds to
+     * disabled). A {@link ToolGroup} element fans the change out to all its tools;
+     * a {@link String} element is a single tool. Any other element type is ignored.
+     *
+     * @param element the changed tree element (a {@link ToolGroup} or tool-name {@link String})
+     * @param checked {@code true} when the element was checked (enabled)
+     */
+    private void applyCheckChange(Object element, boolean checked)
+    {
+        if (element instanceof ToolGroup group)
+        {
+            for (String toolName : group.getToolNames())
+            {
+                if (checked)
+                {
+                    disabledTools.remove(toolName);
+                }
+                else
+                {
+                    disabledTools.add(toolName);
+                }
+            }
+        }
+        else if (element instanceof String toolName)
+        {
+            if (checked)
+            {
+                disabledTools.remove(toolName);
+            }
+            else
+            {
+                disabledTools.add(toolName);
+            }
+        }
     }
 
     private void createCountLabel(Composite parent)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/JsonUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/JsonUtils.java
@@ -267,29 +267,13 @@ public final class JsonUtils
         // Check if it's a JSON array
         if (value.startsWith("[")) //$NON-NLS-1$
         {
-            try
+            List<String> jsonResult = parseJsonStringArray(value);
+            if (jsonResult != null)
             {
-                JsonElement element = JsonParser.parseString(value);
-                if (element.isJsonArray())
-                {
-                    JsonArray array = element.getAsJsonArray();
-                    List<String> result = new ArrayList<>(array.size());
-                    for (JsonElement el : array)
-                    {
-                        if (el.isJsonPrimitive())
-                        {
-                            result.add(el.getAsString());
-                        }
-                    }
-                    return result;
-                }
-            }
-            catch (Exception e)
-            {
-                // Fall through to comma-separated parsing
+                return jsonResult;
             }
         }
-        
+
         // Parse as comma-separated
         List<String> result = new ArrayList<>();
         for (String part : value.split(",")) //$NON-NLS-1$
@@ -303,7 +287,39 @@ public final class JsonUtils
         
         return result.isEmpty() ? null : result;
     }
-    
+
+    /**
+     * Parses {@code value} (already known to start with {@code [}) as a JSON array of strings, keeping
+     * only primitive elements. Returns the resulting list (possibly empty) when {@code value} is a valid
+     * JSON array, or {@code null} when it is not an array or cannot be parsed — the {@code null} signals
+     * {@link #extractArrayArgument} to fall through to comma-separated parsing.
+     */
+    private static List<String> parseJsonStringArray(String value)
+    {
+        try
+        {
+            JsonElement element = JsonParser.parseString(value);
+            if (element.isJsonArray())
+            {
+                JsonArray array = element.getAsJsonArray();
+                List<String> result = new ArrayList<>(array.size());
+                for (JsonElement el : array)
+                {
+                    if (el.isJsonPrimitive())
+                    {
+                        result.add(el.getAsString());
+                    }
+                }
+                return result;
+            }
+        }
+        catch (Exception e)
+        {
+            // Fall through to comma-separated parsing
+        }
+        return null;
+    }
+
     /**
      * Extracts an array-of-objects argument from the params map. A complex argument arrives here as
      * its JSON text (the protocol layer re-serializes nested JSON values into the string map), so a

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/handlers/ToggleTagByIndexHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/handlers/ToggleTagByIndexHandler.java
@@ -70,19 +70,8 @@ public class ToggleTagByIndexHandler extends AbstractTagHandler {
         }
         
         // Group selected objects by project
-        List<ObjectInfo> objectsToProcess = new ArrayList<>();
-        for (Iterator<?> it = ssel.iterator(); it.hasNext();) {
-            Object element = it.next();
-            EObject mdObject = TagUtils.extractMdObject(element);
-            if (mdObject != null) {
-                IProject project = TagUtils.extractProjectFromElement(element);
-                String fqn = TagUtils.extractFqn(mdObject);
-                if (project != null && fqn != null) {
-                    objectsToProcess.add(new ObjectInfo(project, fqn));
-                }
-            }
-        }
-        
+        List<ObjectInfo> objectsToProcess = collectObjectsToProcess(ssel);
+
         if (objectsToProcess.isEmpty()) {
             return null;
         }
@@ -113,7 +102,32 @@ public class ToggleTagByIndexHandler extends AbstractTagHandler {
         
         return null;
     }
-    
+
+    /**
+     * Collects the resolvable metadata objects from the current structured
+     * selection, paired with their owning project. Behaviour is identical to the
+     * inline grouping loop it replaces: same iteration order, same null/fqn
+     * filtering, same resulting list.
+     *
+     * @param ssel the current structured selection
+     * @return the (possibly empty) list of objects to process
+     */
+    private List<ObjectInfo> collectObjectsToProcess(IStructuredSelection ssel) {
+        List<ObjectInfo> objectsToProcess = new ArrayList<>();
+        for (Iterator<?> it = ssel.iterator(); it.hasNext();) {
+            Object element = it.next();
+            EObject mdObject = TagUtils.extractMdObject(element);
+            if (mdObject != null) {
+                IProject project = TagUtils.extractProjectFromElement(element);
+                String fqn = TagUtils.extractFqn(mdObject);
+                if (project != null && fqn != null) {
+                    objectsToProcess.add(new ObjectInfo(project, fqn));
+                }
+            }
+        }
+        return objectsToProcess;
+    }
+
     /**
      * Record for storing object info during processing.
      */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagFilterView.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagFilterView.java
@@ -595,39 +595,56 @@ public class TagFilterView extends ViewPart implements ITagChangeListener {
             manager.add(new Action("Copy Selected (" + selection.size() + ")") {
                 @Override
                 public void run() {
-                    StringBuilder sb = new StringBuilder();
-                    for (Object obj : selection) {
-                        if (sb.length() > 0) {
-                            sb.append("\n");
-                        }
-                        // Copy simplified FQN as displayed
-                        if (obj instanceof ObjectEntry entry) {
-                            sb.append(simplifyFqn(entry.fqn()));
-                        } else {
-                            sb.append(String.valueOf(obj));
-                        }
-                    }
-                    copyToClipboard(sb.toString());
+                    copyToClipboard(buildSelectionClipboardText(selection));
                 }
             });
         }
-        
+
         // Copy All FQNs
         if (!filteredObjects.isEmpty()) {
             manager.add(new Action("Copy All (" + filteredObjects.size() + ")") {
                 @Override
                 public void run() {
-                    StringBuilder sb = new StringBuilder();
-                    for (ObjectEntry entry : filteredObjects) {
-                        if (sb.length() > 0) {
-                            sb.append("\n");
-                        }
-                        sb.append(simplifyFqn(entry.fqn()));
-                    }
-                    copyToClipboard(sb.toString());
+                    copyToClipboard(buildAllClipboardText());
                 }
             });
         }
+    }
+
+    /**
+     * Builds the newline-separated clipboard text for the current selection,
+     * using the simplified FQN for {@link ObjectEntry} elements and the raw
+     * string form otherwise. Pure: builds and returns the text only.
+     */
+    private String buildSelectionClipboardText(IStructuredSelection selection) {
+        StringBuilder sb = new StringBuilder();
+        for (Object obj : selection) {
+            if (sb.length() > 0) {
+                sb.append("\n");
+            }
+            // Copy simplified FQN as displayed
+            if (obj instanceof ObjectEntry entry) {
+                sb.append(simplifyFqn(entry.fqn()));
+            } else {
+                sb.append(String.valueOf(obj));
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Builds the newline-separated clipboard text of simplified FQNs for all
+     * filtered objects. Pure: builds and returns the text only.
+     */
+    private String buildAllClipboardText() {
+        StringBuilder sb = new StringBuilder();
+        for (ObjectEntry entry : filteredObjects) {
+            if (sb.length() > 0) {
+                sb.append("\n");
+            }
+            sb.append(simplifyFqn(entry.fqn()));
+        }
+        return sb.toString();
     }
     
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagTrieStateProvider.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagTrieStateProvider.java
@@ -253,15 +253,9 @@ public class TagTrieStateProvider implements INavigatorContentProviderStateProvi
                         ((com._1c.g5.v8.dt.core.platform.IConfigurationAware) v8Project).getConfiguration();
                     if (configuration != null) {
                         // Search in Configuration.getSubsystems() for the matching subsystem
-                        for (com._1c.g5.v8.dt.metadata.mdclass.Subsystem subsystem : configuration.getSubsystems()) {
-                            if (subsystemName.equals(subsystem.getName())) {
-                                return subsystem;
-                            }
-                            // Also search in child subsystems (recursive)
-                            EObject found = findChildSubsystem(subsystem, subsystemName);
-                            if (found != null) {
-                                return found;
-                            }
+                        EObject found = findSubsystemInConfiguration(configuration, subsystemName);
+                        if (found != null) {
+                            return found;
                         }
                     }
                 }
@@ -271,7 +265,28 @@ public class TagTrieStateProvider implements INavigatorContentProviderStateProvi
         }
         return null;
     }
-    
+
+    /**
+     * Searches a Configuration's top-level subsystems (and, recursively, their
+     * child subsystems) for the one matching the given name.
+     *
+     * @return the matching subsystem, or {@code null} if none matches
+     */
+    private EObject findSubsystemInConfiguration(
+            com._1c.g5.v8.dt.metadata.mdclass.Configuration configuration, String subsystemName) {
+        for (com._1c.g5.v8.dt.metadata.mdclass.Subsystem subsystem : configuration.getSubsystems()) {
+            if (subsystemName.equals(subsystem.getName())) {
+                return subsystem;
+            }
+            // Also search in child subsystems (recursive)
+            EObject found = findChildSubsystem(subsystem, subsystemName);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
     /**
      * Recursively searches for a child subsystem by name.
      */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagsMenuContribution.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagsMenuContribution.java
@@ -199,8 +199,33 @@ public class TagsMenuContribution extends CompoundContributionItem {
         @Override
         public void fill(Menu menu, int index) {
             MenuItem item = new MenuItem(menu, SWT.CHECK, index);
-            
-            // Build text with optional hotkey
+
+            item.setText(buildItemText());
+            item.setSelection(isChecked);
+
+            // Create image and dispose it when menu item is disposed
+            Image image = TagColorIconFactory.getCircularColorIconWithCheck(
+                color, 16, isChecked).createImage();
+            item.setImage(image);
+            item.addDisposeListener(e -> image.dispose());
+
+            item.addSelectionListener(new SelectionAdapter() {
+                @Override
+                public void widgetSelected(SelectionEvent e) {
+                    // Capture selection value before asyncExec since menu item may be disposed
+                    boolean selected = item.getSelection();
+                    Display.getCurrent().asyncExec(() -> applyTagToSelection(selected));
+                }
+            });
+        }
+
+        /**
+         * Builds the menu item label: the tag name, optionally followed by a tab and the configured
+         * hotkey. Extracted verbatim from {@link #fill(Menu, int)} to keep its complexity in check.
+         *
+         * @return the label text for the menu item
+         */
+        private String buildItemText() {
             String text = tagName;
             if (hotkeyIndex >= 1 && hotkeyIndex <= 10) {
                 String hotkey = getHotkeyString(hotkeyIndex);
@@ -208,44 +233,37 @@ public class TagsMenuContribution extends CompoundContributionItem {
                     text = tagName + "\t" + hotkey;
                 }
             }
-            item.setText(text);
-            item.setSelection(isChecked);
-            
-            // Create image and dispose it when menu item is disposed
-            Image image = TagColorIconFactory.getCircularColorIconWithCheck(
-                color, 16, isChecked).createImage();
-            item.setImage(image);
-            item.addDisposeListener(e -> image.dispose());
-            
-            item.addSelectionListener(new SelectionAdapter() {
-                @Override
-                public void widgetSelected(SelectionEvent e) {
-                    // Capture selection value before asyncExec since menu item may be disposed
-                    boolean selected = item.getSelection();
-                    Display.getCurrent().asyncExec(() -> {
-                        // Apply to all objects in all projects
-                        for (Map.Entry<IProject, List<String>> entry : objectsByProject.entrySet()) {
-                            IProject project = entry.getKey();
-                            List<String> fqns = entry.getValue();
-                            
-                            // Check if this project has this tag
-                            Tag tag = tagService.getTagStorage(project).getTagByName(tagName);
-                            if (tag == null) {
-                                // This project doesn't have this tag, skip
-                                continue;
-                            }
-                            
-                            for (String fqn : fqns) {
-                                if (selected) {
-                                    tagService.assignTag(project, fqn, tagName);
-                                } else {
-                                    tagService.unassignTag(project, fqn, tagName);
-                                }
-                            }
-                        }
-                    });
+            return text;
+        }
+
+        /**
+         * Applies (or removes) this tag for every selected object in every project that defines the tag.
+         * Extracted verbatim from the {@code asyncExec} body in {@link #fill(Menu, int)} to keep its
+         * complexity in check; the loop-local {@code continue} stays confined to this method.
+         *
+         * @param selected {@code true} to assign the tag, {@code false} to unassign it
+         */
+        private void applyTagToSelection(boolean selected) {
+            // Apply to all objects in all projects
+            for (Map.Entry<IProject, List<String>> entry : objectsByProject.entrySet()) {
+                IProject project = entry.getKey();
+                List<String> fqns = entry.getValue();
+
+                // Check if this project has this tag
+                Tag tag = tagService.getTagStorage(project).getTagByName(tagName);
+                if (tag == null) {
+                    // This project doesn't have this tag, skip
+                    continue;
                 }
-            });
+
+                for (String fqn : fqns) {
+                    if (selected) {
+                        tagService.assignTag(project, fqn, tagName);
+                    } else {
+                        tagService.unassignTag(project, fqn, tagName);
+                    }
+                }
+            }
         }
     }
     

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/doc/PlatformDocumentationService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/doc/PlatformDocumentationService.java
@@ -641,17 +641,31 @@ public class PlatformDocumentationService
         if (propTypes != null && !propTypes.isEmpty())
         {
             sb.append("**Type:** "); //$NON-NLS-1$
-            List<String> typeNames = new ArrayList<>();
-            for (TypeItem typeItem : propTypes)
-            {
-                String typeName = useRussian ? typeItem.getNameRu() : typeItem.getName();
-                if (typeName != null)
-                {
-                    typeNames.add(typeName);
-                }
-            }
+            List<String> typeNames = collectTypeNames(propTypes, useRussian);
             sb.append(String.join(" | ", typeNames)).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
         }
+    }
+
+    /**
+     * Collects the localized display names of the given type items, in order,
+     * skipping items whose chosen name is {@code null}.
+     *
+     * @param types the type items to render (must not be {@code null})
+     * @param useRussian {@code true} to prefer the Russian name, {@code false} for English
+     * @return the collected non-{@code null} type names, possibly empty
+     */
+    private static List<String> collectTypeNames(EList<TypeItem> types, boolean useRussian)
+    {
+        List<String> typeNames = new ArrayList<>();
+        for (TypeItem typeItem : types)
+        {
+            String typeName = useRussian ? typeItem.getNameRu() : typeItem.getName();
+            if (typeName != null)
+            {
+                typeNames.add(typeName);
+            }
+        }
+        return typeNames;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/form/FormLayoutSnapshotService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/form/FormLayoutSnapshotService.java
@@ -518,21 +518,7 @@ public class FormLayoutSnapshotService
         }
         if (value instanceof Collection<?>)
         {
-            List<Object> values = new ArrayList<>();
-            for (Object item : (Collection<?>)value)
-            {
-                Object converted = convertFeatureValue(item);
-                if (converted != null)
-                {
-                    values.add(converted);
-                }
-                if (values.size() >= 50)
-                {
-                    values.add("..."); //$NON-NLS-1$
-                    break;
-                }
-            }
-            return values.isEmpty() ? null : values;
+            return convertCollectionValue((Collection<?>)value);
         }
 
         Map<String, Object> inspected = describeInspectableValue(value);
@@ -542,6 +528,31 @@ public class FormLayoutSnapshotService
         }
 
         return String.valueOf(value);
+    }
+
+    /**
+     * Converts a collection feature value element-by-element, capping the result
+     * at 50 entries with a trailing {@code "..."} marker. Behaviour is identical
+     * to the inline Collection branch it was extracted from: same element order,
+     * same null-skipping, same cap, same empty-to-{@code null} mapping.
+     */
+    private Object convertCollectionValue(Collection<?> collection)
+    {
+        List<Object> values = new ArrayList<>();
+        for (Object item : collection)
+        {
+            Object converted = convertFeatureValue(item);
+            if (converted != null)
+            {
+                values.add(converted);
+            }
+            if (values.size() >= 50)
+            {
+                values.add("..."); //$NON-NLS-1$
+                break;
+            }
+        }
+        return values.isEmpty() ? null : values;
     }
 
     private Object convertCategoriesHolder(Object value)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
@@ -268,18 +268,11 @@ public class DebugLaunchTool implements IMcpTool
             }
 
             // For runtime-client configs, run the usual DB-update preflight.
-            if (!isAttach && updateBeforeLaunch && configProject != null && !configProject.isEmpty())
+            String preflightError =
+                runUpdatePreflight(isAttach, updateBeforeLaunch, configProject, effectiveAppId);
+            if (preflightError != null)
             {
-                String notReady = ProjectStateChecker.checkReadyOrError(configProject);
-                if (notReady != null)
-                {
-                    return ToolResult.error(notReady).toJson();
-                }
-                String updateError = updateDatabaseIfNeeded(configProject, effectiveAppId);
-                if (updateError != null)
-                {
-                    return ToolResult.error(updateError).toJson();
-                }
+                return preflightError;
             }
 
             String launchError = performLaunch(config, updateBeforeLaunch);
@@ -288,34 +281,69 @@ public class DebugLaunchTool implements IMcpTool
                 return ToolResult.error("Failed to launch debug session: " + launchError).toJson(); //$NON-NLS-1$
             }
 
-            ToolResult result = ToolResult.success()
-                .put(KEY_LAUNCH_CONFIGURATION, config.getName())
-                .put(KEY_CONFIGURATION_TYPE, typeId)
-                .put(KEY_ATTACH, isAttach)
-                .put("mode", "debug") //$NON-NLS-1$ //$NON-NLS-2$
-                .put(KEY_STATUS, "launching") //$NON-NLS-1$
-                .put(McpKeys.MESSAGE, isAttach
-                    ? "Attach debug session is connecting — poll debug_status to confirm it is " //$NON-NLS-1$
-                        + "running, then wait_for_break to block until a breakpoint is hit." //$NON-NLS-1$
-                    : "Debug session is starting asynchronously. The 1C client may show startup " //$NON-NLS-1$
-                        + "dialogs (login / database update); this call does NOT wait for it. " //$NON-NLS-1$
-                        + "Poll debug_status until the session appears running, then use " //$NON-NLS-1$
-                        + "wait_for_break."); //$NON-NLS-1$
-            if (configProject != null && !configProject.isEmpty())
-            {
-                result.put(McpKeys.PROJECT, configProject);
-            }
-            if (effectiveAppId != null)
-            {
-                result.put(McpKeys.APPLICATION_ID, effectiveAppId);
-            }
-            return result.toJson();
+            return buildLaunchSuccess(config, typeId, isAttach, configProject, effectiveAppId);
         }
         catch (Exception e)
         {
             Activator.logError("Unexpected error during debug launch by name", e); //$NON-NLS-1$
             return ToolResult.error("Unexpected error: " + e.getMessage()).toJson(); //$NON-NLS-1$
         }
+    }
+
+    /**
+     * Runtime-client DB-update preflight for the by-name path. Returns a ready
+     * error-JSON string when the project is not ready or the database update
+     * fails, or {@code null} to proceed. Behaviour is identical to the inline
+     * guard it replaces: same condition, same order, same exceptions propagate.
+     */
+    private String runUpdatePreflight(boolean isAttach, boolean updateBeforeLaunch, String configProject,
+        String effectiveAppId)
+    {
+        if (!isAttach && updateBeforeLaunch && configProject != null && !configProject.isEmpty())
+        {
+            String notReady = ProjectStateChecker.checkReadyOrError(configProject);
+            if (notReady != null)
+            {
+                return ToolResult.error(notReady).toJson();
+            }
+            String updateError = updateDatabaseIfNeeded(configProject, effectiveAppId);
+            if (updateError != null)
+            {
+                return ToolResult.error(updateError).toJson();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Builds the success response for the by-name launch path. Pure formatting of
+     * read-only inputs; no behavioural change relative to the inline builder.
+     */
+    private String buildLaunchSuccess(ILaunchConfiguration config, String typeId, boolean isAttach,
+        String configProject, String effectiveAppId)
+    {
+        ToolResult result = ToolResult.success()
+            .put(KEY_LAUNCH_CONFIGURATION, config.getName())
+            .put(KEY_CONFIGURATION_TYPE, typeId)
+            .put(KEY_ATTACH, isAttach)
+            .put("mode", "debug") //$NON-NLS-1$ //$NON-NLS-2$
+            .put(KEY_STATUS, "launching") //$NON-NLS-1$
+            .put(McpKeys.MESSAGE, isAttach
+                ? "Attach debug session is connecting — poll debug_status to confirm it is " //$NON-NLS-1$
+                    + "running, then wait_for_break to block until a breakpoint is hit." //$NON-NLS-1$
+                : "Debug session is starting asynchronously. The 1C client may show startup " //$NON-NLS-1$
+                    + "dialogs (login / database update); this call does NOT wait for it. " //$NON-NLS-1$
+                    + "Poll debug_status until the session appears running, then use " //$NON-NLS-1$
+                    + "wait_for_break."); //$NON-NLS-1$
+        if (configProject != null && !configProject.isEmpty())
+        {
+            result.put(McpKeys.PROJECT, configProject);
+        }
+        if (effectiveAppId != null)
+        {
+            result.put(McpKeys.APPLICATION_ID, effectiveAppId);
+        }
+        return result.toJson();
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 
 import com._1c.g5.v8.bm.core.IBmObject;
+import com._1c.g5.v8.bm.core.IBmTransaction;
 import com._1c.g5.v8.dt.md.refactoring.core.IMdRefactoringService;
 import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
 import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
@@ -350,45 +351,56 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
 
         for (IRefactoringProblem problem : problems)
         {
-            Map<String, Object> problemMap = new java.util.LinkedHashMap<>();
-            problemMap.put("problemType", problem.getClass().getSimpleName()); //$NON-NLS-1$
-            // Best-effort description; never let a single odd problem abort the whole check.
-            try
-            {
-                if (problem instanceof CleanReferenceProblem crp)
-                {
-                    EObject refObj = crp.getReferencingObject();
-                    if (refObj instanceof IBmObject bmObj)
-                    {
-                        String refFqn = bmFqnSafe(bmObj);
-                        if (refFqn != null)
-                        {
-                            problemMap.put("referencingObject", refFqn); //$NON-NLS-1$
-                        }
-                    }
-                    EStructuralFeature feat = crp.getReference();
-                    if (feat != null)
-                    {
-                        problemMap.put("reference", feat.getName()); //$NON-NLS-1$
-                    }
-                }
-                EObject obj = problem.getObject();
-                if (obj instanceof IBmObject bmObj)
-                {
-                    String tgtFqn = bmFqnSafe(bmObj);
-                    if (tgtFqn != null)
-                    {
-                        problemMap.put("targetObject", tgtFqn); //$NON-NLS-1$
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                Activator.logError("Error describing refactoring problem", e); //$NON-NLS-1$
-            }
-            result.add(problemMap);
+            result.add(describeProblem(problem));
         }
         return result;
+    }
+
+    /**
+     * Describes a single refactoring {@link IRefactoringProblem} as a JSON-ready map: the problem type
+     * plus, best-effort, the referencing object / feature (for a {@link CleanReferenceProblem}) and the
+     * target object. Mirrors what the EDT/Configurator UI shows per blocking reference. Never throws on
+     * a single odd problem — a description failure is logged and the partial map is still returned.
+     */
+    private static Map<String, Object> describeProblem(IRefactoringProblem problem)
+    {
+        Map<String, Object> problemMap = new java.util.LinkedHashMap<>();
+        problemMap.put("problemType", problem.getClass().getSimpleName()); //$NON-NLS-1$
+        // Best-effort description; never let a single odd problem abort the whole check.
+        try
+        {
+            if (problem instanceof CleanReferenceProblem crp)
+            {
+                EObject refObj = crp.getReferencingObject();
+                if (refObj instanceof IBmObject bmObj)
+                {
+                    String refFqn = bmFqnSafe(bmObj);
+                    if (refFqn != null)
+                    {
+                        problemMap.put("referencingObject", refFqn); //$NON-NLS-1$
+                    }
+                }
+                EStructuralFeature feat = crp.getReference();
+                if (feat != null)
+                {
+                    problemMap.put("reference", feat.getName()); //$NON-NLS-1$
+                }
+            }
+            EObject obj = problem.getObject();
+            if (obj instanceof IBmObject bmObj)
+            {
+                String tgtFqn = bmFqnSafe(bmObj);
+                if (tgtFqn != null)
+                {
+                    problemMap.put("targetObject", tgtFqn); //$NON-NLS-1$
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Activator.logError("Error describing refactoring problem", e); //$NON-NLS-1$
+        }
+        return problemMap;
     }
 
     /**
@@ -620,15 +632,7 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         MdObject mdForm = FormStructureReader.resolveMdForm(config, formPath);
         if (mdForm == null)
         {
-            // Distinguish a missing owner from a missing form for a sharper message.
-            MdObject owner = MetadataTypeUtils.findObject(config, ref.ownerType, ref.ownerName);
-            if (owner == null)
-            {
-                return ToolResult.error("Owner object not found: " + ref.ownerFqn() + ". " //$NON-NLS-1$ //$NON-NLS-2$
-                    + "Use get_metadata_objects to list available objects.").toJson(); //$NON-NLS-1$
-            }
-            return ToolResult.error("Form '" + ref.formName + "' not found on " + ref.ownerFqn() //$NON-NLS-1$ //$NON-NLS-2$
-                + ". Use get_metadata_details to list the object's forms.").toJson(); //$NON-NLS-1$
+            return formObjectNotFoundError(config, ref);
         }
         if (!(mdForm instanceof IBmObject))
         {
@@ -673,25 +677,8 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         try
         {
             FormElementWriter.FormEditContext fctx = FormElementWriter.editContextFor(project, mdForm);
-            FormElementWriter.writeMdForm(fctx, "DeleteFormObject", (txMdForm, tx) -> //$NON-NLS-1$
-            {
-                EObject owner = txMdForm.eContainer();
-                // Detach the content Form top object (the BM store the attach created) before removing the
-                // MD-form, so no store-less top object is left orphaned in the namespace.
-                EObject content = FormElementWriter.getEditableForm(txMdForm);
-                if (content instanceof IBmObject)
-                {
-                    tx.detachTopObject((IBmObject)content);
-                }
-                // Clear any single-valued default-form reference on the owner that points at this form
-                // (defaultObjectForm / defaultListForm / ...), so removing the form leaves no dangling ref.
-                if (owner != null)
-                {
-                    clearReferencesTo(owner, txMdForm);
-                }
-                // Remove the MD-form from the owner's 'forms' containment list.
-                EcoreUtil.remove(txMdForm);
-            });
+            FormElementWriter.writeMdForm(fctx, "DeleteFormObject", //$NON-NLS-1$
+                DeleteMetadataTool::removeFormObjectInTx);
         }
         catch (Exception e)
         {
@@ -726,6 +713,50 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
                         + "it).") //$NON-NLS-1$
                 + folderCleanupMessage(folderCleanup))
             .toJson();
+    }
+
+    /**
+     * Builds the "form object not found" error for {@link #deleteFormObject}: distinguishes a missing
+     * owner from a missing form (the form lookup failed) for a sharper message. Pure message selection,
+     * no mutation.
+     */
+    private static String formObjectNotFoundError(Configuration config, FormElementWriter.FormObjectRef ref)
+    {
+        // Distinguish a missing owner from a missing form for a sharper message.
+        MdObject owner = MetadataTypeUtils.findObject(config, ref.ownerType, ref.ownerName);
+        if (owner == null)
+        {
+            return ToolResult.error("Owner object not found: " + ref.ownerFqn() + ". " //$NON-NLS-1$ //$NON-NLS-2$
+                + "Use get_metadata_objects to list available objects.").toJson(); //$NON-NLS-1$
+        }
+        return ToolResult.error("Form '" + ref.formName + "' not found on " + ref.ownerFqn() //$NON-NLS-1$ //$NON-NLS-2$
+            + ". Use get_metadata_details to list the object's forms.").toJson(); //$NON-NLS-1$
+    }
+
+    /**
+     * The {@code confirm=true} write-transaction body for {@link #deleteFormObject}: detaches the
+     * content {@code Form} top object, clears any default-form reference the owner held to this form,
+     * and removes the MD-form from the owner's {@code forms} containment list. Runs inside the BM write
+     * transaction supplied by {@link FormElementWriter#writeMdForm}.
+     */
+    private static void removeFormObjectInTx(EObject txMdForm, IBmTransaction tx)
+    {
+        EObject owner = txMdForm.eContainer();
+        // Detach the content Form top object (the BM store the attach created) before removing the
+        // MD-form, so no store-less top object is left orphaned in the namespace.
+        EObject content = FormElementWriter.getEditableForm(txMdForm);
+        if (content instanceof IBmObject)
+        {
+            tx.detachTopObject((IBmObject)content);
+        }
+        // Clear any single-valued default-form reference on the owner that points at this form
+        // (defaultObjectForm / defaultListForm / ...), so removing the form leaves no dangling ref.
+        if (owner != null)
+        {
+            clearReferencesTo(owner, txMdForm);
+        }
+        // Remove the MD-form from the owner's 'forms' containment list.
+        EcoreUtil.remove(txMdForm);
     }
 
     /** Outcome of the orphan form-folder cleanup - never conflate "not found" with "removed". */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/EvaluateExpressionTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/EvaluateExpressionTool.java
@@ -149,13 +149,7 @@ public class EvaluateExpressionTool implements IMcpTool
             }
             if (result.hasErrors())
             {
-                StringBuilder errs = new StringBuilder();
-                for (String e : result.getErrorMessages())
-                {
-                    if (errs.length() > 0) errs.append("; "); //$NON-NLS-1$
-                    errs.append(e);
-                }
-                return ToolResult.error(errs.toString()).toJson();
+                return ToolResult.error(joinErrorMessages(result.getErrorMessages())).toJson();
             }
 
             IValue value = result.getValue();
@@ -194,6 +188,21 @@ public class EvaluateExpressionTool implements IMcpTool
             Activator.logError("Error in evaluate_expression", e); //$NON-NLS-1$
             return ToolResult.error(e.getMessage()).toJson(); //$NON-NLS-1$
         }
+    }
+
+    /**
+     * Joins watch-expression error messages into a single {@code "; "}-separated
+     * string, preserving the original order and separator.
+     */
+    private static String joinErrorMessages(String[] messages)
+    {
+        StringBuilder errs = new StringBuilder();
+        for (String e : messages)
+        {
+            if (errs.length() > 0) errs.append("; "); //$NON-NLS-1$
+            errs.append(e);
+        }
+        return errs.toString();
     }
 
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
@@ -245,27 +245,54 @@ public class GetMethodCallHierarchyTool implements IMcpTool
             }
 
             boolean candidateIsTarget = relToSrc.equalsIgnoreCase(modulePath);
-            for (Iterator<EObject> iter = candidateModule.eAllContents(); iter.hasNext();)
-            {
-                EObject obj = iter.next();
-                if (!(obj instanceof Invocation))
-                {
-                    continue;
-                }
-                Invocation inv = (Invocation)obj;
-                if (!invocationTargetsMethod(inv, methodUri, methodName, targetModuleName, candidateIsTarget))
-                {
-                    continue;
-                }
-                totalReferences++;
-                if (callers.size() < limit)
-                {
-                    callers.add(buildCallerInfo(inv, relToSrc, methodName));
-                }
-            }
+            totalReferences += scanCandidateInvocations(candidateModule, methodUri, methodName,
+                targetModuleName, candidateIsTarget, relToSrc, callers, limit);
         }
 
         return formatCallersOutput(modulePath, methodName, callers, limit, totalReferences);
+    }
+
+    /**
+     * Scans a single candidate module for invocations that resolve to the target method, appending a
+     * {@link CallerInfo} for each match (up to {@code limit} total across all candidates) into the
+     * shared {@code callers} list. Extracted verbatim from
+     * {@link #findCallers(String, String, String, int)} to keep that method's complexity in check; the
+     * loop-local {@code continue} statements stay confined to this scan.
+     *
+     * @param candidateModule the module to scan
+     * @param methodUri the URI of the target method
+     * @param methodName the target method name
+     * @param targetModuleName the simple name of the module declaring the target method
+     * @param candidateIsTarget {@code true} when this candidate is the module declaring the method
+     * @param relToSrc the candidate's source-relative path, used when building a {@link CallerInfo}
+     * @param callers the shared accumulator of matched callers (appended to, never reassigned)
+     * @param limit the maximum number of callers to retain in {@code callers}
+     * @return the number of invocations in this candidate that target the method
+     */
+    private int scanCandidateInvocations(Module candidateModule, URI methodUri, String methodName,
+        String targetModuleName, boolean candidateIsTarget, String relToSrc, List<CallerInfo> callers,
+        int limit)
+    {
+        int matched = 0;
+        for (Iterator<EObject> iter = candidateModule.eAllContents(); iter.hasNext();)
+        {
+            EObject obj = iter.next();
+            if (!(obj instanceof Invocation))
+            {
+                continue;
+            }
+            Invocation inv = (Invocation)obj;
+            if (!invocationTargetsMethod(inv, methodUri, methodName, targetModuleName, candidateIsTarget))
+            {
+                continue;
+            }
+            matched++;
+            if (callers.size() < limit)
+            {
+                callers.add(buildCallerInfo(inv, relToSrc, methodName));
+            }
+        }
+        return matched;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetObjectsByTagsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetObjectsByTagsTool.java
@@ -143,41 +143,7 @@ public class GetObjectsByTagsTool implements IMcpTool
             }
             
             Set<String> objects = storage.getObjectsByTag(tagName);
-            
-            // Tag header with description
-            sb.append("## Tag: ").append(tag.getName()).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            sb.append("- **Color:** ").append(tag.getColor()).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            
-            String description = tag.getDescription();
-            if (description != null && !description.isEmpty())
-            {
-                sb.append("- **Description:** ").append(description).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            }
-            
-            sb.append("- **Objects count:** ").append(objects.size()).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            
-            if (objects.isEmpty())
-            {
-                sb.append("*No objects assigned to this tag*\n\n"); //$NON-NLS-1$
-            }
-            else
-            {
-                sb.append(MarkdownUtils.tableHeader("#", "Object FQN")); //$NON-NLS-1$ //$NON-NLS-2$
-
-                int count = 0;
-                for (String fqn : objects)
-                {
-                    if (count >= limit)
-                    {
-                        sb.append(MarkdownUtils.tableRow("...", //$NON-NLS-1$
-                            "*" + (objects.size() - limit) + " more objects (limit reached)*")); //$NON-NLS-1$ //$NON-NLS-2$
-                        break;
-                    }
-                    sb.append(MarkdownUtils.tableRow(String.valueOf(++count), fqn));
-                }
-                sb.append("\n"); //$NON-NLS-1$
-                totalObjects += Math.min(objects.size(), limit);
-            }
+            totalObjects += appendTagSection(sb, tag, objects, limit);
         }
         
         // Report not found tags
@@ -199,7 +165,56 @@ public class GetObjectsByTagsTool implements IMcpTool
         
         return sb.toString();
     }
-    
+
+    /**
+     * Appends a single tag's section (header, metadata and object table) to
+     * {@code sb} and returns the number of objects counted toward the summary
+     * total for this tag.
+     *
+     * @param sb the Markdown buffer to append to
+     * @param tag the resolved tag
+     * @param objects the FQNs assigned to the tag
+     * @param limit maximum objects to list for the tag
+     * @return objects counted toward the total ({@code 0} when the tag has none,
+     *         otherwise {@code min(objects.size(), limit)})
+     */
+    private int appendTagSection(StringBuilder sb, Tag tag, Set<String> objects, int limit)
+    {
+        // Tag header with description
+        sb.append("## Tag: ").append(tag.getName()).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("- **Color:** ").append(tag.getColor()).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        String description = tag.getDescription();
+        if (description != null && !description.isEmpty())
+        {
+            sb.append("- **Description:** ").append(description).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+
+        sb.append("- **Objects count:** ").append(objects.size()).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        if (objects.isEmpty())
+        {
+            sb.append("*No objects assigned to this tag*\n\n"); //$NON-NLS-1$
+            return 0;
+        }
+
+        sb.append(MarkdownUtils.tableHeader("#", "Object FQN")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        int count = 0;
+        for (String fqn : objects)
+        {
+            if (count >= limit)
+            {
+                sb.append(MarkdownUtils.tableRow("...", //$NON-NLS-1$
+                    "*" + (objects.size() - limit) + " more objects (limit reached)*")); //$NON-NLS-1$ //$NON-NLS-2$
+                break;
+            }
+            sb.append(MarkdownUtils.tableRow(String.valueOf(++count), fqn));
+        }
+        sb.append("\n"); //$NON-NLS-1$
+        return Math.min(objects.size(), limit);
+    }
+
     @Override
     public ResponseType getResponseType()
     {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GoToDefinitionTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GoToDefinitionTool.java
@@ -324,6 +324,18 @@ public class GoToDefinitionTool implements IMcpTool
             fm.put("qualifiedName", qualifiedPrefix + "." + method.getName()); //$NON-NLS-1$ //$NON-NLS-2$
         }
 
+        return fm.wrapContent(buildMethodSource(includeSource, allLines, from, to, method));
+    }
+
+    /**
+     * Builds the fenced BSL source block for {@link #formatMethodDefinition}. When {@code includeSource}
+     * is false the result is empty. The preferred source is the {@code [from, to]} slice of the file
+     * lines; if the file could not be read ({@code allLines == null}) it falls back to the method's EMF
+     * {@code getText()}. Pure string assembly, no side effects.
+     */
+    private static String buildMethodSource(boolean includeSource, List<String> allLines, int from, int to,
+        Method method)
+    {
         StringBuilder sb = new StringBuilder();
         if (includeSource)
         {
@@ -352,8 +364,7 @@ public class GoToDefinitionTool implements IMcpTool
                 }
             }
         }
-
-        return fm.wrapContent(sb.toString());
+        return sb.toString();
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListConfigurationsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListConfigurationsTool.java
@@ -141,43 +141,7 @@ public class ListConfigurationsTool implements IMcpTool
                     continue;
                 }
 
-                Map<String, Object> entry = new LinkedHashMap<>();
-                entry.put("name", cfg.getName()); //$NON-NLS-1$
-                entry.put("type", typeId); //$NON-NLS-1$
-                entry.put(KEY_ATTACH, isAttach);
-
-                String appId = LaunchConfigUtils.getApplicationIdFor(cfg);
-                if (appId != null)
-                {
-                    entry.put("applicationId", appId); //$NON-NLS-1$
-                }
-                if (!project.isEmpty())
-                {
-                    entry.put("project", project); //$NON-NLS-1$
-                }
-
-                String alias = LaunchConfigUtils.readAttribute(cfg,
-                    LaunchConfigUtils.ATTR_DEBUG_INFOBASE_ALIAS, ""); //$NON-NLS-1$
-                if (!alias.isEmpty())
-                {
-                    entry.put("infobaseAlias", alias); //$NON-NLS-1$
-                }
-                String url = LaunchConfigUtils.readAttribute(cfg,
-                    LaunchConfigUtils.ATTR_DEBUG_SERVER_URL, ""); //$NON-NLS-1$
-                if (!url.isEmpty())
-                {
-                    entry.put("debugServerUrl", url); //$NON-NLS-1$
-                }
-
-                ILaunch liveLaunch = appId != null ? liveByAppId.get(appId) : null;
-                boolean running = liveLaunch != null;
-                entry.put("running", running); //$NON-NLS-1$
-                if (running)
-                {
-                    entry.put("mode", liveLaunch.getLaunchMode()); //$NON-NLS-1$
-                    entry.put("suspended", anyThreadSuspended(liveLaunch)); //$NON-NLS-1$
-                }
-                configs.add(entry);
+                configs.add(buildConfigEntry(cfg, typeId, isAttach, project, liveByAppId));
             }
 
             return ToolResult.success()
@@ -190,6 +154,54 @@ public class ListConfigurationsTool implements IMcpTool
             Activator.logError("Error in list_configurations", e); //$NON-NLS-1$
             return ToolResult.error(e.getMessage()).toJson(); //$NON-NLS-1$
         }
+    }
+
+    /**
+     * Builds the JSON entry for one launch configuration: its name/type/attach flag plus any present
+     * applicationId, project, infobase alias and debug server URL, and — when a matching live launch
+     * exists — its running/mode/suspended state. The caller has already applied the type and project
+     * filters; this is pure entry assembly with no side effects.
+     */
+    private static Map<String, Object> buildConfigEntry(ILaunchConfiguration cfg, String typeId,
+        boolean isAttach, String project, Map<String, ILaunch> liveByAppId)
+    {
+        Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put("name", cfg.getName()); //$NON-NLS-1$
+        entry.put("type", typeId); //$NON-NLS-1$
+        entry.put(KEY_ATTACH, isAttach);
+
+        String appId = LaunchConfigUtils.getApplicationIdFor(cfg);
+        if (appId != null)
+        {
+            entry.put("applicationId", appId); //$NON-NLS-1$
+        }
+        if (!project.isEmpty())
+        {
+            entry.put("project", project); //$NON-NLS-1$
+        }
+
+        String alias = LaunchConfigUtils.readAttribute(cfg,
+            LaunchConfigUtils.ATTR_DEBUG_INFOBASE_ALIAS, ""); //$NON-NLS-1$
+        if (!alias.isEmpty())
+        {
+            entry.put("infobaseAlias", alias); //$NON-NLS-1$
+        }
+        String url = LaunchConfigUtils.readAttribute(cfg,
+            LaunchConfigUtils.ATTR_DEBUG_SERVER_URL, ""); //$NON-NLS-1$
+        if (!url.isEmpty())
+        {
+            entry.put("debugServerUrl", url); //$NON-NLS-1$
+        }
+
+        ILaunch liveLaunch = appId != null ? liveByAppId.get(appId) : null;
+        boolean running = liveLaunch != null;
+        entry.put("running", running); //$NON-NLS-1$
+        if (running)
+        {
+            entry.put("mode", liveLaunch.getLaunchMode()); //$NON-NLS-1$
+            entry.put("suspended", anyThreadSuspended(liveLaunch)); //$NON-NLS-1$
+        }
+        return entry;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetBreakpointTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetBreakpointTool.java
@@ -136,29 +136,45 @@ public class SetBreakpointTool implements IMcpTool
         try
         {
             IBreakpoint bp = BreakpointUtils.createLineBreakpoint(file, lineNumber);
-            long markerId = bp.getMarker() != null ? bp.getMarker().getId() : -1L;
-            boolean degraded = bp instanceof BreakpointUtils.MarkerOnlyBreakpoint;
-            Activator.logInfo("Breakpoint set: " + file.getFullPath() + ":" + lineNumber //$NON-NLS-1$ //$NON-NLS-2$
-                + (degraded ? " (degraded — marker-only)" : "")); //$NON-NLS-1$ //$NON-NLS-2$
-            ToolResult res = ToolResult.success()
-                .put("breakpointId", markerId) //$NON-NLS-1$
-                .put(McpKeys.MODULE_PATH, module)
-                .put(KEY_MODULE, module)
-                .put("resolvedFile", file.getFullPath().toString()) //$NON-NLS-1$
-                .put(KEY_LINE_NUMBER, lineNumber);
-            if (degraded)
-            {
-                res.put("degraded", true); //$NON-NLS-1$
-                res.put("warning", "EDT BSL breakpoint class not available — created a marker-only " //$NON-NLS-1$ //$NON-NLS-2$
-                    + "breakpoint that may NOT trigger debug suspend events. " //$NON-NLS-1$
-                    + "Verify in EDT that the breakpoint appears in the Breakpoints view."); //$NON-NLS-1$
-            }
-            return res.toJson();
+            return buildSuccessResult(bp, file, module, lineNumber);
         }
         catch (Exception e)
         {
             Activator.logError("Failed to set breakpoint", e); //$NON-NLS-1$
             return ToolResult.error("Failed to set breakpoint: " + e.getMessage()).toJson(); //$NON-NLS-1$
         }
+    }
+
+    /**
+     * Builds the success JSON for a created breakpoint, logging the outcome and
+     * flagging the degraded (marker-only) case. Pure with respect to caller
+     * state — reads only the supplied breakpoint/file/coordinates.
+     *
+     * @param bp the created breakpoint
+     * @param file the resolved module file
+     * @param module the module path/alias echoed back to the caller
+     * @param lineNumber the breakpoint line
+     * @return the success result JSON
+     */
+    private static String buildSuccessResult(IBreakpoint bp, IFile file, String module, int lineNumber)
+    {
+        long markerId = bp.getMarker() != null ? bp.getMarker().getId() : -1L;
+        boolean degraded = bp instanceof BreakpointUtils.MarkerOnlyBreakpoint;
+        Activator.logInfo("Breakpoint set: " + file.getFullPath() + ":" + lineNumber //$NON-NLS-1$ //$NON-NLS-2$
+            + (degraded ? " (degraded — marker-only)" : "")); //$NON-NLS-1$ //$NON-NLS-2$
+        ToolResult res = ToolResult.success()
+            .put("breakpointId", markerId) //$NON-NLS-1$
+            .put(McpKeys.MODULE_PATH, module)
+            .put(KEY_MODULE, module)
+            .put("resolvedFile", file.getFullPath().toString()) //$NON-NLS-1$
+            .put(KEY_LINE_NUMBER, lineNumber);
+        if (degraded)
+        {
+            res.put("degraded", true); //$NON-NLS-1$
+            res.put("warning", "EDT BSL breakpoint class not available — created a marker-only " //$NON-NLS-1$ //$NON-NLS-2$
+                + "breakpoint that may NOT trigger debug suspend events. " //$NON-NLS-1$
+                + "Verify in EDT that the breakpoint appears in the Breakpoints view."); //$NON-NLS-1$
+        }
+        return res.toJson();
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchTool.java
@@ -731,48 +731,14 @@ public class TerminateLaunchTool implements IMcpTool
     private static String renderResults(List<TerminationResult> results, String configName,
             String projectName, String applicationId, boolean all, boolean includeAttach)
     {
-        int terminated = 0;
-        int detached = 0;
-        int timedOut = 0;
-        int errors = 0;
-        int alreadyTerminated = 0;
-        int removed = 0;
-        int staleCleaned = 0;
-        for (TerminationResult r : results)
-        {
-            if (r.removed)
-            {
-                removed++;
-            }
-            switch (r.code)
-            {
-                case R_TERMINATED:
-                case R_FORCE_TERMINATED:
-                    terminated++;
-                    break;
-                case R_DETACHED:
-                    detached++;
-                    break;
-                case R_TIMEOUT:
-                    timedOut++;
-                    break;
-                case R_ERROR:
-                    errors++;
-                    break;
-                case R_ALREADY_TERMINATED:
-                    alreadyTerminated++;
-                    // Stale entry (was already terminated, only lingered in the
-                    // manager) that this call actually evicted — report these
-                    // distinctly from real terminations.
-                    if (r.removed)
-                    {
-                        staleCleaned++;
-                    }
-                    break;
-                default:
-                    break;
-            }
-        }
+        Counts counts = countResults(results);
+        int terminated = counts.terminated;
+        int detached = counts.detached;
+        int timedOut = counts.timedOut;
+        int errors = counts.errors;
+        int alreadyTerminated = counts.alreadyTerminated;
+        int removed = counts.removed;
+        int staleCleaned = counts.staleCleaned;
 
         boolean hasIssues = timedOut > 0 || errors > 0;
         StringBuilder sb = new StringBuilder();
@@ -826,6 +792,59 @@ public class TerminateLaunchTool implements IMcpTool
         sb.append("\n> Only launches started from this EDT instance are affected. " //$NON-NLS-1$
             + "Externally launched 1C clients are not touched by this tool.\n"); //$NON-NLS-1$
         return sb.toString();
+    }
+
+    /** Aggregated per-outcome tallies for a batch of {@link TerminationResult}s. */
+    private static final class Counts
+    {
+        int terminated;
+        int detached;
+        int timedOut;
+        int errors;
+        int alreadyTerminated;
+        int removed;
+        int staleCleaned;
+    }
+
+    private static Counts countResults(List<TerminationResult> results)
+    {
+        Counts c = new Counts();
+        for (TerminationResult r : results)
+        {
+            if (r.removed)
+            {
+                c.removed++;
+            }
+            switch (r.code)
+            {
+                case R_TERMINATED:
+                case R_FORCE_TERMINATED:
+                    c.terminated++;
+                    break;
+                case R_DETACHED:
+                    c.detached++;
+                    break;
+                case R_TIMEOUT:
+                    c.timedOut++;
+                    break;
+                case R_ERROR:
+                    c.errors++;
+                    break;
+                case R_ALREADY_TERMINATED:
+                    c.alreadyTerminated++;
+                    // Stale entry (was already terminated, only lingered in the
+                    // manager) that this call actually evicted — report these
+                    // distinctly from real terminations.
+                    if (r.removed)
+                    {
+                        c.staleCleaned++;
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+        return c;
     }
 
     private static void renderSingle(StringBuilder sb, TerminationResult r)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
@@ -135,17 +135,10 @@ public class UpdateDatabaseTool implements IMcpTool
             JsonUtils.extractBooleanArgument(params, "terminateRunningClients", true); //$NON-NLS-1$
 
         boolean hasName = configName != null && !configName.isEmpty();
-        if (!hasName)
+        String argError = validateDirectArguments(hasName, projectName, applicationId);
+        if (argError != null)
         {
-            if (projectName == null || projectName.isEmpty())
-            {
-                return ToolResult.error("projectName is required (or pass launchConfigurationName)").toJson(); //$NON-NLS-1$
-            }
-            if (applicationId == null || applicationId.isEmpty())
-            {
-                return ToolResult.error("applicationId is required (or pass launchConfigurationName). " //$NON-NLS-1$
-                    + "Use get_applications or list_configurations.").toJson(); //$NON-NLS-1$
-            }
+            return argError;
         }
 
         // Resolve via launch config if name is given — it fixes the project + applicationId pair.
@@ -190,6 +183,37 @@ public class UpdateDatabaseTool implements IMcpTool
 
         return updateDatabase(projectName, applicationId, fullUpdate, confirm,
             terminateRunningClients);
+    }
+
+    /**
+     * Validates the directly supplied target arguments used when no launch
+     * configuration name is given. Returns a ready {@link ToolResult#error} JSON
+     * payload describing the first missing argument, or {@code null} when the
+     * arguments are acceptable. When {@code hasName} is {@code true} the target is
+     * derived from the launch configuration instead, so no direct argument is
+     * required and {@code null} is returned.
+     *
+     * @param hasName whether a launch configuration name was supplied
+     * @param projectName the directly supplied project name (may be {@code null})
+     * @param applicationId the directly supplied application ID (may be {@code null})
+     * @return error JSON when a required direct argument is missing, otherwise {@code null}
+     */
+    private static String validateDirectArguments(boolean hasName, String projectName,
+            String applicationId)
+    {
+        if (!hasName)
+        {
+            if (projectName == null || projectName.isEmpty())
+            {
+                return ToolResult.error("projectName is required (or pass launchConfigurationName)").toJson(); //$NON-NLS-1$
+            }
+            if (applicationId == null || applicationId.isEmpty())
+            {
+                return ToolResult.error("applicationId is required (or pass launchConfigurationName). " //$NON-NLS-1$
+                    + "Use get_applications or list_configurations.").toJson(); //$NON-NLS-1$
+            }
+        }
+        return null;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ValidateQueryTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ValidateQueryTool.java
@@ -219,62 +219,9 @@ public class ValidateQueryTool implements IMcpTool
                 return ToolResult.error("Failed to get resource validator").toJson(); //$NON-NLS-1$
             }
             
-            // Collect syntax errors from resource diagnostics
-            List<QueryIssue> issues = new ArrayList<>();
-            
-            for (Resource.Diagnostic error : resource.getErrors())
-            {
-                issues.add(new QueryIssue(
-                    "ERROR", //$NON-NLS-1$
-                    error.getMessage(),
-                    error.getLine(),
-                    error.getColumn(),
-                    -1
-                ));
-            }
-            
-            for (Resource.Diagnostic warning : resource.getWarnings())
-            {
-                issues.add(new QueryIssue(
-                    "WARNING", //$NON-NLS-1$
-                    warning.getMessage(),
-                    warning.getLine(),
-                    warning.getColumn(),
-                    -1
-                ));
-            }
-            
-            // Run full validation (semantic checks)
-            List<Issue> validationIssues = validator.validate(resource, CheckMode.ALL, CancelIndicator.NullImpl);
-            
-            for (Issue issue : validationIssues)
-            {
-                String severity;
-                switch (issue.getSeverity())
-                {
-                    case ERROR:
-                        severity = "ERROR"; //$NON-NLS-1$
-                        break;
-                    case WARNING:
-                        severity = "WARNING"; //$NON-NLS-1$
-                        break;
-                    case INFO:
-                        severity = "INFO"; //$NON-NLS-1$
-                        break;
-                    default:
-                        severity = "WARNING"; //$NON-NLS-1$
-                        break;
-                }
-                
-                issues.add(new QueryIssue(
-                    severity,
-                    issue.getMessage(),
-                    issue.getLineNumber() != null ? issue.getLineNumber() : -1,
-                    issue.getColumn() != null ? issue.getColumn() : -1,
-                    issue.getOffset() != null ? issue.getOffset() : -1
-                ));
-            }
-            
+            // Collect syntax errors from resource diagnostics and semantic checks
+            List<QueryIssue> issues = collectIssues(resource, validator);
+
             // Build the result
             return buildResult(issues, dcsMode);
         }
@@ -310,6 +257,73 @@ public class ValidateQueryTool implements IMcpTool
         }
     }
     
+    /**
+     * Collects syntax diagnostics (resource errors/warnings) and semantic
+     * validation issues into a single list, preserving the original ordering
+     * (errors, then warnings, then semantic issues).
+     *
+     * @param resource the loaded Xtext resource carrying syntax diagnostics
+     * @param validator the resource validator used for semantic checks
+     * @return the collected query issues
+     */
+    private static List<QueryIssue> collectIssues(XtextResource resource, IResourceValidator validator)
+    {
+        List<QueryIssue> issues = new ArrayList<>();
+
+        for (Resource.Diagnostic error : resource.getErrors())
+        {
+            issues.add(new QueryIssue(
+                "ERROR", //$NON-NLS-1$
+                error.getMessage(),
+                error.getLine(),
+                error.getColumn(),
+                -1
+            ));
+        }
+
+        for (Resource.Diagnostic warning : resource.getWarnings())
+        {
+            issues.add(new QueryIssue(
+                "WARNING", //$NON-NLS-1$
+                warning.getMessage(),
+                warning.getLine(),
+                warning.getColumn(),
+                -1
+            ));
+        }
+
+        // Run full validation (semantic checks)
+        List<Issue> validationIssues = validator.validate(resource, CheckMode.ALL, CancelIndicator.NullImpl);
+
+        for (Issue issue : validationIssues)
+        {
+            issues.add(new QueryIssue(
+                severityName(issue.getSeverity()),
+                issue.getMessage(),
+                issue.getLineNumber() != null ? issue.getLineNumber() : -1,
+                issue.getColumn() != null ? issue.getColumn() : -1,
+                issue.getOffset() != null ? issue.getOffset() : -1
+            ));
+        }
+
+        return issues;
+    }
+
+    /** Maps an Xtext issue {@link Severity} to the wire string (unknown/blank -> WARNING). */
+    private static String severityName(org.eclipse.xtext.diagnostics.Severity severity)
+    {
+        switch (severity)
+        {
+            case ERROR:
+                return "ERROR"; //$NON-NLS-1$
+            case INFO:
+                return "INFO"; //$NON-NLS-1$
+            case WARNING:
+            default:
+                return "WARNING"; //$NON-NLS-1$
+        }
+    }
+
     /**
      * Builds the JSON result from validation issues, via the shared
      * {@link ToolResult} builder (consistent with the tool's error paths and

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
@@ -609,24 +609,7 @@ public class WriteModuleSourceTool implements IMcpTool
         }
 
         // Determine default moduleType based on metadata type
-        if (moduleType == null || moduleType.isEmpty())
-        {
-            if ("CommonModule".equals(englishType) //$NON-NLS-1$
-                || "CommonForm".equals(englishType) //$NON-NLS-1$
-                || "WebService".equals(englishType) //$NON-NLS-1$
-                || "HTTPService".equals(englishType)) //$NON-NLS-1$
-            {
-                moduleType = "Module"; //$NON-NLS-1$
-            }
-            else if ("CommonCommand".equals(englishType)) //$NON-NLS-1$
-            {
-                moduleType = "CommandModule"; //$NON-NLS-1$
-            }
-            else
-            {
-                moduleType = "ObjectModule"; //$NON-NLS-1$
-            }
-        }
+        moduleType = resolveDefaultModuleType(moduleType, englishType);
 
         // Build path based on moduleType
         switch (moduleType)
@@ -672,6 +655,37 @@ public class WriteModuleSourceTool implements IMcpTool
                     ". Allowed: ObjectModule, ManagerModule, FormModule, " + //$NON-NLS-1$
                     "CommandModule, RecordSetModule, Module").toJson(); //$NON-NLS-1$
         }
+    }
+
+    /**
+     * Returns the supplied {@code moduleType} unchanged when it is non-empty,
+     * otherwise derives the default module type from the English metadata type:
+     * {@code Module} for module-bearing singletons (CommonModule, CommonForm,
+     * WebService, HTTPService), {@code CommandModule} for CommonCommand, and
+     * {@code ObjectModule} for everything else.
+     *
+     * @param moduleType the requested module type (may be {@code null} or empty)
+     * @param englishType the resolved English singular metadata type
+     * @return the explicit module type, or the derived default when none was given
+     */
+    private static String resolveDefaultModuleType(String moduleType, String englishType)
+    {
+        if (moduleType != null && !moduleType.isEmpty())
+        {
+            return moduleType;
+        }
+        if ("CommonModule".equals(englishType) //$NON-NLS-1$
+            || "CommonForm".equals(englishType) //$NON-NLS-1$
+            || "WebService".equals(englishType) //$NON-NLS-1$
+            || "HTTPService".equals(englishType)) //$NON-NLS-1$
+        {
+            return "Module"; //$NON-NLS-1$
+        }
+        if ("CommonCommand".equals(englishType)) //$NON-NLS-1$
+        {
+            return "CommandModule"; //$NON-NLS-1$
+        }
+        return "ObjectModule"; //$NON-NLS-1$
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/reference/MetadataReferenceService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/reference/MetadataReferenceService.java
@@ -906,6 +906,21 @@ public class MetadataReferenceService
                 return referenceFeature != null ? getFeatureLabel(referenceFeature) : null;
             }
 
+            return buildPathString(path);
+        }
+
+        /**
+         * Renders the EDT-style path string from the segment deque built by
+         * {@link #buildInnerPathEdtStyle}. Consumes the (already non-empty) deque
+         * head-first, exactly as the inline tail it was extracted from: same
+         * feature-label seeding, same null-segment skipping, same redundant
+         * "Items" collapsing, same empty-to-{@code null} mapping.
+         *
+         * @param path the non-empty segment deque, top object first
+         * @return the rendered path, or {@code null} when nothing renders
+         */
+        private String buildPathString(Deque<PathSegment> path)
+        {
             // Build path string exactly like EDT:
             // referenceName = featureLabel(topObjectPair.second)
             // for each segment: referenceName + "." + objectName + "." + featureLabel

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/symbol/SymbolInfoService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/symbol/SymbolInfoService.java
@@ -243,26 +243,10 @@ public class SymbolInfoService
             }
 
             // === Level 2: EObject analysis ===
-            IXtextDocument xtextDocument = xtextEditor.getDocument();
-            if (xtextDocument != null)
+            String eobjectResult = resolveEObjectInfoFromDocument(xtextEditor.getDocument(), offset);
+            if (eobjectResult != null && !eobjectResult.isEmpty())
             {
-                String eobjectResult = xtextDocument.readOnly(new IUnitOfWork<String, XtextResource>()
-                {
-                    @Override
-                    public String exec(XtextResource resource) throws Exception
-                    {
-                        if (resource == null)
-                        {
-                            return null;
-                        }
-                        return resolveEObjectInfo(resource, offset);
-                    }
-                });
-
-                if (eobjectResult != null && !eobjectResult.isEmpty())
-                {
-                    return eobjectResult;
-                }
+                return eobjectResult;
             }
 
             // Nothing found at this position
@@ -276,6 +260,32 @@ public class SymbolInfoService
                 page.closeEditor(editorPart, false);
             }
         }
+    }
+
+    /**
+     * Runs the Level-2 EObject analysis inside the Xtext document's read-only
+     * transaction. Returns {@code null} when the document or the parsed resource
+     * is unavailable, matching the previous inline behaviour (the caller then
+     * falls through to the next resolution step).
+     */
+    private String resolveEObjectInfoFromDocument(IXtextDocument xtextDocument, int offset) throws Exception
+    {
+        if (xtextDocument == null)
+        {
+            return null;
+        }
+        return xtextDocument.readOnly(new IUnitOfWork<String, XtextResource>()
+        {
+            @Override
+            public String exec(XtextResource resource) throws Exception
+            {
+                if (resource == null)
+                {
+                    return null;
+                }
+                return resolveEObjectInfo(resource, offset);
+            }
+        });
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/EditorScreenshotHelper.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/EditorScreenshotHelper.java
@@ -953,7 +953,27 @@ public final class EditorScreenshotHelper
         // mapping-root callback skips re-entrant rebuilds while the representation's rebuild lock is
         // held, so a single request can be dropped; re-requesting until the image is present makes the
         // wait robust.
-        deadline = System.currentTimeMillis() + timeoutMs;
+        return runAsyncRebuildFallback(representation, timeoutMs, display, baseline, requireNewInstance);
+    }
+
+    /**
+     * Fallback render wait used when the synchronous render hooks are not reachable on this EDT.
+     * Re-triggers the asynchronous rebuild and polls until a (fresh, when forced) non-empty image is
+     * available, performing one final check after the budget elapses. Extracted verbatim from
+     * {@link #ensureRenderedFormImage(Object, int, boolean)} to keep that method's complexity in check.
+     *
+     * @param representation the {@code FormWysiwygRepresentation} instance
+     * @param timeoutMs maximum time to wait, in milliseconds
+     * @param display the current display used to pump the event loop (may be {@code null})
+     * @param baseline the image observed before the wait, used for freshness comparison
+     * @param requireNewInstance {@code true} to require a different {@code ImageData} instance than the
+     *            baseline (used when the stale buffer could not be cleared)
+     * @return {@code true} if a (fresh, when forced) non-empty image became available within the budget
+     */
+    private static boolean runAsyncRebuildFallback(Object representation, int timeoutMs, Display display,
+        ImageData baseline, boolean requireNewInstance)
+    {
+        long deadline = System.currentTimeMillis() + timeoutMs;
         while (System.currentTimeMillis() < deadline)
         {
             rebuildRepresentation(representation);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/JUnitMarkdownFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/JUnitMarkdownFormatter.java
@@ -103,34 +103,49 @@ public final class JUnitMarkdownFormatter
         sb.append("\n## ").append(title).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
         for (JUnitTestResults.TestCase tc : cases)
         {
-            sb.append("\n### ").append(tc.name).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            if (tc.message != null && !tc.message.isEmpty())
+            appendCase(sb, tc, withTrace);
+        }
+    }
+
+    /**
+     * Renders a single test case (heading, optional message, optional location and compacted trace)
+     * into {@code sb}. Extracted verbatim from
+     * {@link #appendSection(StringBuilder, String, List, boolean)} to keep that method's complexity in
+     * check; this only appends to {@code sb} and changes no control flow.
+     *
+     * @param sb the target builder (appended to)
+     * @param tc the test case to render
+     * @param withTrace {@code true} to additionally render the source location and compacted trace
+     */
+    private static void appendCase(StringBuilder sb, JUnitTestResults.TestCase tc, boolean withTrace)
+    {
+        sb.append("\n### ").append(tc.name).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (tc.message != null && !tc.message.isEmpty())
+        {
+            sb.append("**Message:** ").append(tc.message).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        if (withTrace && tc.trace != null)
+        {
+            // Surface the failing source location so the caller can chain
+            // straight into set_breakpoint / read_module_source.
+            FrameLocation loc = firstUserFrameLocation(tc.trace);
+            if (loc != null)
             {
-                sb.append("**Message:** ").append(tc.message).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            }
-            if (withTrace && tc.trace != null)
-            {
-                // Surface the failing source location so the caller can chain
-                // straight into set_breakpoint / read_module_source.
-                FrameLocation loc = firstUserFrameLocation(tc.trace);
-                if (loc != null)
+                sb.append("**Location:** ").append(loc.modulePath) //$NON-NLS-1$
+                    .append(':').append(loc.line);
+                if (loc.extension != null && !loc.extension.isEmpty())
                 {
-                    sb.append("**Location:** ").append(loc.modulePath) //$NON-NLS-1$
-                        .append(':').append(loc.line);
-                    if (loc.extension != null && !loc.extension.isEmpty())
-                    {
-                        sb.append(" (extension: ").append(loc.extension).append(')'); //$NON-NLS-1$
-                    }
-                    sb.append("\n"); //$NON-NLS-1$
+                    sb.append(" (extension: ").append(loc.extension).append(')'); //$NON-NLS-1$
                 }
+                sb.append("\n"); //$NON-NLS-1$
             }
-            if (withTrace && tc.trace != null && !tc.trace.trim().isEmpty())
+        }
+        if (withTrace && tc.trace != null && !tc.trace.trim().isEmpty())
+        {
+            String trace = compactTrace(tc.trace, tc.message);
+            if (!trace.isEmpty())
             {
-                String trace = compactTrace(tc.trace, tc.message);
-                if (!trace.isEmpty())
-                {
-                    sb.append("```\n").append(trace).append("\n```\n"); //$NON-NLS-1$ //$NON-NLS-2$
-                }
+                sb.append("```\n").append(trace).append("\n```\n"); //$NON-NLS-1$ //$NON-NLS-2$
             }
         }
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
@@ -590,43 +590,7 @@ public final class LaunchLifecycleUtils
             {
                 continue;
             }
-            try
-            {
-                if (Activator.getDefault() == null)
-                {
-                    continue;
-                }
-                IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
-                if (dtProjectManager == null)
-                {
-                    continue;
-                }
-                IDtProject dtProject = dtProjectManager.getDtProject(project);
-                if (dtProject == null)
-                {
-                    continue;
-                }
-                IDerivedDataManagerProvider ddProvider =
-                    Activator.getDefault().getDerivedDataManagerProvider();
-                if (ddProvider == null)
-                {
-                    continue;
-                }
-                IDerivedDataManager ddManager = ddProvider.get(dtProject);
-                if (ddManager == null)
-                {
-                    continue;
-                }
-                Activator.logInfo("Pre-launch: forcing derived-data recompute for project: " //$NON-NLS-1$
-                    + project.getName());
-                ddManager.recomputeAll();
-            }
-            catch (RuntimeException e)
-            {
-                // A recompute failure must never abort the launch — log and move on.
-                Activator.logError("Error forcing derived-data recompute for " //$NON-NLS-1$
-                    + project.getName(), e);
-            }
+            forceRecompute(project);
         }
 
         // Phase 2: drain the workspace-wide build job families once. This is not
@@ -643,6 +607,56 @@ public final class LaunchLifecycleUtils
                 continue;
             }
             BuildUtils.waitForDerivedData(project);
+        }
+    }
+
+    /**
+     * Forces a derived-data recompute for a single open project via the standard
+     * {@code IDtProjectManager -> IDerivedDataManagerProvider -> IDerivedDataManager}
+     * chain. Any missing EDT service makes this a no-op for the project, and a
+     * {@link RuntimeException} is logged and swallowed — a recompute failure must
+     * never abort the launch hot path.
+     *
+     * @param project an open project (callers guard {@code null}/closed projects)
+     */
+    private static void forceRecompute(IProject project)
+    {
+        try
+        {
+            if (Activator.getDefault() == null)
+            {
+                return;
+            }
+            IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
+            if (dtProjectManager == null)
+            {
+                return;
+            }
+            IDtProject dtProject = dtProjectManager.getDtProject(project);
+            if (dtProject == null)
+            {
+                return;
+            }
+            IDerivedDataManagerProvider ddProvider =
+                Activator.getDefault().getDerivedDataManagerProvider();
+            if (ddProvider == null)
+            {
+                return;
+            }
+            IDerivedDataManager ddManager = ddProvider.get(dtProject);
+            if (ddManager == null)
+            {
+                return;
+            }
+            Activator.logInfo("Pre-launch: forcing derived-data recompute for project: " //$NON-NLS-1$
+                + project.getName());
+            ddManager.recomputeAll();
+        }
+        catch (RuntimeException e)
+        {
+            // A recompute failure must never abort the launch — log and move on.
+            Activator.logError("Error forcing derived-data recompute for " //$NON-NLS-1$
+                + project.getName(), e);
         }
     }
 
@@ -1173,16 +1187,7 @@ public final class LaunchLifecycleUtils
 
             if (isInProgress(state))
             {
-                // Another caller (or a UI gesture) is already updating this IB.
-                // Wait (event-driven) until it actually applies — if we launched now,
-                // the run would execute a half-updated IB.
-                state = awaitUpdateState(appManager, application,
-                    s -> classify(s) == SyncCategory.SYNCED, syncApplyTimeoutMs);
-                if (isSynced(state))
-                {
-                    return Optional.empty();
-                }
-                return Optional.of(staleInfobaseError(state));
+                return awaitInProgressUpdate(appManager, application);
             }
 
             if (isSynced(state))
@@ -1212,51 +1217,99 @@ public final class LaunchLifecycleUtils
 
             // Phase B — IB needs an update (or state is UNKNOWN). Issue the update,
             // then await the UPDATE_STATE_CHANGED→UPDATED event before returning.
-            ExecutionContext context = new ExecutionContext();
-            Shell shell = grabActiveShell();
-            if (shell != null)
-            {
-                context.setProperty(ExecutionContext.ACTIVE_SHELL_NAME, shell);
-            }
-            Activator.logInfo("Pre-launch DB update: application=" + applicationId //$NON-NLS-1$
-                + ", stateBefore=" + state); //$NON-NLS-1$
-            ApplicationUpdateState after = appManager.update(application,
-                ApplicationUpdateType.INCREMENTAL, context, new NullProgressMonitor());
-            Activator.logInfo("Pre-launch DB update returned: stateAfter=" + after //$NON-NLS-1$
-                + " (now awaiting the UPDATE_STATE_CHANGED→UPDATED event)"); //$NON-NLS-1$
-
-            // Post-condition gate: the auto-chain promises the IB is actually in
-            // UPDATED state (the .cfe applied) before workingCopy.launch() runs.
-            // appManager.update() may return UPDATED (done) or a transitional
-            // BEING_UPDATED/UNKNOWN on the async path — those are awaited below.
-            // A …UPDATE_REQUIRED return, however, is TERMINAL: the update itself
-            // decided it cannot proceed without user action (e.g. an interactive
-            // restructure), so no further UPDATE_STATE_CHANGED transition can ever
-            // arrive. Awaiting SYNCED would stall the MCP call for the full apply
-            // timeout and then fail with the very same out-of-sync error — fail
-            // fast instead, restoring the old prompt-error behaviour.
-            if (needsUpdate(after))
-            {
-                return Optional.of(terminalOutOfSyncError(after));
-            }
-            if (!isSynced(after))
-            {
-                after = awaitUpdateState(appManager, application,
-                    s -> classify(s) == SyncCategory.SYNCED, syncApplyTimeoutMs);
-            }
-            if (isSynced(after))
-            {
-                Activator.logInfo("Pre-launch DB update applied: IB is UPDATED for application=" //$NON-NLS-1$
-                    + applicationId);
-                return Optional.empty();
-            }
-            return Optional.of(staleInfobaseError(after));
+            return performUpdateAndAwaitApplied(appManager, application, applicationId, state);
         }
         catch (ApplicationException e)
         {
             Activator.logError("Error during pre-launch DB update", e); //$NON-NLS-1$
             return Optional.of("Database update failed: " + e.getMessage()); //$NON-NLS-1$
         }
+    }
+
+    /**
+     * Handles the "another caller is already updating this IB" case: waits
+     * (event-driven) until the in-progress update actually applies, then reports
+     * success or the stale-infobase refusal. Launching while the update is mid-flight
+     * would execute a half-updated IB.
+     *
+     * @param appManager the EDT application manager (event source)
+     * @param application the application being updated by another caller
+     * @return {@link Optional#empty()} once the IB reaches SYNCED, otherwise the
+     *         stale-infobase error message
+     */
+    private static Optional<String> awaitInProgressUpdate(IApplicationManager appManager,
+        IApplication application)
+    {
+        ApplicationUpdateState state = awaitUpdateState(appManager, application,
+            s -> classify(s) == SyncCategory.SYNCED, syncApplyTimeoutMs);
+        if (isSynced(state))
+        {
+            return Optional.empty();
+        }
+        return Optional.of(staleInfobaseError(state));
+    }
+
+    /**
+     * Phase B of {@link #updateApplicationIfNeeded}: issues the incremental DB
+     * update and gates on the {@code UPDATE_STATE_CHANGED→UPDATED} event before
+     * returning, so a launch never runs against a not-yet-applied IB.
+     *
+     * <p>A terminal {@code …UPDATE_REQUIRED} return from {@code update()} fails fast
+     * (no further transition can arrive without user action); a transitional
+     * {@code BEING_UPDATED}/{@code UNKNOWN} is awaited up to {@link #syncApplyTimeoutMs}.
+     * {@link ApplicationException} is propagated to the caller's existing handler.
+     *
+     * @param appManager the EDT application manager
+     * @param application the application whose IB is updated
+     * @param applicationId the application id (for log messages)
+     * @param stateBefore the update state observed before issuing the update (logged)
+     * @return {@link Optional#empty()} once the IB is UPDATED, otherwise an
+     *         actionable out-of-sync error message
+     * @throws ApplicationException if the update call itself fails
+     */
+    private static Optional<String> performUpdateAndAwaitApplied(IApplicationManager appManager,
+        IApplication application, String applicationId, ApplicationUpdateState stateBefore)
+        throws ApplicationException
+    {
+        ExecutionContext context = new ExecutionContext();
+        Shell shell = grabActiveShell();
+        if (shell != null)
+        {
+            context.setProperty(ExecutionContext.ACTIVE_SHELL_NAME, shell);
+        }
+        Activator.logInfo("Pre-launch DB update: application=" + applicationId //$NON-NLS-1$
+            + ", stateBefore=" + stateBefore); //$NON-NLS-1$
+        ApplicationUpdateState after = appManager.update(application,
+            ApplicationUpdateType.INCREMENTAL, context, new NullProgressMonitor());
+        Activator.logInfo("Pre-launch DB update returned: stateAfter=" + after //$NON-NLS-1$
+            + " (now awaiting the UPDATE_STATE_CHANGED→UPDATED event)"); //$NON-NLS-1$
+
+        // Post-condition gate: the auto-chain promises the IB is actually in
+        // UPDATED state (the .cfe applied) before workingCopy.launch() runs.
+        // appManager.update() may return UPDATED (done) or a transitional
+        // BEING_UPDATED/UNKNOWN on the async path — those are awaited below.
+        // A …UPDATE_REQUIRED return, however, is TERMINAL: the update itself
+        // decided it cannot proceed without user action (e.g. an interactive
+        // restructure), so no further UPDATE_STATE_CHANGED transition can ever
+        // arrive. Awaiting SYNCED would stall the MCP call for the full apply
+        // timeout and then fail with the very same out-of-sync error — fail
+        // fast instead, restoring the old prompt-error behaviour.
+        if (needsUpdate(after))
+        {
+            return Optional.of(terminalOutOfSyncError(after));
+        }
+        if (!isSynced(after))
+        {
+            after = awaitUpdateState(appManager, application,
+                s -> classify(s) == SyncCategory.SYNCED, syncApplyTimeoutMs);
+        }
+        if (isSynced(after))
+        {
+            Activator.logInfo("Pre-launch DB update applied: IB is UPDATED for application=" //$NON-NLS-1$
+                + applicationId);
+            return Optional.empty();
+        }
+        return Optional.of(staleInfobaseError(after));
     }
 
     /**


### PR DESCRIPTION
Tier-C part 2 of the SonarCloud code-smell cleanup (#164): the **cc 19-22** band of S3776 (non-god-class). **29 of 34** methods reduced under the limit of 15 via one/two coherent Extract-Method refactors; 5 skipped (parent-targeting returns / multi-local mutation). Same rigorous pipeline as #172: deep-study implement -> **INDEPENDENT adversarial verify of every diff** -> `mvn clean verify` (2202 tests) — all CONFIRMED behaviour-identical, zero concerns. **Destructive tools handled with extra care:** DeleteMetadataTool's write-transaction moved verbatim (same confirm-gate/transaction), only argument-validation extracted from UpdateDatabaseTool, DebugLaunchTool's DB-update preflight kept its exact place + exception path. No behaviour change. Follows #166–#170, #172.