### PR TITLE
Reduce cognitive complexity via Extract Method, part 3 (S3776 cc 23-30, 33 methods)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/EdtServices.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/EdtServices.java
@@ -221,137 +221,53 @@ public class EdtServices
      */
     public void dispose()
     {
-        // Close service trackers
-        if (v8ProjectManagerTracker != null)
+        // Close service trackers (each closeTracker() closes when non-null and returns null,
+        // exactly reproducing the former "if (t != null) { t.close(); t = null; }" per-field block).
+        v8ProjectManagerTracker = closeTracker(v8ProjectManagerTracker);
+        dtProjectManagerTracker = closeTracker(dtProjectManagerTracker);
+        configurationProviderTracker = closeTracker(configurationProviderTracker);
+        markerManagerTracker = closeTracker(markerManagerTracker);
+        checkSchedulerTracker = closeTracker(checkSchedulerTracker);
+        checkRepositoryTracker = closeTracker(checkRepositoryTracker);
+        bmModelManagerTracker = closeTracker(bmModelManagerTracker);
+        derivedDataManagerProviderTracker = closeTracker(derivedDataManagerProviderTracker);
+        servicesOrchestratorTracker = closeTracker(servicesOrchestratorTracker);
+        resourceSetProviderTracker = closeTracker(resourceSetProviderTracker);
+        applicationManagerTracker = closeTracker(applicationManagerTracker);
+        infobaseManagerTracker = closeTracker(infobaseManagerTracker);
+        infobaseAssociationManagerTracker = closeTracker(infobaseAssociationManagerTracker);
+        navigatorStateProviderTracker = closeTracker(navigatorStateProviderTracker);
+        mdRefactoringServiceTracker = closeTracker(mdRefactoringServiceTracker);
+        topObjectFqnGeneratorTracker = closeTracker(topObjectFqnGeneratorTracker);
+        extensionProjectManagerTracker = closeTracker(extensionProjectManagerTracker);
+        configurationProjectManagerTracker = closeTracker(configurationProjectManagerTracker);
+        externalObjectProjectManagerTracker = closeTracker(externalObjectProjectManagerTracker);
+        formModelObjectFactoryTracker = closeTracker(formModelObjectFactoryTracker);
+        exportConfigurationFilesApiTracker = closeTracker(exportConfigurationFilesApiTracker);
+        importConfigurationFilesApiTracker = closeTracker(importConfigurationFilesApiTracker);
+        generateTranslationStringsApiTracker = closeTracker(generateTranslationStringsApiTracker);
+        synchronizeProjectApiTracker = closeTracker(synchronizeProjectApiTracker);
+        projectInformationApiTracker = closeTracker(projectInformationApiTracker);
+        runtimeDebugClientTargetManagerTracker = closeTracker(runtimeDebugClientTargetManagerTracker);
+    }
+
+    /**
+     * Closes the given service tracker when it is non-{@code null} and returns {@code null} so the
+     * caller can clear its field. Behaviour-identical to the former inline
+     * {@code if (tracker != null) { tracker.close(); tracker = null; }} block.
+     *
+     * @param <S> the tracker's tracked-service type
+     * @param <T> the tracker's tracked-object type
+     * @param tracker the tracker to close, may be {@code null}
+     * @return {@code null} always
+     */
+    private static <S, T> ServiceTracker<S, T> closeTracker(ServiceTracker<S, T> tracker)
+    {
+        if (tracker != null)
         {
-            v8ProjectManagerTracker.close();
-            v8ProjectManagerTracker = null;
+            tracker.close();
         }
-        if (dtProjectManagerTracker != null)
-        {
-            dtProjectManagerTracker.close();
-            dtProjectManagerTracker = null;
-        }
-        if (configurationProviderTracker != null)
-        {
-            configurationProviderTracker.close();
-            configurationProviderTracker = null;
-        }
-        if (markerManagerTracker != null)
-        {
-            markerManagerTracker.close();
-            markerManagerTracker = null;
-        }
-        if (checkSchedulerTracker != null)
-        {
-            checkSchedulerTracker.close();
-            checkSchedulerTracker = null;
-        }
-        if (checkRepositoryTracker != null)
-        {
-            checkRepositoryTracker.close();
-            checkRepositoryTracker = null;
-        }
-        if (bmModelManagerTracker != null)
-        {
-            bmModelManagerTracker.close();
-            bmModelManagerTracker = null;
-        }
-        if (derivedDataManagerProviderTracker != null)
-        {
-            derivedDataManagerProviderTracker.close();
-            derivedDataManagerProviderTracker = null;
-        }
-        if (servicesOrchestratorTracker != null)
-        {
-            servicesOrchestratorTracker.close();
-            servicesOrchestratorTracker = null;
-        }
-        if (resourceSetProviderTracker != null)
-        {
-            resourceSetProviderTracker.close();
-            resourceSetProviderTracker = null;
-        }
-        if (applicationManagerTracker != null)
-        {
-            applicationManagerTracker.close();
-            applicationManagerTracker = null;
-        }
-        if (infobaseManagerTracker != null)
-        {
-            infobaseManagerTracker.close();
-            infobaseManagerTracker = null;
-        }
-        if (infobaseAssociationManagerTracker != null)
-        {
-            infobaseAssociationManagerTracker.close();
-            infobaseAssociationManagerTracker = null;
-        }
-        if (navigatorStateProviderTracker != null)
-        {
-            navigatorStateProviderTracker.close();
-            navigatorStateProviderTracker = null;
-        }
-        if (mdRefactoringServiceTracker != null)
-        {
-            mdRefactoringServiceTracker.close();
-            mdRefactoringServiceTracker = null;
-        }
-        if (topObjectFqnGeneratorTracker != null)
-        {
-            topObjectFqnGeneratorTracker.close();
-            topObjectFqnGeneratorTracker = null;
-        }
-        if (extensionProjectManagerTracker != null)
-        {
-            extensionProjectManagerTracker.close();
-            extensionProjectManagerTracker = null;
-        }
-        if (configurationProjectManagerTracker != null)
-        {
-            configurationProjectManagerTracker.close();
-            configurationProjectManagerTracker = null;
-        }
-        if (externalObjectProjectManagerTracker != null)
-        {
-            externalObjectProjectManagerTracker.close();
-            externalObjectProjectManagerTracker = null;
-        }
-        if (formModelObjectFactoryTracker != null)
-        {
-            formModelObjectFactoryTracker.close();
-            formModelObjectFactoryTracker = null;
-        }
-        if (exportConfigurationFilesApiTracker != null)
-        {
-            exportConfigurationFilesApiTracker.close();
-            exportConfigurationFilesApiTracker = null;
-        }
-        if (importConfigurationFilesApiTracker != null)
-        {
-            importConfigurationFilesApiTracker.close();
-            importConfigurationFilesApiTracker = null;
-        }
-        if (generateTranslationStringsApiTracker != null)
-        {
-            generateTranslationStringsApiTracker.close();
-            generateTranslationStringsApiTracker = null;
-        }
-        if (synchronizeProjectApiTracker != null)
-        {
-            synchronizeProjectApiTracker.close();
-            synchronizeProjectApiTracker = null;
-        }
-        if (projectInformationApiTracker != null)
-        {
-            projectInformationApiTracker.close();
-            projectInformationApiTracker = null;
-        }
-        if (runtimeDebugClientTargetManagerTracker != null)
-        {
-            runtimeDebugClientTargetManagerTracker.close();
-            runtimeDebugClientTargetManagerTracker = null;
-        }
+        return null;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/NewGroupHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/NewGroupHandler.java
@@ -107,24 +107,8 @@ public class NewGroupHandler extends AbstractHandler {
         final IProject finalProject = project;
         final String finalParentPath = parentPath;
         
-        EditGroupDialog dialog = new EditGroupDialog(shell, name -> {
-            if (name == null || name.trim().isEmpty()) {
-                return "Group name cannot be empty";
-            }
-            String trimmed = name.trim();
-            if (trimmed.contains("/") || trimmed.contains("\\")) {
-                return "Group name cannot contain path separators";
-            }
-            // Check for existing group with same name
-            IGroupService service = Activator.getGroupServiceStatic();
-            String fullPath = finalParentPath.isEmpty() 
-                ? trimmed 
-                : finalParentPath + "/" + trimmed;
-            if (service.getGroupStorage(finalProject).getGroupByFullPath(fullPath) != null) {
-                return "A group with this name already exists";
-            }
-            return null;
-        });
+        EditGroupDialog dialog = new EditGroupDialog(shell,
+            name -> validateGroupName(name, finalProject, finalParentPath));
         
         if (dialog.open() == Window.OK) {
             String groupName = dialog.getGroupName();
@@ -149,7 +133,37 @@ public class NewGroupHandler extends AbstractHandler {
         
         return null;
     }
-    
+
+    /**
+     * Validates a proposed group name for the {@link EditGroupDialog}. Returns an
+     * error message to display, or {@code null} when the name is acceptable: it must
+     * be non-blank, contain no path separators, and not collide with an existing
+     * group at the same parent path. Performs no mutations.
+     *
+     * @param name the candidate name entered in the dialog
+     * @param project the project the group would be created in
+     * @param parentPath the collection path the group would live under
+     * @return the validation error message, or {@code null} if the name is valid
+     */
+    private String validateGroupName(String name, IProject project, String parentPath) {
+        if (name == null || name.trim().isEmpty()) {
+            return "Group name cannot be empty";
+        }
+        String trimmed = name.trim();
+        if (trimmed.contains("/") || trimmed.contains("\\")) {
+            return "Group name cannot contain path separators";
+        }
+        // Check for existing group with same name
+        IGroupService service = Activator.getGroupServiceStatic();
+        String fullPath = parentPath.isEmpty()
+            ? trimmed
+            : parentPath + "/" + trimmed;
+        if (service.getGroupStorage(project).getGroupByFullPath(fullPath) != null) {
+            return "A group with this name already exists";
+        }
+        return null;
+    }
+
     /**
      * Checks if the element is a collection adapter.
      */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/RemoveFromGroupHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/RemoveFromGroupHandler.java
@@ -74,27 +74,11 @@ public class RemoveFromGroupHandler extends AbstractHandler {
         }
         
         IGroupService service = Activator.getGroupServiceStatic();
-        
+
         // Collect selected objects that are in groups
         List<ObjectInGroup> objectsToRemove = new ArrayList<>();
-        IProject project = null;
-        
-        for (Object element : structuredSelection.toList()) {
-            if (element instanceof EObject eObject) {
-                IProject objProject = TagUtils.extractProject(eObject);
-                String fqn = TagUtils.extractFqn(eObject);
-                if (objProject != null && fqn != null) {
-                    Group group = service.findGroupForObject(objProject, fqn);
-                    if (group != null) {
-                        objectsToRemove.add(new ObjectInGroup(objProject, fqn));
-                        if (project == null) {
-                            project = objProject;
-                        }
-                    }
-                }
-            }
-        }
-        
+        IProject project = collectObjectsInGroups(structuredSelection, service, objectsToRemove);
+
         if (objectsToRemove.isEmpty() || project == null) {
             return null;
         }
@@ -126,7 +110,44 @@ public class RemoveFromGroupHandler extends AbstractHandler {
             }
         }
         
-        // Show result
+        showRemovalResult(shell, successCount, failCount);
+
+        return null;
+    }
+
+    /**
+     * Collects, from the current selection, every {@link EObject} that resolves to a project +
+     * FQN and is currently in a group; each match is appended to {@code objectsToRemove}. Returns
+     * the project of the first such match (the original location to report against), or
+     * {@code null} when no selected object is in a group.
+     */
+    private IProject collectObjectsInGroups(IStructuredSelection structuredSelection,
+            IGroupService service, List<ObjectInGroup> objectsToRemove) {
+        IProject project = null;
+        for (Object element : structuredSelection.toList()) {
+            if (element instanceof EObject eObject) {
+                IProject objProject = TagUtils.extractProject(eObject);
+                String fqn = TagUtils.extractFqn(eObject);
+                if (objProject != null && fqn != null) {
+                    Group group = service.findGroupForObject(objProject, fqn);
+                    if (group != null) {
+                        objectsToRemove.add(new ObjectInGroup(objProject, fqn));
+                        if (project == null) {
+                            project = objProject;
+                        }
+                    }
+                }
+            }
+        }
+        return project;
+    }
+
+    /**
+     * Shows the post-removal feedback dialog: an information dialog on a fully successful run, a
+     * warning dialog when at least one removal failed, and nothing when nothing succeeded and
+     * nothing failed (mirrors the original inline behaviour exactly).
+     */
+    private void showRemovalResult(Shell shell, int successCount, int failCount) {
         if (successCount > 0 && failCount == 0) {
             MessageDialog.openInformation(shell, REMOVE_FROM_GROUP,
                 "Removed " + successCount + " object(s) from their groups.");
@@ -134,8 +155,6 @@ public class RemoveFromGroupHandler extends AbstractHandler {
             MessageDialog.openWarning(shell, REMOVE_FROM_GROUP,
                 "Removed " + successCount + " object(s), failed to remove " + failCount + " object(s).");
         }
-        
-        return null;
     }
     
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupSelectionHelper.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupSelectionHelper.java
@@ -155,33 +155,9 @@ public class GroupSelectionHelper implements ISelectionChangedListener {
         if (groupService == null) {
             return;
         }
-        
-        List<TreePath> treePaths = new ArrayList<>();
-        
-        for (Iterator<?> it = lastNonEmptySelection.iterator(); it.hasNext();) {
-            Object element = it.next();
-            
-            if (element instanceof EObject eObject) {
-                IProject project = TagUtils.extractProject(eObject);
-                String fqn = TagUtils.extractFqn(eObject);
-                
-                if (project != null && fqn != null) {
-                    Group group = groupService.findGroupForObject(project, fqn);
-                    
-                    if (group != null) {
-                        // Find the GroupNavigatorAdapter for this group
-                        GroupNavigatorAdapter groupAdapter = findOrCreateGroupAdapter(project, group);
-                        
-                        if (groupAdapter != null) {
-                            // Create TreePath: groupAdapter -> element
-                            TreePath path = new TreePath(new Object[] { groupAdapter, element });
-                            treePaths.add(path);
-                        }
-                    }
-                }
-            }
-        }
-        
+
+        List<TreePath> treePaths = collectGroupedTreePaths(groupService);
+
         if (!treePaths.isEmpty()) {
             TreeSelection treeSelection = new TreeSelection(treePaths.toArray(new TreePath[0]));
             viewer.setSelection(treeSelection, true);
@@ -191,6 +167,45 @@ public class GroupSelectionHelper implements ISelectionChangedListener {
         }
     }
     
+    /**
+     * Builds the {@link TreePath}s for every element of {@link #lastNonEmptySelection}
+     * that resolves to an object inside a group, routing each through its
+     * {@link GroupNavigatorAdapter}. Elements that are not {@link EObject}s, carry no
+     * project/fqn, are not grouped, or whose adapter cannot be located are skipped.
+     *
+     * @param groupService the (non-{@code null}) group service to resolve groups with
+     * @return the collected tree paths (possibly empty, never {@code null})
+     */
+    private List<TreePath> collectGroupedTreePaths(IGroupService groupService) {
+        List<TreePath> treePaths = new ArrayList<>();
+
+        for (Iterator<?> it = lastNonEmptySelection.iterator(); it.hasNext();) {
+            Object element = it.next();
+
+            if (element instanceof EObject eObject) {
+                IProject project = TagUtils.extractProject(eObject);
+                String fqn = TagUtils.extractFqn(eObject);
+
+                if (project != null && fqn != null) {
+                    Group group = groupService.findGroupForObject(project, fqn);
+
+                    if (group != null) {
+                        // Find the GroupNavigatorAdapter for this group
+                        GroupNavigatorAdapter groupAdapter = findOrCreateGroupAdapter(project, group);
+
+                        if (groupAdapter != null) {
+                            // Create TreePath: groupAdapter -> element
+                            TreePath path = new TreePath(new Object[] { groupAdapter, element });
+                            treePaths.add(path);
+                        }
+                    }
+                }
+            }
+        }
+
+        return treePaths;
+    }
+
     /**
      * Finds GroupNavigatorAdapter for the given group by traversing the tree structure.
      * Uses the ContentProvider to navigate through the tree hierarchy.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagSearchFilter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagSearchFilter.java
@@ -471,90 +471,117 @@ public class TagSearchFilter extends ViewerFilter {
     private Boolean checkNestedObjectFolder(Object element) {
         try {
             // First get the parent EObject
-            EObject parent = null;
-            
-            // Try getModel() or getModel(false)
-            for (String methodName : new String[]{"getModel"}) {
-                try {
-                    // Try getModel(boolean)
-                    var method = element.getClass().getMethod(methodName, boolean.class);
-                    Object result = method.invoke(element, false);
-                    if (result instanceof EObject eObj) {
-                        parent = eObj;
-                        break;
-                    }
-                } catch (NoSuchMethodException e) {
-                    // Try without parameter
-                    try {
-                        var method = element.getClass().getMethod(methodName);
-                        Object result = method.invoke(element);
-                        if (result instanceof EObject eObj) {
-                            parent = eObj;
-                            break;
-                        }
-                    } catch (NoSuchMethodException e2) {
-                        // Ignore
-                    }
-                }
-            }
-            
+            EObject parent = resolveNestedFolderParent(element);
             if (parent == null) {
                 return null; // Not a nested folder
             }
-            
+
             // Get the parent's FQN
             String parentFqn = TagUtils.extractFqn(parent);
             if (parentFqn == null) {
                 return null;
             }
-            
+
             // Get the model object name (Attribute, EnumValue, TabularSection, etc.)
-            String modelObjectName = null;
-            try {
-                var method = element.getClass().getMethod("getModelObjectName");
-                Object result = method.invoke(element);
-                if (result != null) {
-                    modelObjectName = result.toString();
-                }
-            } catch (NoSuchMethodException e) {
-                // Ignore
-            }
-            
+            String modelObjectName = resolveModelObjectName(element);
             if (modelObjectName == null) {
                 return null;
             }
-            
+
             Set<String> projectFqns = getCurrentMatchingFqns();
-            
+
             // Map folder model object names to FQN type prefixes
             // For example, "Attribute" in Document -> "DocumentAttribute"
             // "EnumValue" in Enum -> "EnumValue"
             String fqnTypePrefix = mapModelObjectNameToFqnType(parentFqn, modelObjectName);
-            
-            if (fqnTypePrefix == null) {
-                // No mapping, fall back to checking if any matching FQN contains this segment
-                for (String fqn : projectFqns) {
-                    if (fqn.contains("." + modelObjectName + ".") && fqn.startsWith(parentFqn + ".")) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-            
-            // Check if any matching FQN is a child of parent.FqnType.*
-            String searchPrefix = parentFqn + "." + fqnTypePrefix + ".";
-            for (String fqn : projectFqns) {
-                if (fqn.startsWith(searchPrefix)) {
-                    return true;
-                }
-            }
-            
-            return false;
-            
+
+            return matchesNestedFolderChild(projectFqns, parentFqn, modelObjectName, fqnTypePrefix);
+
         } catch (Exception e) {
             Activator.logError("Error checking nested folder", e);
             return null;
         }
+    }
+
+    /**
+     * Resolves the parent {@link EObject} of a nested object folder via reflection: tries
+     * {@code getModel(boolean)} then {@code getModel()}. Returns the parent EObject, or
+     * {@code null} when neither accessor yields an EObject. Side-effect free; non-
+     * {@link NoSuchMethodException} reflection failures propagate to the caller (preserving
+     * the original outer try/catch behaviour).
+     */
+    private static EObject resolveNestedFolderParent(Object element) throws Exception {
+        // Try getModel() or getModel(false)
+        for (String methodName : new String[]{"getModel"}) {
+            try {
+                // Try getModel(boolean)
+                var method = element.getClass().getMethod(methodName, boolean.class);
+                Object result = method.invoke(element, false);
+                if (result instanceof EObject eObj) {
+                    return eObj;
+                }
+            } catch (NoSuchMethodException e) {
+                // Try without parameter
+                try {
+                    var method = element.getClass().getMethod(methodName);
+                    Object result = method.invoke(element);
+                    if (result instanceof EObject eObj) {
+                        return eObj;
+                    }
+                } catch (NoSuchMethodException e2) {
+                    // Ignore
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Reads the folder's model object name (Attribute, EnumValue, TabularSection, etc.) via the
+     * reflective {@code getModelObjectName()} accessor. Returns the name, or {@code null} when the
+     * accessor is absent or yields null. Side-effect free; non-{@link NoSuchMethodException}
+     * reflection failures propagate to the caller (preserving the original outer try/catch).
+     */
+    private static String resolveModelObjectName(Object element) throws Exception {
+        try {
+            var method = element.getClass().getMethod("getModelObjectName");
+            Object result = method.invoke(element);
+            if (result != null) {
+                return result.toString();
+            }
+        } catch (NoSuchMethodException e) {
+            // Ignore
+        }
+        return null;
+    }
+
+    /**
+     * Decides whether any matching FQN is a child of the nested folder. With a known
+     * {@code fqnTypePrefix}, a child is {@code parentFqn.fqnTypePrefix.*}; without a mapping, it
+     * falls back to any FQN that contains {@code .modelObjectName.} and starts with {@code parentFqn.}.
+     * Pure computation over the supplied FQN set.
+     */
+    private static boolean matchesNestedFolderChild(Set<String> projectFqns, String parentFqn,
+        String modelObjectName, String fqnTypePrefix) {
+        if (fqnTypePrefix == null) {
+            // No mapping, fall back to checking if any matching FQN contains this segment
+            for (String fqn : projectFqns) {
+                if (fqn.contains("." + modelObjectName + ".") && fqn.startsWith(parentFqn + ".")) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Check if any matching FQN is a child of parent.FqnType.*
+        String searchPrefix = parentFqn + "." + fqnTypePrefix + ".";
+        for (String fqn : projectFqns) {
+            if (fqn.startsWith(searchPrefix)) {
+                return true;
+            }
+        }
+
+        return false;
     }
     
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagsMenuContribution.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagsMenuContribution.java
@@ -81,61 +81,16 @@ public class TagsMenuContribution extends CompoundContributionItem {
         }
         
         // Collect all selected objects grouped by project
-        Map<IProject, List<String>> objectsByProject = new HashMap<>();
-        for (Iterator<?> it = structuredSelection.iterator(); it.hasNext();) {
-            Object element = it.next();
-            EObject eObject = TagUtils.extractMdObject(element);
-            if (eObject == null) {
-                continue;
-            }
-            
-            IProject project = TagUtils.extractProject(eObject);
-            String fqn = TagUtils.extractFqn(eObject);
-            
-            if (project != null && fqn != null) {
-                objectsByProject.computeIfAbsent(project, k -> new ArrayList<>()).add(fqn);
-            }
-        }
-        
+        Map<IProject, List<String>> objectsByProject = collectObjectsByProject(structuredSelection);
+
         if (objectsByProject.isEmpty()) {
             return new IContributionItem[0];
         }
-        
+
         // Collect all unique tags from all projects and their assignment state
         // Also track the minimum index for each tag across all projects
-        Map<String, TagState> tagStates = new HashMap<>();
-        
-        for (Map.Entry<IProject, List<String>> entry : objectsByProject.entrySet()) {
-            IProject project = entry.getKey();
-            List<String> fqns = entry.getValue();
-            
-            List<Tag> projectTags = tagService.getTags(project);
-            
-            for (int tagIndex = 0; tagIndex < projectTags.size(); tagIndex++) {
-                Tag tag = projectTags.get(tagIndex);
-                String tagName = tag.getName();
-                TagState state = tagStates.computeIfAbsent(tagName, 
-                    k -> new TagState(tag.getColor()));
-                
-                // Track the minimum storage index (for hotkey display)
-                // Use 1-based index (1-10), convert 10 to 0 for display
-                int hotkeyIndex = tagIndex + 1;
-                if (hotkeyIndex <= 10 && (state.hotkeyIndex == -1 || hotkeyIndex < state.hotkeyIndex)) {
-                    state.hotkeyIndex = hotkeyIndex;
-                }
-                
-                for (String fqn : fqns) {
-                    Set<Tag> assignedTags = tagService.getObjectTags(project, fqn);
-                    boolean hasTag = assignedTags.stream()
-                        .anyMatch(t -> t.getName().equals(tagName));
-                    if (hasTag) {
-                        state.assignedCount++;
-                    }
-                    state.totalCount++;
-                }
-            }
-        }
-        
+        Map<String, TagState> tagStates = buildTagStates(objectsByProject);
+
         if (tagStates.isEmpty()) {
             return new IContributionItem[0];
         }
@@ -158,10 +113,73 @@ public class TagsMenuContribution extends CompoundContributionItem {
         
         // Add separator before "Manage Tags..."
         items[sortedTagNames.size()] = new SeparatorItem();
-        
+
         return items;
     }
-    
+
+    /**
+     * Groups the selected metadata objects by their owning project, keeping only the
+     * elements that resolve to both a project and an FQN.
+     */
+    private Map<IProject, List<String>> collectObjectsByProject(IStructuredSelection structuredSelection) {
+        Map<IProject, List<String>> objectsByProject = new HashMap<>();
+        for (Iterator<?> it = structuredSelection.iterator(); it.hasNext();) {
+            Object element = it.next();
+            EObject eObject = TagUtils.extractMdObject(element);
+            if (eObject == null) {
+                continue;
+            }
+
+            IProject project = TagUtils.extractProject(eObject);
+            String fqn = TagUtils.extractFqn(eObject);
+
+            if (project != null && fqn != null) {
+                objectsByProject.computeIfAbsent(project, k -> new ArrayList<>()).add(fqn);
+            }
+        }
+        return objectsByProject;
+    }
+
+    /**
+     * Builds the union of tags across all projects, tracking each tag's assignment counts
+     * (assigned/total) and minimum hotkey index for the menu.
+     */
+    private Map<String, TagState> buildTagStates(Map<IProject, List<String>> objectsByProject) {
+        Map<String, TagState> tagStates = new HashMap<>();
+
+        for (Map.Entry<IProject, List<String>> entry : objectsByProject.entrySet()) {
+            IProject project = entry.getKey();
+            List<String> fqns = entry.getValue();
+
+            List<Tag> projectTags = tagService.getTags(project);
+
+            for (int tagIndex = 0; tagIndex < projectTags.size(); tagIndex++) {
+                Tag tag = projectTags.get(tagIndex);
+                String tagName = tag.getName();
+                TagState state = tagStates.computeIfAbsent(tagName,
+                    k -> new TagState(tag.getColor()));
+
+                // Track the minimum storage index (for hotkey display)
+                // Use 1-based index (1-10), convert 10 to 0 for display
+                int hotkeyIndex = tagIndex + 1;
+                if (hotkeyIndex <= 10 && (state.hotkeyIndex == -1 || hotkeyIndex < state.hotkeyIndex)) {
+                    state.hotkeyIndex = hotkeyIndex;
+                }
+
+                for (String fqn : fqns) {
+                    Set<Tag> assignedTags = tagService.getObjectTags(project, fqn);
+                    boolean hasTag = assignedTags.stream()
+                        .anyMatch(t -> t.getName().equals(tagName));
+                    if (hasTag) {
+                        state.assignedCount++;
+                    }
+                    state.totalCount++;
+                }
+            }
+        }
+        return tagStates;
+    }
+
     /**
      * State for tracking tag assignment across multiple objects.
      */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/doc/PlatformDocumentationService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/doc/PlatformDocumentationService.java
@@ -400,47 +400,66 @@ public class PlatformDocumentationService
     {
         if (projectName == null || projectName.isEmpty())
         {
-            // Try to get from first available project
-            IV8ProjectManager v8pm = Activator.getDefault().getV8ProjectManager();
-            if (v8pm != null)
-            {
-                java.util.Iterator<IV8Project> it = v8pm.getProjects().iterator();
-                if (it.hasNext())
-                {
-                    return it.next().getVersion();
-                }
-            }
-            return null;
+            return firstProjectVersion();
         }
 
         try
         {
             ProjectContext ctx = ProjectContext.of(projectName);
-            IProject project = ctx.project();
             if (ctx.exists())
             {
-                IDtProjectManager dtpm = Activator.getDefault().getDtProjectManager();
-                if (dtpm != null)
-                {
-                    IDtProject dtProject = dtpm.getDtProject(project);
-                    if (dtProject != null)
-                    {
-                        IV8ProjectManager v8pm = Activator.getDefault().getV8ProjectManager();
-                        if (v8pm != null)
-                        {
-                            IV8Project v8Project = v8pm.getProject(dtProject);
-                            if (v8Project != null)
-                            {
-                                return v8Project.getVersion();
-                            }
-                        }
-                    }
-                }
+                return versionForContext(ctx);
             }
         }
         catch (Exception e)
         {
             Activator.logError("Error getting project version", e); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Returns the platform version of the first available project, or {@code null} when
+     * there is none. Used as the fallback when no project name is supplied.
+     */
+    private Version firstProjectVersion()
+    {
+        IV8ProjectManager v8pm = Activator.getDefault().getV8ProjectManager();
+        if (v8pm != null)
+        {
+            java.util.Iterator<IV8Project> it = v8pm.getProjects().iterator();
+            if (it.hasNext())
+            {
+                return it.next().getVersion();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the platform version for an existing project context by walking
+     * {@code IProject -> IDtProject -> IV8Project}, returning {@code null} when any link in
+     * the chain is unavailable.
+     */
+    private Version versionForContext(ProjectContext ctx)
+    {
+        IProject project = ctx.project();
+        IDtProjectManager dtpm = Activator.getDefault().getDtProjectManager();
+        if (dtpm != null)
+        {
+            IDtProject dtProject = dtpm.getDtProject(project);
+            if (dtProject != null)
+            {
+                IV8ProjectManager v8pm = Activator.getDefault().getV8ProjectManager();
+                if (v8pm != null)
+                {
+                    IV8Project v8Project = v8pm.getProject(dtProject);
+                    if (v8Project != null)
+                    {
+                        return v8Project.getVersion();
+                    }
+                }
+            }
         }
         return null;
     }
@@ -518,6 +537,24 @@ public class PlatformDocumentationService
 
         // Parameter sets (overloads) - use getParamSet() not getParamSets()
         EList<ParamSet> paramSets = method.getParamSet();
+        appendMethodParamSets(sb, paramSets, useRussian);
+
+        // Return type - on method level, not ParamSet
+        EList<TypeItem> retValTypes = method.getRetValType();
+        if (retValTypes != null && !retValTypes.isEmpty())
+        {
+            sb.append("**Returns:** ").append(joinTypeNames(retValTypes, useRussian)).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+
+        sb.append("\n"); //$NON-NLS-1$
+    }
+
+    /**
+     * Appends the parameter sets (overloads) of a method, prefixing each with an
+     * "Overload N" heading when more than one set is present.
+     */
+    private void appendMethodParamSets(StringBuilder sb, EList<ParamSet> paramSets, boolean useRussian)
+    {
         if (paramSets != null && !paramSets.isEmpty())
         {
             for (int i = 0; i < paramSets.size(); i++)
@@ -530,25 +567,24 @@ public class PlatformDocumentationService
                 appendParamSetDocumentation(sb, ps, useRussian);
             }
         }
+    }
 
-        // Return type - on method level, not ParamSet
-        EList<TypeItem> retValTypes = method.getRetValType();
-        if (retValTypes != null && !retValTypes.isEmpty())
+    /**
+     * Joins the localized names of the given type items with " | ", skipping items whose
+     * name is {@code null}.
+     */
+    private String joinTypeNames(EList<TypeItem> typeItems, boolean useRussian)
+    {
+        List<String> typeNames = new ArrayList<>();
+        for (TypeItem typeItem : typeItems)
         {
-            sb.append("**Returns:** "); //$NON-NLS-1$
-            List<String> typeNames = new ArrayList<>();
-            for (TypeItem typeItem : retValTypes)
+            String typeName = useRussian ? typeItem.getNameRu() : typeItem.getName();
+            if (typeName != null)
             {
-                String typeName = useRussian ? typeItem.getNameRu() : typeItem.getName();
-                if (typeName != null)
-                {
-                    typeNames.add(typeName);
-                }
+                typeNames.add(typeName);
             }
-            sb.append(String.join(" | ", typeNames)).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
         }
-
-        sb.append("\n"); //$NON-NLS-1$
+        return String.join(" | ", typeNames); //$NON-NLS-1$
     }
 
     /**
@@ -823,6 +859,28 @@ public class PlatformDocumentationService
     {
         StringBuilder sb = new StringBuilder();
 
+        appendBuiltinMethodHeader(sb, method, useRussian);
+
+        // Parameter sets (overloads)
+        EList<ParamSet> paramSets = method.getParamSet();
+        appendBuiltinParamSets(sb, paramSets, useRussian);
+
+        // Return type
+        EList<TypeItem> retValTypes = method.getRetValType();
+        if (retValTypes != null && !retValTypes.isEmpty())
+        {
+            sb.append("## Return Type\n\n"); //$NON-NLS-1$
+            sb.append("**Returns:** ").append(joinTypeNames(retValTypes, useRussian)).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Appends the title, category and return/procedure flag header of a built-in method.
+     */
+    private void appendBuiltinMethodHeader(StringBuilder sb, Method method, boolean useRussian)
+    {
         // Method header
         String displayName = useRussian ? method.getNameRu() : method.getName();
         String altName = useRussian ? method.getName() : method.getNameRu();
@@ -845,9 +903,15 @@ public class PlatformDocumentationService
         {
             sb.append("*Procedure (no return value)*\n\n"); //$NON-NLS-1$
         }
+    }
 
-        // Parameter sets (overloads)
-        EList<ParamSet> paramSets = method.getParamSet();
+    /**
+     * Appends the "Parameters" section of a built-in method, rendering one block per
+     * overload (with an "Overload N" heading when there are several) or a "No parameters"
+     * note when the method has none.
+     */
+    private void appendBuiltinParamSets(StringBuilder sb, EList<ParamSet> paramSets, boolean useRussian)
+    {
         if (paramSets != null && !paramSets.isEmpty())
         {
             sb.append("## Parameters\n\n"); //$NON-NLS-1$
@@ -866,24 +930,5 @@ public class PlatformDocumentationService
         {
             sb.append("## Parameters\n\n*No parameters*\n\n"); //$NON-NLS-1$
         }
-
-        // Return type
-        EList<TypeItem> retValTypes = method.getRetValType();
-        if (retValTypes != null && !retValTypes.isEmpty())
-        {
-            sb.append("## Return Type\n\n"); //$NON-NLS-1$
-            List<String> typeNames = new ArrayList<>();
-            for (TypeItem typeItem : retValTypes)
-            {
-                String typeName = useRussian ? typeItem.getNameRu() : typeItem.getName();
-                if (typeName != null)
-                {
-                    typeNames.add(typeName);
-                }
-            }
-            sb.append("**Returns:** ").append(String.join(" | ", typeNames)).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        }
-
-        return sb.toString();
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/form/FormLayoutSnapshotService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/form/FormLayoutSnapshotService.java
@@ -442,14 +442,7 @@ public class FormLayoutSnapshotService
         {
             if ("categoriesHolder".equals(feature.getName())) //$NON-NLS-1$
             {
-                if (fullMode)
-                {
-                    Object categories = convertCategoriesHolder(object.eGet(feature, false));
-                    if (categories != null)
-                    {
-                        properties.put("categories", categories); //$NON-NLS-1$
-                    }
-                }
+                collectCategoriesHolder(properties, object, feature, fullMode);
                 continue;
             }
             if (!fullMode && !DISPLAY_PROPERTY_NAMES.contains(feature.getName()))
@@ -465,15 +458,42 @@ public class FormLayoutSnapshotService
                 continue;
             }
 
-            Object value = object.eGet(feature, false);
-            Object converted = "border".equals(feature.getName()) //$NON-NLS-1$
-                ? convertBorderValue(value) : convertFeatureValue(value);
-            if (converted != null)
-            {
-                properties.put(feature.getName(), converted);
-            }
+            collectConvertedFeature(properties, object, feature);
         }
         return properties;
+    }
+
+    /**
+     * Handles the {@code categoriesHolder} feature: in full mode, converts it and adds a
+     * {@code categories} entry to {@code properties} when the conversion is non-null. No-op otherwise.
+     * Mirrors the original inline branch (the enclosing {@code continue} stays in the caller).
+     */
+    private void collectCategoriesHolder(Map<String, Object> properties, EObject object,
+        EStructuralFeature feature, boolean fullMode)
+    {
+        if (fullMode)
+        {
+            Object categories = convertCategoriesHolder(object.eGet(feature, false));
+            if (categories != null)
+            {
+                properties.put("categories", categories); //$NON-NLS-1$
+            }
+        }
+    }
+
+    /**
+     * Reads, converts and (when the result is non-null) stores a single feature value into
+     * {@code properties}. Uses the border-specific converter for the {@code border} feature.
+     */
+    private void collectConvertedFeature(Map<String, Object> properties, EObject object, EStructuralFeature feature)
+    {
+        Object value = object.eGet(feature, false);
+        Object converted = "border".equals(feature.getName()) //$NON-NLS-1$
+            ? convertBorderValue(value) : convertFeatureValue(value);
+        if (converted != null)
+        {
+            properties.put(feature.getName(), converted);
+        }
     }
 
     private String dumpYaml(Map<String, Object> result)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/AdoptMetadataObjectTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/AdoptMetadataObjectTool.java
@@ -132,23 +132,13 @@ public class AdoptMetadataObjectTool extends AbstractMetadataWriteTool
         // Resolve the source: a top object or a member (attribute/tabular section/...) via the shared
         // resolver; a FORM object via the form resolver (forms are a separate getForms() collection,
         // not in the mdclass child-token tree, so resolveExisting does not see them).
-        EObject source;
-        MetadataNodeResolver.MetadataNode node = MetadataNodeResolver.resolveExisting(ctx.config, normFqn);
-        if (node != null && node.object != null)
+        EObject source = resolveAdoptionSource(ctx.config, normFqn);
+        if (source == null)
         {
-            source = node.object;
-        }
-        else
-        {
-            MdObject form = resolveFormObject(ctx.config, normFqn);
-            if (form == null)
-            {
-                return ToolResult.error("Object not found: " + normFqn + ". " //$NON-NLS-1$ //$NON-NLS-2$
-                    + "Check the FQN: 'Type.Name' for a top object (e.g. 'Catalog.Products'), " //$NON-NLS-1$
-                    + "'Type.Name.Kind.Name' for a member (e.g. 'Catalog.Products.Attribute.Weight'), " //$NON-NLS-1$
-                    + "'Type.Name.Form.FormName' for a form (e.g. 'Catalog.Products.Form.ItemForm').").toJson(); //$NON-NLS-1$
-            }
-            source = form;
+            return ToolResult.error("Object not found: " + normFqn + ". " //$NON-NLS-1$ //$NON-NLS-2$
+                + "Check the FQN: 'Type.Name' for a top object (e.g. 'Catalog.Products'), " //$NON-NLS-1$
+                + "'Type.Name.Kind.Name' for a member (e.g. 'Catalog.Products.Attribute.Weight'), " //$NON-NLS-1$
+                + "'Type.Name.Form.FormName' for a form (e.g. 'Catalog.Products.Form.ItemForm').").toJson(); //$NON-NLS-1$
         }
 
         // Resolve the target extension: the configuration extensions whose parent is this config project.
@@ -162,7 +152,7 @@ public class AdoptMetadataObjectTool extends AbstractMetadataWriteTool
             .collect(Collectors.toList());
 
         IExtensionProject target;
-        if (extensionProjectName != null && !extensionProjectName.isEmpty())
+        if (isNonEmpty(extensionProjectName))
         {
             target = candidates.stream()
                 .filter(c -> extensionProjectName.equals(c.getProject().getName()))
@@ -229,6 +219,50 @@ public class AdoptMetadataObjectTool extends AbstractMetadataWriteTool
         // Configuration.mdo registration (the parent collection changed), mirroring create_metadata.
         // bmGetTopObject()/its bmGetFqn() are safe identity reads on the object the platform returned.
         String adoptedFqn = normFqn;
+        List<String> dirty = collectDirtyFqns(adopted, target);
+        boolean persisted = !dirty.isEmpty() && BmTransactions.forceExportToDisk(target.getProject(), dirty);
+
+        return ToolResult.success()
+            .put(McpKeys.ACTION, "adopted") //$NON-NLS-1$
+            .put("fqn", adoptedFqn) //$NON-NLS-1$
+            .put(KEY_EXTENSION_PROJECT, extName)
+            .put(KEY_OBJECT_BELONGING, "ADOPTED") //$NON-NLS-1$
+            .put(KEY_PERSISTED, persisted)
+            .toJson();
+    }
+
+    /**
+     * Resolves the source object to adopt: a top object or a member via the shared
+     * {@link MetadataNodeResolver}, falling back to a FORM object via {@link #resolveFormObject}. A
+     * read-only resolution; returns {@code null} when the FQN addresses nothing. Behaviour-identical to
+     * the former inline node/form resolution that set the {@code source} local.
+     *
+     * @param config the configuration to resolve against
+     * @param normFqn the normalized FQN
+     * @return the resolved source object, or {@code null} when not found
+     */
+    private static EObject resolveAdoptionSource(Configuration config, String normFqn)
+    {
+        MetadataNodeResolver.MetadataNode node = MetadataNodeResolver.resolveExisting(config, normFqn);
+        if (node != null && node.object != null)
+        {
+            return node.object;
+        }
+        return resolveFormObject(config, normFqn);
+    }
+
+    /**
+     * Collects the FQNs of the objects whose {@code .mdo} must be re-exported after an adoption: the
+     * adopted object's TOP object (when it is a {@link IBmObject}) and the extension
+     * {@code Configuration} (whose child collection changed). A read-only computation — the actual
+     * disk export is done by the caller. Behaviour-identical to the former inline dirty-list building.
+     *
+     * @param adopted the object returned by the adopter
+     * @param target the target extension project
+     * @return the (possibly empty) list of dirty FQNs, in the original order
+     */
+    private static List<String> collectDirtyFqns(EObject adopted, IExtensionProject target)
+    {
         List<String> dirty = new ArrayList<>();
         if (adopted instanceof IBmObject)
         {
@@ -239,20 +273,25 @@ public class AdoptMetadataObjectTool extends AbstractMetadataWriteTool
             }
         }
         IConfigurationProvider configProvider = Activator.getDefault().getConfigurationProvider();
-        Configuration extConfig = configProvider != null ? configProvider.getConfiguration(target.getProject()) : null;
+        Configuration extConfig =
+            configProvider != null ? configProvider.getConfiguration(target.getProject()) : null;
         if (extConfig instanceof IBmObject)
         {
             dirty.add(((IBmObject)extConfig).bmGetFqn());
         }
-        boolean persisted = !dirty.isEmpty() && BmTransactions.forceExportToDisk(target.getProject(), dirty);
+        return dirty;
+    }
 
-        return ToolResult.success()
-            .put(McpKeys.ACTION, "adopted") //$NON-NLS-1$
-            .put("fqn", adoptedFqn) //$NON-NLS-1$
-            .put(KEY_EXTENSION_PROJECT, extName)
-            .put(KEY_OBJECT_BELONGING, "ADOPTED") //$NON-NLS-1$
-            .put(KEY_PERSISTED, persisted)
-            .toJson();
+    /**
+     * Tells whether the given string is non-{@code null} and non-empty. Behaviour-identical to the former
+     * inline {@code s != null && !s.isEmpty()}.
+     *
+     * @param value the value to test
+     * @return {@code true} when {@code value} is non-{@code null} and non-empty
+     */
+    private static boolean isNonEmpty(String value)
+    {
+        return value != null && !value.isEmpty();
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CleanProjectTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CleanProjectTool.java
@@ -114,64 +114,21 @@ public class CleanProjectTool implements IMcpTool
         {
             IProgressMonitor monitor = new NullProgressMonitor();
             IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
-            
-            List<String> projectNamesList = new ArrayList<>();
-            List<ProjectCleanInfo> projectsToClean = new ArrayList<>();
-            
-            if (projectName != null && !projectName.isEmpty())
+
+            // Resolve the set of projects to clean (read-only: validates state and
+            // builds the work lists; performs no clean build itself).
+            CleanCollection collection = collectProjectsToClean(projectName, dtProjectManager);
+            if (collection.error != null)
             {
-                // Clean specific project
-                ProjectContext ctx = ProjectContext.of(projectName);
-                if (!ctx.exists())
-                {
-                    return ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson();
-                }
-
-                if (!ctx.isOpen())
-                {
-                    return ToolResult.error("Project is closed: " + projectName).toJson(); //$NON-NLS-1$
-                }
-
-                IProject project = ctx.project();
-
-                IDtProject dtProject = dtProjectManager != null ? 
-                    dtProjectManager.getDtProject(project) : null;
-                
-                projectsToClean.add(new ProjectCleanInfo(project, dtProject));
-                projectNamesList.add(projectName);
+                return collection.error;
             }
-            else
-            {
-                // Clean all EDT projects
-                if (dtProjectManager != null)
-                {
-                    for (IDtProject dtProject : dtProjectManager.getDtProjects())
-                    {
-                        IProject project = dtProject.getWorkspaceProject();
-                        if (project != null && project.isOpen())
-                        {
-                            projectsToClean.add(new ProjectCleanInfo(project, dtProject));
-                            projectNamesList.add(project.getName());
-                        }
-                    }
-                }
-            }
-            
+            List<ProjectCleanInfo> projectsToClean = collection.projectsToClean;
+            List<String> projectNamesList = collection.projectNamesList;
+
             // Phase 1: Register lifecycle listeners BEFORE triggering clean builds
             // This avoids race condition where STOPPED event could be missed
-            List<ProjectRestartWaiter> waiters = new ArrayList<>();
-            for (ProjectCleanInfo info : projectsToClean)
-            {
-                if (info.dtProject != null)
-                {
-                    ProjectRestartWaiter waiter = LifecycleWaiter.prepareForRestart(info.dtProject);
-                    if (waiter != null)
-                    {
-                        waiters.add(waiter);
-                    }
-                }
-            }
-            
+            List<ProjectRestartWaiter> waiters = registerRestartWaiters(projectsToClean);
+
             // Phase 2: Trigger clean build for all projects
             for (ProjectCleanInfo info : projectsToClean)
             {
@@ -204,6 +161,92 @@ public class CleanProjectTool implements IMcpTool
     }
     
     /**
+     * Resolves the projects to clean (read-only): for a named project it validates
+     * existence/open state, otherwise it collects every open EDT project. Builds the
+     * parallel work lists used by the clean phases. Performs no clean build.
+     *
+     * @param projectName name of the project to clean (null/empty for all projects)
+     * @param dtProjectManager the DT project manager (may be null)
+     * @return a {@link CleanCollection} holding the work lists, or one whose
+     *     {@code error} is a {@link ToolResult#error} JSON payload when the named
+     *     project does not exist or is closed
+     */
+    private static CleanCollection collectProjectsToClean(String projectName,
+        IDtProjectManager dtProjectManager)
+    {
+        CleanCollection collection = new CleanCollection();
+
+        if (projectName != null && !projectName.isEmpty())
+        {
+            // Clean specific project
+            ProjectContext ctx = ProjectContext.of(projectName);
+            if (!ctx.exists())
+            {
+                collection.error = ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson();
+                return collection;
+            }
+
+            if (!ctx.isOpen())
+            {
+                collection.error = ToolResult.error("Project is closed: " + projectName).toJson(); //$NON-NLS-1$
+                return collection;
+            }
+
+            IProject project = ctx.project();
+
+            IDtProject dtProject = dtProjectManager != null ?
+                dtProjectManager.getDtProject(project) : null;
+
+            collection.projectsToClean.add(new ProjectCleanInfo(project, dtProject));
+            collection.projectNamesList.add(projectName);
+        }
+        else
+        {
+            // Clean all EDT projects
+            if (dtProjectManager != null)
+            {
+                for (IDtProject dtProject : dtProjectManager.getDtProjects())
+                {
+                    IProject project = dtProject.getWorkspaceProject();
+                    if (project != null && project.isOpen())
+                    {
+                        collection.projectsToClean.add(new ProjectCleanInfo(project, dtProject));
+                        collection.projectNamesList.add(project.getName());
+                    }
+                }
+            }
+        }
+
+        return collection;
+    }
+
+    /**
+     * Phase 1 helper: registers a lifecycle restart listener for every project that has
+     * a DT project, BEFORE any clean build is triggered, so the STOPPED event cannot be
+     * missed. Returns the waiters to {@code await} after the clean builds are scheduled.
+     *
+     * @param projectsToClean the projects being cleaned
+     * @return the registered restart waiters (one per DT project that produced a waiter)
+     */
+    private static List<ProjectRestartWaiter> registerRestartWaiters(
+        List<ProjectCleanInfo> projectsToClean)
+    {
+        List<ProjectRestartWaiter> waiters = new ArrayList<>();
+        for (ProjectCleanInfo info : projectsToClean)
+        {
+            if (info.dtProject != null)
+            {
+                ProjectRestartWaiter waiter = LifecycleWaiter.prepareForRestart(info.dtProject);
+                if (waiter != null)
+                {
+                    waiters.add(waiter);
+                }
+            }
+        }
+        return waiters;
+    }
+
+    /**
      * Cleans a single project using Eclipse CLEAN_BUILD.
      * This triggers EDT's full project rebuild including:
      * - CLEAN phase (stops project context)
@@ -228,6 +271,17 @@ public class CleanProjectTool implements IMcpTool
         Activator.logInfo("Clean build scheduled for: " + project.getName()); //$NON-NLS-1$
     }
     
+    /**
+     * Holder for the result of {@link #collectProjectsToClean}: the parallel work lists,
+     * or an {@code error} JSON payload that the caller should return as-is.
+     */
+    private static class CleanCollection
+    {
+        final List<ProjectCleanInfo> projectsToClean = new ArrayList<>();
+        final List<String> projectNamesList = new ArrayList<>();
+        String error;
+    }
+
     /**
      * Helper class to store project info for cleaning.
      */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
@@ -605,23 +605,15 @@ public class CreateInfobaseTool implements IMcpTool
         }
 
         // --- 3. Fail-fast runtime probe (BEFORE the Job, so "no runtime" fails instantly) ---
-        final String versionMask = platform != null ? platform : ""; //$NON-NLS-1$
+        final String versionMask = orEmpty(platform);
         boolean hasRuntime = ssHasRuntime(serverService, versionMask);
         if (!hasRuntime)
         {
-            return ToolResult.error("No standalone-server runtime registered" //$NON-NLS-1$
-                + (platform != null && !platform.isEmpty() ? " for version '" + platform + "'" : "") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-                + ". Install a 1C platform >= 8.3.23 with the standalone server (ibsrv/ibcmd) and " //$NON-NLS-1$
-                + "register it in EDT (Window -> Preferences -> 1C:Enterprise -> Installed " //$NON-NLS-1$
-                + "Installations), or pass a matching platform=...").toJson(); //$NON-NLS-1$
+            return ToolResult.error(noRuntimeError(platform)).toJson();
         }
 
         // --- 4. Auto-generate the infobase name from the directory if omitted ---
-        if (infobaseName == null || infobaseName.isEmpty())
-        {
-            Path fileName = infobaseDir.getFileName();
-            infobaseName = fileName != null ? fileName.toString() : projectName;
-        }
+        infobaseName = effectiveStandaloneInfobaseName(infobaseName, infobaseDir, projectName);
 
         // --- 5. Build the FILE infobase reference for the new IB ---
         InfobaseReference ibRef =
@@ -710,8 +702,8 @@ public class CreateInfobaseTool implements IMcpTool
                 .toJson();
         }
 
-        Pair<?, ?> pair = (jobResult.get() instanceof Pair) ? (Pair<?, ?>)jobResult.get() : null;
-        if (pair == null || pair.getSecond() == null)
+        Pair<?, ?> pair = asPair(jobResult.get());
+        if (!hasInfobaseHandle(pair))
         {
             return ToolResult.error("Standalone-server creation returned no infobase handle.").toJson(); //$NON-NLS-1$
         }
@@ -725,14 +717,14 @@ public class CreateInfobaseTool implements IMcpTool
         // requested name; reading the actual value future-proofs the read-back / applicationId / reported
         // name against any platform that de-duplicates a colliding name. Falls back to the requested name.
         String actualName = ssGetInfobaseName(pair.getSecond());
-        String effectiveName = (actualName != null && !actualName.isEmpty()) ? actualName : infobaseName;
+        String effectiveName = firstNonEmpty(actualName, infobaseName);
 
         // --- 8. Resolve the web URL (best-effort; ssGetInfobaseUrl returns null on any failure) ---
         // The ACTUAL port is read back from the resolved URL (EDT auto-allocates it), not the hint we
         // passed in. When the URL cannot be resolved we report no port rather than echoing a fiction.
         URI url = ssGetInfobaseUrl(finalService, pair.getSecond());
-        String webUrl = (url != null) ? url.toString() : null;
-        int actualPort = (url != null) ? url.getPort() : -1;
+        String webUrl = urlToString(url);
+        int actualPort = urlToPort(url);
 
         // --- 9. Read back applications and return ---
         return buildStandaloneServerResult(projectName, infobaseDir, effectiveName, actualPort,
@@ -996,6 +988,117 @@ public class CreateInfobaseTool implements IMcpTool
         }
         String fromProject = projectName != null ? projectName.replaceAll("[^A-Za-z0-9]", "") : ""; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         return fromProject.isEmpty() ? KIND_INFOBASE : fromProject;
+    }
+
+    /**
+     * Builds the "no standalone-server runtime registered" error message. Behaviour-identical to the
+     * former inline string concatenation, including the optional {@code for version '...'} fragment.
+     *
+     * @param platform the requested platform version mask (may be {@code null}/empty)
+     * @return the error message
+     */
+    /**
+     * Returns the given string, or the empty string when it is {@code null}. Behaviour-identical to the
+     * former inline {@code platform != null ? platform : ""}.
+     *
+     * @param value the value (may be {@code null})
+     * @return {@code value}, or {@code ""} when {@code null}
+     */
+    private static String orEmpty(String value)
+    {
+        return value != null ? value : ""; //$NON-NLS-1$
+    }
+
+    private static String noRuntimeError(String platform)
+    {
+        return "No standalone-server runtime registered" //$NON-NLS-1$
+            + (platform != null && !platform.isEmpty() ? " for version '" + platform + "'" : "") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            + ". Install a 1C platform >= 8.3.23 with the standalone server (ibsrv/ibcmd) and " //$NON-NLS-1$
+            + "register it in EDT (Window -> Preferences -> 1C:Enterprise -> Installed " //$NON-NLS-1$
+            + "Installations), or pass a matching platform=..."; //$NON-NLS-1$
+    }
+
+    /**
+     * Resolves the effective infobase name when the caller omitted it: derives it from the infobase
+     * directory's file name, falling back to the project name. Behaviour-identical to the former inline
+     * {@code if (infobaseName == null || infobaseName.isEmpty()) { ... }} block — returns the original
+     * name unchanged when it is non-empty.
+     *
+     * @param infobaseName the requested infobase name (may be {@code null}/empty)
+     * @param infobaseDir the infobase directory
+     * @param projectName the project name (final fallback)
+     * @return the effective infobase name
+     */
+    private static String effectiveStandaloneInfobaseName(String infobaseName, Path infobaseDir,
+            String projectName)
+    {
+        if (infobaseName == null || infobaseName.isEmpty())
+        {
+            Path fileName = infobaseDir.getFileName();
+            return fileName != null ? fileName.toString() : projectName;
+        }
+        return infobaseName;
+    }
+
+    /**
+     * Casts the create-job result to a {@link Pair} when it is one, else {@code null}. Behaviour-identical
+     * to the former inline {@code (result instanceof Pair) ? (Pair<?, ?>)result : null}.
+     *
+     * @param result the value read back from the create job
+     * @return the result as a {@link Pair}, or {@code null}
+     */
+    private static Pair<?, ?> asPair(Object result)
+    {
+        return (result instanceof Pair) ? (Pair<?, ?>)result : null;
+    }
+
+    /**
+     * Tells whether the create-job pair carries a usable infobase handle. Behaviour-identical to the
+     * former inline {@code !(pair == null || pair.getSecond() == null)} guard.
+     *
+     * @param pair the create-job result pair (may be {@code null})
+     * @return {@code true} when the pair and its second element are both non-{@code null}
+     */
+    private static boolean hasInfobaseHandle(Pair<?, ?> pair)
+    {
+        return pair != null && pair.getSecond() != null;
+    }
+
+    /**
+     * Returns the first argument when it is non-empty, else the second. Behaviour-identical to the former
+     * inline {@code (actualName != null && !actualName.isEmpty()) ? actualName : infobaseName}.
+     *
+     * @param preferred the preferred value (used when non-{@code null}/non-empty)
+     * @param fallback the fallback value
+     * @return {@code preferred} when non-empty, else {@code fallback}
+     */
+    private static String firstNonEmpty(String preferred, String fallback)
+    {
+        return (preferred != null && !preferred.isEmpty()) ? preferred : fallback;
+    }
+
+    /**
+     * The URL as a string, or {@code null} when the URL is {@code null}. Behaviour-identical to the former
+     * inline {@code (url != null) ? url.toString() : null}.
+     *
+     * @param url the resolved web URL (may be {@code null})
+     * @return the string form, or {@code null}
+     */
+    private static String urlToString(URI url)
+    {
+        return (url != null) ? url.toString() : null;
+    }
+
+    /**
+     * The URL's port, or {@code -1} when the URL is {@code null}. Behaviour-identical to the former inline
+     * {@code (url != null) ? url.getPort() : -1}.
+     *
+     * @param url the resolved web URL (may be {@code null})
+     * @return the port, or {@code -1}
+     */
+    private static int urlToPort(URI url)
+    {
+        return (url != null) ? url.getPort() : -1;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateLaunchConfigTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateLaunchConfigTool.java
@@ -207,75 +207,19 @@ public class CreateLaunchConfigTool implements IMcpTool
         IProject project = ctx.project();
 
         // ── 4. Reject non-configuration projects ───────────────────────────────
-        try
+        String natureErr = checkConfigurationNature(project, projectName);
+        if (natureErr != null)
         {
-            if (!project.hasNature(V8_CONFIGURATION_NATURE))
-            {
-                return ToolResult.error("Not a V8 configuration project: '" + projectName //$NON-NLS-1$
-                    + "'. A runtime-client launch configuration requires a V8ConfigurationNature " //$NON-NLS-1$
-                    + "project (e.g. use list_projects and look for type='configuration').").toJson(); //$NON-NLS-1$
-            }
-        }
-        catch (CoreException e)
-        {
-            Activator.logError("Error checking project nature for: " + projectName, e); //$NON-NLS-1$
-            return ToolResult.error("Cannot check project nature for '" + projectName //$NON-NLS-1$
-                + "': " + e.getMessage()).toJson(); //$NON-NLS-1$
+            return natureErr;
         }
 
         // ── 5. Resolve application id ──────────────────────────────────────────
-        String effectiveApplicationId;
-        IApplicationManager appManager = Activator.getDefault().getApplicationManager();
-        if (appManager == null)
+        AppIdResolution appIdResolution = resolveApplicationId(project, projectName, applicationIdParam);
+        if (appIdResolution.error != null)
         {
-            return ToolResult.error("IApplicationManager service is not available. " //$NON-NLS-1$
-                + "EDT may still be starting up — retry in a moment.").toJson(); //$NON-NLS-1$
+            return appIdResolution.error;
         }
-
-        if (applicationIdParam != null && !applicationIdParam.isEmpty())
-        {
-            // Caller supplied an explicit id — validate it exists for this project.
-            // Distinguish "not found" (empty Optional) from a transient service failure
-            // (exception while EDT is mid-index) so the diagnosis is not misleading.
-            try
-            {
-                Optional<IApplication> appOpt = appManager.getApplication(project, applicationIdParam);
-                if (!appOpt.isPresent())
-                {
-                    return buildAppNotFoundError(projectName, applicationIdParam);
-                }
-                effectiveApplicationId = applicationIdParam;
-            }
-            catch (ApplicationException e)
-            {
-                Activator.logError("Error resolving application for: " + projectName, e); //$NON-NLS-1$
-                return ToolResult.error("Could not resolve application '" + applicationIdParam //$NON-NLS-1$
-                    + "' for project '" + projectName + "': " + e.getMessage() //$NON-NLS-1$ //$NON-NLS-2$
-                    + ". The project may still be indexing — retry in a moment.").toJson(); //$NON-NLS-1$
-            }
-        }
-        else
-        {
-            // Resolve the project's default application.
-            try
-            {
-                Optional<IApplication> defaultApp = appManager.getDefaultApplication(project);
-                if (!defaultApp.isPresent())
-                {
-                    return ToolResult.error("Project '" + projectName //$NON-NLS-1$
-                        + "' has no applications (infobases). Create an infobase first " //$NON-NLS-1$
-                        + "(Window -> Preferences -> EDT -> Applications or the 1C Administrator " //$NON-NLS-1$
-                        + "console), then retry. Use get_applications to check available applications.").toJson(); //$NON-NLS-1$
-                }
-                effectiveApplicationId = defaultApp.get().getId();
-            }
-            catch (ApplicationException e)
-            {
-                Activator.logError("Error resolving default application for: " + projectName, e); //$NON-NLS-1$
-                return ToolResult.error("Cannot resolve default application for '" + projectName //$NON-NLS-1$
-                    + "': " + e.getMessage() + ". Use get_applications to list available applications.").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
-            }
-        }
+        String effectiveApplicationId = appIdResolution.applicationId;
 
         // ── 6. Acquire launch manager and type ────────────────────────────────
         ILaunchManager lm = LaunchConfigUtils.getLaunchManager();
@@ -421,5 +365,120 @@ public class CreateLaunchConfigTool implements IMcpTool
             + "' was not found for project '" + projectName //$NON-NLS-1$
             + "'. Use get_applications(projectName='" + projectName //$NON-NLS-1$
             + "') to see the valid application IDs for this project.").toJson(); //$NON-NLS-1$
+    }
+
+    /**
+     * Rejects a project that is not a V8 configuration project (a runtime-client launch config requires
+     * {@code V8ConfigurationNature}). Returns a JSON error to reject, or {@code null} to proceed. The
+     * nature check is a read-only query; a {@link CoreException} is logged and surfaced as an error
+     * exactly as in the original inline block.
+     */
+    private static String checkConfigurationNature(IProject project, String projectName)
+    {
+        try
+        {
+            if (!project.hasNature(V8_CONFIGURATION_NATURE))
+            {
+                return ToolResult.error("Not a V8 configuration project: '" + projectName //$NON-NLS-1$
+                    + "'. A runtime-client launch configuration requires a V8ConfigurationNature " //$NON-NLS-1$
+                    + "project (e.g. use list_projects and look for type='configuration').").toJson(); //$NON-NLS-1$
+            }
+        }
+        catch (CoreException e)
+        {
+            Activator.logError("Error checking project nature for: " + projectName, e); //$NON-NLS-1$
+            return ToolResult.error("Cannot check project nature for '" + projectName //$NON-NLS-1$
+                + "': " + e.getMessage()).toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the effective application (infobase) id for the config: validates the caller-supplied
+     * {@code applicationIdParam} against the project when present, otherwise resolves the project's
+     * default application. Read-only (no config is created here); the resolution distinguishes
+     * "not found" (an empty {@link Optional}) from a transient {@link ApplicationException} (EDT
+     * mid-index) with the same messages as the original inline block. Returns an
+     * {@link AppIdResolution} carrying either an error JSON string or the resolved id.
+     */
+    private static AppIdResolution resolveApplicationId(IProject project, String projectName,
+        String applicationIdParam)
+    {
+        IApplicationManager appManager = Activator.getDefault().getApplicationManager();
+        if (appManager == null)
+        {
+            return AppIdResolution.error(ToolResult.error("IApplicationManager service is not available. " //$NON-NLS-1$
+                + "EDT may still be starting up — retry in a moment.").toJson()); //$NON-NLS-1$
+        }
+
+        if (applicationIdParam != null && !applicationIdParam.isEmpty())
+        {
+            // Caller supplied an explicit id — validate it exists for this project.
+            // Distinguish "not found" (empty Optional) from a transient service failure
+            // (exception while EDT is mid-index) so the diagnosis is not misleading.
+            try
+            {
+                Optional<IApplication> appOpt = appManager.getApplication(project, applicationIdParam);
+                if (!appOpt.isPresent())
+                {
+                    return AppIdResolution.error(buildAppNotFoundError(projectName, applicationIdParam));
+                }
+                return AppIdResolution.id(applicationIdParam);
+            }
+            catch (ApplicationException e)
+            {
+                Activator.logError("Error resolving application for: " + projectName, e); //$NON-NLS-1$
+                return AppIdResolution.error(ToolResult.error("Could not resolve application '" //$NON-NLS-1$
+                    + applicationIdParam
+                    + "' for project '" + projectName + "': " + e.getMessage() //$NON-NLS-1$ //$NON-NLS-2$
+                    + ". The project may still be indexing — retry in a moment.").toJson()); //$NON-NLS-1$
+            }
+        }
+        // Resolve the project's default application.
+        try
+        {
+            Optional<IApplication> defaultApp = appManager.getDefaultApplication(project);
+            if (!defaultApp.isPresent())
+            {
+                return AppIdResolution.error(ToolResult.error("Project '" + projectName //$NON-NLS-1$
+                    + "' has no applications (infobases). Create an infobase first " //$NON-NLS-1$
+                    + "(Window -> Preferences -> EDT -> Applications or the 1C Administrator " //$NON-NLS-1$
+                    + "console), then retry. Use get_applications to check available applications.").toJson()); //$NON-NLS-1$
+            }
+            return AppIdResolution.id(defaultApp.get().getId());
+        }
+        catch (ApplicationException e)
+        {
+            Activator.logError("Error resolving default application for: " + projectName, e); //$NON-NLS-1$
+            return AppIdResolution.error(ToolResult.error("Cannot resolve default application for '" //$NON-NLS-1$
+                + projectName
+                + "': " + e.getMessage() + ". Use get_applications to list available applications.").toJson()); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+    }
+
+    /**
+     * Outcome of {@link #resolveApplicationId}: exactly one of {@link #error} (a JSON error string to
+     * return) or {@link #applicationId} (the resolved id) is non-null.
+     */
+    private static final class AppIdResolution
+    {
+        private final String error;
+        private final String applicationId;
+
+        private AppIdResolution(String error, String applicationId)
+        {
+            this.error = error;
+            this.applicationId = applicationId;
+        }
+
+        static AppIdResolution error(String error)
+        {
+            return new AppIdResolution(error, null);
+        }
+
+        static AppIdResolution id(String applicationId)
+        {
+            return new AppIdResolution(null, applicationId);
+        }
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
@@ -342,58 +342,23 @@ public class DebugLaunchTool implements IMcpTool
 
             // Verify application exists and get its name
             IApplicationManager appManager = Activator.getDefault().getApplicationManager();
-            String applicationName = applicationId; // Default to ID if can't get name
-            IApplication application = null;
-
-            if (appManager != null)
+            ApplicationResolution appResolution = resolveApplication(project, applicationId, appManager);
+            if (appResolution.error != null)
             {
-                try
-                {
-                    Optional<IApplication> appOpt = appManager.getApplication(project, applicationId);
-                    if (!appOpt.isPresent())
-                    {
-                        return ToolResult.error("Application not found: " + applicationId + //$NON-NLS-1$
-                                ". Use get_applications to get valid application IDs.").toJson(); //$NON-NLS-1$
-                    }
-                    application = appOpt.get();
-                    applicationName = application.getName();
-                }
-                catch (ApplicationException e)
-                {
-                    Activator.logError("Error checking application", e); //$NON-NLS-1$
-                    // Continue - we'll try to find launch config anyway
-                }
+                return appResolution.error;
             }
+            String applicationName = appResolution.applicationName;
+            IApplication application = appResolution.application;
 
-            // Unified existing-session decision — the SAME
-            // CLIENT-typed-thread-discriminated detector + restartIfRunning handling
-            // the by-name path uses, so both call styles behave identically. A live
-            // DEBUG client target OR a debug-target-less RUN-mode launch
-            // short-circuits (the legacy already-running guard); a standalone-SERVER session
-            // sharing this app id — even a debug-mode one with a live SERVER-typed
-            // thread — does NOT (the client proceeds and attaches). To force a fresh
-            // launch when restartIfRunning is false, terminate_launch first.
-            ExistingClientSession existingByApp =
-                LaunchLifecycleUtils.resolveExistingClientSession(applicationId);
-            if (existingByApp != null)
+            // Unified existing-session decision (see helper): a live DEBUG client target
+            // OR a debug-target-less RUN-mode launch short-circuits; a standalone-SERVER
+            // session sharing this app id does NOT. Returns null to fall through and
+            // (re)launch, otherwise the short-circuit / already-running payload.
+            String existingSessionResult =
+                handleExistingByAppSession(applicationId, projectName, restartIfRunning);
+            if (existingSessionResult != null)
             {
-                ILaunchConfiguration activeConfig = existingByApp.launch != null
-                    ? existingByApp.launch.getLaunchConfiguration() : null;
-                AlreadyRunningContext runningCtx = new AlreadyRunningContext(ALREADY_RUNNING_MESSAGE);
-                runningCtx.project = projectName;
-                runningCtx.attach = Boolean.FALSE;
-                if (activeConfig != null)
-                {
-                    runningCtx.launchConfiguration = activeConfig.getName();
-                }
-                String shortCircuit = handleExistingClientSession(existingByApp, applicationId,
-                    restartIfRunning, runningCtx);
-                if (shortCircuit != null)
-                {
-                    return shortCircuit;
-                }
-                // restartIfRunning=true: the old client was terminated — fall through
-                // and relaunch.
+                return existingSessionResult;
             }
 
             // Update database before launch if requested. Routes through the
@@ -484,6 +449,103 @@ public class DebugLaunchTool implements IMcpTool
             Activator.logError("Unexpected error during debug launch", e); //$NON-NLS-1$
             return ToolResult.error("Unexpected error: " + e.getMessage()).toJson(); //$NON-NLS-1$
         }
+    }
+
+    /**
+     * Resolves the application by id and its display name for the legacy
+     * project+applicationId path. Mirrors the original inline guard: when {@code appManager}
+     * is null the application stays unresolved (name defaults to the id); a present manager
+     * that cannot find the id yields an {@code error} payload, while an
+     * {@link ApplicationException} is logged and swallowed so the caller still tries to
+     * find a launch configuration.
+     *
+     * @param project the project to look the application up in
+     * @param applicationId the application id to resolve
+     * @param appManager the application manager (may be null)
+     * @return an {@link ApplicationResolution}; its {@code error} is non-null only when the
+     *     id was definitively not found
+     */
+    private static ApplicationResolution resolveApplication(IProject project, String applicationId,
+        IApplicationManager appManager)
+    {
+        ApplicationResolution resolution = new ApplicationResolution();
+        resolution.applicationName = applicationId; // Default to ID if can't get name
+
+        if (appManager != null)
+        {
+            try
+            {
+                Optional<IApplication> appOpt = appManager.getApplication(project, applicationId);
+                if (!appOpt.isPresent())
+                {
+                    resolution.error = ToolResult.error("Application not found: " + applicationId + //$NON-NLS-1$
+                            ". Use get_applications to get valid application IDs.").toJson(); //$NON-NLS-1$
+                    return resolution;
+                }
+                resolution.application = appOpt.get();
+                resolution.applicationName = resolution.application.getName();
+            }
+            catch (ApplicationException e)
+            {
+                Activator.logError("Error checking application", e); //$NON-NLS-1$
+                // Continue - we'll try to find launch config anyway
+            }
+        }
+        return resolution;
+    }
+
+    /**
+     * Unified existing-session decision for the project+applicationId path — the SAME
+     * CLIENT-typed-thread-discriminated detector + restartIfRunning handling the by-name
+     * path uses, so both call styles behave identically. A live DEBUG client target OR a
+     * debug-target-less RUN-mode launch short-circuits (the legacy already-running guard);
+     * a standalone-SERVER session sharing this app id — even a debug-mode one with a live
+     * SERVER-typed thread — does NOT (the client proceeds and attaches). To force a fresh
+     * launch when restartIfRunning is false, terminate_launch first.
+     *
+     * @param applicationId the application id to match an existing client session on
+     * @param projectName the project name echoed into the already-running payload
+     * @param restartIfRunning whether to terminate an existing client and relaunch
+     * @return the short-circuit / already-running payload, or {@code null} to fall through
+     *     and (re)launch (no existing client, or restartIfRunning terminated the old one)
+     */
+    private String handleExistingByAppSession(String applicationId, String projectName,
+        boolean restartIfRunning)
+    {
+        ExistingClientSession existingByApp =
+            LaunchLifecycleUtils.resolveExistingClientSession(applicationId);
+        if (existingByApp != null)
+        {
+            ILaunchConfiguration activeConfig = existingByApp.launch != null
+                ? existingByApp.launch.getLaunchConfiguration() : null;
+            AlreadyRunningContext runningCtx = new AlreadyRunningContext(ALREADY_RUNNING_MESSAGE);
+            runningCtx.project = projectName;
+            runningCtx.attach = Boolean.FALSE;
+            if (activeConfig != null)
+            {
+                runningCtx.launchConfiguration = activeConfig.getName();
+            }
+            String shortCircuit = handleExistingClientSession(existingByApp, applicationId,
+                restartIfRunning, runningCtx);
+            if (shortCircuit != null)
+            {
+                return shortCircuit;
+            }
+            // restartIfRunning=true: the old client was terminated — fall through
+            // and relaunch.
+        }
+        return null;
+    }
+
+    /**
+     * Holder for {@link #resolveApplication}: the resolved {@link IApplication} (may stay
+     * null) and its display name, or an {@code error} payload the caller returns as-is.
+     */
+    private static class ApplicationResolution
+    {
+        IApplication application;
+        String applicationName;
+        String error;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteInfobaseTool.java
@@ -432,59 +432,27 @@ public class DeleteInfobaseTool implements IMcpTool
         final String resolvedName = targetApp.getName();
         final String resolvedId = targetApp.getId();
 
-        // Resolve the standalone-server service reflectively (no Require-Bundle on the optional feature).
-        Object service = StandaloneServerSupport.acquireService();
-        if (service == null)
+        // Resolve the standalone-server service, backing WST server, infobaseId and served-DB
+        // directory (read-only: acquires services and reads paths; deletes nothing). On a
+        // missing service/server it carries an error payload the caller returns as-is.
+        DeletionContext deletionCtx = resolveDeletionContext(targetApp, appManager, project,
+            resolvedName, resolvedId, deleteDatabaseFiles);
+        if (deletionCtx.error != null)
         {
-            return ToolResult.error("Standalone-server service is not available; the EDT " //$NON-NLS-1$
-                + "standalone-server feature is missing. Cannot delete server application '" //$NON-NLS-1$
-                + resolvedName + "'.").toJson(); //$NON-NLS-1$
+            return deletionCtx.error;
         }
-
-        // Resolve the backing WST IServer: direct IServerApplication.getServer(), else a name scan.
-        Object server = StandaloneServerSupport.serverOfApplication(targetApp);
-        if (server == null)
-        {
-            server = StandaloneServerSupport.findServerByModuleName(service, resolvedName);
-        }
-        if (server == null)
-        {
-            return ToolResult.error("Could not resolve the WST server backing application '" //$NON-NLS-1$
-                + resolvedName + "' (id=" + resolvedId //$NON-NLS-1$
-                + "). It may already be deleted — re-run get_applications.").toJson(); //$NON-NLS-1$
-        }
-
-        // Capture the infobaseId AND the served-DB directory (database.path) BEFORE deletion — the
-        // module/config is torn down by deleteServer. The infobaseId drives the yaml cleanup; the DB
-        // directory is used only when deleteDatabaseFiles=true (deleteServer itself never deletes it).
-        Object module = StandaloneServerSupport.moduleOfApplication(targetApp);
-        final String infobaseId = module != null ? StandaloneServerSupport.infobaseIdOf(module) : null;
-        final String dbDirStr = module != null ? StandaloneServerSupport.databaseDirOf(module) : null;
-        final Path dbDir = (dbDirStr != null && !dbDirStr.isEmpty()) ? Paths.get(dbDirStr) : null;
-        // A server's served DB is normally dedicated, but EDT does not forbid another project from
-        // registering the same directory as a FILE infobase — so apply the same shared-files guard.
-        final boolean dbSharedWithOthers = deleteDatabaseFiles && dbDir != null
-            && isSharedWithOtherProjects(appManager, project, dbDir);
+        Object service = deletionCtx.service;
+        Object server = deletionCtx.server;
+        final String infobaseId = deletionCtx.infobaseId;
+        final Path dbDir = deletionCtx.dbDir;
+        final boolean dbSharedWithOthers = deletionCtx.dbSharedWithOthers;
 
         // --- Confirm-preview gate ---
-        if (!confirm)
+        String preview = buildStandaloneServerPreview(confirm, projectName, resolvedId, resolvedName,
+            deleteRegistration, deleteDatabaseFiles, dbDir, dbSharedWithOthers);
+        if (preview != null)
         {
-            return ToolResult.success()
-                .put(McpKeys.ACTION, "preview") //$NON-NLS-1$
-                .put(KEY_CONFIRMATION_REQUIRED, true)
-                .put(KEY_APPLICATION_KIND, "standaloneServer") //$NON-NLS-1$
-                .put(McpKeys.PROJECT, projectName)
-                .put(McpKeys.APPLICATION_ID, resolvedId)
-                .put(KEY_INFOBASE_NAME, resolvedName)
-                .put(KEY_DELETE_REGISTRATION, deleteRegistration)
-                .put(McpKeys.MESSAGE, "PREVIEW: this would delete standalone server '" + resolvedName //$NON-NLS-1$
-                    + "' (stop it, remove the WST server and its server config folder)" //$NON-NLS-1$
-                    + (deleteRegistration ? " AND clean its infobases.yaml registry entry" //$NON-NLS-1$
-                        : " (infobases.yaml entry kept)") //$NON-NLS-1$
-                    + databasePreviewNote(deleteDatabaseFiles, dbDir, dbSharedWithOthers)
-                    + " for project '" + projectName //$NON-NLS-1$
-                    + "'. This is irreversible. Re-call with confirm=true to apply.") //$NON-NLS-1$
-                .toJson();
+            return preview;
         }
 
         // Capture how many applications currently carry this id, so the read-back can confirm THIS
@@ -551,22 +519,10 @@ public class DeleteInfobaseTool implements IMcpTool
             return ToolResult.error("Standalone-server deletion was interrupted.").toJson(); //$NON-NLS-1$
         }
 
-        if (jobError.get() != null)
+        String outcomeError = checkDeletionOutcome(jobError.get(), jobStatus.get(), resolvedName);
+        if (outcomeError != null)
         {
-            Activator.logError("delete_infobase: standalone-server deletion failed for " //$NON-NLS-1$
-                + resolvedName, jobError.get());
-            return ToolResult.error("Standalone-server deletion failed for '" + resolvedName //$NON-NLS-1$
-                + "': " + jobError.get().getMessage()).toJson(); //$NON-NLS-1$
-        }
-        IStatus status = jobStatus.get();
-        if (status == null || !status.isOK())
-        {
-            // null = deleteServer returned a non-IStatus (reflective miss); non-OK = the platform
-            // reported a failure. Either way the server was NOT cleanly deleted — report an error.
-            String detail = status != null ? status.getMessage() : "no status returned"; //$NON-NLS-1$
-            Activator.logError("delete_infobase: deleteServer did not succeed: " + detail, null); //$NON-NLS-1$
-            return ToolResult.error("Standalone-server deletion did not complete cleanly for '" //$NON-NLS-1$
-                + resolvedName + "': " + detail).toJson(); //$NON-NLS-1$
+            return outcomeError;
         }
 
         StandaloneServerSupport.RegistryCleanup cleanup = jobCleanup.get();
@@ -584,6 +540,151 @@ public class DeleteInfobaseTool implements IMcpTool
         // Read-back: confirm THIS deletion via a count decrease (tolerant of same-id twins).
         boolean removed = confirmApplicationRemoved(appManager, project, resolvedId, beforeCount);
 
+        return buildDeletedResult(projectName, resolvedId, resolvedName, deleteRegistration,
+            deleteDatabaseFiles, dbDir, dbFilesDeleted, dbSharedWithOthers, cleanup, removed);
+    }
+
+    /**
+     * Resolves the standalone-server service, its backing WST server, the served-DB
+     * directory and the shared-files guard (read-only — acquires services and reads paths,
+     * deletes nothing). On a missing service or unresolvable server the returned context
+     * carries an {@code error} JSON payload that the caller should return as-is.
+     *
+     * @param targetApp the application being deleted
+     * @param appManager the application manager (for the shared-files guard)
+     * @param project the owning project
+     * @param resolvedName the application name (for error messages)
+     * @param resolvedId the application id (for error messages)
+     * @param deleteDatabaseFiles whether the caller intends to delete the served DB files
+     *     (the shared-files guard is only computed when true)
+     * @return a {@link DeletionContext}; its {@code error} is non-null only on a resolution
+     *     failure
+     */
+    private DeletionContext resolveDeletionContext(IApplication targetApp,
+        IApplicationManager appManager, IProject project, String resolvedName, String resolvedId,
+        boolean deleteDatabaseFiles)
+    {
+        DeletionContext ctx = new DeletionContext();
+
+        // Resolve the standalone-server service reflectively (no Require-Bundle on the optional feature).
+        Object service = StandaloneServerSupport.acquireService();
+        if (service == null)
+        {
+            ctx.error = ToolResult.error("Standalone-server service is not available; the EDT " //$NON-NLS-1$
+                + "standalone-server feature is missing. Cannot delete server application '" //$NON-NLS-1$
+                + resolvedName + "'.").toJson(); //$NON-NLS-1$
+            return ctx;
+        }
+
+        // Resolve the backing WST IServer: direct IServerApplication.getServer(), else a name scan.
+        Object server = StandaloneServerSupport.serverOfApplication(targetApp);
+        if (server == null)
+        {
+            server = StandaloneServerSupport.findServerByModuleName(service, resolvedName);
+        }
+        if (server == null)
+        {
+            ctx.error = ToolResult.error("Could not resolve the WST server backing application '" //$NON-NLS-1$
+                + resolvedName + "' (id=" + resolvedId //$NON-NLS-1$
+                + "). It may already be deleted — re-run get_applications.").toJson(); //$NON-NLS-1$
+            return ctx;
+        }
+
+        // Capture the infobaseId AND the served-DB directory (database.path) BEFORE deletion — the
+        // module/config is torn down by deleteServer. The infobaseId drives the yaml cleanup; the DB
+        // directory is used only when deleteDatabaseFiles=true (deleteServer itself never deletes it).
+        Object module = StandaloneServerSupport.moduleOfApplication(targetApp);
+        final String infobaseId = module != null ? StandaloneServerSupport.infobaseIdOf(module) : null;
+        final String dbDirStr = module != null ? StandaloneServerSupport.databaseDirOf(module) : null;
+        final Path dbDir = (dbDirStr != null && !dbDirStr.isEmpty()) ? Paths.get(dbDirStr) : null;
+        // A server's served DB is normally dedicated, but EDT does not forbid another project from
+        // registering the same directory as a FILE infobase — so apply the same shared-files guard.
+        final boolean dbSharedWithOthers = deleteDatabaseFiles && dbDir != null
+            && isSharedWithOtherProjects(appManager, project, dbDir);
+
+        ctx.service = service;
+        ctx.server = server;
+        ctx.infobaseId = infobaseId;
+        ctx.dbDir = dbDir;
+        ctx.dbSharedWithOthers = dbSharedWithOthers;
+        return ctx;
+    }
+
+    /**
+     * Builds the confirm-preview payload for a standalone-server deletion (pure string
+     * building — no side effects). Returns {@code null} when {@code confirm} is true, so
+     * the caller proceeds to the real deletion.
+     *
+     * @return the preview JSON payload, or {@code null} when {@code confirm} is true
+     */
+    private String buildStandaloneServerPreview(boolean confirm, String projectName, String resolvedId,
+        String resolvedName, boolean deleteRegistration, boolean deleteDatabaseFiles, Path dbDir,
+        boolean dbSharedWithOthers)
+    {
+        if (confirm)
+        {
+            return null;
+        }
+        return ToolResult.success()
+            .put(McpKeys.ACTION, "preview") //$NON-NLS-1$
+            .put(KEY_CONFIRMATION_REQUIRED, true)
+            .put(KEY_APPLICATION_KIND, "standaloneServer") //$NON-NLS-1$
+            .put(McpKeys.PROJECT, projectName)
+            .put(McpKeys.APPLICATION_ID, resolvedId)
+            .put(KEY_INFOBASE_NAME, resolvedName)
+            .put(KEY_DELETE_REGISTRATION, deleteRegistration)
+            .put(McpKeys.MESSAGE, "PREVIEW: this would delete standalone server '" + resolvedName //$NON-NLS-1$
+                + "' (stop it, remove the WST server and its server config folder)" //$NON-NLS-1$
+                + (deleteRegistration ? " AND clean its infobases.yaml registry entry" //$NON-NLS-1$
+                    : " (infobases.yaml entry kept)") //$NON-NLS-1$
+                + databasePreviewNote(deleteDatabaseFiles, dbDir, dbSharedWithOthers)
+                + " for project '" + projectName //$NON-NLS-1$
+                + "'. This is irreversible. Re-call with confirm=true to apply.") //$NON-NLS-1$
+            .toJson();
+    }
+
+    /**
+     * Inspects the background deletion Job's outcome (read-only — only reads the captured
+     * error/status and logs). Returns an error JSON payload when the Job threw or the
+     * platform reported a non-OK / missing status, or {@code null} when the server was
+     * cleanly deleted.
+     *
+     * @param jobError the exception the Job captured, if any
+     * @param status the {@link IStatus} the Job captured, if any
+     * @param resolvedName the application name (for messages)
+     * @return an error payload, or {@code null} when the deletion succeeded cleanly
+     */
+    private String checkDeletionOutcome(Exception jobError, IStatus status, String resolvedName)
+    {
+        if (jobError != null)
+        {
+            Activator.logError("delete_infobase: standalone-server deletion failed for " //$NON-NLS-1$
+                + resolvedName, jobError);
+            return ToolResult.error("Standalone-server deletion failed for '" + resolvedName //$NON-NLS-1$
+                + "': " + jobError.getMessage()).toJson(); //$NON-NLS-1$
+        }
+        if (status == null || !status.isOK())
+        {
+            // null = deleteServer returned a non-IStatus (reflective miss); non-OK = the platform
+            // reported a failure. Either way the server was NOT cleanly deleted — report an error.
+            String detail = status != null ? status.getMessage() : "no status returned"; //$NON-NLS-1$
+            Activator.logError("delete_infobase: deleteServer did not succeed: " + detail, null); //$NON-NLS-1$
+            return ToolResult.error("Standalone-server deletion did not complete cleanly for '" //$NON-NLS-1$
+                + resolvedName + "': " + detail).toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Builds the success payload for a completed standalone-server deletion (pure string
+     * building — no side effects).
+     *
+     * @return the success JSON payload
+     */
+    private String buildDeletedResult(String projectName, String resolvedId, String resolvedName,
+        boolean deleteRegistration, boolean deleteDatabaseFiles, Path dbDir, boolean dbFilesDeleted,
+        boolean dbSharedWithOthers, StandaloneServerSupport.RegistryCleanup cleanup, boolean removed)
+    {
         return ToolResult.success()
             .put(McpKeys.ACTION, VAL_DELETED)
             .put(KEY_APPLICATION_KIND, "standaloneServer") //$NON-NLS-1$
@@ -600,6 +701,21 @@ public class DeleteInfobaseTool implements IMcpTool
                 + databaseResultNote(deleteDatabaseFiles, dbDir, dbFilesDeleted, dbSharedWithOthers)
                 + (removed ? "" : " NOTE: it may still appear in get_applications briefly.")) //$NON-NLS-1$ //$NON-NLS-2$
             .toJson();
+    }
+
+    /**
+     * Holder for {@link #resolveDeletionContext}: the resolved service, WST server,
+     * infobaseId, served-DB directory and shared-files guard, or an {@code error} payload
+     * the caller returns as-is.
+     */
+    private static class DeletionContext
+    {
+        Object service;
+        Object server;
+        String infobaseId;
+        Path dbDir;
+        boolean dbSharedWithOthers;
+        String error;
     }
 
     /** Human-readable note describing the infobases.yaml cleanup outcome (deleteRegistration=true). */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/EnableToolsetTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/EnableToolsetTool.java
@@ -104,34 +104,7 @@ public class EnableToolsetTool implements IMcpTool
             List<String> applied = new ArrayList<>();
             List<String> invalid = new ArrayList<>();
             List<String> ignored = new ArrayList<>();
-            for (String raw : requested)
-            {
-                String id = raw == null ? null : raw.trim();
-                if (id == null || id.isEmpty())
-                {
-                    continue;
-                }
-                if (!Toolsets.exists(id))
-                {
-                    invalid.add(id);
-                    continue;
-                }
-                if (Toolsets.CORE.equals(id))
-                {
-                    // Core is always visible; toggling it is meaningless, not an error.
-                    ignored.add(id);
-                    continue;
-                }
-                if (disable)
-                {
-                    state.disable(id);
-                }
-                else
-                {
-                    state.enable(id);
-                }
-                applied.add(id);
-            }
+            categorizeToolsets(requested, disable, state, applied, invalid, ignored);
 
             // All requested ids were invalid (none applied, none ignored-as-core) -> a clear error
             // that names the bad values and points at the discovery tool.
@@ -156,15 +129,7 @@ public class EnableToolsetTool implements IMcpTool
             }
             result.put("progressiveDisclosure", pd); //$NON-NLS-1$
 
-            List<String> visible = new ArrayList<>();
-            for (Toolset ts : Toolsets.all())
-            {
-                if (!pd || state.isVisible(ts.getId()))
-                {
-                    visible.add(ts.getId());
-                }
-            }
-            result.put("visibleToolsets", visible); //$NON-NLS-1$
+            result.put("visibleToolsets", collectVisibleToolsets(pd, state)); //$NON-NLS-1$
 
             result.put("note", pd //$NON-NLS-1$
                 ? "Re-request tools/list to see the updated tool set." //$NON-NLS-1$
@@ -186,5 +151,62 @@ public class EnableToolsetTool implements IMcpTool
             Activator.logError("Error in enable_toolset", e); //$NON-NLS-1$
             return ToolResult.error(e.getMessage()).toJson();
         }
+    }
+
+    /**
+     * Classifies each requested id and applies the toggle: blank ids are skipped, unknown ids go to
+     * {@code invalid}, the always-visible {@code core} toolset goes to {@code ignored}, and every other
+     * valid id is enabled / disabled on {@code state} and recorded in {@code applied}. Populates the
+     * three supplied lists in place (no list is reassigned); preserves the original per-id ordering and
+     * the early-skip semantics exactly.
+     */
+    private static void categorizeToolsets(List<String> requested, boolean disable, ToolsetState state,
+        List<String> applied, List<String> invalid, List<String> ignored)
+    {
+        for (String raw : requested)
+        {
+            String id = raw == null ? null : raw.trim();
+            if (id == null || id.isEmpty())
+            {
+                continue;
+            }
+            if (!Toolsets.exists(id))
+            {
+                invalid.add(id);
+                continue;
+            }
+            if (Toolsets.CORE.equals(id))
+            {
+                // Core is always visible; toggling it is meaningless, not an error.
+                ignored.add(id);
+                continue;
+            }
+            if (disable)
+            {
+                state.disable(id);
+            }
+            else
+            {
+                state.enable(id);
+            }
+            applied.add(id);
+        }
+    }
+
+    /**
+     * The toolset ids visible in {@code tools/list} after the change: every toolset when progressive
+     * disclosure is off, otherwise only the ones {@code state} reports visible. Read-only.
+     */
+    private static List<String> collectVisibleToolsets(boolean pd, ToolsetState state)
+    {
+        List<String> visible = new ArrayList<>();
+        for (Toolset ts : Toolsets.all())
+        {
+            if (!pd || state.isVisible(ts.getId()))
+            {
+                visible.add(ts.getId());
+            }
+        }
+        return visible;
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMarkersTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMarkersTool.java
@@ -182,62 +182,10 @@ public class GetMarkersTool implements IMcpTool
                 projects = ProjectContext.allProjects();
             }
 
-            for (IProject project : projects)
-            {
-                if (!project.isOpen())
-                {
-                    continue;
-                }
+            collectMarkerRows(projects, includeBookmarks, includeTasks, filePath, priorityFilter,
+                limit, rows, seenTasks);
 
-                if (includeBookmarks && rows.size() < limit)
-                {
-                    collectBookmarks(project, rows, filePath, limit);
-                }
-                if (includeTasks && rows.size() < limit)
-                {
-                    collectTasks(project, TASK_MARKER_TYPE, rows, seenTasks, filePath, priorityFilter, limit);
-                    if (rows.size() < limit)
-                    {
-                        collectTasks(project, XTEXT_TASK_MARKER_TYPE, rows, seenTasks, filePath, priorityFilter, limit);
-                    }
-                }
-
-                if (rows.size() >= limit)
-                {
-                    break;
-                }
-            }
-
-            md.append("## Markers\n\n"); //$NON-NLS-1$
-            md.append("**Found:** ").append(rows.size()).append(" markers"); //$NON-NLS-1$ //$NON-NLS-2$
-            if (rows.size() >= limit)
-            {
-                md.append(Pagination.limitReachedNotice(limit));
-            }
-            md.append("\n\n"); //$NON-NLS-1$
-
-            if (rows.isEmpty())
-            {
-                md.append("*No markers found.*\n"); //$NON-NLS-1$
-            }
-            else
-            {
-                // Table header (cells escaped by MarkdownUtils.tableRow). The Path
-                // already carries the project name as its first segment, so there
-                // is no separate Project column.
-                md.append(MarkdownUtils.tableHeader("Kind", "Type", "Priority", "Message", "Path", "Line")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
-
-                for (MarkerRow row : rows)
-                {
-                    md.append(MarkdownUtils.tableRow(
-                        row.kind,
-                        row.type,
-                        row.priority,
-                        row.message,
-                        row.path,
-                        String.valueOf(row.line)));
-                }
-            }
+            appendMarkersTable(md, rows, limit);
         }
         catch (Exception e)
         {
@@ -246,6 +194,94 @@ public class GetMarkersTool implements IMcpTool
         }
 
         return md.toString();
+    }
+
+    /**
+     * Scans the resolved projects for the selected marker families, appending the
+     * collected rows to {@code rows} (and de-duplicating task markers via
+     * {@code seenTasks}). Stops once {@code limit} rows have been gathered.
+     *
+     * @param projects the projects to scan (already resolved/filtered)
+     * @param includeBookmarks whether to scan bookmark markers
+     * @param includeTasks whether to scan task markers
+     * @param filePath case-insensitive path-substring filter (null/empty = no filter)
+     * @param priorityFilter task priority filter (null = no filter); ignored for bookmarks
+     * @param limit maximum number of rows to collect (already clamped)
+     * @param rows accumulator the collected rows are appended to
+     * @param seenTasks dedup set shared across the two task marker types
+     */
+    private static void collectMarkerRows(IProject[] projects, boolean includeBookmarks,
+        boolean includeTasks, String filePath, Integer priorityFilter, int limit,
+        List<MarkerRow> rows, Set<String> seenTasks)
+    {
+        for (IProject project : projects)
+        {
+            if (!project.isOpen())
+            {
+                continue;
+            }
+
+            if (includeBookmarks && rows.size() < limit)
+            {
+                collectBookmarks(project, rows, filePath, limit);
+            }
+            if (includeTasks && rows.size() < limit)
+            {
+                collectTasks(project, TASK_MARKER_TYPE, rows, seenTasks, filePath, priorityFilter, limit);
+                if (rows.size() < limit)
+                {
+                    collectTasks(project, XTEXT_TASK_MARKER_TYPE, rows, seenTasks, filePath, priorityFilter, limit);
+                }
+            }
+
+            if (rows.size() >= limit)
+            {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Renders the collected marker {@code rows} as the markdown report body,
+     * appending to {@code md}: the heading, the found-count (with the limit-reached
+     * notice when applicable) and either the empty-state line or the markers table.
+     *
+     * @param md the buffer the report body is appended to
+     * @param rows the collected marker rows
+     * @param limit the (clamped) row limit, used to detect the limit-reached case
+     */
+    private static void appendMarkersTable(StringBuilder md, List<MarkerRow> rows, int limit)
+    {
+        md.append("## Markers\n\n"); //$NON-NLS-1$
+        md.append("**Found:** ").append(rows.size()).append(" markers"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (rows.size() >= limit)
+        {
+            md.append(Pagination.limitReachedNotice(limit));
+        }
+        md.append("\n\n"); //$NON-NLS-1$
+
+        if (rows.isEmpty())
+        {
+            md.append("*No markers found.*\n"); //$NON-NLS-1$
+        }
+        else
+        {
+            // Table header (cells escaped by MarkdownUtils.tableRow). The Path
+            // already carries the project name as its first segment, so there
+            // is no separate Project column.
+            md.append(MarkdownUtils.tableHeader("Kind", "Type", "Priority", "Message", "Path", "Line")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+
+            for (MarkerRow row : rows)
+            {
+                md.append(MarkdownUtils.tableRow(
+                    row.kind,
+                    row.type,
+                    row.priority,
+                    row.message,
+                    row.path,
+                    String.valueOf(row.line)));
+            }
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetModuleStructureTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetModuleStructureTool.java
@@ -285,6 +285,17 @@ public class GetModuleStructureTool implements IMcpTool
         }
         boolean showComments = detailed && hasComments;
 
+        appendMethodsTableHeader(sb, detailed, showComments);
+        appendMethodsTableRows(sb, methods, detailed, showComments);
+    }
+
+    /**
+     * Appends the {@code ### Methods} title and the markdown header/separator rows. The column
+     * set mirrors {@link #appendMethodsTableRows}: detailed adds the Parameters column, and
+     * detailed+comments additionally adds the Description column; concise drops both.
+     */
+    private void appendMethodsTableHeader(StringBuilder sb, boolean detailed, boolean showComments)
+    {
         sb.append("### Methods\n\n"); //$NON-NLS-1$
         if (detailed)
         {
@@ -304,7 +315,16 @@ public class GetModuleStructureTool implements IMcpTool
             sb.append("| # | Type | Name | Export | Context | Lines | Region |\n"); //$NON-NLS-1$
             sb.append("|---|------|------|--------|---------|-------|--------|\n"); //$NON-NLS-1$
         }
+    }
 
+    /**
+     * Appends one markdown table row per method, with the same column set the header advertises:
+     * the Parameters column only in {@code detailed} mode, the Description column only when
+     * {@code showComments} (detailed + collected doc-comments).
+     */
+    private void appendMethodsTableRows(StringBuilder sb, List<MethodInfo> methods,
+        boolean detailed, boolean showComments)
+    {
         int idx = 1;
         for (MethodInfo m : methods)
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProblemSummaryTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProblemSummaryTool.java
@@ -103,46 +103,9 @@ public class GetProblemSummaryTool implements IMcpTool
             // Get all markers
             Stream<Marker> markerStream = markerManager.markers();
             final String filterProject = projectName;
-            
-            markerStream.forEach(marker -> {
-                IProject markerProject = marker.getProject();
-                if (markerProject == null)
-                {
-                    return;
-                }
-                
-                String markerProjectName = markerProject.getName();
-                
-                // Filter by project if specified
-                if (filterProject != null && !filterProject.isEmpty() && 
-                    !markerProjectName.equals(filterProject))
-                {
-                    return;
-                }
-                
-                MarkerSeverity severity = marker.getSeverity();
-                if (severity == null)
-                {
-                    severity = MarkerSeverity.NONE;
-                }
-                
-                // Update project summary
-                projectSummaries.computeIfAbsent(markerProjectName, k -> {
-                    Map<MarkerSeverity, Integer> map = new HashMap<>();
-                    for (MarkerSeverity sev : MarkerSeverity.values())
-                    {
-                        map.put(sev, 0);
-                    }
-                    return map;
-                });
-                
-                Map<MarkerSeverity, Integer> projectCounts = projectSummaries.get(markerProjectName);
-                projectCounts.put(severity, projectCounts.get(severity) + 1);
-                
-                // Update totals
-                totals.put(severity, totals.get(severity) + 1);
-            });
-            
+
+            markerStream.forEach(marker -> accumulateMarker(marker, filterProject, projectSummaries, totals));
+
             // Calculate total
             int grandTotal = totals.values().stream().mapToInt(Integer::intValue).sum();
             
@@ -150,55 +113,10 @@ public class GetProblemSummaryTool implements IMcpTool
             md.append("## Problem Summary\n\n"); //$NON-NLS-1$
             
             // Totals section
-            md.append("### Overall Totals\n\n"); //$NON-NLS-1$
-            md.append("| Severity | Count |\n"); //$NON-NLS-1$
-            md.append("|----------|-------|\n"); //$NON-NLS-1$
-            
-            for (MarkerSeverity sev : MarkerSeverity.values())
-            {
-                if (sev == MarkerSeverity.NONE && totals.get(sev) == 0)
-                {
-                    continue; // Skip NONE if empty
-                }
-                md.append("| ").append(sev.name()).append(" | ").append(totals.get(sev)).append(" |\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-            }
-            md.append("| **TOTAL** | **").append(grandTotal).append("** |\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            
+            appendOverallTotals(md, totals, grandTotal);
+
             // Projects section
-            if (!projectSummaries.isEmpty())
-            {
-                md.append("### By Project\n\n"); //$NON-NLS-1$
-                md.append("| Project | Errors | Blocker | Critical | Major | Minor | Trivial | Total |\n"); //$NON-NLS-1$
-                md.append("|---------|--------|---------|----------|-------|-------|---------|-------|\n"); //$NON-NLS-1$
-                
-                for (Map.Entry<String, Map<MarkerSeverity, Integer>> entry : projectSummaries.entrySet())
-                {
-                    Map<MarkerSeverity, Integer> counts = entry.getValue();
-                    int projectTotal = sumDisplayedSeverities(counts);
-                    
-                    md.append("| "); //$NON-NLS-1$
-                    md.append(MarkdownUtils.escapeForTable(entry.getKey()));
-                    md.append(" | "); //$NON-NLS-1$
-                    md.append(counts.getOrDefault(MarkerSeverity.ERRORS, 0));
-                    md.append(" | "); //$NON-NLS-1$
-                    md.append(counts.getOrDefault(MarkerSeverity.BLOCKER, 0));
-                    md.append(" | "); //$NON-NLS-1$
-                    md.append(counts.getOrDefault(MarkerSeverity.CRITICAL, 0));
-                    md.append(" | "); //$NON-NLS-1$
-                    md.append(counts.getOrDefault(MarkerSeverity.MAJOR, 0));
-                    md.append(" | "); //$NON-NLS-1$
-                    md.append(counts.getOrDefault(MarkerSeverity.MINOR, 0));
-                    md.append(" | "); //$NON-NLS-1$
-                    md.append(counts.getOrDefault(MarkerSeverity.TRIVIAL, 0));
-                    md.append(" | "); //$NON-NLS-1$
-                    md.append(projectTotal);
-                    md.append(" |\n"); //$NON-NLS-1$
-                }
-            }
-            else
-            {
-                md.append("*No problems found.*\n"); //$NON-NLS-1$
-            }
+            appendByProjectSection(md, projectSummaries);
         }
         catch (Exception e)
         {
@@ -207,6 +125,129 @@ public class GetProblemSummaryTool implements IMcpTool
         }
         
         return md.toString();
+    }
+
+    /**
+     * Folds a single marker into the running counters: skips markers without a
+     * project, applies the optional project filter, normalises a missing severity
+     * to {@link MarkerSeverity#NONE}, then increments both the per-project map and
+     * the overall totals (lazily initialising the per-project entry on first sight).
+     *
+     * @param marker the marker to fold in
+     * @param filterProject project name to keep (others skipped); {@code null}/empty keeps all
+     * @param projectSummaries projectName -&gt; (severity -&gt; count); mutated in place
+     * @param totals severity -&gt; count overall; mutated in place
+     */
+    private static void accumulateMarker(Marker marker, String filterProject,
+        Map<String, Map<MarkerSeverity, Integer>> projectSummaries, Map<MarkerSeverity, Integer> totals)
+    {
+        IProject markerProject = marker.getProject();
+        if (markerProject == null)
+        {
+            return;
+        }
+
+        String markerProjectName = markerProject.getName();
+
+        // Filter by project if specified
+        if (filterProject != null && !filterProject.isEmpty() &&
+            !markerProjectName.equals(filterProject))
+        {
+            return;
+        }
+
+        MarkerSeverity severity = marker.getSeverity();
+        if (severity == null)
+        {
+            severity = MarkerSeverity.NONE;
+        }
+
+        // Update project summary
+        projectSummaries.computeIfAbsent(markerProjectName, k -> {
+            Map<MarkerSeverity, Integer> map = new HashMap<>();
+            for (MarkerSeverity sev : MarkerSeverity.values())
+            {
+                map.put(sev, 0);
+            }
+            return map;
+        });
+
+        Map<MarkerSeverity, Integer> projectCounts = projectSummaries.get(markerProjectName);
+        projectCounts.put(severity, projectCounts.get(severity) + 1);
+
+        // Update totals
+        totals.put(severity, totals.get(severity) + 1);
+    }
+
+    /**
+     * Appends the "Overall Totals" table, one row per severity (NONE skipped when zero)
+     * plus a TOTAL row, to {@code md}.
+     *
+     * @param md destination buffer (appended to)
+     * @param totals severity -&gt; count overall
+     * @param grandTotal the precomputed grand total across all severities
+     */
+    private static void appendOverallTotals(StringBuilder md, Map<MarkerSeverity, Integer> totals, int grandTotal)
+    {
+        md.append("### Overall Totals\n\n"); //$NON-NLS-1$
+        md.append("| Severity | Count |\n"); //$NON-NLS-1$
+        md.append("|----------|-------|\n"); //$NON-NLS-1$
+
+        for (MarkerSeverity sev : MarkerSeverity.values())
+        {
+            if (sev == MarkerSeverity.NONE && totals.get(sev) == 0)
+            {
+                continue; // Skip NONE if empty
+            }
+            md.append("| ").append(sev.name()).append(" | ").append(totals.get(sev)).append(" |\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        }
+        md.append("| **TOTAL** | **").append(grandTotal).append("** |\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Appends the "By Project" table (one row per project) to {@code md}, or a
+     * "No problems found" line when there are no project summaries.
+     *
+     * @param md destination buffer (appended to)
+     * @param projectSummaries projectName -&gt; (severity -&gt; count)
+     */
+    private static void appendByProjectSection(StringBuilder md,
+        Map<String, Map<MarkerSeverity, Integer>> projectSummaries)
+    {
+        if (!projectSummaries.isEmpty())
+        {
+            md.append("### By Project\n\n"); //$NON-NLS-1$
+            md.append("| Project | Errors | Blocker | Critical | Major | Minor | Trivial | Total |\n"); //$NON-NLS-1$
+            md.append("|---------|--------|---------|----------|-------|-------|---------|-------|\n"); //$NON-NLS-1$
+
+            for (Map.Entry<String, Map<MarkerSeverity, Integer>> entry : projectSummaries.entrySet())
+            {
+                Map<MarkerSeverity, Integer> counts = entry.getValue();
+                int projectTotal = sumDisplayedSeverities(counts);
+
+                md.append("| "); //$NON-NLS-1$
+                md.append(MarkdownUtils.escapeForTable(entry.getKey()));
+                md.append(" | "); //$NON-NLS-1$
+                md.append(counts.getOrDefault(MarkerSeverity.ERRORS, 0));
+                md.append(" | "); //$NON-NLS-1$
+                md.append(counts.getOrDefault(MarkerSeverity.BLOCKER, 0));
+                md.append(" | "); //$NON-NLS-1$
+                md.append(counts.getOrDefault(MarkerSeverity.CRITICAL, 0));
+                md.append(" | "); //$NON-NLS-1$
+                md.append(counts.getOrDefault(MarkerSeverity.MAJOR, 0));
+                md.append(" | "); //$NON-NLS-1$
+                md.append(counts.getOrDefault(MarkerSeverity.MINOR, 0));
+                md.append(" | "); //$NON-NLS-1$
+                md.append(counts.getOrDefault(MarkerSeverity.TRIVIAL, 0));
+                md.append(" | "); //$NON-NLS-1$
+                md.append(projectTotal);
+                md.append(" |\n"); //$NON-NLS-1$
+            }
+        }
+        else
+        {
+            md.append("*No problems found.*\n"); //$NON-NLS-1$
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -423,37 +423,11 @@ public class GetProjectErrorsTool implements IMcpTool
         }
         
         // Objects filter (FQN matching against the resolved object presentation)
-        if (!objects.isEmpty())
+        if (excludedByObjectsFilter(objects, presentationResolved, objectPresentation, unresolvedFilteredOut))
         {
-            if (!presentationResolved)
-            {
-                // Cannot resolve the location, so we cannot decide membership for an
-                // explicit object filter. The marker is excluded from the result; count it
-                // separately so the caller is warned that it was filtered out, not shown.
-                unresolvedFilteredOut[0]++;
-                return null;
-            }
-            if (objectPresentation.isEmpty())
-            {
-                return null;
-            }
-            
-            String presentationLower = objectPresentation.toLowerCase();
-            boolean matched = false;
-            for (String fqnVariant : objects)
-            {
-                if (presentationLower.contains(fqnVariant))
-                {
-                    matched = true;
-                    break;
-                }
-            }
-            if (!matched)
-            {
-                return null;
-            }
+            return null;
         }
-        
+
         // Build the ErrorInfo, reusing the already resolved symbolic check id and presentation.
         ErrorInfo error = new ErrorInfo();
         error.checkCode = shortUid;
@@ -480,7 +454,45 @@ public class GetProjectErrorsTool implements IMcpTool
         }
         return error;
     }
-    
+
+    /**
+     * Decides whether the marker is excluded by an explicit objects filter, matching the
+     * resolved object presentation against the FQN variants. Returns {@code false} when no
+     * objects filter is active. As a side effect, increments {@code unresolvedFilteredOut}
+     * for a marker whose presentation could not be resolved while a filter is active (the
+     * marker is excluded but counted separately so the caller can warn about it).
+     */
+    static boolean excludedByObjectsFilter(Set<String> objects, boolean presentationResolved,
+        String objectPresentation, int[] unresolvedFilteredOut)
+    {
+        if (objects.isEmpty())
+        {
+            return false;
+        }
+        if (!presentationResolved)
+        {
+            // Cannot resolve the location, so we cannot decide membership for an
+            // explicit object filter. The marker is excluded from the result; count it
+            // separately so the caller is warned that it was filtered out, not shown.
+            unresolvedFilteredOut[0]++;
+            return true;
+        }
+        if (objectPresentation.isEmpty())
+        {
+            return true;
+        }
+
+        String presentationLower = objectPresentation.toLowerCase();
+        for (String fqnVariant : objects)
+        {
+            if (presentationLower.contains(fqnVariant))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /**
      * Resolves the symbolic check id (e.g. "bsl-legacy-check-expression-type") for a marker's
      * short UID (e.g. "SU23") exactly once. Returns {@code null} when it cannot be resolved.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -347,24 +347,12 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         if (FormElementWriter.isHandlerToken(ref.kindToken) || ref.isItemLevel())
         {
             String procName = handlerProcedureValue(properties);
-            if (procName != null)
+            String rebindErr = validateHandlerRebind(properties, procName);
+            if (rebindErr != null)
             {
-                // A handler rebind is structural and must not be mixed with other property changes in
-                // one call - the same policy the move ('parent'/'position') and button-command
-                // ('command') branches enforce. Reject BEFORE any mutation.
-                String mixed = firstNonHandlerRebindProperty(properties);
-                if (mixed != null)
-                {
-                    return ToolResult.error("Rebinding a handler's procedure ('procedure') cannot be " //$NON-NLS-1$
-                        + "combined with other property changes ('" + mixed + "') in one call. Rebind " //$NON-NLS-1$ //$NON-NLS-2$
-                        + "the procedure first, then make the other changes in a separate call.").toJson(); //$NON-NLS-1$
-                }
-                return rebindFormHandler(ctx, normFqn, ref, procName);
+                return rebindErr;
             }
-            return ToolResult.error("On a form event-handler FQN, modify_metadata can only REBIND the " //$NON-NLS-1$
-                + "bound procedure - pass a 'procedure' property (e.g. {name:'procedure', " //$NON-NLS-1$
-                + "value:'NewProc'}). To bind a new event use create_metadata, to remove it " //$NON-NLS-1$
-                + "delete_metadata.").toJson(); //$NON-NLS-1$
+            return rebindFormHandler(ctx, normFqn, ref, procName);
         }
 
         // A button's command targets a FormCommand (a form-model object, not an mdclass object), so it
@@ -415,21 +403,8 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                             + ref.name + " (kind '" + ref.kindToken + "') on " + ref.formPath //$NON-NLS-1$ //$NON-NLS-2$
                             + ". Use get_metadata_details to list the members.").toJson()); //$NON-NLS-1$
                     }
-                    List<PreparedChange> changes = new ArrayList<>();
-                    for (JsonObject prop : properties)
-                    {
-                        String guard = guardFormProperty(prop);
-                        if (guard != null)
-                        {
-                            throw new FormValidationException(guard);
-                        }
-                        String pErr = prepare(config, version, member,
-                            normalizeFormProperty(member, prop), changes, normReport);
-                        if (pErr != null)
-                        {
-                            throw new FormValidationException(pErr);
-                        }
-                    }
+                    List<PreparedChange> changes =
+                        prepareFormMemberChanges(config, version, member, properties, normReport);
                     for (PreparedChange change : changes)
                     {
                         change.applyTo(member, tx);
@@ -459,6 +434,66 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         return result
             .put(McpKeys.MESSAGE, "Modified " + normFqn + " (" + String.join(", ", applied) + ")") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
             .toJson();
+    }
+
+    /**
+     * Validates a handler-rebind request on a handler / item-level FQN. A handler FQN supports only
+     * REBINDING its BSL procedure, and that rebind is structural so it must not be mixed with other
+     * property changes. Returns a JSON error to refuse the call - when no {@code procedure} value was
+     * supplied ({@code procName == null}), or when the rebind is mixed with another property change -
+     * or {@code null} when the rebind is valid and the caller may proceed to {@link #rebindFormHandler}.
+     * Pure (no model mutation): reads only the supplied property list.
+     */
+    private static String validateHandlerRebind(List<JsonObject> properties, String procName)
+    {
+        if (procName != null)
+        {
+            // A handler rebind is structural and must not be mixed with other property changes in
+            // one call - the same policy the move ('parent'/'position') and button-command
+            // ('command') branches enforce. Reject BEFORE any mutation.
+            String mixed = firstNonHandlerRebindProperty(properties);
+            if (mixed != null)
+            {
+                return ToolResult.error("Rebinding a handler's procedure ('procedure') cannot be " //$NON-NLS-1$
+                    + "combined with other property changes ('" + mixed + "') in one call. Rebind " //$NON-NLS-1$ //$NON-NLS-2$
+                    + "the procedure first, then make the other changes in a separate call.").toJson(); //$NON-NLS-1$
+            }
+            return null;
+        }
+        return ToolResult.error("On a form event-handler FQN, modify_metadata can only REBIND the " //$NON-NLS-1$
+            + "bound procedure - pass a 'procedure' property (e.g. {name:'procedure', " //$NON-NLS-1$
+            + "value:'NewProc'}). To bind a new event use create_metadata, to remove it " //$NON-NLS-1$
+            + "delete_metadata.").toJson(); //$NON-NLS-1$
+    }
+
+    /**
+     * Validates every property of a form-member modify against the introspected schema and builds the
+     * ordered list of {@link PreparedChange}s to apply. Runs inside the BM write transaction (called
+     * from the {@code writeEditableForm} callback) but performs NO model mutation itself - it only
+     * reads {@code member}'s schema and constructs the changes; a structural-property guard or an
+     * invalid value throws {@link FormValidationException} BEFORE any {@code eSet}, exactly as the
+     * inline loop did, so the transaction rolls back with no partial mutation. The returned changes are
+     * applied by the caller.
+     */
+    private List<PreparedChange> prepareFormMemberChanges(Configuration config, Version version,
+        EObject member, List<JsonObject> properties, MdNameNormalizer.Report normReport)
+    {
+        List<PreparedChange> changes = new ArrayList<>();
+        for (JsonObject prop : properties)
+        {
+            String guard = guardFormProperty(prop);
+            if (guard != null)
+            {
+                throw new FormValidationException(guard);
+            }
+            String pErr = prepare(config, version, member,
+                normalizeFormProperty(member, prop), changes, normReport);
+            if (pErr != null)
+            {
+                throw new FormValidationException(pErr);
+            }
+        }
+        return changes;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskTool.java
@@ -604,19 +604,7 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
         boolean removedAny = false;
         for (EReference ref : cfg.eClass().getEAllReferences())
         {
-            if (!ref.isMany())
-            {
-                // Single-valued references are not the "lost reference at position N"
-                // collections the md-reference-intergrity check reports; skip them.
-                continue;
-            }
-            if (ref.isDerived() || ref.isTransient() || ref.isVolatile() || !ref.isChangeable())
-            {
-                // Derived/computed collections are not the persisted Configuration.mdo
-                // registrations and may be unmodifiable - never the dangling source.
-                continue;
-            }
-            if (!isMdObjectReference(ref))
+            if (!isCandidateReference(ref))
             {
                 continue;
             }
@@ -628,25 +616,7 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
                 continue;
             }
             EList<EObject> list = (EList<EObject>)value;
-            // Walk a snapshot of positions so the reported position matches the
-            // original .mdo layout even as earlier entries are removed.
-            List<EObject> dangling = new ArrayList<>();
-            int position = 0;
-            for (EObject element : list)
-            {
-                if (element != null && isDanglingReference(element, tx))
-                {
-                    result.found++;
-                    String lostFqn = proxyFqnOf(element);
-                    Map<String, Object> entry = new LinkedHashMap<>();
-                    entry.put("field", ref.getName()); //$NON-NLS-1$
-                    entry.put("lostFqn", lostFqn != null ? lostFqn : "(unknown)"); //$NON-NLS-1$ //$NON-NLS-2$
-                    entry.put("position", Integer.valueOf(position)); //$NON-NLS-1$
-                    result.details.add(entry);
-                    dangling.add(element);
-                }
-                position++;
-            }
+            List<EObject> dangling = collectDangling(list, ref, tx, result);
             if (remove && !dangling.isEmpty())
             {
                 list.removeAll(dangling);
@@ -654,6 +624,63 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
             }
         }
         return removedAny;
+    }
+
+    /**
+     * Decides whether a Configuration reference is a candidate "lost reference at
+     * position N" collection the md-reference-integrity check reports, i.e. a
+     * many-valued, persisted, changeable {@link MdObject} reference. Single-valued,
+     * derived/transient/volatile/unmodifiable and non-{@code MdObject} references
+     * are never the dangling source and are skipped.
+     */
+    private static boolean isCandidateReference(EReference ref)
+    {
+        if (!ref.isMany())
+        {
+            // Single-valued references are not the "lost reference at position N"
+            // collections the md-reference-intergrity check reports; skip them.
+            return false;
+        }
+        if (ref.isDerived() || ref.isTransient() || ref.isVolatile() || !ref.isChangeable())
+        {
+            // Derived/computed collections are not the persisted Configuration.mdo
+            // registrations and may be unmodifiable - never the dangling source.
+            return false;
+        }
+        return isMdObjectReference(ref);
+    }
+
+    /**
+     * Scans a single many-valued reference's {@code list} for dangling proxies,
+     * recording each into {@code result} (incrementing {@code result.found} and
+     * appending a {field, lostFqn, position} detail entry), and returns the dangling
+     * elements in encounter order. Positions are taken from a snapshot walk so the
+     * reported position matches the original .mdo layout even when the caller later
+     * removes earlier entries. Does not mutate {@code list}.
+     */
+    private static List<EObject> collectDangling(EList<EObject> list, EReference ref,
+        IBmTransaction tx, DanglingResult result)
+    {
+        // Walk a snapshot of positions so the reported position matches the
+        // original .mdo layout even as earlier entries are removed.
+        List<EObject> dangling = new ArrayList<>();
+        int position = 0;
+        for (EObject element : list)
+        {
+            if (element != null && isDanglingReference(element, tx))
+            {
+                result.found++;
+                String lostFqn = proxyFqnOf(element);
+                Map<String, Object> entry = new LinkedHashMap<>();
+                entry.put("field", ref.getName()); //$NON-NLS-1$
+                entry.put("lostFqn", lostFqn != null ? lostFqn : "(unknown)"); //$NON-NLS-1$ //$NON-NLS-2$
+                entry.put("position", Integer.valueOf(position)); //$NON-NLS-1$
+                result.details.add(entry);
+                dangling.add(element);
+            }
+            position++;
+        }
+        return dangling;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RevalidateObjectsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RevalidateObjectsTool.java
@@ -200,86 +200,25 @@ public class RevalidateObjectsTool implements IMcpTool
             IProgressMonitor monitor) throws CoreException
     {
         String projectName = project.getName();
-        
-        // Get services from Activator
-        IBmModelManager bmModelManager = Activator.getDefault().getBmModelManager();
-        ICheckScheduler checkScheduler = Activator.getDefault().getCheckScheduler();
-        
-        if (bmModelManager == null)
-        {
-            return ToolResult.error("IBmModelManager service is not available").toJson(); //$NON-NLS-1$
-        }
-        
-        if (checkScheduler == null)
-        {
-            return ToolResult.error("ICheckScheduler service is not available").toJson(); //$NON-NLS-1$
-        }
-        
-        // Get DtProject
-        IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
-        IDtProject dtProject = dtProjectManager != null ? dtProjectManager.getDtProject(project) : null;
-        
-        if (dtProject == null)
-        {
-            return ToolResult.error("Not an EDT project: " + projectName).toJson(); //$NON-NLS-1$
-        }
-        
-        // Get BM model
-        IBmModel bmModel = bmModelManager.getModel(dtProject);
-        if (bmModel == null)
-        {
-            return ToolResult.error("BM model not available for project: " + projectName).toJson(); //$NON-NLS-1$
-        }
-        
-        // Find objects by FQN using executeReadonlyTask
-        List<String> found = new ArrayList<>();
-        List<String> notFound = new ArrayList<>();
-        List<String> skippedNullUri = new ArrayList<>();
-        Collection<Object> objectsToValidate = new ArrayList<>();
-        
-        // Normalize FQNs to English singular form (supports Russian type names),
-        // but keep the original user input for result reporting
-        List<String> originalFqns = new ArrayList<>(objectFqns);
-        List<String> normalizedFqns = new ArrayList<>();
-        for (String fqn : objectFqns)
-        {
-            normalizedFqns.add(MetadataTypeUtils.normalizeFqn(fqn));
-        }
 
-        BmTransactions.<Void>read(bmModel, "RevalidateObjectsLookup", (tx, pm) -> //$NON-NLS-1$
+        // Resolve the required services / BM model (read-only: returns an error payload
+        // when a service or the model is unavailable). No validation is scheduled here.
+        RevalidateServices services = resolveServices(project, projectName);
+        if (services.error != null)
         {
-            for (int i = 0; i < normalizedFqns.size(); i++)
-            {
-                String normalizedFqn = normalizedFqns.get(i);
-                String originalFqn = originalFqns.get(i);
+            return services.error;
+        }
+        ICheckScheduler checkScheduler = services.checkScheduler;
+        IBmModel bmModel = services.bmModel;
 
-                IBmObject obj = tx.getTopObjectByFqn(normalizedFqn);
-                if (obj != null)
-                {
-                    // Use bmGetId() - returns Long which is accepted by scheduleValidation
-                    long bmId = obj.bmGetId();
-                    if (bmId > 0)
-                    {
-                        Activator.logInfo("Found object: " + originalFqn + " -> bmId: " + bmId); //$NON-NLS-1$ //$NON-NLS-2$
-                        objectsToValidate.add(Long.valueOf(bmId));
-                        found.add(originalFqn);
-                    }
-                    else
-                    {
-                        // Object found but has invalid ID (transient object)
-                        Activator.logInfo("Object has invalid bmId: " + originalFqn + " -> " + bmId); //$NON-NLS-1$ //$NON-NLS-2$
-                        skippedNullUri.add(originalFqn);
-                    }
-                }
-                else
-                {
-                    Activator.logInfo("Object not found: " + originalFqn + " (normalized: " + normalizedFqn + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-                    notFound.add(originalFqn);
-                }
-            }
-            return null;
-        });
-        
+        // Find objects by FQN (read-only lookup): classifies each requested FQN into
+        // found / not-found / skipped buckets and collects the bmIds to validate.
+        ObjectLookupResult lookup = lookupObjectsToValidate(bmModel, objectFqns);
+        List<String> found = lookup.found;
+        List<String> notFound = lookup.notFound;
+        List<String> skippedNullUri = lookup.skippedNullUri;
+        Collection<Object> objectsToValidate = lookup.objectsToValidate;
+
         // Schedule validation if we found objects
         if (!objectsToValidate.isEmpty())
         {
@@ -329,6 +268,141 @@ public class RevalidateObjectsTool implements IMcpTool
         appendFqnSection(body, "Skipped (no persistent id)", skippedNullUri); //$NON-NLS-1$
 
         return fm.wrapContent(body.toString());
+    }
+
+    /**
+     * Resolves the services and BM model needed to schedule validation (read-only). On
+     * any unavailable service / model the returned holder carries an {@code error} JSON
+     * payload that the caller should return as-is; no validation is scheduled here.
+     *
+     * @param project the project to work with
+     * @param projectName the project name (used only for error messages)
+     * @return a {@link RevalidateServices} holder with the model + scheduler, or an error
+     */
+    private static RevalidateServices resolveServices(IProject project, String projectName)
+    {
+        RevalidateServices services = new RevalidateServices();
+
+        // Get services from Activator
+        IBmModelManager bmModelManager = Activator.getDefault().getBmModelManager();
+        ICheckScheduler checkScheduler = Activator.getDefault().getCheckScheduler();
+
+        if (bmModelManager == null)
+        {
+            services.error = ToolResult.error("IBmModelManager service is not available").toJson(); //$NON-NLS-1$
+            return services;
+        }
+
+        if (checkScheduler == null)
+        {
+            services.error = ToolResult.error("ICheckScheduler service is not available").toJson(); //$NON-NLS-1$
+            return services;
+        }
+
+        // Get DtProject
+        IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
+        IDtProject dtProject = dtProjectManager != null ? dtProjectManager.getDtProject(project) : null;
+
+        if (dtProject == null)
+        {
+            services.error = ToolResult.error("Not an EDT project: " + projectName).toJson(); //$NON-NLS-1$
+            return services;
+        }
+
+        // Get BM model
+        IBmModel bmModel = bmModelManager.getModel(dtProject);
+        if (bmModel == null)
+        {
+            services.error = ToolResult.error("BM model not available for project: " + projectName).toJson(); //$NON-NLS-1$
+            return services;
+        }
+
+        services.checkScheduler = checkScheduler;
+        services.bmModel = bmModel;
+        return services;
+    }
+
+    /**
+     * Finds the requested objects by FQN inside a read-only BM transaction and classifies
+     * each into found / not-found / skipped (transient id) buckets, collecting the bmIds to
+     * validate. Read-only: looks objects up and logs, but schedules nothing.
+     *
+     * @param bmModel the BM model to query
+     * @param objectFqns the user-supplied FQNs (normalized to English singular for lookup,
+     *     reported back in their original form)
+     * @return an {@link ObjectLookupResult} with the per-bucket FQN lists and the bmIds
+     */
+    private static ObjectLookupResult lookupObjectsToValidate(IBmModel bmModel, List<String> objectFqns)
+    {
+        ObjectLookupResult result = new ObjectLookupResult();
+
+        // Normalize FQNs to English singular form (supports Russian type names),
+        // but keep the original user input for result reporting
+        List<String> originalFqns = new ArrayList<>(objectFqns);
+        List<String> normalizedFqns = new ArrayList<>();
+        for (String fqn : objectFqns)
+        {
+            normalizedFqns.add(MetadataTypeUtils.normalizeFqn(fqn));
+        }
+
+        BmTransactions.<Void>read(bmModel, "RevalidateObjectsLookup", (tx, pm) -> //$NON-NLS-1$
+        {
+            for (int i = 0; i < normalizedFqns.size(); i++)
+            {
+                String normalizedFqn = normalizedFqns.get(i);
+                String originalFqn = originalFqns.get(i);
+
+                IBmObject obj = tx.getTopObjectByFqn(normalizedFqn);
+                if (obj != null)
+                {
+                    // Use bmGetId() - returns Long which is accepted by scheduleValidation
+                    long bmId = obj.bmGetId();
+                    if (bmId > 0)
+                    {
+                        Activator.logInfo("Found object: " + originalFqn + " -> bmId: " + bmId); //$NON-NLS-1$ //$NON-NLS-2$
+                        result.objectsToValidate.add(Long.valueOf(bmId));
+                        result.found.add(originalFqn);
+                    }
+                    else
+                    {
+                        // Object found but has invalid ID (transient object)
+                        Activator.logInfo("Object has invalid bmId: " + originalFqn + " -> " + bmId); //$NON-NLS-1$ //$NON-NLS-2$
+                        result.skippedNullUri.add(originalFqn);
+                    }
+                }
+                else
+                {
+                    Activator.logInfo("Object not found: " + originalFqn + " (normalized: " + normalizedFqn + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                    result.notFound.add(originalFqn);
+                }
+            }
+            return null;
+        });
+
+        return result;
+    }
+
+    /**
+     * Holder for {@link #resolveServices}: the resolved scheduler + BM model, or an
+     * {@code error} JSON payload the caller returns as-is.
+     */
+    private static class RevalidateServices
+    {
+        ICheckScheduler checkScheduler;
+        IBmModel bmModel;
+        String error;
+    }
+
+    /**
+     * Holder for {@link #lookupObjectsToValidate}: the per-bucket FQN lists and the bmIds
+     * collected for scheduling.
+     */
+    private static class ObjectLookupResult
+    {
+        final List<String> found = new ArrayList<>();
+        final List<String> notFound = new ArrayList<>();
+        final List<String> skippedNullUri = new ArrayList<>();
+        final Collection<Object> objectsToValidate = new ArrayList<>();
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/StepTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/StepTool.java
@@ -8,6 +8,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import java.util.Map;
 
+import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.model.IDebugTarget;
 import org.eclipse.debug.core.model.IStep;
 import org.eclipse.debug.core.model.IThread;
@@ -135,22 +136,7 @@ public class StepTool implements IMcpTool
         // even when the session is keyed by its owning launch id, so clearSnapshot
         // cleared the wrong key and the caller's next wait_for_break returned the
         // surviving PRE-step snapshot.
-        String appId = registry.getThreadApplicationId(threadId);
-        if (appId == null)
-        {
-            // Fallback: the same canonical policy the resolver applies to every
-            // applicationId-based call (owning-launch id first, minted id else).
-            IDebugTarget owner = null;
-            try
-            {
-                owner = thread.getDebugTarget();
-            }
-            catch (Exception ex)
-            {
-                // best-effort
-            }
-            appId = DebugTargetResolver.canonicalIdFor(owner, serverTarget);
-        }
+        String appId = resolveApplicationId(registry, threadId, thread, serverTarget);
         if (appId == null)
         {
             return ToolResult.error("could not determine applicationId for thread").toJson(); //$NON-NLS-1$
@@ -162,32 +148,10 @@ public class StepTool implements IMcpTool
             // SUSPEND event after the step, not the stale pre-step snapshot.
             registry.clearSnapshot(appId);
 
-            switch (kind.toLowerCase())
+            String stepError = performStep(stepper, kind);
+            if (stepError != null)
             {
-                case "over": //$NON-NLS-1$
-                    if (!stepper.canStepOver())
-                    {
-                        return ToolResult.error("cannot step over").toJson(); //$NON-NLS-1$
-                    }
-                    stepper.stepOver();
-                    break;
-                case "into": //$NON-NLS-1$
-                    if (!stepper.canStepInto())
-                    {
-                        return ToolResult.error("cannot step into").toJson(); //$NON-NLS-1$
-                    }
-                    stepper.stepInto();
-                    break;
-                case "out": //$NON-NLS-1$
-                case "return": //$NON-NLS-1$
-                    if (!stepper.canStepReturn())
-                    {
-                        return ToolResult.error("cannot step out").toJson(); //$NON-NLS-1$
-                    }
-                    stepper.stepReturn();
-                    break;
-                default:
-                    return ToolResult.error("unknown kind: " + kind).toJson(); //$NON-NLS-1$
+                return stepError;
             }
 
             DebugSessionRegistry.SuspendSnapshot snapshot;
@@ -240,6 +204,71 @@ public class StepTool implements IMcpTool
             Activator.logError("Error in step", e); //$NON-NLS-1$
             return ToolResult.error(e.getMessage()).toJson(); //$NON-NLS-1$
         }
+    }
+
+    /**
+     * Resolves the canonical applicationId for the stepped thread. The registry's
+     * thread&rarr;appId mapping is authoritative (it carries the key recorded when this
+     * threadId was registered); only when it is absent does this fall back to the same
+     * canonical policy the resolver applies to every applicationId-based call
+     * (owning-launch id first, minted id else). Returns {@code null} when undeterminable.
+     */
+    private static String resolveApplicationId(DebugSessionRegistry registry, long threadId,
+            IThread thread, DebugServerTargetSupport.ServerTarget serverTarget)
+    {
+        String appId = registry.getThreadApplicationId(threadId);
+        if (appId == null)
+        {
+            IDebugTarget owner = null;
+            try
+            {
+                owner = thread.getDebugTarget();
+            }
+            catch (Exception ex)
+            {
+                // best-effort
+            }
+            appId = DebugTargetResolver.canonicalIdFor(owner, serverTarget);
+        }
+        return appId;
+    }
+
+    /**
+     * Issues the requested step (over / into / out) on the suspended thread. Returns an
+     * error-response JSON string when the step cannot be performed (capability missing or
+     * unknown kind), or {@code null} when the step was issued successfully and the caller
+     * should proceed to wait for the next suspend.
+     */
+    private static String performStep(IStep stepper, String kind) throws DebugException
+    {
+        switch (kind.toLowerCase())
+        {
+            case "over": //$NON-NLS-1$
+                if (!stepper.canStepOver())
+                {
+                    return ToolResult.error("cannot step over").toJson(); //$NON-NLS-1$
+                }
+                stepper.stepOver();
+                break;
+            case "into": //$NON-NLS-1$
+                if (!stepper.canStepInto())
+                {
+                    return ToolResult.error("cannot step into").toJson(); //$NON-NLS-1$
+                }
+                stepper.stepInto();
+                break;
+            case "out": //$NON-NLS-1$
+            case "return": //$NON-NLS-1$
+                if (!stepper.canStepReturn())
+                {
+                    return ToolResult.error("cannot step out").toJson(); //$NON-NLS-1$
+                }
+                stepper.stepReturn();
+                break;
+            default:
+                return ToolResult.error("unknown kind: " + kind).toJson(); //$NON-NLS-1$
+        }
+        return null;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchTool.java
@@ -409,52 +409,83 @@ public class TerminateLaunchTool implements IMcpTool
         }
         for (ILaunch launch : launches)
         {
-            // Live launches are the primary selection's job; the identity skip
-            // covers a launch that terminated between the two scans.
-            if (launch == null || !launch.isTerminated()
-                || containsIdentity(alreadySelected, launch))
+            if (matchesStaleSelection(launch, alreadySelected, configName, projectName,
+                applicationId, all, hasName, hasProject, hasAppId))
             {
-                continue;
-            }
-            ILaunchConfiguration config = launch.getLaunchConfiguration();
-            if (config == null || !LaunchConfigUtils.isEdtConfig(config))
-            {
-                continue;
-            }
-            if (hasName)
-            {
-                if (configName.equals(config.getName()))
-                {
-                    stale.add(launch);
-                }
-                continue;
-            }
-            if (hasProject && hasAppId)
-            {
-                String project = LaunchConfigUtils.readAttribute(config,
-                    LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
-                if (projectName.equals(project)
-                    && applicationId.equals(LaunchConfigUtils.getApplicationIdFor(launch)))
-                {
-                    stale.add(launch);
-                }
-                continue;
-            }
-            if (all)
-            {
-                if (hasProject)
-                {
-                    String project = LaunchConfigUtils.readAttribute(config,
-                        LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
-                    if (!projectName.equals(project))
-                    {
-                        continue;
-                    }
-                }
                 stale.add(launch);
             }
         }
         return stale;
+    }
+
+    /**
+     * Decides whether a single launch belongs to the stale-terminated selection,
+     * applying exactly the same skip/match logic as the in-loop body it was
+     * extracted from (terminated + EDT-config gate, then config name / project +
+     * applicationId / all scope). Pure predicate: reads the launch and the
+     * selection criteria, never mutates anything.
+     *
+     * @param launch          candidate launch (may be {@code null})
+     * @param alreadySelected launches the live selection already picked
+     * @return {@code true} if the launch should be added to the stale list
+     */
+    private static boolean matchesStaleSelection(ILaunch launch, List<ILaunch> alreadySelected,
+            String configName, String projectName, String applicationId, boolean all,
+            boolean hasName, boolean hasProject, boolean hasAppId)
+    {
+        // Live launches are the primary selection's job; the identity skip
+        // covers a launch that terminated between the two scans.
+        if (launch == null || !launch.isTerminated()
+            || containsIdentity(alreadySelected, launch))
+        {
+            return false;
+        }
+        ILaunchConfiguration config = launch.getLaunchConfiguration();
+        if (config == null || !LaunchConfigUtils.isEdtConfig(config))
+        {
+            return false;
+        }
+        if (hasName)
+        {
+            return configName.equals(config.getName());
+        }
+        if (hasProject && hasAppId)
+        {
+            String project = LaunchConfigUtils.readAttribute(config,
+                LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+            return projectName.equals(project)
+                && applicationId.equals(LaunchConfigUtils.getApplicationIdFor(launch));
+        }
+        if (all)
+        {
+            return matchesAllScope(config, projectName, hasProject);
+        }
+        return false;
+    }
+
+    /**
+     * The {@code all}-scope branch of {@link #matchesStaleSelection}: with no name
+     * and no project+applicationId narrowing, every EDT launch matches, optionally
+     * restricted to a single project when {@code hasProject} is set.
+     *
+     * @param config      the launch configuration (non-{@code null})
+     * @param projectName project to restrict to when {@code hasProject}
+     * @param hasProject  whether the project narrowing applies
+     * @return {@code true} if the launch matches the all-scope
+     */
+    private static boolean matchesAllScope(ILaunchConfiguration config, String projectName,
+            boolean hasProject)
+    {
+        if (hasProject)
+        {
+            String project = LaunchConfigUtils.readAttribute(config,
+                LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+            if (!projectName.equals(project))
+            {
+                return false;
+            }
+        }
+        return true;
     }
 
     /** Identity-based contains — {@link ILaunch} has no value equality. */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
@@ -246,24 +246,8 @@ public class UpdateDatabaseTool implements IMcpTool
             // application exists, not already being updated) has run, so the preview is trustworthy.
             if (!confirm)
             {
-                return ToolResult.success()
-                    .put(McpKeys.ACTION, "preview") //$NON-NLS-1$
-                    .put("confirmationRequired", true) //$NON-NLS-1$
-                    .put(McpKeys.PROJECT, projectName)
-                    .put(McpKeys.APPLICATION_ID, applicationId)
-                    .put(KEY_APPLICATION_NAME, application.getName())
-                    .put(KEY_UPDATE_TYPE, updateType.name())
-                    .put(KEY_STATE_BEFORE, stateBefore.name())
-                    .put("willTerminateRunningClients", terminateRunningClients) //$NON-NLS-1$
-                    .put(McpKeys.MESSAGE, "PREVIEW: this would apply a " + updateType.name() //$NON-NLS-1$
-                        + " configuration update to the database of application '" + application.getName() //$NON-NLS-1$
-                        + "' (project " + projectName + "). This mutates the infobase and is " //$NON-NLS-1$ //$NON-NLS-2$
-                        + "IRREVERSIBLE." //$NON-NLS-1$
-                        + (terminateRunningClients
-                            ? " It will first terminate any 1C client this EDT launched on the infobase." //$NON-NLS-1$
-                            : "") //$NON-NLS-1$
-                        + " Re-call with confirm=true to apply it.") //$NON-NLS-1$
-                    .toJson();
+                return buildPreviewResult(projectName, applicationId, application, updateType,
+                    stateBefore, terminateRunningClients);
             }
 
             // Create execution context with the active Shell so EDT can parent
@@ -318,62 +302,13 @@ public class UpdateDatabaseTool implements IMcpTool
                 }
             }
 
-            // Build result. terminatedClient is emitted ONLY when a client was actually terminated
-            // (truthful; "swept but none / not confirmed" and opt-out are indistinguishable by
-            // absence — the confirmationRequired idiom).
-            ToolResult result = ToolResult.success()
-                .put(McpKeys.ACTION, "updated") //$NON-NLS-1$
-                .put(McpKeys.PROJECT, projectName)
-                .put(McpKeys.APPLICATION_ID, applicationId)
-                .put(KEY_APPLICATION_NAME, application.getName())
-                .put(KEY_UPDATE_TYPE, updateType.name())
-                .put(KEY_STATE_BEFORE, stateBefore.name())
-                .put("stateAfter", stateAfter.name()); //$NON-NLS-1$
-            if (terminatedClient)
-            {
-                result.put(KEY_TERMINATED_CLIENT, true);
-            }
-            
-            // Add status message based on result
-            if (stateAfter == ApplicationUpdateState.UPDATED)
-            {
-                result.put(McpKeys.MESSAGE, "Database updated successfully"); //$NON-NLS-1$
-            }
-            else if (stateAfter == ApplicationUpdateState.BEING_UPDATED)
-            {
-                result.put(McpKeys.MESSAGE, "Update in progress"); //$NON-NLS-1$
-            }
-            else
-            {
-                result.put(McpKeys.MESSAGE, "Update completed with state: " + stateAfter.name()); //$NON-NLS-1$
-            }
-            
-            return result.toJson();
+            return buildUpdatedResult(projectName, applicationId, application, updateType,
+                stateBefore, stateAfter, terminatedClient);
         }
         catch (ApplicationException e)
         {
             Activator.logError("Error updating database for application: " + applicationId, e); //$NON-NLS-1$
-            
-            // The common failure is the exclusive lock: name a 1C client that still holds the
-            // infobase (an MCP-owned sibling launch is exempt from the sweep, or a client outlived
-            // the terminate window) so the agent can act instead of seeing a bare failure.
-            ToolResult errorResult = ToolResult.error("Database update failed: " //$NON-NLS-1$
-                + e.getMessage() + describeInfobaseHolder(applicationId));
-            errorResult.put(McpKeys.APPLICATION_ID, applicationId);
-            errorResult.put(McpKeys.PROJECT, projectName);
-            if (terminatedClient)
-            {
-                errorResult.put(KEY_TERMINATED_CLIENT, true);
-            }
-
-            // Try to get additional error details
-            if (e.getCause() != null)
-            {
-                errorResult.put("causeMessage", e.getCause().getMessage()); //$NON-NLS-1$
-                errorResult.put("causeType", e.getCause().getClass().getSimpleName()); //$NON-NLS-1$
-            }
-            
-            return errorResult.toJson();
+            return buildApplicationErrorResult(e, projectName, applicationId, terminatedClient);
         }
         catch (Exception e)
         {
@@ -385,6 +320,102 @@ public class UpdateDatabaseTool implements IMcpTool
             }
             return errorResult.toJson();
         }
+    }
+
+    /**
+     * Builds the confirm-preview JSON (no infobase change): resolves and reports the exact
+     * IRREVERSIBLE action that confirm=true would apply. Side-effect-free.
+     */
+    private static String buildPreviewResult(String projectName, String applicationId,
+            IApplication application, ApplicationUpdateType updateType,
+            ApplicationUpdateState stateBefore, boolean terminateRunningClients)
+    {
+        return ToolResult.success()
+            .put(McpKeys.ACTION, "preview") //$NON-NLS-1$
+            .put("confirmationRequired", true) //$NON-NLS-1$
+            .put(McpKeys.PROJECT, projectName)
+            .put(McpKeys.APPLICATION_ID, applicationId)
+            .put(KEY_APPLICATION_NAME, application.getName())
+            .put(KEY_UPDATE_TYPE, updateType.name())
+            .put(KEY_STATE_BEFORE, stateBefore.name())
+            .put("willTerminateRunningClients", terminateRunningClients) //$NON-NLS-1$
+            .put(McpKeys.MESSAGE, "PREVIEW: this would apply a " + updateType.name() //$NON-NLS-1$
+                + " configuration update to the database of application '" + application.getName() //$NON-NLS-1$
+                + "' (project " + projectName + "). This mutates the infobase and is " //$NON-NLS-1$ //$NON-NLS-2$
+                + "IRREVERSIBLE." //$NON-NLS-1$
+                + (terminateRunningClients
+                    ? " It will first terminate any 1C client this EDT launched on the infobase." //$NON-NLS-1$
+                    : "") //$NON-NLS-1$
+                + " Re-call with confirm=true to apply it.") //$NON-NLS-1$
+            .toJson();
+    }
+
+    /**
+     * Builds the success JSON after an applied update. terminatedClient is emitted ONLY when a
+     * client was actually terminated (truthful; "swept but none / not confirmed" and opt-out are
+     * indistinguishable by absence — the confirmationRequired idiom). Side-effect-free.
+     */
+    private static String buildUpdatedResult(String projectName, String applicationId,
+            IApplication application, ApplicationUpdateType updateType,
+            ApplicationUpdateState stateBefore, ApplicationUpdateState stateAfter,
+            boolean terminatedClient)
+    {
+        ToolResult result = ToolResult.success()
+            .put(McpKeys.ACTION, "updated") //$NON-NLS-1$
+            .put(McpKeys.PROJECT, projectName)
+            .put(McpKeys.APPLICATION_ID, applicationId)
+            .put(KEY_APPLICATION_NAME, application.getName())
+            .put(KEY_UPDATE_TYPE, updateType.name())
+            .put(KEY_STATE_BEFORE, stateBefore.name())
+            .put("stateAfter", stateAfter.name()); //$NON-NLS-1$
+        if (terminatedClient)
+        {
+            result.put(KEY_TERMINATED_CLIENT, true);
+        }
+
+        // Add status message based on result
+        if (stateAfter == ApplicationUpdateState.UPDATED)
+        {
+            result.put(McpKeys.MESSAGE, "Database updated successfully"); //$NON-NLS-1$
+        }
+        else if (stateAfter == ApplicationUpdateState.BEING_UPDATED)
+        {
+            result.put(McpKeys.MESSAGE, "Update in progress"); //$NON-NLS-1$
+        }
+        else
+        {
+            result.put(McpKeys.MESSAGE, "Update completed with state: " + stateAfter.name()); //$NON-NLS-1$
+        }
+
+        return result.toJson();
+    }
+
+    /**
+     * Builds the JSON for an {@link ApplicationException} failure. The common failure is the
+     * exclusive lock: name a 1C client that still holds the infobase (an MCP-owned sibling launch
+     * is exempt from the sweep, or a client outlived the terminate window) so the agent can act
+     * instead of seeing a bare failure. Side-effect-free (the error is already logged by the caller).
+     */
+    private static String buildApplicationErrorResult(ApplicationException e, String projectName,
+            String applicationId, boolean terminatedClient)
+    {
+        ToolResult errorResult = ToolResult.error("Database update failed: " //$NON-NLS-1$
+            + e.getMessage() + describeInfobaseHolder(applicationId));
+        errorResult.put(McpKeys.APPLICATION_ID, applicationId);
+        errorResult.put(McpKeys.PROJECT, projectName);
+        if (terminatedClient)
+        {
+            errorResult.put(KEY_TERMINATED_CLIENT, true);
+        }
+
+        // Try to get additional error details
+        if (e.getCause() != null)
+        {
+            errorResult.put("causeMessage", e.getCause().getMessage()); //$NON-NLS-1$
+            errorResult.put("causeType", e.getCause().getClass().getSimpleName()); //$NON-NLS-1$
+        }
+
+        return errorResult.toJson();
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
@@ -151,87 +151,108 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
     {
         for (EStructuralFeature feature : mdObject.eClass().getEAllStructuralFeatures())
         {
-            if (!(feature instanceof EReference))
+            Collection<?> collection = eligibleContainmentCollection(feature, mdObject);
+            if (collection == null || collection.isEmpty())
             {
                 continue;
             }
-            
-            EReference ref = (EReference) feature;
-            
-            // Only process containment many-valued references
-            if (!ref.isContainment() || !ref.isMany())
-            {
-                continue;
-            }
-            
-            // Skip derived, transient, volatile
-            if (ref.isDerived() || ref.isTransient() || ref.isVolatile())
-            {
-                continue;
-            }
-            
-            if (!mdObject.eIsSet(ref))
-            {
-                continue;
-            }
-            
-            Object value = mdObject.eGet(ref);
-            if (!(value instanceof Collection))
-            {
-                continue;
-            }
-            
-            Collection<?> collection = (Collection<?>) value;
-            if (collection.isEmpty())
-            {
-                continue;
-            }
-            
-            String collectionName = formatFeatureName(ref.getName());
-            
+
+            String collectionName = formatFeatureName(((EReference) feature).getName());
+
             // Special handling for known collection types
             Object firstItem = collection.iterator().next();
-            
-            if (firstItem instanceof BasicForm)
-            {
-                formatFormsCollection(sb, collectionName, collection, language);
-            }
-            else if (firstItem instanceof BasicCommand)
-            {
-                formatCommandsCollection(sb, collectionName, collection, language);
-            }
-            else if (firstItem instanceof StandardAttribute)
-            {
-                // StandardAttributes are now formatted via formatStandardAttributes() method
-                // Skip them here to avoid duplication
-            }
-            else if (firstItem instanceof CharacteristicsDescription)
-            {
-                formatCharacteristicsCollection(sb, collectionName, collection);
-            }
-            else if (firstItem instanceof BasicTabularSection)
-            {
-                // Tabular Sections - format with extended details
-                formatTabularSectionsExtended(sb, collectionName, collection, full, language);
-            }
-            else if (firstItem instanceof BasicFeature)
-            {
-                // Attributes - format with extended properties
-                formatAttributesCollection(sb, collectionName, collection, full, language);
-            }
-            else if (firstItem instanceof java.util.Map.Entry)
-            {
-                // Handle EMap collections like Synonym, ObjectPresentation
-                formatMapEntryCollection(sb, collectionName, collection);
-            }
-            else if (firstItem instanceof MdObject)
-            {
-                formatMdObjectCollection(sb, collectionName, collection, full, language);
-            }
-            else if (firstItem instanceof EObject)
-            {
-                formatEObjectCollection(sb, collectionName, collection);
-            }
+
+            dispatchContainmentCollection(sb, collectionName, collection, firstItem, full, language);
+        }
+    }
+
+    /**
+     * Returns the containment-collection value of {@code feature} on {@code mdObject} when the
+     * feature is a non-derived, non-transient, non-volatile, set, many-valued containment
+     * {@link EReference} whose value is a {@link Collection}; otherwise returns {@code null}.
+     * Mirrors the original skip guards (each {@code null} return matches a {@code continue}).
+     */
+    private static Collection<?> eligibleContainmentCollection(EStructuralFeature feature, MdObject mdObject)
+    {
+        if (!(feature instanceof EReference))
+        {
+            return null;
+        }
+
+        EReference ref = (EReference) feature;
+
+        // Only process containment many-valued references
+        if (!ref.isContainment() || !ref.isMany())
+        {
+            return null;
+        }
+
+        // Skip derived, transient, volatile
+        if (ref.isDerived() || ref.isTransient() || ref.isVolatile())
+        {
+            return null;
+        }
+
+        if (!mdObject.eIsSet(ref))
+        {
+            return null;
+        }
+
+        Object value = mdObject.eGet(ref);
+        if (!(value instanceof Collection))
+        {
+            return null;
+        }
+
+        return (Collection<?>) value;
+    }
+
+    /**
+     * Dispatches a non-empty containment collection to the matching type-specific formatter, based on
+     * the runtime type of its first element ({@code firstItem}). Preserves the original if/else-if order.
+     */
+    private void dispatchContainmentCollection(StringBuilder sb, String collectionName, Collection<?> collection,
+        Object firstItem, boolean full, String language)
+    {
+        if (firstItem instanceof BasicForm)
+        {
+            formatFormsCollection(sb, collectionName, collection, language);
+        }
+        else if (firstItem instanceof BasicCommand)
+        {
+            formatCommandsCollection(sb, collectionName, collection, language);
+        }
+        else if (firstItem instanceof StandardAttribute)
+        {
+            // StandardAttributes are now formatted via formatStandardAttributes() method
+            // Skip them here to avoid duplication
+        }
+        else if (firstItem instanceof CharacteristicsDescription)
+        {
+            formatCharacteristicsCollection(sb, collectionName, collection);
+        }
+        else if (firstItem instanceof BasicTabularSection)
+        {
+            // Tabular Sections - format with extended details
+            formatTabularSectionsExtended(sb, collectionName, collection, full, language);
+        }
+        else if (firstItem instanceof BasicFeature)
+        {
+            // Attributes - format with extended properties
+            formatAttributesCollection(sb, collectionName, collection, full, language);
+        }
+        else if (firstItem instanceof java.util.Map.Entry)
+        {
+            // Handle EMap collections like Synonym, ObjectPresentation
+            formatMapEntryCollection(sb, collectionName, collection);
+        }
+        else if (firstItem instanceof MdObject)
+        {
+            formatMdObjectCollection(sb, collectionName, collection, full, language);
+        }
+        else if (firstItem instanceof EObject)
+        {
+            formatEObjectCollection(sb, collectionName, collection);
         }
     }
     
@@ -469,91 +490,123 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
     private void formatTabularSectionsExtended(StringBuilder sb, String name, Collection<?> items, boolean full, String language)
     {
         addSectionHeader(sb, name);
-        
+
         for (Object item : items)
         {
             if (item instanceof BasicTabularSection)
             {
-                BasicTabularSection ts = (BasicTabularSection) item;
-                
-                // Sub-header for this tabular section
-                sb.append("\n#### ").append(ts.getName()).append("\n\n");
-                
-                // Properties table for the TS itself
-                startTable(sb, "Property", VALUE_TOKEN);
-                addPropertyRow(sb, "Name", ts.getName());
-                addPropertyRow(sb, SYNONYM_TOKEN, getSynonym(ts.getSynonym(), language));
-                
-                String comment = ts.getComment();
-                if (comment != null && !comment.isEmpty())
+                formatTabularSection(sb, (BasicTabularSection) item, full, language);
+            }
+        }
+    }
+
+    /**
+     * Renders a single tabular section: its sub-header, the properties table (Name, Synonym, Comment,
+     * Tool Tip, Fill Checking, and the reflective Use / Line Number Length rows) and its attributes.
+     */
+    private void formatTabularSection(StringBuilder sb, BasicTabularSection ts, boolean full, String language)
+    {
+        // Sub-header for this tabular section
+        sb.append("\n#### ").append(ts.getName()).append("\n\n");
+
+        // Properties table for the TS itself
+        startTable(sb, "Property", VALUE_TOKEN);
+        addPropertyRow(sb, "Name", ts.getName());
+        addPropertyRow(sb, SYNONYM_TOKEN, getSynonym(ts.getSynonym(), language));
+
+        String comment = ts.getComment();
+        if (comment != null && !comment.isEmpty())
+        {
+            addPropertyRow(sb, "Comment", comment);
+        }
+
+        // Tool Tip
+        String toolTip = getSynonym(ts.getToolTip(), language);
+        if (toolTip != null && !toolTip.isEmpty())
+        {
+            addPropertyRow(sb, "Tool Tip", toolTip);
+        }
+
+        // Fill Checking
+        addPropertyRow(sb, "Fill Checking", formatEnum(ts.getFillChecking()));
+
+        formatTabularSectionUse(sb, ts);
+        formatTabularSectionLineNumberLength(sb, ts);
+        formatTabularSectionAttributes(sb, ts, full, language);
+    }
+
+    /**
+     * Adds the "Use" row of a tabular section, read reflectively (available in
+     * HierarchicalDbObjectTabularSection). No-op when the getter is absent or returns {@code null}.
+     */
+    private void formatTabularSectionUse(StringBuilder sb, BasicTabularSection ts)
+    {
+        // Use (via reflection, available in HierarchicalDbObjectTabularSection)
+        try
+        {
+            java.lang.reflect.Method method = ts.getClass().getMethod("getUse");
+            Object use = method.invoke(ts);
+            if (use != null)
+            {
+                addPropertyRow(sb, "Use", formatEnum(use));
+            }
+        }
+        catch (Exception e)
+        {
+            // Method doesn't exist - skip
+        }
+    }
+
+    /**
+     * Adds the "Line Number Length" row of a tabular section, read reflectively. No-op when the getter
+     * is absent or returns {@code null}.
+     */
+    private void formatTabularSectionLineNumberLength(StringBuilder sb, BasicTabularSection ts)
+    {
+        // LineNumberLength (via reflection)
+        try
+        {
+            java.lang.reflect.Method method = ts.getClass().getMethod("getLineNumberLength");
+            Object lineNumLen = method.invoke(ts);
+            if (lineNumLen != null)
+            {
+                addPropertyRow(sb, "Line Number Length", lineNumLen.toString());
+            }
+        }
+        catch (Exception e)
+        {
+            // Method doesn't exist - skip
+        }
+    }
+
+    /**
+     * Renders the attributes of a tabular section, obtained via EMF reflection on the
+     * {@code attributes} feature. No-op when the feature is absent or its collection is empty.
+     */
+    private void formatTabularSectionAttributes(StringBuilder sb, BasicTabularSection ts, boolean full, String language)
+    {
+        // Get attributes collection via EMF reflection
+        try
+        {
+            EObject eObj = (EObject) ts;
+            EStructuralFeature attrFeature = eObj.eClass().getEStructuralFeature("attributes");
+            if (attrFeature != null)
+            {
+                Object attrValue = eObj.eGet(attrFeature);
+                if (attrValue instanceof Collection && !((Collection<?>) attrValue).isEmpty())
                 {
-                    addPropertyRow(sb, "Comment", comment);
-                }
-                
-                // Tool Tip
-                String toolTip = getSynonym(ts.getToolTip(), language);
-                if (toolTip != null && !toolTip.isEmpty())
-                {
-                    addPropertyRow(sb, "Tool Tip", toolTip);
-                }
-                
-                // Fill Checking
-                addPropertyRow(sb, "Fill Checking", formatEnum(ts.getFillChecking()));
-                
-                // Use (via reflection, available in HierarchicalDbObjectTabularSection)
-                try
-                {
-                    java.lang.reflect.Method method = ts.getClass().getMethod("getUse");
-                    Object use = method.invoke(ts);
-                    if (use != null)
-                    {
-                        addPropertyRow(sb, "Use", formatEnum(use));
-                    }
-                }
-                catch (Exception e)
-                {
-                    // Method doesn't exist - skip
-                }
-                
-                // LineNumberLength (via reflection)
-                try
-                {
-                    java.lang.reflect.Method method = ts.getClass().getMethod("getLineNumberLength");
-                    Object lineNumLen = method.invoke(ts);
-                    if (lineNumLen != null)
-                    {
-                        addPropertyRow(sb, "Line Number Length", lineNumLen.toString());
-                    }
-                }
-                catch (Exception e)
-                {
-                    // Method doesn't exist - skip
-                }
-                
-                // Get attributes collection via EMF reflection
-                try
-                {
-                    EObject eObj = (EObject) ts;
-                    EStructuralFeature attrFeature = eObj.eClass().getEStructuralFeature("attributes");
-                    if (attrFeature != null)
-                    {
-                        Object attrValue = eObj.eGet(attrFeature);
-                        if (attrValue instanceof Collection && !((Collection<?>) attrValue).isEmpty())
-                        {
-                            Collection<?> attributes = (Collection<?>) attrValue;
-                            
-                            // Format attributes of this tabular section
-                            sb.append("\n**Attributes:**\n\n");
-                            formatAttributesCollection(sb, "", attributes, full, language);
-                        }
-                    }
-                }
-                catch (Exception e)
-                {
-                    // Error getting attributes - skip
-                    System.err.println("Error formatting tabular section attributes: " + e.getMessage());
+                    Collection<?> attributes = (Collection<?>) attrValue;
+
+                    // Format attributes of this tabular section
+                    sb.append("\n**Attributes:**\n\n");
+                    formatAttributesCollection(sb, "", attributes, full, language);
                 }
             }
+        }
+        catch (Exception e)
+        {
+            // Error getting attributes - skip
+            System.err.println("Error formatting tabular section attributes: " + e.getMessage());
         }
     }
     

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/reference/MetadataReferenceService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/reference/MetadataReferenceService.java
@@ -404,31 +404,37 @@ public class MetadataReferenceService
                 TypeItem typeItem = getTypeItem(type);
                 if (typeItem instanceof IBmObject)
                 {
-                    Collection<IBmCrossReference> refs = engine.getBackReferences((IBmObject) typeItem);
-                    for (IBmCrossReference ref : refs)
-                    {
-                        if (references.size() >= limit * 10)
-                        {
-                            break;
-                        }
-
-                        IBmObject sourceObject = ref.getObject();
-                        if (sourceObject == null || isInternalReference(ref))
-                        {
-                            continue;
-                        }
-
-                        String category = getCategoryFromObject(sourceObject);
-                        String sourcePath = getFullReferencePath(sourceObject, ref);
-                        if (sourcePath == null)
-                        {
-                            continue;
-                        }
-                        String feature = "Type: " + (ref.getFeature() != null ? ref.getFeature().getName() : ""); //$NON-NLS-1$ //$NON-NLS-2$
-
-                        addReference(new ReferenceInfo(category, sourcePath, feature));
-                    }
+                    collectTypeItemBackReferences(engine, (IBmObject) typeItem);
                 }
+            }
+        }
+
+        /** Collects the (non-internal) back references of a single produced-type item, tagged "Type: ...". */
+        private void collectTypeItemBackReferences(IBmEngine engine, IBmObject typeItem)
+        {
+            Collection<IBmCrossReference> refs = engine.getBackReferences(typeItem);
+            for (IBmCrossReference ref : refs)
+            {
+                if (references.size() >= limit * 10)
+                {
+                    break;
+                }
+
+                IBmObject sourceObject = ref.getObject();
+                if (sourceObject == null || isInternalReference(ref))
+                {
+                    continue;
+                }
+
+                String category = getCategoryFromObject(sourceObject);
+                String sourcePath = getFullReferencePath(sourceObject, ref);
+                if (sourcePath == null)
+                {
+                    continue;
+                }
+                String feature = "Type: " + (ref.getFeature() != null ? ref.getFeature().getName() : ""); //$NON-NLS-1$ //$NON-NLS-2$
+
+                addReference(new ReferenceInfo(category, sourcePath, feature));
             }
         }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BreakpointUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BreakpointUtils.java
@@ -149,11 +149,48 @@ public final class BreakpointUtils
 
         IBreakpointManager bpManager = DebugPlugin.getDefault().getBreakpointManager();
 
-        // Strategy 1: load EDT-specific BslLineBreakpoint via the owning bundle's
-        // class loader. The class lives in an `internal.*` package that OSGi will
-        // not export through Import-Package, so a plain Class.forName() from this
-        // bundle would fail with ClassNotFoundException — but Bundle.loadClass()
-        // bypasses the export restriction and returns the class directly.
+        // Strategy 1: load EDT-specific BslLineBreakpoint via the owning bundle's class loader.
+        IBreakpoint edtBreakpoint = tryCreateEdtBreakpoint(file, lineNumber, bpManager);
+        if (edtBreakpoint != null)
+        {
+            return edtBreakpoint;
+        }
+
+        // Strategy 2: create marker of EDT type and wrap as generic ILineBreakpoint via DebugPlugin
+        IBreakpoint markerBreakpoint = tryCreateMarkerBreakpoint(file, lineNumber, bpManager);
+        if (markerBreakpoint != null)
+        {
+            return markerBreakpoint;
+        }
+
+        // Strategy 3: generic Eclipse line marker (least useful, but compiles & runs)
+        IMarker marker = file.createMarker(GENERIC_LINE_MARKER);
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put(IMarker.LINE_NUMBER, Integer.valueOf(lineNumber));
+        attrs.put(IBreakpoint.ENABLED, Boolean.TRUE);
+        marker.setAttributes(attrs);
+        MarkerOnlyBreakpoint fallback = new MarkerOnlyBreakpoint(marker);
+        bpManager.addBreakpoint(fallback);
+        fallback.registered = true;
+        return fallback;
+    }
+
+    /**
+     * Strategy 1: loads the EDT-specific {@code BslLineBreakpoint} via the owning bundle's class loader
+     * and instantiates it. The class lives in an {@code internal.*} package that OSGi will not export
+     * through Import-Package, so a plain {@code Class.forName()} from this bundle would fail with
+     * {@code ClassNotFoundException} — but {@code Bundle.loadClass()} bypasses the export restriction and
+     * returns the class directly. Registers the created breakpoint with the manager (EDT's constructor
+     * creates the marker but does not register). Behaviour-identical to the former inline Strategy 1.
+     *
+     * @param file the resource the breakpoint is on
+     * @param lineNumber the 1-based line number
+     * @param bpManager the breakpoint manager to register with
+     * @return the created EDT breakpoint, or {@code null} when the bundle/class is unavailable
+     */
+    private static IBreakpoint tryCreateEdtBreakpoint(IFile file, int lineNumber,
+            IBreakpointManager bpManager)
+    {
         Bundle debugCoreBundle = Platform.getBundle(BSL_DEBUG_CORE_BUNDLE);
         if (debugCoreBundle != null)
         {
@@ -191,8 +228,24 @@ public final class BreakpointUtils
             Activator.logError("Bundle " + BSL_DEBUG_CORE_BUNDLE //$NON-NLS-1$
                     + " not found — falling back to marker", new IllegalStateException("bundle missing")); //$NON-NLS-1$ //$NON-NLS-2$
         }
+        return null;
+    }
 
-        // Strategy 2: create marker of EDT type and wrap as generic ILineBreakpoint via DebugPlugin
+    /**
+     * Strategy 2: creates a marker of an EDT breakpoint type and wraps it as a generic breakpoint via the
+     * {@link DebugPlugin}. When EDT is loaded it picks the marker up via its lifecycle listener; otherwise
+     * the marker is kept and reported as a degraded {@link MarkerOnlyBreakpoint}. Behaviour-identical to
+     * the former inline Strategy 2: returns on the first marker type that does not throw, falling through
+     * (returning {@code null}) only when every marker type fails.
+     *
+     * @param file the resource the breakpoint is on
+     * @param lineNumber the 1-based line number
+     * @param bpManager the breakpoint manager to register with
+     * @return the created/looked-up breakpoint, or {@code null} when every marker type throws
+     */
+    private static IBreakpoint tryCreateMarkerBreakpoint(IFile file, int lineNumber,
+            IBreakpointManager bpManager)
+    {
         for (String markerType : BSL_MARKER_TYPES)
         {
             try
@@ -221,17 +274,7 @@ public final class BreakpointUtils
                 // try next marker type
             }
         }
-
-        // Strategy 3: generic Eclipse line marker (least useful, but compiles & runs)
-        IMarker marker = file.createMarker(GENERIC_LINE_MARKER);
-        Map<String, Object> attrs = new HashMap<>();
-        attrs.put(IMarker.LINE_NUMBER, Integer.valueOf(lineNumber));
-        attrs.put(IBreakpoint.ENABLED, Boolean.TRUE);
-        marker.setAttributes(attrs);
-        MarkerOnlyBreakpoint fallback = new MarkerOnlyBreakpoint(marker);
-        bpManager.addBreakpoint(fallback);
-        fallback.registered = true;
-        return fallback;
+        return null;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/GuideRenderer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/GuideRenderer.java
@@ -112,33 +112,8 @@ public final class GuideRenderer
      */
     private static void appendParameters(StringBuilder sb, String inputSchema)
     {
-        JsonObject properties = null;
-        JsonArray required = null;
-        try
-        {
-            if (inputSchema != null && !inputSchema.isEmpty())
-            {
-                JsonElement parsed = JsonParser.parseString(inputSchema);
-                if (parsed != null && parsed.isJsonObject())
-                {
-                    JsonObject root = parsed.getAsJsonObject();
-                    if (root.has(PROPERTIES) && root.get(PROPERTIES).isJsonObject())
-                    {
-                        properties = root.getAsJsonObject(PROPERTIES);
-                    }
-                    if (root.has(REQUIRED) && root.get(REQUIRED).isJsonArray())
-                    {
-                        required = root.getAsJsonArray(REQUIRED);
-                    }
-                }
-            }
-        }
-        catch (RuntimeException e)
-        {
-            // Malformed schema: skip the table gracefully, never throw.
-            properties = null;
-            required = null;
-        }
+        ParsedSchema schema = parseSchema(inputSchema);
+        JsonObject properties = schema.properties;
 
         if (properties == null || properties.size() == 0)
         {
@@ -149,18 +124,81 @@ public final class GuideRenderer
         sb.append(MarkdownUtils.tableHeader("Parameter", "Required", "Type", "Description")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
         for (Map.Entry<String, JsonElement> entry : properties.entrySet())
         {
-            String name = entry.getKey();
-            JsonObject prop = entry.getValue().isJsonObject() ? entry.getValue().getAsJsonObject() : new JsonObject();
-
-            String requiredCell = isRequired(required, name) ? "yes" : "—"; //$NON-NLS-1$ //$NON-NLS-2$
-            String type = prop.has("type") && prop.get("type").isJsonPrimitive() //$NON-NLS-1$ //$NON-NLS-2$
-                ? prop.get("type").getAsString() : ""; //$NON-NLS-1$ //$NON-NLS-2$
-            String typeCell = appendEnum(type, prop);
-            String descriptionCell = prop.has(DESCRIPTION) && prop.get(DESCRIPTION).isJsonPrimitive()
-                ? prop.get(DESCRIPTION).getAsString() : ""; //$NON-NLS-1$
-
-            sb.append(MarkdownUtils.tableRow(name, requiredCell, typeCell, descriptionCell));
+            sb.append(renderParameterRow(entry, schema.required));
         }
+    }
+
+    /**
+     * Holds the {@code properties} object and {@code required} array parsed from an input schema.
+     * Either field may be {@code null} when absent or when the schema is malformed.
+     */
+    private static final class ParsedSchema
+    {
+        private JsonObject properties;
+        private JsonArray required;
+    }
+
+    /**
+     * Defensively parses the JSON {@code inputSchema}, extracting its {@code properties} object and
+     * {@code required} array. Any malformed schema is swallowed and an empty result is returned (the
+     * method never throws).
+     *
+     * @param inputSchema the tool's input schema as a JSON string (may be {@code null}/empty)
+     * @return the parsed properties/required pair; fields are {@code null} when absent or on error
+     */
+    private static ParsedSchema parseSchema(String inputSchema)
+    {
+        ParsedSchema result = new ParsedSchema();
+        try
+        {
+            if (inputSchema != null && !inputSchema.isEmpty())
+            {
+                JsonElement parsed = JsonParser.parseString(inputSchema);
+                if (parsed != null && parsed.isJsonObject())
+                {
+                    JsonObject root = parsed.getAsJsonObject();
+                    if (root.has(PROPERTIES) && root.get(PROPERTIES).isJsonObject())
+                    {
+                        result.properties = root.getAsJsonObject(PROPERTIES);
+                    }
+                    if (root.has(REQUIRED) && root.get(REQUIRED).isJsonArray())
+                    {
+                        result.required = root.getAsJsonArray(REQUIRED);
+                    }
+                }
+            }
+        }
+        catch (RuntimeException e)
+        {
+            // Malformed schema: skip the table gracefully, never throw.
+            result.properties = null;
+            result.required = null;
+        }
+
+        return result;
+    }
+
+    /**
+     * Renders a single parameter row (Parameter, Required, Type, Description) for one
+     * {@code properties} entry, resolving its required flag against {@code required}.
+     *
+     * @param entry the property entry (name to schema)
+     * @param required the schema's required array (may be {@code null})
+     * @return the rendered Markdown table row
+     */
+    private static String renderParameterRow(Map.Entry<String, JsonElement> entry, JsonArray required)
+    {
+        String name = entry.getKey();
+        JsonObject prop = entry.getValue().isJsonObject() ? entry.getValue().getAsJsonObject() : new JsonObject();
+
+        String requiredCell = isRequired(required, name) ? "yes" : "—"; //$NON-NLS-1$ //$NON-NLS-2$
+        String type = prop.has("type") && prop.get("type").isJsonPrimitive() //$NON-NLS-1$ //$NON-NLS-2$
+            ? prop.get("type").getAsString() : ""; //$NON-NLS-1$ //$NON-NLS-2$
+        String typeCell = appendEnum(type, prop);
+        String descriptionCell = prop.has(DESCRIPTION) && prop.get(DESCRIPTION).isJsonPrimitive()
+            ? prop.get(DESCRIPTION).getAsString() : ""; //$NON-NLS-1$
+
+        return MarkdownUtils.tableRow(name, requiredCell, typeCell, descriptionCell);
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataPropertyIntrospector.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataPropertyIntrospector.java
@@ -261,49 +261,64 @@ public final class MetadataPropertyIntrospector
         }
         if (feature instanceof EAttribute)
         {
-            EClassifier type = ((EAttribute)feature).getEAttributeType();
-            if (type instanceof EEnum)
-            {
-                return ValueKind.ENUM;
-            }
-            String typeName = type != null ? type.getInstanceClassName() : null;
-            if ("boolean".equals(typeName) || "java.lang.Boolean".equals(typeName)) //$NON-NLS-1$ //$NON-NLS-2$
-            {
-                return ValueKind.BOOLEAN;
-            }
-            if ("int".equals(typeName) || "java.lang.Integer".equals(typeName) //$NON-NLS-1$ //$NON-NLS-2$
-                || "long".equals(typeName) || "java.lang.Long".equals(typeName)) //$NON-NLS-1$ //$NON-NLS-2$
-            {
-                return ValueKind.INTEGER;
-            }
-            return ValueKind.STRING;
+            return classifyAttribute((EAttribute)feature);
         }
         if (feature instanceof EReference)
         {
-            EReference ref = (EReference)feature;
-            // The synonym (and other localized strings) is a containment map-entry reference reached
-            // via getSynonym(); the data type is a contained TypeDescription. Both ARE assignable
-            // values. Every other reference - child collections (attributes/forms/...) and plain
-            // object references - is NOT a simple assignable value, so it is excluded (null).
-            if ("synonym".equals(ref.getName()) || isMapEntry(ref)) //$NON-NLS-1$
-            {
-                return ValueKind.LOCALIZED_STRING;
-            }
-            if (isTypeDescription(ref))
-            {
-                return ValueKind.TYPE_DESCRIPTION;
-            }
-            // A non-containment reference whose target is a metadata object (MdObject subtype) is a
-            // plain object reference, settable by FQN. Containment refs (child collections) and
-            // non-MdObject refs (e.g. the EObject-typed suppressObject) are excluded. Derived /
-            // transient / non-changeable refs are already filtered upstream by isAssignable.
-            EClass targetType = ref.getEReferenceType();
-            if (!ref.isContainment() && targetType != null
-                && MdClassPackage.Literals.MD_OBJECT.isSuperTypeOf(targetType))
-            {
-                return ref.isMany() ? ValueKind.MANY_REFERENCE : ValueKind.REFERENCE;
-            }
-            return null;
+            return classifyReference((EReference)feature);
+        }
+        return null;
+    }
+
+    /** Classifies an attribute feature into a scalar {@link ValueKind} (enum / boolean / integer / string). */
+    private static ValueKind classifyAttribute(EAttribute feature)
+    {
+        EClassifier type = feature.getEAttributeType();
+        if (type instanceof EEnum)
+        {
+            return ValueKind.ENUM;
+        }
+        String typeName = type != null ? type.getInstanceClassName() : null;
+        if ("boolean".equals(typeName) || "java.lang.Boolean".equals(typeName)) //$NON-NLS-1$ //$NON-NLS-2$
+        {
+            return ValueKind.BOOLEAN;
+        }
+        if ("int".equals(typeName) || "java.lang.Integer".equals(typeName) //$NON-NLS-1$ //$NON-NLS-2$
+            || "long".equals(typeName) || "java.lang.Long".equals(typeName)) //$NON-NLS-1$ //$NON-NLS-2$
+        {
+            return ValueKind.INTEGER;
+        }
+        return ValueKind.STRING;
+    }
+
+    /**
+     * Classifies a reference feature: the localized synonym map and the contained TypeDescription are
+     * assignable values; a non-containment reference to an {@code MdObject} is a plain object reference
+     * (single or many); every other reference is excluded ({@code null}).
+     */
+    private static ValueKind classifyReference(EReference ref)
+    {
+        // The synonym (and other localized strings) is a containment map-entry reference reached
+        // via getSynonym(); the data type is a contained TypeDescription. Both ARE assignable
+        // values. Every other reference - child collections (attributes/forms/...) and plain
+        // object references - is NOT a simple assignable value, so it is excluded (null).
+        if ("synonym".equals(ref.getName()) || isMapEntry(ref)) //$NON-NLS-1$
+        {
+            return ValueKind.LOCALIZED_STRING;
+        }
+        if (isTypeDescription(ref))
+        {
+            return ValueKind.TYPE_DESCRIPTION;
+        }
+        // A non-containment reference whose target is a metadata object (MdObject subtype) is a
+        // plain object reference, settable by FQN. Containment refs (child collections) and
+        // non-MdObject refs (e.g. the EObject-typed suppressObject) are excluded. Derived /
+        // transient / non-changeable refs are already filtered upstream by isAssignable.
+        EClass targetType = ref.getEReferenceType();
+        if (!ref.isContainment() && targetType != null
+            && MdClassPackage.Literals.MD_OBJECT.isSuperTypeOf(targetType))
+        {
+            return ref.isMany() ? ValueKind.MANY_REFERENCE : ValueKind.REFERENCE;
         }
         return null;
     }


### PR DESCRIPTION
Tier-C part 3 of the SonarCloud code-smell cleanup (#164): the **cc 23-30** band of S3776 (non-god-class), branched from current master. **33 of 37** methods reduced under the limit of 15 via 2-3 Extract-Method refactors each; 4 skipped (parent-targeting returns / multi-local mutation / would touch a write-transaction). Same rigorous pipeline: deep-study implement → **9 INDEPENDENT adversarial verify agents** (every diff reviewed) → `mvn clean verify` (2202 tests). Where a block carried an early return it was threaded out via a small **holder** object / nullable error-String so the parent re-checks and returns the SAME value in the SAME cases. **Destructive tools handled with extra care** — only side-effect-free blocks extracted; the delete/update/write-transaction/Job action stays inline at the same point under the same confirm-gate (DeleteInfobaseTool, UpdateDatabaseTool, CleanProjectTool, RevalidateObjectsTool, ModifyMetadataTool, CreateInfobaseTool, AdoptMetadataObjectTool, CreateLaunchConfigTool, ResyncToDiskTool). One checked-exception fix the build caught (StepTool.performStep now `throws DebugException`, same catch as before). No behaviour change. Follows #166–170, #172, #173.