### PR TITLE
Reduce cognitive complexity via Extract Method, part 4 (S3776 cc 31-40, 25 methods)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/internal/GroupServiceImpl.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/internal/GroupServiceImpl.java
@@ -227,40 +227,10 @@ public class GroupServiceImpl implements IGroupService, IResourceChangeListener 
             if (service == null) {
                 break;
             }
-            
+
             try {
                 WatchKey key = service.take();
-                java.nio.file.Path settingsPath;
-                
-                synchronized (watcherLock) {
-                    settingsPath = watchKeyToPath.get(key);
-                }
-                
-                if (settingsPath != null) {
-                    for (WatchEvent<?> event : key.pollEvents()) {
-                        if (event.kind() == StandardWatchEventKinds.OVERFLOW) {
-                            continue;
-                        }
-                        
-                        @SuppressWarnings("unchecked")
-                        WatchEvent<java.nio.file.Path> pathEvent = (WatchEvent<java.nio.file.Path>) event;
-                        java.nio.file.Path fileName = pathEvent.context();
-                        
-                        if (GroupConstants.GROUPS_FILE.equals(fileName.toString())) {
-                            java.nio.file.Path projectPath = settingsPath.getParent();
-                            if (projectPath != null) {
-                                refreshProjectGroups(projectPath.getFileName().toString());
-                            }
-                        }
-                    }
-                }
-                
-                boolean valid = key.reset();
-                if (!valid) {
-                    synchronized (watcherLock) {
-                        watchKeyToPath.remove(key);
-                    }
-                }
+                processWatchKey(key);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 break;
@@ -268,6 +238,58 @@ public class GroupServiceImpl implements IGroupService, IResourceChangeListener 
                 if (!shutdown.get()) {
                     Activator.logError("Error in file watcher", e);
                 }
+            }
+        }
+    }
+
+    /**
+     * Processes the pending events of a single watch key: refreshes affected project groups and
+     * resets the key (dropping it from the registry when it is no longer valid). Extracted from
+     * {@link #runFileWatcher()} to keep that loop's complexity in check; carries no checked
+     * exception of its own.
+     */
+    private void processWatchKey(WatchKey key) {
+        java.nio.file.Path settingsPath;
+
+        synchronized (watcherLock) {
+            settingsPath = watchKeyToPath.get(key);
+        }
+
+        if (settingsPath != null) {
+            for (WatchEvent<?> event : key.pollEvents()) {
+                processWatchEvent(event, settingsPath);
+            }
+        }
+
+        boolean valid = key.reset();
+        if (!valid) {
+            synchronized (watcherLock) {
+                watchKeyToPath.remove(key);
+            }
+        }
+    }
+
+    /**
+     * Handles a single watch event: when it refers to the groups file, refreshes the owning
+     * project's groups. Overflow events are ignored. Extracted from {@link #processWatchKey(WatchKey)}
+     * to keep its nesting shallow.
+     *
+     * @param event the watch event to handle
+     * @param settingsPath the watched {@code .settings} directory the event originated from
+     */
+    private void processWatchEvent(WatchEvent<?> event, java.nio.file.Path settingsPath) {
+        if (event.kind() == StandardWatchEventKinds.OVERFLOW) {
+            return;
+        }
+
+        @SuppressWarnings("unchecked")
+        WatchEvent<java.nio.file.Path> pathEvent = (WatchEvent<java.nio.file.Path>) event;
+        java.nio.file.Path fileName = pathEvent.context();
+
+        if (GroupConstants.GROUPS_FILE.equals(fileName.toString())) {
+            java.nio.file.Path projectPath = settingsPath.getParent();
+            if (projectPath != null) {
+                refreshProjectGroups(projectPath.getFileName().toString());
             }
         }
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/McpProtocolHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/McpProtocolHandler.java
@@ -309,33 +309,34 @@ public class McpProtocolHandler
         boolean plainTextMode = Activator.getDefault() != null
             && Activator.getDefault().getPreferenceStore()
                 .getBoolean(PreferenceConstants.PREF_PLAIN_TEXT_MODE);
-        
+
         // Return response based on tool's declared response type
+        return buildToolCallResponse(tool, result, signal, plainTextMode, requestId, params);
+    }
+
+    /**
+     * Builds the tools/call response from the raw tool {@code result}, dispatching on
+     * the tool's declared {@link IMcpTool.ResponseType}. Holds the per-type delivery
+     * logic extracted verbatim from {@link #handleToolCall}: signal augmentation, the
+     * plain-text fallback, the structuredContent capability gate (JSON), and the
+     * error-diversion to a structured JSON error (non-JSON types). Returns the same
+     * response in the same case as the original inline switch.
+     *
+     * @param tool the resolved tool
+     * @param result the raw tool result payload (may be augmented per type)
+     * @param signal a user signal raised during execution, or {@code null}
+     * @param plainTextMode whether Cursor-compatible plain-text mode is enabled
+     * @param requestId the JSON-RPC request id to echo
+     * @param params the tool params (used only for the result file name)
+     * @return the serialized JSON-RPC response
+     */
+    private String buildToolCallResponse(IMcpTool tool, String result, UserSignal signal,
+        boolean plainTextMode, Object requestId, Map<String, String> params)
+    {
         switch (tool.getResponseType())
         {
             case JSON:
-                // For JSON, add signal as a separate field if present
-                if (signal != null)
-                {
-                    // Parse JSON and add userSignal field
-                    result = addUserSignalToJson(result, signal);
-                }
-                // In plain text mode, return markdown as plain text instead of structured content
-                if (plainTextMode)
-                {
-                    return buildToolCallTextResponse(result, requestId);
-                }
-                // Capability gate for structuredContent. By DEFAULT (no capabilities,
-                // or a client that does not explicitly opt out) this is true, so the
-                // structuredContent response below is emitted exactly as before — the
-                // no-regression guarantee. Only a client that EXPLICITLY declared it
-                // cannot accept structuredContent suppresses it; the JSON payload is
-                // then delivered as text so the data is still returned.
-                if (!clientCapabilities.get().allowsStructuredContent())
-                {
-                    return buildToolCallTextResponse(result, requestId);
-                }
-                return buildToolCallJsonResponse(result, requestId, tool.getName());
+                return buildJsonToolResponse(tool, result, signal, plainTextMode, requestId);
             case MARKDOWN:
                 // A ToolResult.error JSON payload is delivered as a structured JSON
                 // error (isError:true) instead of a markdown resource, so failures
@@ -398,6 +399,48 @@ public class McpProtocolHandler
                 }
                 return buildToolCallTextResponse(result, requestId);
         }
+    }
+
+    /**
+     * Builds the {@code ResponseType.JSON} tools/call response, holding the JSON-case
+     * logic extracted verbatim from {@link #handleToolCall}: a user signal is merged in
+     * as a {@code userSignal} field; plain-text mode delivers the payload as text; the
+     * structuredContent capability gate suppresses structured content only when the
+     * client explicitly opted out (default keeps it). Returns the same response in the
+     * same case as the original inline {@code JSON} branch.
+     *
+     * @param tool the resolved tool (its name is used for the JSON response)
+     * @param result the raw JSON tool result payload
+     * @param signal a user signal raised during execution, or {@code null}
+     * @param plainTextMode whether Cursor-compatible plain-text mode is enabled
+     * @param requestId the JSON-RPC request id to echo
+     * @return the serialized JSON-RPC response
+     */
+    private String buildJsonToolResponse(IMcpTool tool, String result, UserSignal signal,
+        boolean plainTextMode, Object requestId)
+    {
+        // For JSON, add signal as a separate field if present
+        if (signal != null)
+        {
+            // Parse JSON and add userSignal field
+            result = addUserSignalToJson(result, signal);
+        }
+        // In plain text mode, return markdown as plain text instead of structured content
+        if (plainTextMode)
+        {
+            return buildToolCallTextResponse(result, requestId);
+        }
+        // Capability gate for structuredContent. By DEFAULT (no capabilities,
+        // or a client that does not explicitly opt out) this is true, so the
+        // structuredContent response below is emitted exactly as before — the
+        // no-regression guarantee. Only a client that EXPLICITLY declared it
+        // cannot accept structuredContent suppresses it; the JSON payload is
+        // then delivered as text so the data is still returned.
+        if (!clientCapabilities.get().allowsStructuredContent())
+        {
+            return buildToolCallTextResponse(result, requestId);
+        }
+        return buildToolCallJsonResponse(result, requestId, tool.getName());
     }
     
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagSearchFilter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagSearchFilter.java
@@ -250,77 +250,104 @@ public class TagSearchFilter extends ViewerFilter {
         
         // Check if element matches
         if (element instanceof EObject eObject) {
-            // Get the project this EObject belongs to for project-specific matching
-            IProject project = TagUtils.extractProject(eObject);
-            if (project != null) {
-                currentFilterProject = project;
-            }
-            
-            // Special handling for Configuration - always visible if there are matching FQNs for this project
-            String typeName = eObject.eClass().getName();
-            if ("Configuration".equals(typeName)) {
-                Set<String> projectFqns = getMatchingFqnsForProject(currentFilterProject);
-                return !projectFqns.isEmpty();
-            }
-            
-            String fqn = TagUtils.extractFqn(eObject);
-
-            if (fqn != null) {
-                // Check if this FQN or any parent matches IN THIS PROJECT
-                boolean result = matchesFqnOrParentInProject(fqn, currentFilterProject);
-                
-                // Special handling for Subsystems: parent subsystem should be visible if ANY child matches
-                // Using hardcoded "Subsystem" as the EClass name
-                if (!result && "Subsystem".equals(typeName)) {
-                    result = hasMatchingChildSubsystemInProject(eObject, currentFilterProject);
-                }
-                
-                return result;
-            } else {
-                // If we can't extract FQN, assume visible (might be a special element)
-                return true;
-            }
+            return selectEObject(eObject);
         } else {
-            // Check if this is a Navigator folder (e.g., DocumentNavigatorAdapter$Folder)
-            String className = element.getClass().getName();
-            
-            // Handle CommonNavigatorAdapter - it's the "Common" folder containing subsystems, common modules, etc.
-            if (className.endsWith("CommonNavigatorAdapter")) {
-                // Check if any matching FQN belongs to a "common" metadata type
-                return hasMatchingFqnsForAnyType(COMMON_METADATA_TYPES);
-            }
-            
-            // Handle navigator folder containers - fix operator precedence
-            if (className.contains("NavigatorAdapter$Folder") || 
-                    (className.contains("NavigatorAdapter") && !className.endsWith("CommonNavigatorAdapter"))) {
-                
-                // First, try to handle as a nested object folder (Attributes, TabularSections, etc.)
-                // These folders have a parent EObject and a model object name
-                Boolean nestedResult = checkNestedObjectFolder(element);
-                if (nestedResult != null) {
-                    return nestedResult;
-                }
-                
-                // Fall back to type-based check for top-level folders
-                String metadataType = extractMetadataTypeFromFolderClass(className);
-                if (metadataType != null) {
-                    return hasMatchingFqnsForType(metadataType);
-                }
-            }
-            
-            // Try to unwrap CommonNavigatorAdapter or similar
-            EObject unwrapped = TagUtils.unwrapToEObject(element);
-            if (unwrapped != null) {
-                String fqn = TagUtils.extractFqn(unwrapped);
-                if (fqn != null) {
-                    return matchesFqnOrParent(fqn);
-                }
-            }
-            
-            // IMPORTANT: Unknown elements should NOT be visible by default during tag search!
-            // Only show elements we explicitly matched
-            return false;
+            return selectByElementClass(element);
         }
+    }
+
+    /**
+     * Decides visibility for an {@link EObject} element: Configuration is shown when its project has
+     * any matching FQNs; otherwise the element's FQN (or a child subsystem for a Subsystem) is checked
+     * against the matching FQNs. Elements without an FQN are assumed visible. Extracted verbatim from
+     * {@link #selectByMatchingFqns(Object, Object)}; updates {@link #currentFilterProject} exactly as
+     * the inlined block did.
+     *
+     * @param eObject the element to test
+     * @return true if the element should be visible
+     */
+    private boolean selectEObject(EObject eObject) {
+        // Get the project this EObject belongs to for project-specific matching
+        IProject project = TagUtils.extractProject(eObject);
+        if (project != null) {
+            currentFilterProject = project;
+        }
+
+        // Special handling for Configuration - always visible if there are matching FQNs for this project
+        String typeName = eObject.eClass().getName();
+        if ("Configuration".equals(typeName)) {
+            Set<String> projectFqns = getMatchingFqnsForProject(currentFilterProject);
+            return !projectFqns.isEmpty();
+        }
+
+        String fqn = TagUtils.extractFqn(eObject);
+
+        if (fqn != null) {
+            // Check if this FQN or any parent matches IN THIS PROJECT
+            boolean result = matchesFqnOrParentInProject(fqn, currentFilterProject);
+
+            // Special handling for Subsystems: parent subsystem should be visible if ANY child matches
+            // Using hardcoded "Subsystem" as the EClass name
+            if (!result && "Subsystem".equals(typeName)) {
+                result = hasMatchingChildSubsystemInProject(eObject, currentFilterProject);
+            }
+
+            return result;
+        } else {
+            // If we can't extract FQN, assume visible (might be a special element)
+            return true;
+        }
+    }
+
+    /**
+     * Decides visibility for a non-{@link EObject} navigator element by inspecting its class name:
+     * the "Common" folder, navigator folder containers (nested-object or top-level type folders), and
+     * a final attempt to unwrap an underlying EObject. Unknown elements are hidden. Extracted verbatim
+     * from {@link #selectByMatchingFqns(Object, Object)}.
+     *
+     * @param element the navigator element to test
+     * @return true if the element should be visible
+     */
+    private boolean selectByElementClass(Object element) {
+        // Check if this is a Navigator folder (e.g., DocumentNavigatorAdapter$Folder)
+        String className = element.getClass().getName();
+
+        // Handle CommonNavigatorAdapter - it's the "Common" folder containing subsystems, common modules, etc.
+        if (className.endsWith("CommonNavigatorAdapter")) {
+            // Check if any matching FQN belongs to a "common" metadata type
+            return hasMatchingFqnsForAnyType(COMMON_METADATA_TYPES);
+        }
+
+        // Handle navigator folder containers - fix operator precedence
+        if (className.contains("NavigatorAdapter$Folder") ||
+                (className.contains("NavigatorAdapter") && !className.endsWith("CommonNavigatorAdapter"))) {
+
+            // First, try to handle as a nested object folder (Attributes, TabularSections, etc.)
+            // These folders have a parent EObject and a model object name
+            Boolean nestedResult = checkNestedObjectFolder(element);
+            if (nestedResult != null) {
+                return nestedResult;
+            }
+
+            // Fall back to type-based check for top-level folders
+            String metadataType = extractMetadataTypeFromFolderClass(className);
+            if (metadataType != null) {
+                return hasMatchingFqnsForType(metadataType);
+            }
+        }
+
+        // Try to unwrap CommonNavigatorAdapter or similar
+        EObject unwrapped = TagUtils.unwrapToEObject(element);
+        if (unwrapped != null) {
+            String fqn = TagUtils.extractFqn(unwrapped);
+            if (fqn != null) {
+                return matchesFqnOrParent(fqn);
+            }
+        }
+
+        // IMPORTANT: Unknown elements should NOT be visible by default during tag search!
+        // Only show elements we explicitly matched
+        return false;
     }
     
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
@@ -1286,61 +1286,22 @@ public class CreateInfobaseTool implements IMcpTool
         {
             appsArray = new JsonArray();
             newAppId = null;
+            String[] newAppIdHolder = new String[1];
 
-            try
+            if (!readBackApplications(appManager, project, ibRef, appsArray, newAppIdHolder))
             {
-                List<IApplication> applications = appManager.getApplications(project);
-                if (applications != null)
-                {
-                    for (IApplication app : applications)
-                    {
-                        JsonObject appObj = new JsonObject();
-                        appObj.addProperty("id", app.getId()); //$NON-NLS-1$
-                        appObj.addProperty("name", app.getName()); //$NON-NLS-1$
-                        if (app.getType() != null)
-                        {
-                            appObj.addProperty("type", app.getType().getId()); //$NON-NLS-1$
-                        }
-                        addUpdateState(appObj, appManager, app);
-                        // Identify the newly created application by matching the infobase reference.
-                        if (newAppId == null
-                            && app instanceof IInfobaseApplication
-                            && INFOBASE_APP_TYPE.equals(
-                                app.getType() != null ? app.getType().getId() : null))
-                        {
-                            IInfobaseApplication ibApp = (IInfobaseApplication) app;
-                            if (ibApp.getInfobase() != null
-                                && matchesRef(ibApp.getInfobase(), ibRef))
-                            {
-                                newAppId = app.getId();
-                            }
-                        }
-                        appsArray.add(appObj);
-                    }
-                }
+                break; // Read failed (logged) — stop re-polling.
             }
-            catch (ApplicationException e)
-            {
-                Activator.logError("create_infobase: error reading back applications", e); //$NON-NLS-1$
-                break;
-            }
+            newAppId = newAppIdHolder[0];
 
             if (newAppId != null)
             {
                 break; // Found the new application — no need to re-poll.
             }
 
-            if (poll < READ_BACK_MAX_POLLS - 1)
+            if (poll < READ_BACK_MAX_POLLS - 1 && !sleepBetweenPolls())
             {
-                try
-                {
-                    Thread.sleep(READ_BACK_POLL_DELAY_MS);
-                }
-                catch (InterruptedException ie)
-                {
-                    Thread.currentThread().interrupt();
-                    break;
-                }
+                break; // Interrupted — stop re-polling.
             }
         }
 
@@ -1365,6 +1326,84 @@ public class CreateInfobaseTool implements IMcpTool
         result.put(McpKeys.MESSAGE, message);
 
         return result.toJson();
+    }
+
+    /**
+     * Reads the project's applications once, populating {@code appsArray} with one JSON object per
+     * application and storing the matched new-infobase application id in {@code newAppIdHolder[0]}
+     * (left {@code null} when not yet visible). Read-only.
+     *
+     * @return {@code true} if the read completed (whether or not the new application was found),
+     *         {@code false} if reading the applications failed (already logged) so the caller stops
+     *         re-polling
+     */
+    private static boolean readBackApplications(IApplicationManager appManager, IProject project,
+            InfobaseReference ibRef, JsonArray appsArray, String[] newAppIdHolder)
+    {
+        try
+        {
+            List<IApplication> applications = appManager.getApplications(project);
+            if (applications != null)
+            {
+                for (IApplication app : applications)
+                {
+                    JsonObject appObj = new JsonObject();
+                    appObj.addProperty("id", app.getId()); //$NON-NLS-1$
+                    appObj.addProperty("name", app.getName()); //$NON-NLS-1$
+                    if (app.getType() != null)
+                    {
+                        appObj.addProperty("type", app.getType().getId()); //$NON-NLS-1$
+                    }
+                    addUpdateState(appObj, appManager, app);
+                    // Identify the newly created application by matching the infobase reference.
+                    if (newAppIdHolder[0] == null && isMatchingNewInfobaseApp(app, ibRef))
+                    {
+                        newAppIdHolder[0] = app.getId();
+                    }
+                    appsArray.add(appObj);
+                }
+            }
+            return true;
+        }
+        catch (ApplicationException e)
+        {
+            Activator.logError("create_infobase: error reading back applications", e); //$NON-NLS-1$
+            return false;
+        }
+    }
+
+    /**
+     * Whether the application is the newly created FILE infobase application, identified by type and
+     * a connection-string match against {@code ibRef}. Read-only.
+     */
+    private static boolean isMatchingNewInfobaseApp(IApplication app, InfobaseReference ibRef)
+    {
+        if (!(app instanceof IInfobaseApplication)
+            || !INFOBASE_APP_TYPE.equals(app.getType() != null ? app.getType().getId() : null))
+        {
+            return false;
+        }
+        IInfobaseApplication ibApp = (IInfobaseApplication) app;
+        return ibApp.getInfobase() != null && matchesRef(ibApp.getInfobase(), ibRef);
+    }
+
+    /**
+     * Sleeps {@link #READ_BACK_POLL_DELAY_MS} between read-back polls. Returns {@code false} (with
+     * the thread's interrupt flag restored) if interrupted, so the caller stops re-polling — mirrors
+     * the original inline {@code Thread.sleep} / interrupt handling.
+     */
+    private static boolean sleepBetweenPolls()
+    {
+        try
+        {
+            Thread.sleep(READ_BACK_POLL_DELAY_MS);
+            return true;
+        }
+        catch (InterruptedException ie)
+        {
+            Thread.currentThread().interrupt();
+            return false;
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
@@ -892,26 +892,13 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
     private String createFormHandler(String projectName, String normFqn,
         FormElementWriter.FormMemberRef ref, List<JsonObject> properties, String callType)
     {
-        String procName = null;
-        for (JsonObject prop : properties)
+        String[] procNameHolder = new String[1];
+        String propError = parseHandlerProperties(properties, procNameHolder);
+        if (propError != null)
         {
-            String pName = asString(prop.get("name")); //$NON-NLS-1$
-            if (pName == null || pName.isEmpty())
-            {
-                return ToolResult.error(ERR_PROPERTY_NEEDS_NAME).toJson();
-            }
-            switch (pName.toLowerCase())
-            {
-                case "procedure": //$NON-NLS-1$
-                case "handler": //$NON-NLS-1$
-                    procName = asString(prop.get(KEY_VALUE));
-                    break;
-                default:
-                    return ToolResult.error(ERR_PROPERTY_PREFIX + pName + "' is not supported for a form " //$NON-NLS-1$
-                        + "handler. Use 'procedure' (the BSL handler procedure name; defaults to the " //$NON-NLS-1$
-                        + "event name).").toJson(); //$NON-NLS-1$
-            }
+            return propError;
         }
+        String procName = procNameHolder[0];
 
         ProjectContext ctx = resolveProjectAndConfig(projectName);
         if (ctx.hasError())
@@ -997,6 +984,50 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
             return ToolResult.error("Failed to create form handler: " + unwrapCauseMessage(e)).toJson(); //$NON-NLS-1$
         }
 
+        return buildHandlerResult(ref, normFqn, eventName, fProc, callType, extensionHandler,
+            createdKind[0], persisted);
+    }
+
+    /**
+     * Parses the handler {@code properties} array, resolving the optional BSL procedure name from a
+     * {@code procedure} / {@code handler} property into {@code procNameHolder[0]}. Side-effect-free:
+     * returns a JSON error string when a property is malformed or unsupported, or {@code null} on
+     * success (the same error JSON the caller would otherwise have returned inline).
+     */
+    private String parseHandlerProperties(List<JsonObject> properties, String[] procNameHolder)
+    {
+        for (JsonObject prop : properties)
+        {
+            String pName = asString(prop.get("name")); //$NON-NLS-1$
+            if (pName == null || pName.isEmpty())
+            {
+                return ToolResult.error(ERR_PROPERTY_NEEDS_NAME).toJson();
+            }
+            switch (pName.toLowerCase())
+            {
+                case "procedure": //$NON-NLS-1$
+                case "handler": //$NON-NLS-1$
+                    procNameHolder[0] = asString(prop.get(KEY_VALUE));
+                    break;
+                default:
+                    return ToolResult.error(ERR_PROPERTY_PREFIX + pName + "' is not supported for a form " //$NON-NLS-1$
+                        + "handler. Use 'procedure' (the BSL handler procedure name; defaults to the " //$NON-NLS-1$
+                        + "event name).").toJson(); //$NON-NLS-1$
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Builds the success JSON for a created form event handler (location string, message and result
+     * fields). Side-effect-free: pure formatting of the already-applied change.
+     *
+     * @param createdKind the kind reported by the writer ({@code null} =&gt; {@code "EventHandler"})
+     */
+    private String buildHandlerResult(FormElementWriter.FormMemberRef ref, String normFqn,
+        String eventName, String fProc, String callType, boolean extensionHandler,
+        String createdKind, boolean persisted)
+    {
         String location = ref.isItemLevel() ? ref.formPath + "." + ref.itemName : ref.formPath; //$NON-NLS-1$
         String effectiveProc = (fProc == null || fProc.isEmpty()) ? eventName : fProc;
         String message;
@@ -1013,7 +1044,7 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         ToolResult result = ToolResult.success()
             .put(McpKeys.ACTION, VAL_CREATED)
             .put("fqn", normFqn) //$NON-NLS-1$
-            .put("kind", createdKind[0] != null ? createdKind[0] : "EventHandler") //$NON-NLS-1$ //$NON-NLS-2$
+            .put("kind", createdKind != null ? createdKind : "EventHandler") //$NON-NLS-1$ //$NON-NLS-2$
             .put("name", eventName) //$NON-NLS-1$
             .put(KEY_PERSISTED, persisted)
             .put(McpKeys.MESSAGE, message);
@@ -1411,21 +1442,8 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
          */
         static CommonModuleFlags resolve(Map<String, String> params)
         {
-            String kindToken = JsonUtils.extractStringArgument(params, KEY_COMMON_MODULE_KIND);
-            CommonModuleKind kind;
-            if (kindToken == null || kindToken.trim().isEmpty())
-            {
-                kind = CommonModuleKind.SERVER;
-            }
-            else
-            {
-                kind = CommonModuleKind.fromToken(kindToken.trim());
-                if (kind == null)
-                {
-                    throw new IllegalArgumentException("Unknown commonModuleKind '" + kindToken //$NON-NLS-1$
-                        + "'. Supported: " + CommonModuleKind.quotedList() + "."); //$NON-NLS-1$ //$NON-NLS-2$
-                }
-            }
+            CommonModuleKind kind =
+                resolveKind(JsonUtils.extractStringArgument(params, KEY_COMMON_MODULE_KIND));
 
             boolean serverCall = JsonUtils.extractBooleanArgument(params, "serverCall", false); //$NON-NLS-1$
             boolean privileged = JsonUtils.extractBooleanArgument(params, "privileged", false); //$NON-NLS-1$
@@ -1437,8 +1455,42 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
                 serverCall = true;
             }
 
-            // --- Cross-flag validation (clear, actionable messages) ---
+            validateModifiers(kind, serverCall, privileged, reuse);
 
+            boolean cached = reuse == ReturnValuesReuse.DURING_SESSION;
+            return toCanonicalFlags(kind, serverCall, privileged, cached);
+        }
+
+        /**
+         * Resolves the {@code commonModuleKind} token (defaulting to {@code Server} when blank) to
+         * its {@link CommonModuleKind}. Side-effect-free.
+         *
+         * @throws IllegalArgumentException if the token is non-blank but unknown
+         */
+        private static CommonModuleKind resolveKind(String kindToken)
+        {
+            if (kindToken == null || kindToken.trim().isEmpty())
+            {
+                return CommonModuleKind.SERVER;
+            }
+            CommonModuleKind kind = CommonModuleKind.fromToken(kindToken.trim());
+            if (kind == null)
+            {
+                throw new IllegalArgumentException("Unknown commonModuleKind '" + kindToken //$NON-NLS-1$
+                    + "'. Supported: " + CommonModuleKind.quotedList() + "."); //$NON-NLS-1$ //$NON-NLS-2$
+            }
+            return kind;
+        }
+
+        /**
+         * Cross-flag validation with clear, actionable messages. Rejects modifier/kind combinations
+         * that have no standards-compliant (validator-accepted) flag set. Side-effect-free.
+         *
+         * @throws IllegalArgumentException if the requested combination is invalid
+         */
+        private static void validateModifiers(CommonModuleKind kind, boolean serverCall,
+            boolean privileged, ReturnValuesReuse reuse)
+        {
             boolean serverSideKind = kind == CommonModuleKind.SERVER
                 || kind == CommonModuleKind.SERVER_CALL
                 || kind == CommonModuleKind.CLIENT_SERVER;
@@ -1492,13 +1544,18 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
                         + "it is not valid for kind '" + kind.token() + "'."); //$NON-NLS-1$ //$NON-NLS-2$
                 }
             }
+        }
 
-            // --- Map (kind, modifiers) to a canonical, validator-accepted combo ---
-            // Flags order: clientManaged, clientOrdinary, server, serverCall, externalConnection,
-            // global, privileged, reuse.
-
-            boolean cached = reuse == ReturnValuesReuse.DURING_SESSION;
-
+        /**
+         * Maps a validated {@code (kind, modifiers)} combination to its canonical,
+         * validator-accepted flag set. Side-effect-free.
+         *
+         * <p>Flags order: clientManaged, clientOrdinary, server, serverCall, externalConnection,
+         * global, privileged, reuse.
+         */
+        private static CommonModuleFlags toCanonicalFlags(CommonModuleKind kind, boolean serverCall,
+            boolean privileged, boolean cached)
+        {
             switch (kind)
             {
             case SERVER:

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateProjectTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateProjectTool.java
@@ -327,6 +327,112 @@ public class CreateProjectTool implements IMcpTool
         }
 
         // 3. Validate kind-specific parameter constraints
+        String constraintErr = validateKindConstraints(projectKind, isExtension, isExternalObjects,
+            versionStr, baseProjectName, prefix, purposeStr, compatModeStr, synonym, comment, scriptVariantStr);
+        if (constraintErr != null)
+        {
+            return constraintErr;
+        }
+
+        // 4. Validate 'name'
+        if (configName != null)
+        {
+            configName = configName.trim();
+        }
+        String nameErr = validateName(configName);
+        if (nameErr != null)
+        {
+            return nameErr;
+        }
+
+        // 5. Trim projectName if provided
+        projectName = normalizeProjectName(projectName);
+
+        // Normalize empties
+        if (prefix == null)
+        {
+            prefix = ""; //$NON-NLS-1$
+        }
+        if (compatModeStr != null && compatModeStr.isEmpty())
+        {
+            compatModeStr = null;
+        }
+        if (versionStr != null && versionStr.isEmpty())
+        {
+            versionStr = null;
+        }
+
+        // Dispatch to kind-specific handler
+        if (isExtension)
+        {
+            return executeExtension(configName, projectName, baseProjectName, prefix, synonym, comment,
+                purposeStr, compatModeStr, standardChecks, commonChecks);
+        }
+        else if (isConfiguration)
+        {
+            return executeConfiguration(configName, projectName, versionStr, synonym, comment,
+                scriptVariantStr, standardChecks, commonChecks);
+        }
+        else
+        {
+            return executeExternalObjects(configName, projectName, versionStr, scriptVariantStr,
+                standardChecks, commonChecks);
+        }
+    }
+
+    /**
+     * Validates the (already trimmed) Configuration name: must be non-blank and a valid
+     * 1C identifier.
+     *
+     * @param configName the trimmed name (may be {@code null})
+     * @return a ready-to-return JSON error string when invalid, or {@code null} when valid
+     */
+    private static String validateName(String configName)
+    {
+        if (configName == null || configName.isEmpty())
+        {
+            return ToolResult.error("'name' must not be blank.").toJson(); //$NON-NLS-1$
+        }
+        if (!isValidIdentifier(configName))
+        {
+            return ToolResult.error("Invalid name '" + configName //$NON-NLS-1$
+                + "'. A name must start with a letter or underscore and contain only " //$NON-NLS-1$
+                + "letters, digits and underscores (Cyrillic letters are allowed).").toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Trims the supplied EDT project name and collapses a now-empty value to {@code null}
+     * so the kind handlers fall back to their default-name derivation.
+     *
+     * @param projectName the raw project name (may be {@code null})
+     * @return the trimmed project name, or {@code null} when absent or blank
+     */
+    private static String normalizeProjectName(String projectName)
+    {
+        if (projectName != null)
+        {
+            projectName = projectName.trim();
+        }
+        if (projectName != null && projectName.isEmpty())
+        {
+            projectName = null;
+        }
+        return projectName;
+    }
+
+    /**
+     * Validates the kind-specific parameter constraints (which parameters are allowed for
+     * which {@code projectKind}) plus the strict scriptVariant value check.
+     *
+     * @return a ready-to-return JSON error string when a constraint is violated, or
+     *     {@code null} when all constraints pass
+     */
+    private static String validateKindConstraints(String projectKind, boolean isExtension,
+        boolean isExternalObjects, String versionStr, String baseProjectName, String prefix,
+        String purposeStr, String compatModeStr, String synonym, String comment, String scriptVariantStr)
+    {
         if (isExtension && versionStr != null && !versionStr.isEmpty())
         {
             return ToolResult.error(
@@ -377,63 +483,7 @@ public class CreateProjectTool implements IMcpTool
             return ToolResult.error("Invalid scriptVariant value: '" + scriptVariantStr //$NON-NLS-1$
                 + "'. Allowed values: 'Russian', 'English'.").toJson(); //$NON-NLS-1$
         }
-
-        // 4. Validate 'name'
-        if (configName != null)
-        {
-            configName = configName.trim();
-        }
-        if (configName == null || configName.isEmpty())
-        {
-            return ToolResult.error("'name' must not be blank.").toJson(); //$NON-NLS-1$
-        }
-        if (!isValidIdentifier(configName))
-        {
-            return ToolResult.error("Invalid name '" + configName //$NON-NLS-1$
-                + "'. A name must start with a letter or underscore and contain only " //$NON-NLS-1$
-                + "letters, digits and underscores (Cyrillic letters are allowed).").toJson(); //$NON-NLS-1$
-        }
-
-        // 5. Trim projectName if provided
-        if (projectName != null)
-        {
-            projectName = projectName.trim();
-        }
-        if (projectName != null && projectName.isEmpty())
-        {
-            projectName = null;
-        }
-
-        // Normalize empties
-        if (prefix == null)
-        {
-            prefix = ""; //$NON-NLS-1$
-        }
-        if (compatModeStr != null && compatModeStr.isEmpty())
-        {
-            compatModeStr = null;
-        }
-        if (versionStr != null && versionStr.isEmpty())
-        {
-            versionStr = null;
-        }
-
-        // Dispatch to kind-specific handler
-        if (isExtension)
-        {
-            return executeExtension(configName, projectName, baseProjectName, prefix, synonym, comment,
-                purposeStr, compatModeStr, standardChecks, commonChecks);
-        }
-        else if (isConfiguration)
-        {
-            return executeConfiguration(configName, projectName, versionStr, synonym, comment,
-                scriptVariantStr, standardChecks, commonChecks);
-        }
-        else
-        {
-            return executeExternalObjects(configName, projectName, versionStr, scriptVariantStr,
-                standardChecks, commonChecks);
-        }
+        return null;
     }
 
     // ─────────────────────── EXTENSION path ──────────────────────────────────
@@ -811,38 +861,7 @@ public class CreateProjectTool implements IMcpTool
         // Ensure the configuration has a default Language (per ConfigurationWizard recipe)
         // If fillDefaultReferences already produced a language, reuse it; otherwise create one.
         String effectiveLangCode = langCode;
-        if (!config.getLanguages().isEmpty())
-        {
-            // Align the existing language to the requested script variant
-            Language existingLang = config.getLanguages().get(0);
-            existingLang.setName(langName);
-            existingLang.setLanguageCode(langCode);
-            EMap<String, String> existingSynonym = existingLang.getSynonym();
-            if (existingSynonym != null)
-            {
-                existingSynonym.clear();
-                existingSynonym.put(langCode, langName);
-            }
-            if (config.getDefaultLanguage() == null)
-            {
-                config.setDefaultLanguage(existingLang);
-            }
-        }
-        else
-        {
-            // Create a Language exactly per R3 recipe
-            Language lang = MdClassFactory.eINSTANCE.createLanguage();
-            lang.setUuid(UUID.randomUUID());
-            lang.setName(langName);
-            lang.setLanguageCode(langCode);
-            EMap<String, String> langSynonym = lang.getSynonym();
-            if (langSynonym != null)
-            {
-                langSynonym.put(langCode, langName);
-            }
-            config.getLanguages().add(lang);
-            config.setDefaultLanguage(lang);
-        }
+        setupConfigurationLanguage(config, langCode, langName);
 
         // Optional attributes
         if (comment != null && !comment.isEmpty())
@@ -891,25 +910,8 @@ public class CreateProjectTool implements IMcpTool
         if (jobResult.status == CreateStatus.SLOW_EXISTS)
         {
             // Creation completed past the wait window — build the full configuration response
-            ToolResult slowResult = ToolResult.success()
-                .put(McpKeys.ACTION, VAL_CREATED)
-                .put(McpKeys.PROJECT, finalEffectiveProjectName)
-                .put(KEY_PROJECT_KIND, KIND_CONFIGURATION)
-                .put("name", configName) //$NON-NLS-1$
-                .put(KEY_SCRIPT_VARIANT, finalScriptVariant.getLiteral())
-                .put(KEY_VERSION, finalVersion.toString())
-                .put(KEY_STATE, VAL_CREATED)
-                .put(KEY_CODESTYLE, slowPathCodestyleMap())
-                .put(McpKeys.MESSAGE, "Configuration project '" + finalEffectiveProjectName //$NON-NLS-1$
-                    + "' created (creation completed past the " //$NON-NLS-1$
-                    + (CREATE_TIMEOUT_MS / 1000) + MSG_WAIT_WINDOW_SUFFIX);
-            // Mirror the normal success path: report when the synonym could not be applied.
-            if (!synonymApplied)
-            {
-                slowResult.put(KEY_SYNONYM_NOTE,
-                    "Synonym was not applied: synonym map was not available on the new Configuration."); //$NON-NLS-1$
-            }
-            return slowResult.toJson();
+            return buildConfigurationSlowResponse(finalEffectiveProjectName, configName,
+                finalScriptVariant, finalVersion, synonymApplied);
         }
         if (jobResult.errorJson != null)
         {
@@ -947,6 +949,83 @@ public class CreateProjectTool implements IMcpTool
                 "Synonym was not applied: synonym map was not available on the new Configuration."); //$NON-NLS-1$
         }
         return result.toJson();
+    }
+
+    /**
+     * Ensures the new standalone configuration has a default {@link Language} aligned to the
+     * requested script variant (per the ConfigurationWizard recipe). If
+     * {@code fillDefaultReferences} already produced a language it is realigned in place;
+     * otherwise a new language is created and made the default.
+     *
+     * @param config the in-memory Configuration model object being built
+     * @param langCode the language code to apply (e.g. {@code "ru"} or {@code "en"})
+     * @param langName the language name to apply (e.g. {@code "Russian"} or {@code "English"})
+     */
+    private static void setupConfigurationLanguage(Configuration config, String langCode, String langName)
+    {
+        if (!config.getLanguages().isEmpty())
+        {
+            // Align the existing language to the requested script variant
+            Language existingLang = config.getLanguages().get(0);
+            existingLang.setName(langName);
+            existingLang.setLanguageCode(langCode);
+            EMap<String, String> existingSynonym = existingLang.getSynonym();
+            if (existingSynonym != null)
+            {
+                existingSynonym.clear();
+                existingSynonym.put(langCode, langName);
+            }
+            if (config.getDefaultLanguage() == null)
+            {
+                config.setDefaultLanguage(existingLang);
+            }
+        }
+        else
+        {
+            // Create a Language exactly per R3 recipe
+            Language lang = MdClassFactory.eINSTANCE.createLanguage();
+            lang.setUuid(UUID.randomUUID());
+            lang.setName(langName);
+            lang.setLanguageCode(langCode);
+            EMap<String, String> langSynonym = lang.getSynonym();
+            if (langSynonym != null)
+            {
+                langSynonym.put(langCode, langName);
+            }
+            config.getLanguages().add(lang);
+            config.setDefaultLanguage(lang);
+        }
+    }
+
+    /**
+     * Builds the configuration slow-path response (creation completed past the wait window).
+     * Mirrors the normal success path, including the synonym note when the synonym could not
+     * be applied.
+     *
+     * @return the response JSON string
+     */
+    private static String buildConfigurationSlowResponse(String effectiveProjectName, String configName,
+        ScriptVariant scriptVariant, Version version, boolean synonymApplied)
+    {
+        ToolResult slowResult = ToolResult.success()
+            .put(McpKeys.ACTION, VAL_CREATED)
+            .put(McpKeys.PROJECT, effectiveProjectName)
+            .put(KEY_PROJECT_KIND, KIND_CONFIGURATION)
+            .put("name", configName) //$NON-NLS-1$
+            .put(KEY_SCRIPT_VARIANT, scriptVariant.getLiteral())
+            .put(KEY_VERSION, version.toString())
+            .put(KEY_STATE, VAL_CREATED)
+            .put(KEY_CODESTYLE, slowPathCodestyleMap())
+            .put(McpKeys.MESSAGE, "Configuration project '" + effectiveProjectName //$NON-NLS-1$
+                + "' created (creation completed past the " //$NON-NLS-1$
+                + (CREATE_TIMEOUT_MS / 1000) + MSG_WAIT_WINDOW_SUFFIX);
+        // Mirror the normal success path: report when the synonym could not be applied.
+        if (!synonymApplied)
+        {
+            slowResult.put(KEY_SYNONYM_NOTE,
+                "Synonym was not applied: synonym map was not available on the new Configuration."); //$NON-NLS-1$
+        }
+        return slowResult.toJson();
     }
 
     // ─────────────────────── EXTERNAL OBJECTS path ───────────────────────────
@@ -1014,28 +1093,8 @@ public class CreateProjectTool implements IMcpTool
         if (jobResult.status == CreateStatus.SLOW_EXISTS)
         {
             // Creation completed past the wait window — build the full externalObjects response
-            ToolResult slowResult = ToolResult.success()
-                .put(McpKeys.ACTION, VAL_CREATED)
-                .put(McpKeys.PROJECT, finalEffectiveProjectName)
-                .put(KEY_PROJECT_KIND, KIND_EXTERNAL_OBJECTS)
-                .put("name", configName) //$NON-NLS-1$
-                .put(KEY_VERSION, finalVersion.toString())
-                .put(KEY_STATE, VAL_CREATED)
-                .put(KEY_CODESTYLE, slowPathCodestyleMap())
-                .put(McpKeys.MESSAGE, "External objects project '" + finalEffectiveProjectName //$NON-NLS-1$
-                    + "' created (creation completed past the " //$NON-NLS-1$
-                    + (CREATE_TIMEOUT_MS / 1000) + MSG_WAIT_WINDOW_SUFFIX);
-            if (scriptVariantStr != null && !scriptVariantStr.isEmpty())
-            {
-                // Emit canonical literal (normalized from user input casing)
-                ScriptVariant slowSv = SCRIPT_RUSSIAN.equalsIgnoreCase(scriptVariantStr)
-                    ? ScriptVariant.RUSSIAN : ScriptVariant.ENGLISH;
-                slowResult.put(KEY_SCRIPT_VARIANT, slowSv.getLiteral());
-                String slowScriptNote =
-                    "setScriptVariant skipped: creation exceeded the wait window; set the project preferences manually if needed."; //$NON-NLS-1$
-                slowResult.put(KEY_SCRIPT_VARIANT_NOTE, slowScriptNote);
-            }
-            return slowResult.toJson();
+            return buildExternalObjectsSlowResponse(finalEffectiveProjectName, configName,
+                finalVersion, scriptVariantStr);
         }
         if (jobResult.errorJson != null)
         {
@@ -1062,31 +1121,8 @@ public class CreateProjectTool implements IMcpTool
         {
             requestedSv = SCRIPT_RUSSIAN.equalsIgnoreCase(scriptVariantStr)
                 ? ScriptVariant.RUSSIAN : ScriptVariant.ENGLISH;
-            try
-            {
-                IV8ProjectManager v8ProjectManager = Activator.getDefault().getV8ProjectManager();
-                IProject newIProject = createdHolder[0] != null ? createdHolder[0]
-                    : ProjectContext.of(finalEffectiveProjectName).project();
-                if (v8ProjectManager != null && newIProject != null && newIProject.exists())
-                {
-                    IV8Project v8project = v8ProjectManager.getProject(newIProject);
-                    if (v8project instanceof IExternalObjectProject)
-                    {
-                        extObjMgr.setScriptVariant((IExternalObjectProject) v8project, requestedSv,
-                            new NullProgressMonitor());
-                    }
-                    else
-                    {
-                        scriptVariantNote = "setScriptVariant skipped: project is not yet " //$NON-NLS-1$
-                            + "an IExternalObjectProject (state=" + projectState + ")."; //$NON-NLS-1$ //$NON-NLS-2$
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                Activator.logError("create_project (externalObjects): setScriptVariant failed", e); //$NON-NLS-1$
-                scriptVariantNote = "setScriptVariant failed (non-fatal): " + e.getMessage(); //$NON-NLS-1$
-            }
+            scriptVariantNote = applyExternalObjectsScriptVariant(extObjMgr, finalEffectiveProjectName,
+                createdHolder[0], requestedSv, projectState);
         }
 
         // Apply v8codestyle preferences
@@ -1116,6 +1152,84 @@ public class CreateProjectTool implements IMcpTool
             result.put(KEY_SCRIPT_VARIANT_NOTE, scriptVariantNote);
         }
         return result.toJson();
+    }
+
+    /**
+     * Builds the externalObjects slow-path response (creation completed past the wait window).
+     * When a {@code scriptVariantStr} was supplied, emits the canonical ScriptVariant literal
+     * and a note that setScriptVariant was skipped.
+     *
+     * @return the response JSON string
+     */
+    private static String buildExternalObjectsSlowResponse(String effectiveProjectName, String configName,
+        Version version, String scriptVariantStr)
+    {
+        ToolResult slowResult = ToolResult.success()
+            .put(McpKeys.ACTION, VAL_CREATED)
+            .put(McpKeys.PROJECT, effectiveProjectName)
+            .put(KEY_PROJECT_KIND, KIND_EXTERNAL_OBJECTS)
+            .put("name", configName) //$NON-NLS-1$
+            .put(KEY_VERSION, version.toString())
+            .put(KEY_STATE, VAL_CREATED)
+            .put(KEY_CODESTYLE, slowPathCodestyleMap())
+            .put(McpKeys.MESSAGE, "External objects project '" + effectiveProjectName //$NON-NLS-1$
+                + "' created (creation completed past the " //$NON-NLS-1$
+                + (CREATE_TIMEOUT_MS / 1000) + MSG_WAIT_WINDOW_SUFFIX);
+        if (scriptVariantStr != null && !scriptVariantStr.isEmpty())
+        {
+            // Emit canonical literal (normalized from user input casing)
+            ScriptVariant slowSv = SCRIPT_RUSSIAN.equalsIgnoreCase(scriptVariantStr)
+                ? ScriptVariant.RUSSIAN : ScriptVariant.ENGLISH;
+            slowResult.put(KEY_SCRIPT_VARIANT, slowSv.getLiteral());
+            String slowScriptNote =
+                "setScriptVariant skipped: creation exceeded the wait window; set the project preferences manually if needed."; //$NON-NLS-1$
+            slowResult.put(KEY_SCRIPT_VARIANT_NOTE, slowScriptNote);
+        }
+        return slowResult.toJson();
+    }
+
+    /**
+     * Applies the requested script variant to a freshly created externalObjects project
+     * (non-fatal: failures are logged and reported via the returned note, never propagated).
+     * Mirrors the original inline post-create block exactly.
+     *
+     * @param extObjMgr the external-object project manager
+     * @param effectiveProjectName the workspace project name
+     * @param createdProject the {@link IProject} returned by create (may be {@code null})
+     * @param requestedSv the canonical script variant to apply
+     * @param projectState the resolved lifecycle state (for the skip note)
+     * @return a note describing why the variant could not be applied, or {@code null} on success
+     */
+    private static String applyExternalObjectsScriptVariant(IExternalObjectProjectManager extObjMgr,
+        String effectiveProjectName, IProject createdProject, ScriptVariant requestedSv, String projectState)
+    {
+        String scriptVariantNote = null;
+        try
+        {
+            IV8ProjectManager v8ProjectManager = Activator.getDefault().getV8ProjectManager();
+            IProject newIProject = createdProject != null ? createdProject
+                : ProjectContext.of(effectiveProjectName).project();
+            if (v8ProjectManager != null && newIProject != null && newIProject.exists())
+            {
+                IV8Project v8project = v8ProjectManager.getProject(newIProject);
+                if (v8project instanceof IExternalObjectProject)
+                {
+                    extObjMgr.setScriptVariant((IExternalObjectProject) v8project, requestedSv,
+                        new NullProgressMonitor());
+                }
+                else
+                {
+                    scriptVariantNote = "setScriptVariant skipped: project is not yet " //$NON-NLS-1$
+                        + "an IExternalObjectProject (state=" + projectState + ")."; //$NON-NLS-1$ //$NON-NLS-2$
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Activator.logError("create_project (externalObjects): setScriptVariant failed", e); //$NON-NLS-1$
+            scriptVariantNote = "setScriptVariant failed (non-fatal): " + e.getMessage(); //$NON-NLS-1$
+        }
+        return scriptVariantNote;
     }
 
     // ─────────────────────── Shared helpers ──────────────────────────────────

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetEdtVersionTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetEdtVersionTool.java
@@ -68,60 +68,21 @@ public class GetEdtVersionTool implements IMcpTool
             {
                 return buildId;
             }
-            
+
             // Method 2: via Eclipse product
-            if (Platform.getProduct() != null)
+            String productVersion = versionFromProduct();
+            if (productVersion != null)
             {
-                Bundle productBundle = Platform.getProduct().getDefiningBundle();
-                if (productBundle != null)
-                {
-                    String version = productBundle.getVersion().toString();
-                    String marketingVersion = convertToMarketingVersion(version);
-                    if (marketingVersion != null)
-                    {
-                        return marketingVersion + " (" + version + ")"; //$NON-NLS-1$ //$NON-NLS-2$
-                    }
-                    return version;
-                }
+                return productVersion;
             }
-            
-            // Method 3: search for EDT RCP bundle
-            Bundle coreBundle = Platform.getBundle("org.eclipse.core.runtime"); //$NON-NLS-1$
-            if (coreBundle != null && coreBundle.getBundleContext() != null)
+
+            // Methods 3 & 4: search the installed bundles for an EDT bundle
+            String bundleVersion = versionFromBundles();
+            if (bundleVersion != null)
             {
-                Bundle[] bundles = coreBundle.getBundleContext().getBundles();
-                for (Bundle bundle : bundles)
-                {
-                    String symbolicName = bundle.getSymbolicName();
-                    if (symbolicName != null && symbolicName.equals("com._1c.g5.v8.dt.rcp")) //$NON-NLS-1$
-                    {
-                        String version = bundle.getVersion().toString();
-                        String marketingVersion = convertToMarketingVersion(version);
-                        if (marketingVersion != null)
-                        {
-                            return marketingVersion + " (" + version + ")"; //$NON-NLS-1$ //$NON-NLS-2$
-                        }
-                        return version;
-                    }
-                }
-                
-                // Method 4: search for any EDT bundle
-                for (Bundle bundle : bundles)
-                {
-                    String symbolicName = bundle.getSymbolicName();
-                    if (symbolicName != null && symbolicName.startsWith("com._1c.g5.v8.dt")) //$NON-NLS-1$
-                    {
-                        String version = bundle.getVersion().toString();
-                        String marketingVersion = convertToMarketingVersion(version);
-                        if (marketingVersion != null)
-                        {
-                            return marketingVersion + " (" + version + ")"; //$NON-NLS-1$ //$NON-NLS-2$
-                        }
-                        return version;
-                    }
-                }
+                return bundleVersion;
             }
-            
+
             // Method 5: via system property
             String product = System.getProperty("eclipse.product"); //$NON-NLS-1$
             if (product != null)
@@ -133,8 +94,83 @@ public class GetEdtVersionTool implements IMcpTool
         {
             Activator.logError("Failed to get EDT version", e); //$NON-NLS-1$
         }
-        
+
         return "Unknown"; //$NON-NLS-1$
+    }
+
+    /**
+     * Resolves the version string from the running Eclipse product's defining bundle.
+     *
+     * @return the (possibly marketing-formatted) version, or {@code null} when no product
+     *     or defining bundle is available
+     */
+    private static String versionFromProduct()
+    {
+        if (Platform.getProduct() != null)
+        {
+            Bundle productBundle = Platform.getProduct().getDefiningBundle();
+            if (productBundle != null)
+            {
+                return formatVersion(productBundle.getVersion().toString());
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Searches the installed bundles for an EDT bundle: first the EDT RCP bundle
+     * ({@code com._1c.g5.v8.dt.rcp}), then any bundle whose symbolic name starts with
+     * {@code com._1c.g5.v8.dt}.
+     *
+     * @return the (possibly marketing-formatted) version of the first matching bundle,
+     *     or {@code null} when none is found
+     */
+    private static String versionFromBundles()
+    {
+        Bundle coreBundle = Platform.getBundle("org.eclipse.core.runtime"); //$NON-NLS-1$
+        if (coreBundle == null || coreBundle.getBundleContext() == null)
+        {
+            return null;
+        }
+        Bundle[] bundles = coreBundle.getBundleContext().getBundles();
+
+        // Method 3: search for EDT RCP bundle
+        for (Bundle bundle : bundles)
+        {
+            String symbolicName = bundle.getSymbolicName();
+            if (symbolicName != null && symbolicName.equals("com._1c.g5.v8.dt.rcp")) //$NON-NLS-1$
+            {
+                return formatVersion(bundle.getVersion().toString());
+            }
+        }
+
+        // Method 4: search for any EDT bundle
+        for (Bundle bundle : bundles)
+        {
+            String symbolicName = bundle.getSymbolicName();
+            if (symbolicName != null && symbolicName.startsWith("com._1c.g5.v8.dt")) //$NON-NLS-1$
+            {
+                return formatVersion(bundle.getVersion().toString());
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Formats an OSGi version: when a marketing version can be derived, returns
+     * {@code "<marketing> (<version>)"}; otherwise returns the raw version unchanged.
+     *
+     * @param version the raw OSGi version string
+     * @return the formatted version string
+     */
+    private static String formatVersion(String version)
+    {
+        String marketingVersion = convertToMarketingVersion(version);
+        if (marketingVersion != null)
+        {
+            return marketingVersion + " (" + version + ")"; //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return version;
     }
     
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetFormScreenshotTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetFormScreenshotTool.java
@@ -120,69 +120,14 @@ public class GetFormScreenshotTool implements IMcpTool
     {
         try
         {
-            Object editorPage;
             boolean formRequested = formPath != null && !formPath.isEmpty();
 
-            if (formRequested)
+            EditorPageResult pageResult = resolveEditorPage(projectName, formPath, formRequested);
+            if (pageResult.error != null)
             {
-                EditorScreenshotHelper.ensureBufferedNativeRenderMode();
-
-                // Open the requested form and keep a direct handle on the editor that was opened
-                // for it. The image MUST come from this editor's own WYSIWYG representation, not
-                // from the globally active form editor: previously this tool resolved the page via
-                // FormEditor.getActiveFormEditorPage(), which returns whatever form editor currently
-                // has workbench focus, so a previously rendered/active form (e.g. DataProcessor.X)
-                // was captured instead of the requested one.
-                EditorScreenshotHelper.OpenFormResult openResult =
-                    EditorScreenshotHelper.openForm(projectName, formPath);
-                if (!openResult.isSuccess())
-                {
-                    return CaptureResult.error(openResult.getError());
-                }
-
-                IEditorPart editorPart = openResult.getEditorPart();
-
-                // Let UI settle after activation
-                Display display = Display.getCurrent();
-                for (int i = 0; i < 5; i++)
-                {
-                    EditorScreenshotHelper.processEvents(display);
-                    Thread.sleep(100);
-                }
-
-                // Resolve the WYSIWYG page from THIS editor part (findPage), not the global active
-                // page, so the page is guaranteed to belong to the requested form.
-                editorPage = EditorScreenshotHelper.waitForFormEditorPageOf(editorPart);
-                if (editorPage == null)
-                {
-                    return CaptureResult.error(ToolResult.error(
-                        "Form editor opened but WYSIWYG page is not available. " + //$NON-NLS-1$
-                        "The form may still be loading.").toJson()); //$NON-NLS-1$
-                }
-
-                // Identity guard (a): confirm the opened editor actually corresponds to the requested
-                // form before reading its image. If it does not match, fail explicitly rather than
-                // return another form's PNG (the silent wrong-form defect).
-                String actualFqn = EditorScreenshotHelper.getFormEditorFqn(editorPart);
-                if (actualFqn != null && !EditorScreenshotHelper.fqnMatchesFormPath(actualFqn, formPath))
-                {
-                    return CaptureResult.error(ToolResult.error(
-                        "Captured form editor does not match the requested form. Requested '" //$NON-NLS-1$
-                        + formPath + "' but the active editor is '" + actualFqn //$NON-NLS-1$
-                        + "'. No screenshot was taken to avoid returning the wrong form's image; " //$NON-NLS-1$
-                        + "try again once the requested form's editor is fully open.").toJson()); //$NON-NLS-1$
-                }
+                return pageResult.error;
             }
-            else
-            {
-                editorPage = EditorScreenshotHelper.getActiveFormEditorPage();
-                if (editorPage == null)
-                {
-                    return CaptureResult.error(ToolResult.error(
-                        "No active form editor page found. " + //$NON-NLS-1$
-                        "Specify formPath parameter to open a form automatically.").toJson()); //$NON-NLS-1$
-                }
-            }
+            Object editorPage = pageResult.editorPage;
 
             Object wysiwygViewer = ReflectionUtils.getFieldValue(editorPage, WYSIWYG_VIEWER_FIELD);
             if (wysiwygViewer == null)
@@ -238,57 +183,19 @@ public class GetFormScreenshotTool implements IMcpTool
             // render ran during this call; otherwise we fail explicitly below — consistent with the
             // identity-guard philosophy: never a stale/wrong image silently.
             boolean rendered = EditorScreenshotHelper.ensureRenderedFormImage(representation, refresh);
-            if (refresh && !rendered)
+            CaptureResult renderGate = checkRenderGate(rendered, refresh, formRequested, formPath);
+            if (renderGate != null)
             {
-                return CaptureResult.error(ToolResult.error(
-                    "refresh=true was requested but the form could not be re-rendered in time, so no " //$NON-NLS-1$
-                    + "screenshot was taken: returning the previously rendered image would silently " //$NON-NLS-1$
-                    + "show stale (pre-edit) content. Ensure EDT runs with buffered native render " //$NON-NLS-1$
-                    + "(VM option -DnativeFormBufferedLayoutRender=true) and try again, or call with " //$NON-NLS-1$
-                    + "refresh=false to accept the last rendered image.").toJson()); //$NON-NLS-1$
-            }
-            if (formRequested && !rendered)
-            {
-                // Keep the documented render-unavailable sentinel "Form image data is not available"
-                // CONTIGUOUS — callers (and the upstream e2e suite) match it as a substring; the
-                // wait-budget context is carried around it, not inside it.
-                return CaptureResult.error(ToolResult.error(
-                    "Could not render the requested form '" + formPath //$NON-NLS-1$
-                    + "' in time, so no screenshot was taken. Form image data is not available: its " //$NON-NLS-1$
-                    + "WYSIWYG representation produced no image within the wait budget. " //$NON-NLS-1$
-                    + "Ensure EDT runs with buffered native render " //$NON-NLS-1$
-                    + "(VM option -DnativeFormBufferedLayoutRender=true) and try again.").toJson()); //$NON-NLS-1$
+                return renderGate;
             }
 
-            // Read the (identity-verified) rendered image from this representation. For a requested form
-            // this is the requested form's image: representationFormMatches proved the representation's
-            // own form IS the requested form, and ensureRenderedFormImage confirmed formImageData is
-            // non-empty.
-            ImageData imageData = EditorScreenshotHelper.readFormImageData(representation);
-
-            // Fallback: capture control via print (only used for the active-editor case with no
-            // explicit formPath; for a requested form the image above is already the correct one).
-            if (imageData == null && !formRequested)
+            ImageDataResult imageResult = readValidImageData(representation, wysiwygViewer, rendered, formRequested);
+            if (imageResult.error != null)
             {
-                imageData = EditorScreenshotHelper.captureControlImageData(wysiwygViewer);
+                return imageResult.error;
             }
 
-            if (imageData == null || imageData.width <= 0 || imageData.height <= 0)
-            {
-                if (!rendered)
-                {
-                    // Same contiguous-sentinel rule as above: lead with the documented
-                    // "Form image data is not available" phrase, then the wait-budget context.
-                    return CaptureResult.error(ToolResult.error(
-                        "Form image data is not available: the form did not finish rendering " + //$NON-NLS-1$
-                        "in time, so no image could be captured. " + //$NON-NLS-1$
-                        "Ensure EDT runs with buffered native render " + //$NON-NLS-1$
-                        "(VM option -DnativeFormBufferedLayoutRender=true) and try again.").toJson()); //$NON-NLS-1$
-                }
-                return CaptureResult.error(ToolResult.error("Form image data is not available").toJson()); //$NON-NLS-1$
-            }
-
-            String base64 = EditorScreenshotHelper.encodePng(imageData);
+            String base64 = EditorScreenshotHelper.encodePng(imageResult.imageData);
             return CaptureResult.success(base64);
         }
         catch (Exception e)
@@ -300,6 +207,207 @@ public class GetFormScreenshotTool implements IMcpTool
             Activator.logError("Failed to capture form screenshot", e); //$NON-NLS-1$
             return CaptureResult.error(
                 ToolResult.error("Failed to capture form screenshot: " + e.getMessage()).toJson()); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Resolves the WYSIWYG editor page to capture. When a form is requested it opens that form,
+     * lets the UI settle, resolves the page from the opened editor part and applies identity
+     * guard (a); otherwise it falls back to the globally active form editor page. On any failure
+     * the returned holder carries the same {@link CaptureResult} error as the inline code did.
+     * Runs on the UI thread.
+     *
+     * @throws InterruptedException if the UI-settle sleep is interrupted (propagated unchanged)
+     */
+    private EditorPageResult resolveEditorPage(String projectName, String formPath, boolean formRequested)
+        throws Exception
+    {
+        if (formRequested)
+        {
+            EditorScreenshotHelper.ensureBufferedNativeRenderMode();
+
+            // Open the requested form and keep a direct handle on the editor that was opened
+            // for it. The image MUST come from this editor's own WYSIWYG representation, not
+            // from the globally active form editor: previously this tool resolved the page via
+            // FormEditor.getActiveFormEditorPage(), which returns whatever form editor currently
+            // has workbench focus, so a previously rendered/active form (e.g. DataProcessor.X)
+            // was captured instead of the requested one.
+            EditorScreenshotHelper.OpenFormResult openResult =
+                EditorScreenshotHelper.openForm(projectName, formPath);
+            if (!openResult.isSuccess())
+            {
+                return EditorPageResult.error(CaptureResult.error(openResult.getError()));
+            }
+
+            IEditorPart editorPart = openResult.getEditorPart();
+
+            // Let UI settle after activation
+            Display display = Display.getCurrent();
+            for (int i = 0; i < 5; i++)
+            {
+                EditorScreenshotHelper.processEvents(display);
+                Thread.sleep(100);
+            }
+
+            // Resolve the WYSIWYG page from THIS editor part (findPage), not the global active
+            // page, so the page is guaranteed to belong to the requested form.
+            Object editorPage = EditorScreenshotHelper.waitForFormEditorPageOf(editorPart);
+            if (editorPage == null)
+            {
+                return EditorPageResult.error(CaptureResult.error(ToolResult.error(
+                    "Form editor opened but WYSIWYG page is not available. " + //$NON-NLS-1$
+                    "The form may still be loading.").toJson())); //$NON-NLS-1$
+            }
+
+            // Identity guard (a): confirm the opened editor actually corresponds to the requested
+            // form before reading its image. If it does not match, fail explicitly rather than
+            // return another form's PNG (the silent wrong-form defect).
+            String actualFqn = EditorScreenshotHelper.getFormEditorFqn(editorPart);
+            if (actualFqn != null && !EditorScreenshotHelper.fqnMatchesFormPath(actualFqn, formPath))
+            {
+                return EditorPageResult.error(CaptureResult.error(ToolResult.error(
+                    "Captured form editor does not match the requested form. Requested '" //$NON-NLS-1$
+                    + formPath + "' but the active editor is '" + actualFqn //$NON-NLS-1$
+                    + "'. No screenshot was taken to avoid returning the wrong form's image; " //$NON-NLS-1$
+                    + "try again once the requested form's editor is fully open.").toJson())); //$NON-NLS-1$
+            }
+
+            return EditorPageResult.page(editorPage);
+        }
+
+        Object editorPage = EditorScreenshotHelper.getActiveFormEditorPage();
+        if (editorPage == null)
+        {
+            return EditorPageResult.error(CaptureResult.error(ToolResult.error(
+                "No active form editor page found. " + //$NON-NLS-1$
+                "Specify formPath parameter to open a form automatically.").toJson())); //$NON-NLS-1$
+        }
+        return EditorPageResult.page(editorPage);
+    }
+
+    /**
+     * Applies the render gate after {@code ensureRenderedFormImage}: when the render could not be
+     * completed it returns the same explicit error the inline code did (refresh first, then the
+     * requested-form case), or {@code null} when capture may proceed. Behaviour is unchanged.
+     */
+    private static CaptureResult checkRenderGate(boolean rendered, boolean refresh, boolean formRequested,
+        String formPath)
+    {
+        if (refresh && !rendered)
+        {
+            return CaptureResult.error(ToolResult.error(
+                "refresh=true was requested but the form could not be re-rendered in time, so no " //$NON-NLS-1$
+                + "screenshot was taken: returning the previously rendered image would silently " //$NON-NLS-1$
+                + "show stale (pre-edit) content. Ensure EDT runs with buffered native render " //$NON-NLS-1$
+                + "(VM option -DnativeFormBufferedLayoutRender=true) and try again, or call with " //$NON-NLS-1$
+                + "refresh=false to accept the last rendered image.").toJson()); //$NON-NLS-1$
+        }
+        if (formRequested && !rendered)
+        {
+            // Keep the documented render-unavailable sentinel "Form image data is not available"
+            // CONTIGUOUS — callers (and the upstream e2e suite) match it as a substring; the
+            // wait-budget context is carried around it, not inside it.
+            return CaptureResult.error(ToolResult.error(
+                "Could not render the requested form '" + formPath //$NON-NLS-1$
+                + "' in time, so no screenshot was taken. Form image data is not available: its " //$NON-NLS-1$
+                + "WYSIWYG representation produced no image within the wait budget. " //$NON-NLS-1$
+                + "Ensure EDT runs with buffered native render " //$NON-NLS-1$
+                + "(VM option -DnativeFormBufferedLayoutRender=true) and try again.").toJson()); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Reads the rendered image from the representation, applies the active-editor print fallback,
+     * and validates the image dimensions. Returns a holder carrying either a valid {@link ImageData}
+     * or the same {@link CaptureResult} error the inline code produced (the contiguous
+     * "Form image data is not available" sentinel rules are preserved).
+     */
+    private static ImageDataResult readValidImageData(Object representation, Object wysiwygViewer,
+        boolean rendered, boolean formRequested)
+        throws Exception
+    {
+        // Read the (identity-verified) rendered image from this representation. For a requested form
+        // this is the requested form's image: representationFormMatches proved the representation's
+        // own form IS the requested form, and ensureRenderedFormImage confirmed formImageData is
+        // non-empty.
+        ImageData imageData = EditorScreenshotHelper.readFormImageData(representation);
+
+        // Fallback: capture control via print (only used for the active-editor case with no
+        // explicit formPath; for a requested form the image above is already the correct one).
+        if (imageData == null && !formRequested)
+        {
+            imageData = EditorScreenshotHelper.captureControlImageData(wysiwygViewer);
+        }
+
+        if (imageData == null || imageData.width <= 0 || imageData.height <= 0)
+        {
+            if (!rendered)
+            {
+                // Same contiguous-sentinel rule as above: lead with the documented
+                // "Form image data is not available" phrase, then the wait-budget context.
+                return ImageDataResult.error(CaptureResult.error(ToolResult.error(
+                    "Form image data is not available: the form did not finish rendering " + //$NON-NLS-1$
+                    "in time, so no image could be captured. " + //$NON-NLS-1$
+                    "Ensure EDT runs with buffered native render " + //$NON-NLS-1$
+                    "(VM option -DnativeFormBufferedLayoutRender=true) and try again.").toJson())); //$NON-NLS-1$
+            }
+            return ImageDataResult.error(
+                CaptureResult.error(ToolResult.error("Form image data is not available").toJson())); //$NON-NLS-1$
+        }
+
+        return ImageDataResult.image(imageData);
+    }
+
+    /**
+     * Holder threading the resolved editor page or an early-return error out of
+     * {@link #resolveEditorPage}. Exactly one of {@code editorPage} / {@code error} is set.
+     */
+    private static final class EditorPageResult
+    {
+        final Object editorPage;
+        final CaptureResult error;
+
+        private EditorPageResult(Object editorPage, CaptureResult error)
+        {
+            this.editorPage = editorPage;
+            this.error = error;
+        }
+
+        static EditorPageResult page(Object editorPage)
+        {
+            return new EditorPageResult(editorPage, null);
+        }
+
+        static EditorPageResult error(CaptureResult error)
+        {
+            return new EditorPageResult(null, error);
+        }
+    }
+
+    /**
+     * Holder threading the validated image data or an early-return error out of
+     * {@link #readValidImageData}. Exactly one of {@code imageData} / {@code error} is set.
+     */
+    private static final class ImageDataResult
+    {
+        final ImageData imageData;
+        final CaptureResult error;
+
+        private ImageDataResult(ImageData imageData, CaptureResult error)
+        {
+            this.imageData = imageData;
+            this.error = error;
+        }
+
+        static ImageDataResult image(ImageData imageData)
+        {
+            return new ImageDataResult(imageData, null);
+        }
+
+        static ImageDataResult error(CaptureResult error)
+        {
+            return new ImageDataResult(null, error);
         }
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
@@ -512,23 +512,7 @@ public class GetMethodCallHierarchyTool implements IMcpTool
         {
             EObject obj = iter.next();
 
-            String calledName = null;
-            int line = 0;
-
-            if (obj instanceof Invocation)
-            {
-                Invocation inv = (Invocation) obj;
-                EObject methodAccess = inv.getMethodAccess();
-                if (methodAccess instanceof StaticFeatureAccess)
-                {
-                    calledName = ((StaticFeatureAccess) methodAccess).getName();
-                }
-                else if (methodAccess instanceof DynamicFeatureAccess)
-                {
-                    calledName = ((DynamicFeatureAccess) methodAccess).getName();
-                }
-                line = BslModuleUtils.getStartLine(inv);
-            }
+            String calledName = resolveInvocationName(obj);
 
             if (calledName != null && !calledName.isEmpty())
             {
@@ -536,32 +520,71 @@ public class GetMethodCallHierarchyTool implements IMcpTool
 
                 if (callees.size() < limit)
                 {
-                    CalleeInfo callee = new CalleeInfo();
-                    callee.calledMethodName = calledName;
-                    callee.line = line;
-
-                    // Get source text around the invocation
-                    INode node = NodeModelUtils.findActualNodeFor(obj);
-                    if (node != null)
-                    {
-                        String text = node.getText();
-                        if (text != null)
-                        {
-                            text = stripCommentLines(text);
-                            if (text.length() > 100)
-                            {
-                                text = smartTruncateCall(text, calledName);
-                            }
-                            callee.callCode = text;
-                        }
-                    }
-
-                    callees.add(callee);
+                    callees.add(buildCalleeInfo(obj, calledName));
                 }
             }
         }
 
         return formatCalleesOutput(modulePath, methodName, callees, totalInvocations);
+    }
+
+    /**
+     * Returns the called method name for an AST node when it is an {@link Invocation} whose
+     * method access is a static or dynamic feature access; otherwise {@code null}. Extracted from
+     * {@link #findCallees(String, String, String, int)} to keep that loop's complexity in check.
+     *
+     * @param obj the AST node to inspect
+     * @return the invoked method name, or {@code null} when the node is not a recognized invocation
+     */
+    private String resolveInvocationName(EObject obj)
+    {
+        if (!(obj instanceof Invocation))
+        {
+            return null;
+        }
+        EObject methodAccess = ((Invocation) obj).getMethodAccess();
+        if (methodAccess instanceof StaticFeatureAccess)
+        {
+            return ((StaticFeatureAccess) methodAccess).getName();
+        }
+        if (methodAccess instanceof DynamicFeatureAccess)
+        {
+            return ((DynamicFeatureAccess) methodAccess).getName();
+        }
+        return null;
+    }
+
+    /**
+     * Builds a {@link CalleeInfo} for a matched invocation node: records the called method name and
+     * line, then attaches a compacted call snippet from the node's source text. Extracted from
+     * {@link #findCallees(String, String, String, int)}.
+     *
+     * @param obj the invocation AST node
+     * @param calledName the resolved called method name
+     * @return the populated callee info
+     */
+    private CalleeInfo buildCalleeInfo(EObject obj, String calledName)
+    {
+        CalleeInfo callee = new CalleeInfo();
+        callee.calledMethodName = calledName;
+        callee.line = BslModuleUtils.getStartLine(obj);
+
+        // Get source text around the invocation
+        INode node = NodeModelUtils.findActualNodeFor(obj);
+        if (node != null)
+        {
+            String text = node.getText();
+            if (text != null)
+            {
+                text = stripCommentLines(text);
+                if (text.length() > 100)
+                {
+                    text = smartTruncateCall(text, calledName);
+                }
+                callee.callCode = text;
+            }
+        }
+        return callee;
     }
 
     // ========== Helper methods ==========

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProfilingResultsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProfilingResultsTool.java
@@ -182,78 +182,15 @@ public class GetProfilingResultsTool implements IMcpTool
             Method getDurability = timeHolderClass.getMethod("getDurability"); //$NON-NLS-1$
             Method getPureDurability = timeHolderClass.getMethod("getPureDurability"); //$NON-NLS-1$
 
+            ProfilingReflection refl = new ProfilingReflection(getResultName, getTotalDurability,
+                getProfilingResults, getFrequency, getModuleName, getLineNo, getPercentage,
+                getDurability, getPureDurability, getLine, getMethodSignature);
+
             List<Map<String, Object>> resultSummaries = new ArrayList<>();
 
             for (Object result : results)
             {
-                Map<String, Object> summary = new LinkedHashMap<>();
-                String name = (String) getResultName.invoke(result);
-                double totalDur = ((Number) getTotalDurability.invoke(result)).doubleValue();
-                summary.put("name", name); //$NON-NLS-1$
-                summary.put("totalDurability", Math.round(totalDur * 1000.0) / 1000.0); //$NON-NLS-1$
-
-                List<?> lineResults = (List<?>) getProfilingResults.invoke(result);
-                if (lineResults == null)
-                {
-                    summary.put("lines", 0); //$NON-NLS-1$
-                    resultSummaries.add(summary);
-                    continue;
-                }
-
-                // Group by module
-                Map<String, List<Map<String, Object>>> moduleGroups = new LinkedHashMap<>();
-                for (Object lr : lineResults)
-                {
-                    long freq = (long) getFrequency.invoke(lr);
-                    if (freq < minFrequency)
-                    {
-                        continue;
-                    }
-
-                    String modName = (String) getModuleName.invoke(lr);
-                    if (modName == null) modName = "?"; //$NON-NLS-1$
-
-                    if (moduleFilter != null && !moduleFilter.isEmpty()
-                        && !modName.toLowerCase().contains(moduleFilter.toLowerCase()))
-                    {
-                        continue;
-                    }
-
-                    List<Map<String, Object>> lines = moduleGroups.computeIfAbsent(modName,
-                        k -> new ArrayList<>());
-
-                    if (lines.size() >= MAX_LINES_PER_MODULE)
-                    {
-                        continue; // cap per module
-                    }
-
-                    Map<String, Object> lineInfo = new LinkedHashMap<>();
-                    lineInfo.put("line", getLineNo.invoke(lr)); //$NON-NLS-1$
-                    lineInfo.put("calls", freq); //$NON-NLS-1$
-                    lineInfo.put("pct", Math.round(((Number) getPercentage.invoke(lr)).doubleValue() * 100.0) / 100.0); //$NON-NLS-1$
-
-                    // Verbose per-line extras only in detailed: the secondary timing columns
-                    // and the source text + method signature. concise keeps line/calls/pct.
-                    if (detailed)
-                    {
-                        lineInfo.put("dur", Math.round(((Number) getDurability.invoke(lr)).doubleValue() * 1000.0) / 1000.0); //$NON-NLS-1$
-                        lineInfo.put("pureDur", Math.round(((Number) getPureDurability.invoke(lr)).doubleValue() * 1000.0) / 1000.0); //$NON-NLS-1$
-
-                        String code = (String) getLine.invoke(lr);
-                        if (code != null && code.length() > 120)
-                        {
-                            code = code.substring(0, 120) + "..."; //$NON-NLS-1$
-                        }
-                        lineInfo.put("code", code); //$NON-NLS-1$
-                        lineInfo.put("method", getMethodSignature.invoke(lr)); //$NON-NLS-1$
-                    }
-
-                    lines.add(lineInfo);
-                }
-
-                summary.put("moduleCount", moduleGroups.size()); //$NON-NLS-1$
-                summary.put("modules", moduleGroups); //$NON-NLS-1$
-                resultSummaries.add(summary);
+                resultSummaries.add(summarizeResult(result, refl, moduleFilter, minFrequency, detailed));
             }
 
             return ToolResult.success()
@@ -302,5 +239,129 @@ public class GetProfilingResultsTool implements IMcpTool
             latest = results.get(results.size() - 1);
         }
         return List.of(latest);
+    }
+
+    /**
+     * Builds the summary map for a single {@code IProfilingResult}: its name/totalDurability plus
+     * the per-module groups of qualifying lines. When the result exposes no line data, the summary
+     * carries {@code lines=0} and no modules — exactly as the inline loop did before.
+     */
+    private static Map<String, Object> summarizeResult(Object result, ProfilingReflection refl,
+        String moduleFilter, int minFrequency, boolean detailed) throws Exception
+    {
+        Map<String, Object> summary = new LinkedHashMap<>();
+        String name = (String) refl.getResultName.invoke(result);
+        double totalDur = ((Number) refl.getTotalDurability.invoke(result)).doubleValue();
+        summary.put("name", name); //$NON-NLS-1$
+        summary.put("totalDurability", Math.round(totalDur * 1000.0) / 1000.0); //$NON-NLS-1$
+
+        List<?> lineResults = (List<?>) refl.getProfilingResults.invoke(result);
+        if (lineResults == null)
+        {
+            summary.put("lines", 0); //$NON-NLS-1$
+            return summary;
+        }
+
+        // Group by module
+        Map<String, List<Map<String, Object>>> moduleGroups = new LinkedHashMap<>();
+        for (Object lr : lineResults)
+        {
+            long freq = (long) refl.getFrequency.invoke(lr);
+            if (freq < minFrequency)
+            {
+                continue;
+            }
+
+            String modName = (String) refl.getModuleName.invoke(lr);
+            if (modName == null) modName = "?"; //$NON-NLS-1$
+
+            if (moduleFilter != null && !moduleFilter.isEmpty()
+                && !modName.toLowerCase().contains(moduleFilter.toLowerCase()))
+            {
+                continue;
+            }
+
+            List<Map<String, Object>> lines = moduleGroups.computeIfAbsent(modName,
+                k -> new ArrayList<>());
+
+            if (lines.size() >= MAX_LINES_PER_MODULE)
+            {
+                continue; // cap per module
+            }
+
+            lines.add(buildLineInfo(lr, freq, refl, detailed));
+        }
+
+        summary.put("moduleCount", moduleGroups.size()); //$NON-NLS-1$
+        summary.put("modules", moduleGroups); //$NON-NLS-1$
+        return summary;
+    }
+
+    /**
+     * Builds the per-line info map for one {@code ILineProfilingResult}. The verbose timing columns
+     * and the (truncated) source text + method signature are emitted only in {@code detailed} mode;
+     * concise mode keeps just line/calls/pct.
+     */
+    private static Map<String, Object> buildLineInfo(Object lr, long freq, ProfilingReflection refl,
+        boolean detailed) throws Exception
+    {
+        Map<String, Object> lineInfo = new LinkedHashMap<>();
+        lineInfo.put("line", refl.getLineNo.invoke(lr)); //$NON-NLS-1$
+        lineInfo.put("calls", freq); //$NON-NLS-1$
+        lineInfo.put("pct", Math.round(((Number) refl.getPercentage.invoke(lr)).doubleValue() * 100.0) / 100.0); //$NON-NLS-1$
+
+        // Verbose per-line extras only in detailed: the secondary timing columns
+        // and the source text + method signature. concise keeps line/calls/pct.
+        if (detailed)
+        {
+            lineInfo.put("dur", Math.round(((Number) refl.getDurability.invoke(lr)).doubleValue() * 1000.0) / 1000.0); //$NON-NLS-1$
+            lineInfo.put("pureDur", Math.round(((Number) refl.getPureDurability.invoke(lr)).doubleValue() * 1000.0) / 1000.0); //$NON-NLS-1$
+
+            String code = (String) refl.getLine.invoke(lr);
+            if (code != null && code.length() > 120)
+            {
+                code = code.substring(0, 120) + "..."; //$NON-NLS-1$
+            }
+            lineInfo.put("code", code); //$NON-NLS-1$
+            lineInfo.put("method", refl.getMethodSignature.invoke(lr)); //$NON-NLS-1$
+        }
+
+        return lineInfo;
+    }
+
+    /**
+     * Immutable holder for the reflective {@code Method} handles used while summarizing a profiling
+     * result. Groups them so the per-result / per-line helpers keep a small signature.
+     */
+    private static final class ProfilingReflection
+    {
+        final Method getResultName;
+        final Method getTotalDurability;
+        final Method getProfilingResults;
+        final Method getFrequency;
+        final Method getModuleName;
+        final Method getLineNo;
+        final Method getPercentage;
+        final Method getDurability;
+        final Method getPureDurability;
+        final Method getLine;
+        final Method getMethodSignature;
+
+        ProfilingReflection(Method getResultName, Method getTotalDurability, Method getProfilingResults,
+            Method getFrequency, Method getModuleName, Method getLineNo, Method getPercentage,
+            Method getDurability, Method getPureDurability, Method getLine, Method getMethodSignature)
+        {
+            this.getResultName = getResultName;
+            this.getTotalDurability = getTotalDurability;
+            this.getProfilingResults = getProfilingResults;
+            this.getFrequency = getFrequency;
+            this.getModuleName = getModuleName;
+            this.getLineNo = getLineNo;
+            this.getPercentage = getPercentage;
+            this.getDurability = getDurability;
+            this.getPureDurability = getPureDurability;
+            this.getLine = getLine;
+            this.getMethodSignature = getMethodSignature;
+        }
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListModulesTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListModulesTool.java
@@ -373,63 +373,81 @@ public class ListModulesTool implements IMcpTool
         {
             if (member instanceof IFile)
             {
-                IFile file = (IFile) member;
-                if (file.getName().endsWith(".bsl")) //$NON-NLS-1$
-                {
-                    String fullPath = file.getProjectRelativePath().toString();
-                    String modulePath = fullPath.startsWith("src/") //$NON-NLS-1$
-                        ? fullPath.substring(4) : fullPath;
-
-                    String[] segments = modulePath.split("/"); //$NON-NLS-1$
-                    if (segments.length < 2)
-                    {
-                        continue;
-                    }
-
-                    String collectionName = segments[0];
-                    String parentName;
-                    String parentType;
-
-                    if (CONFIGURATION.equals(collectionName))
-                    {
-                        parentName = CONFIGURATION;
-                        parentType = CONFIGURATION;
-                    }
-                    else
-                    {
-                        parentName = segments[1];
-                        parentType = mapCollectionToParentType(collectionName);
-                    }
-
-                    if (objectName != null && !objectName.isEmpty()
-                        && !parentName.equalsIgnoreCase(objectName))
-                    {
-                        continue;
-                    }
-
-                    if (nameFilter != null && !nameFilter.isEmpty()
-                        && !modulePath.toLowerCase().contains(nameFilter.toLowerCase()))
-                    {
-                        continue;
-                    }
-
-                    String basePath = CONFIGURATION.equals(collectionName)
-                        ? collectionName : collectionName + "/" + parentName; //$NON-NLS-1$
-                    String moduleType = determineModuleType(modulePath, basePath);
-
-                    ModuleInfo info = new ModuleInfo();
-                    info.modulePath = modulePath;
-                    info.moduleType = moduleType;
-                    info.parentType = parentType;
-                    info.parentName = parentName;
-                    modules.add(info);
-                }
+                addScannedBslFile((IFile) member, modules, objectName, nameFilter);
             }
             else if (member instanceof IContainer)
             {
                 scanBslFilesRecursive((IContainer) member, modules, objectName, nameFilter, depth + 1);
             }
         }
+    }
+
+    /**
+     * Handles a single file member of the filesystem scan in {@link #scanBslFilesRecursive}:
+     * a non-.bsl file, a file with too few path segments, or a file failing the
+     * {@code objectName}/{@code nameFilter} is ignored; otherwise a {@link ModuleInfo} is
+     * added to {@code modules}. Extracted verbatim from the scan's per-file branch; each
+     * original loop {@code continue} (skip this file) becomes an early {@code return} here.
+     *
+     * @param file the file member to consider
+     * @param modules target list for collected module info
+     * @param objectName optional filter by parent object name (case-insensitive)
+     * @param nameFilter optional filter by module path substring (case-insensitive)
+     */
+    private void addScannedBslFile(IFile file, List<ModuleInfo> modules,
+                                    String objectName, String nameFilter)
+    {
+        if (!file.getName().endsWith(".bsl")) //$NON-NLS-1$
+        {
+            return;
+        }
+        String fullPath = file.getProjectRelativePath().toString();
+        String modulePath = fullPath.startsWith("src/") //$NON-NLS-1$
+            ? fullPath.substring(4) : fullPath;
+
+        String[] segments = modulePath.split("/"); //$NON-NLS-1$
+        if (segments.length < 2)
+        {
+            return;
+        }
+
+        String collectionName = segments[0];
+        String parentName;
+        String parentType;
+
+        if (CONFIGURATION.equals(collectionName))
+        {
+            parentName = CONFIGURATION;
+            parentType = CONFIGURATION;
+        }
+        else
+        {
+            parentName = segments[1];
+            parentType = mapCollectionToParentType(collectionName);
+        }
+
+        if (objectName != null && !objectName.isEmpty()
+            && !parentName.equalsIgnoreCase(objectName))
+        {
+            return;
+        }
+
+        if (nameFilter != null && !nameFilter.isEmpty()
+            && !modulePath.toLowerCase().contains(nameFilter.toLowerCase()))
+        {
+            return;
+        }
+
+        String basePath = CONFIGURATION.equals(collectionName)
+            ? collectionName : collectionName + "/" + parentName; //$NON-NLS-1$
+        String moduleType = determineModuleType(modulePath, basePath);
+
+        ModuleInfo info = new ModuleInfo();
+        info.modulePath = modulePath;
+        info.moduleType = moduleType;
+        info.parentType = parentType;
+        info.parentName = parentName;
+        modules.add(info);
     }
 
     private static String mapCollectionToParentType(String collectionName)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -212,47 +212,26 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         // re-navigate to the leaf's owner BY NAME inside the tx - this is what lets a member of a
         // NESTED object (e.g. a tabular-section attribute) be modified, not just a direct member.
         final String[] parts = normFqn.split("\\."); //$NON-NLS-1$
-        final long topBmId;
-        final EStructuralFeature memberFeature;
-        final String memberName;
-        if (node.topLevel)
+        BmFetchPlan plan = resolveBmFetchPlan(config, node, target, parts);
+        if (plan.error != null)
         {
-            if (!(target instanceof IBmObject))
-            {
-                return ToolResult.error("Target is not a BM object").toJson(); //$NON-NLS-1$
-            }
-            topBmId = ((IBmObject)target).bmGetId();
-            memberFeature = null;
-            memberName = null;
+            return plan.error;
         }
-        else
-        {
-            MdObject topObject = MetadataTypeUtils.findObject(config, parts[0], parts[1]);
-            if (!(topObject instanceof IBmObject))
-            {
-                return ToolResult.error("Top object is not a BM object").toJson(); //$NON-NLS-1$
-            }
-            topBmId = ((IBmObject)topObject).bmGetId();
-            memberFeature = node.feature;
-            memberName = target.getName();
-        }
+        final long topBmId = plan.topBmId;
+        final EStructuralFeature memberFeature = plan.memberFeature;
+        final String memberName = plan.memberName;
 
         // The platform version is needed only to build a 'type' value; resolve it best-effort (a
         // missing version is reported only if a 'type' property is actually set).
-        IV8ProjectManager v8ProjectManager = Activator.getDefault().getV8ProjectManager();
-        IV8Project v8Project = v8ProjectManager != null ? v8ProjectManager.getProject(ctx.project) : null;
-        final Version version = v8Project != null ? v8Project.getVersion() : null;
+        final Version version = resolvePlatformVersion(ctx);
 
         // Validate every property against the introspected schema BEFORE any write (fail fast, no
         // partial mutation). On success, collect the prepared changes to apply inside the tx.
         List<PreparedChange> changes = new ArrayList<>();
-        for (JsonObject prop : properties)
+        String prepErr = validateAndPrepare(config, version, target, properties, changes, normReport);
+        if (prepErr != null)
         {
-            String pErr = prepare(config, version, target, prop, changes, normReport);
-            if (pErr != null)
-            {
-                return pErr;
-            }
+            return prepErr;
         }
 
         // The top object that owns the node's .mdo file.
@@ -272,25 +251,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         {
             BmTransactions.<Void>write(bmModel, "ModifyMetadata", (tx, pm) -> //$NON-NLS-1$
             {
-                EObject top = (EObject)tx.getObjectById(topBmId);
-                if (top == null)
-                {
-                    throw new RuntimeException("Target not found in transaction"); //$NON-NLS-1$
-                }
-                EObject applyTo = top;
-                if (memberFeature != null)
-                {
-                    EObject owner = MetadataNodeResolver.resolveOwnerInTx(top, parts);
-                    if (owner == null)
-                    {
-                        throw new RuntimeException("Could not re-navigate to the owner inside the transaction"); //$NON-NLS-1$
-                    }
-                    applyTo = childByName(owner, memberFeature, memberName);
-                    if (applyTo == null)
-                    {
-                        throw new RuntimeException("Member not found in transaction: " + memberName); //$NON-NLS-1$
-                    }
-                }
+                EObject applyTo = resolveApplyTarget(tx, topBmId, memberFeature, memberName, parts);
                 for (PreparedChange change : changes)
                 {
                     change.applyTo(applyTo, tx);
@@ -306,11 +267,77 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
 
         boolean persisted = BmTransactions.forceExportToDisk(ctx.project, topFqn);
 
+        List<String> applied = appliedFeatureNames(changes);
+        return buildModifiedResult(normFqn, applied, persisted, normReport);
+    }
+
+    /**
+     * Resolves the platform {@link Version} for the project best-effort (used only to build a 'type'
+     * value): {@code null} when the V8 project manager or project is unavailable. Side-effect-free
+     * helper extracted from {@link #executeOnUiThread}.
+     */
+    private static Version resolvePlatformVersion(ProjectContext ctx)
+    {
+        IV8ProjectManager v8ProjectManager = Activator.getDefault().getV8ProjectManager();
+        IV8Project v8Project = v8ProjectManager != null ? v8ProjectManager.getProject(ctx.project) : null;
+        return v8Project != null ? v8Project.getVersion() : null;
+    }
+
+    /**
+     * Re-navigates to the EObject that the prepared changes must be applied to, INSIDE the write
+     * transaction: re-fetches the TOP object by {@code topBmId} and, for a member, re-navigates to
+     * the leaf's owner and then to the leaf BY NAME. Read-only resolution (no eSet) - the actual
+     * mutation stays in the caller's apply loop. Throws the SAME {@link RuntimeException}s as before
+     * (target / owner / member not found), which propagate to the same catch and roll the tx back.
+     * Extracted verbatim from {@link #executeOnUiThread}'s transaction body.
+     */
+    private static EObject resolveApplyTarget(IBmTransaction tx, long topBmId,
+        EStructuralFeature memberFeature, String memberName, String[] parts)
+    {
+        EObject top = (EObject)tx.getObjectById(topBmId);
+        if (top == null)
+        {
+            throw new RuntimeException("Target not found in transaction"); //$NON-NLS-1$
+        }
+        if (memberFeature == null)
+        {
+            return top;
+        }
+        EObject owner = MetadataNodeResolver.resolveOwnerInTx(top, parts);
+        if (owner == null)
+        {
+            throw new RuntimeException("Could not re-navigate to the owner inside the transaction"); //$NON-NLS-1$
+        }
+        EObject applyTo = childByName(owner, memberFeature, memberName);
+        if (applyTo == null)
+        {
+            throw new RuntimeException("Member not found in transaction: " + memberName); //$NON-NLS-1$
+        }
+        return applyTo;
+    }
+
+    /**
+     * Collects the feature names of the applied changes, in order. Pure helper extracted from
+     * {@link #executeOnUiThread}.
+     */
+    private static List<String> appliedFeatureNames(List<PreparedChange> changes)
+    {
         List<String> applied = new ArrayList<>();
         for (PreparedChange change : changes)
         {
             applied.add(change.featureName());
         }
+        return applied;
+    }
+
+    /**
+     * Builds the success JSON for a completed modify (action / fqn / applied / persisted, the
+     * normalization report and the confirmation message). Pure helper extracted from
+     * {@link #executeOnUiThread}; the same shape used by the form-member branch.
+     */
+    private static String buildModifiedResult(String normFqn, List<String> applied, boolean persisted,
+        MdNameNormalizer.Report normReport)
+    {
         ToolResult result = ToolResult.success()
             .put(McpKeys.ACTION, VAL_MODIFIED)
             .put("fqn", normFqn) //$NON-NLS-1$
@@ -320,6 +347,78 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         return result
             .put(McpKeys.MESSAGE, "Modified " + normFqn + " (" + String.join(", ", applied) + ")") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
             .toJson();
+    }
+
+    /**
+     * Holds the BM re-fetch strategy resolved for the modify transaction: the {@code topBmId} of the
+     * re-fetchable top object plus, for a member node, the owning {@code memberFeature} and the leaf's
+     * {@code memberName} to re-navigate by name inside the tx. {@link #error} is non-null (a ready JSON
+     * error) when the target / top object is not a BM object.
+     */
+    private static final class BmFetchPlan
+    {
+        private long topBmId;
+        private EStructuralFeature memberFeature;
+        private String memberName;
+        private String error;
+    }
+
+    /**
+     * Resolves the BM re-fetch strategy for the modify transaction (see {@link BmFetchPlan}). Only TOP
+     * objects are re-fetchable by bmId; for a member the TOP object's bmId is captured and the leaf is
+     * re-navigated by name inside the tx. Side-effect-free: it only reads ids / features. Extracted
+     * verbatim from {@link #executeOnUiThread}; the caller re-checks {@link BmFetchPlan#error} and
+     * returns it unchanged, preserving the original error cases.
+     */
+    private static BmFetchPlan resolveBmFetchPlan(Configuration config,
+        MetadataNodeResolver.MetadataNode node, MdObject target, String[] parts)
+    {
+        BmFetchPlan plan = new BmFetchPlan();
+        if (node.topLevel)
+        {
+            if (!(target instanceof IBmObject))
+            {
+                plan.error = ToolResult.error("Target is not a BM object").toJson(); //$NON-NLS-1$
+                return plan;
+            }
+            plan.topBmId = ((IBmObject)target).bmGetId();
+            plan.memberFeature = null;
+            plan.memberName = null;
+        }
+        else
+        {
+            MdObject topObject = MetadataTypeUtils.findObject(config, parts[0], parts[1]);
+            if (!(topObject instanceof IBmObject))
+            {
+                plan.error = ToolResult.error("Top object is not a BM object").toJson(); //$NON-NLS-1$
+                return plan;
+            }
+            plan.topBmId = ((IBmObject)topObject).bmGetId();
+            plan.memberFeature = node.feature;
+            plan.memberName = target.getName();
+        }
+        return plan;
+    }
+
+    /**
+     * Validates every property against the introspected schema BEFORE any write (fail fast, no partial
+     * mutation), appending a {@link PreparedChange} for each. Returns the first property's JSON error,
+     * or {@code null} when all validated. Side-effect-free apart from populating {@code changes};
+     * extracted verbatim from {@link #executeOnUiThread} so a failure returns the SAME error in the
+     * SAME case, before the BM transaction runs.
+     */
+    private String validateAndPrepare(Configuration config, Version version, MdObject target,
+        List<JsonObject> properties, List<PreparedChange> changes, MdNameNormalizer.Report normReport)
+    {
+        for (JsonObject prop : properties)
+        {
+            String pErr = prepare(config, version, target, prop, changes, normReport);
+            if (pErr != null)
+            {
+                return pErr;
+            }
+        }
+        return null;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ResumeTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ResumeTool.java
@@ -8,6 +8,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import java.util.Map;
 
+import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.model.IDebugTarget;
 import org.eclipse.debug.core.model.IThread;
 
@@ -101,32 +102,7 @@ public class ResumeTool implements IMcpTool
         {
             if (threadId > 0)
             {
-                IThread thread = registry.getThread(threadId);
-                if (thread == null)
-                {
-                    return ToolResult.error("stale threadId — call wait_for_break again").toJson(); //$NON-NLS-1$
-                }
-                if (!thread.canResume())
-                {
-                    return ToolResult.error("thread cannot resume (state: " //$NON-NLS-1$
-                            + (thread.isSuspended() ? "suspended" : "running") + ")").toJson(); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-                }
-                // Canonical snapshot key for this thread's session: the registry's
-                // thread→appId mapping (set when the snapshot was created), falling
-                // back to the launch-attribute id. Computed BEFORE resuming — the
-                // async RESUME event may purge the mapping.
-                String threadAppId = registry.getThreadApplicationId(threadId);
-                if (threadAppId == null)
-                {
-                    threadAppId = DebugSessionRegistry.findApplicationIdFor(thread);
-                }
-                thread.resume();
-                // Drop the now-stale pre-resume snapshot (this branch
-                // previously resumed WITHOUT any clearSnapshot, so the snapshot
-                // outlived its suspend and the next wait_for_break returned it as a
-                // fresh hit). clearSnapshot(null) is a safe no-op.
-                registry.clearSnapshot(threadAppId);
-                return ToolResult.success().put(KEY_RESUMED, true).put(KEY_SCOPE, "thread").toJson(); //$NON-NLS-1$
+                return resumeThread(registry, threadId);
             }
 
             // Unified resolution: accept ANY id form for the same session —
@@ -144,42 +120,9 @@ public class ResumeTool implements IMcpTool
                     + "session available for auto-resolution. Use debug_status to list active sessions.").toJson(); //$NON-NLS-1$
             }
 
-            IDebugTarget target = res.target;
-            String effectiveAppId = res.canonicalId;
+            ResumeOutcome outcome = performResume(res.target);
 
-            // Prefer resuming at the TARGET level when it accepts it (thin-client and
-            // launch targets do). A 1C debug-server target, however, reports
-            // canResume()==false at the target level even while a thread is genuinely
-            // suspended on the breakpoint — so fall back to resuming each suspended
-            // thread (IRuntimeDebugTargetThread implements ISuspendResume), which is the
-            // SAME thread wait_for_break suspends on.
-            boolean resumed = false;
-            String scope = null;
-            if (!target.isTerminated() && target.canResume())
-            {
-                target.resume();
-                resumed = true;
-                scope = "target"; //$NON-NLS-1$
-            }
-            else
-            {
-                int count = 0;
-                for (IThread t : target.getThreads())
-                {
-                    if (t != null && t.isSuspended() && t.canResume())
-                    {
-                        t.resume();
-                        count++;
-                    }
-                }
-                if (count > 0)
-                {
-                    resumed = true;
-                    scope = "thread"; //$NON-NLS-1$
-                }
-            }
-
-            if (!resumed)
+            if (!outcome.resumed)
             {
                 return ToolResult.error(res.isServerTarget()
                     ? "server debug target cannot resume (no suspended thread to resume). " //$NON-NLS-1$
@@ -189,25 +132,128 @@ public class ResumeTool implements IMcpTool
 
             // Drop the cached snapshot so a subsequent wait_for_break does not return
             // the now-stale pre-resume frame.
-            registry.clearSnapshot(effectiveAppId);
-            ToolResult out = ToolResult.success()
-                .put(KEY_RESUMED, true)
-                .put(KEY_SCOPE, scope)
-                .put(McpKeys.APPLICATION_ID, effectiveAppId);
-            if (res.isServerTarget())
-            {
-                out.put("serverTarget", true); //$NON-NLS-1$
-            }
-            if (res.autoResolved)
-            {
-                out.put("autoResolved", true); //$NON-NLS-1$
-            }
-            return out.toJson();
+            registry.clearSnapshot(res.canonicalId);
+            return buildResumeResult(res, outcome.scope).toJson();
         }
         catch (Exception e)
         {
             Activator.logError("Error in resume", e); //$NON-NLS-1$
             return ToolResult.error(e.getMessage()).toJson(); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Resume the thread registered under the given snapshot thread id.
+     *
+     * @param registry the debug session registry
+     * @param threadId the snapshot thread id (already validated to be positive)
+     * @return the JSON result for the resume request (success or a specific error)
+     * @throws DebugException if the underlying {@link IThread#resume()} fails
+     */
+    private static String resumeThread(DebugSessionRegistry registry, long threadId) throws DebugException
+    {
+        IThread thread = registry.getThread(threadId);
+        if (thread == null)
+        {
+            return ToolResult.error("stale threadId — call wait_for_break again").toJson(); //$NON-NLS-1$
+        }
+        if (!thread.canResume())
+        {
+            return ToolResult.error("thread cannot resume (state: " //$NON-NLS-1$
+                    + (thread.isSuspended() ? "suspended" : "running") + ")").toJson(); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        }
+        // Canonical snapshot key for this thread's session: the registry's
+        // thread→appId mapping (set when the snapshot was created), falling
+        // back to the launch-attribute id. Computed BEFORE resuming — the
+        // async RESUME event may purge the mapping.
+        String threadAppId = registry.getThreadApplicationId(threadId);
+        if (threadAppId == null)
+        {
+            threadAppId = DebugSessionRegistry.findApplicationIdFor(thread);
+        }
+        thread.resume();
+        // Drop the now-stale pre-resume snapshot (this branch
+        // previously resumed WITHOUT any clearSnapshot, so the snapshot
+        // outlived its suspend and the next wait_for_break returned it as a
+        // fresh hit). clearSnapshot(null) is a safe no-op.
+        registry.clearSnapshot(threadAppId);
+        return ToolResult.success().put(KEY_RESUMED, true).put(KEY_SCOPE, "thread").toJson(); //$NON-NLS-1$
+    }
+
+    /**
+     * Resume a debug target, preferring a target-level resume and falling back to resuming
+     * each suspended thread.
+     *
+     * <p>A 1C debug-server target reports {@code canResume()==false} at the target level even
+     * while a thread is genuinely suspended on the breakpoint — so the fallback resumes each
+     * suspended thread (the SAME thread wait_for_break suspends on).
+     *
+     * @param target the debug target to resume
+     * @return the outcome describing whether anything was resumed and at which scope
+     * @throws DebugException if an underlying resume fails
+     */
+    private static ResumeOutcome performResume(IDebugTarget target) throws DebugException
+    {
+        // Prefer resuming at the TARGET level when it accepts it (thin-client and
+        // launch targets do).
+        if (!target.isTerminated() && target.canResume())
+        {
+            target.resume();
+            return new ResumeOutcome(true, "target"); //$NON-NLS-1$
+        }
+
+        int count = 0;
+        for (IThread t : target.getThreads())
+        {
+            if (t != null && t.isSuspended() && t.canResume())
+            {
+                t.resume();
+                count++;
+            }
+        }
+        if (count > 0)
+        {
+            return new ResumeOutcome(true, "thread"); //$NON-NLS-1$
+        }
+        return new ResumeOutcome(false, null);
+    }
+
+    /**
+     * Build the success result for a target resume, adding the resolution-derived flags.
+     *
+     * @param res the resolved debug target
+     * @param scope the resume scope ('target' or 'thread')
+     * @return the populated tool result
+     */
+    private static ToolResult buildResumeResult(DebugTargetResolver.Resolution res, String scope)
+    {
+        ToolResult out = ToolResult.success()
+            .put(KEY_RESUMED, true)
+            .put(KEY_SCOPE, scope)
+            .put(McpKeys.APPLICATION_ID, res.canonicalId);
+        if (res.isServerTarget())
+        {
+            out.put("serverTarget", true); //$NON-NLS-1$
+        }
+        if (res.autoResolved)
+        {
+            out.put("autoResolved", true); //$NON-NLS-1$
+        }
+        return out;
+    }
+
+    /**
+     * Outcome of a target resume attempt: whether anything was resumed and at which scope.
+     */
+    private static final class ResumeOutcome
+    {
+        private final boolean resumed;
+        private final String scope;
+
+        ResumeOutcome(boolean resumed, String scope)
+        {
+            this.resumed = resumed;
+            this.scope = scope;
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/AbstractMetadataFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/AbstractMetadataFormatter.java
@@ -385,79 +385,28 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
      */
     protected void formatDynamicPropertiesSeparated(StringBuilder sb, EObject eObject, String language)
     {
-        List<EStructuralFeature> features = eObject.eClass().getEAllStructuralFeatures();
-        
         // Collect simple attributes and references separately
         List<EAttribute> simpleAttributes = new ArrayList<>();
         List<EReference> singleReferences = new ArrayList<>();
-        List<EReference> containmentReferences = new ArrayList<>();
         List<EReference> crossReferences = new ArrayList<>();
-        
-        for (EStructuralFeature feature : features)
-        {
-            if (feature.isDerived() || feature.isTransient() || feature.isVolatile())
-            {
-                continue;
-            }
-            if (!eObject.eIsSet(feature))
-            {
-                continue;
-            }
-            
-            if (feature instanceof EAttribute)
-            {
-                simpleAttributes.add((EAttribute) feature);
-            }
-            else if (feature instanceof EReference)
-            {
-                EReference ref = (EReference) feature;
-                if (ref.isContainment())
-                {
-                    containmentReferences.add(ref);
-                }
-                else if (!ref.isMany())
-                {
-                    singleReferences.add(ref);
-                }
-                else
-                {
-                    crossReferences.add(ref);
-                }
-            }
-        }
-        
+        classifySetFeatures(eObject, simpleAttributes, singleReferences, crossReferences);
+
         // Format simple attributes
         if (!simpleAttributes.isEmpty())
         {
             addSectionHeader(sb, "Properties"); //$NON-NLS-1$
             startTable(sb, PROPERTY, VALUE);
-            for (EAttribute attr : simpleAttributes)
-            {
-                Object value = eObject.eGet(attr);
-                String valueStr = formatDynamicValue(value, language);
-                if (valueStr != null && !valueStr.isEmpty() && !valueStr.equals(DASH))
-                {
-                    addPropertyRow(sb, formatFeatureName(attr.getName()), valueStr);
-                }
-            }
+            appendFeatureValueRows(sb, eObject, simpleAttributes, language);
         }
-        
+
         // Format single references (forms, modules, etc.)
         if (!singleReferences.isEmpty())
         {
             addSectionHeader(sb, "References"); //$NON-NLS-1$
             startTable(sb, PROPERTY, VALUE);
-            for (EReference ref : singleReferences)
-            {
-                Object value = eObject.eGet(ref);
-                String valueStr = formatDynamicValue(value, language);
-                if (valueStr != null && !valueStr.isEmpty() && !valueStr.equals(DASH))
-                {
-                    addPropertyRow(sb, formatFeatureName(ref.getName()), valueStr);
-                }
-            }
+            appendFeatureValueRows(sb, eObject, singleReferences, language);
         }
-        
+
         // Format cross-references (lists of references)
         if (!crossReferences.isEmpty())
         {
@@ -470,8 +419,86 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
                 }
             }
         }
-        
+
         // Note: containment references are typically handled separately (attributes, tabular sections, etc.)
+    }
+
+    /**
+     * Sorts the set, stored structural features of an object into the buckets used by
+     * {@link #formatDynamicPropertiesSeparated}: simple attributes, single (non-many)
+     * non-containment references, and many (cross) non-containment references.
+     * Derived/transient/volatile and unset features are skipped, and containment
+     * references are intentionally dropped (handled separately). Bucket population
+     * order matches the original inline loop exactly.
+     *
+     * @param eObject the object whose features are inspected
+     * @param simpleAttributes receives the set {@link EAttribute}s
+     * @param singleReferences receives the set single non-containment references
+     * @param crossReferences receives the set many non-containment references
+     */
+    private static void classifySetFeatures(EObject eObject, List<EAttribute> simpleAttributes,
+        List<EReference> singleReferences, List<EReference> crossReferences)
+    {
+        List<EStructuralFeature> features = eObject.eClass().getEAllStructuralFeatures();
+        for (EStructuralFeature feature : features)
+        {
+            if (feature.isDerived() || feature.isTransient() || feature.isVolatile())
+            {
+                continue;
+            }
+            if (!eObject.eIsSet(feature))
+            {
+                continue;
+            }
+
+            if (feature instanceof EAttribute)
+            {
+                simpleAttributes.add((EAttribute) feature);
+            }
+            else if (feature instanceof EReference)
+            {
+                EReference ref = (EReference) feature;
+                if (ref.isContainment())
+                {
+                    // Containment references are typically handled separately.
+                    continue;
+                }
+                if (!ref.isMany())
+                {
+                    singleReferences.add(ref);
+                }
+                else
+                {
+                    crossReferences.add(ref);
+                }
+            }
+        }
+    }
+
+    /**
+     * Appends a Property/Value row for each given feature whose formatted value is
+     * non-empty (skipping {@code null}, empty and {@link #DASH} values), matching the
+     * inline attribute/single-reference rendering blocks in
+     * {@link #formatDynamicPropertiesSeparated}. The table header must already have
+     * been emitted by the caller.
+     *
+     * @param sb the table being built
+     * @param eObject the object whose feature values are read
+     * @param features the features to render, in order
+     * @param language language for synonym rendering
+     */
+    private void appendFeatureValueRows(StringBuilder sb, EObject eObject,
+        List<? extends EStructuralFeature> features, String language)
+    {
+        for (EStructuralFeature feature : features)
+        {
+            Object value = eObject.eGet(feature);
+            String valueStr = formatDynamicValue(value, language);
+            if (valueStr != null && !valueStr.isEmpty() && !valueStr.equals(DASH))
+            {
+                addPropertyRow(sb, formatFeatureName(feature.getName()), valueStr);
+            }
+        }
     }
     
     /**
@@ -484,19 +511,10 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
         Object firstItem = collection.iterator().next();
         if (firstItem instanceof java.util.Map.Entry)
         {
-            // For EMap collections like Synonym, ObjectPresentation - format as key-value table
-            addSectionHeader(sb, formatFeatureName(name) + " (" + collection.size() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
-            startTable(sb, "Language", VALUE); //$NON-NLS-1$
-            for (Object item : collection)
-            {
-                java.util.Map.Entry entry = (java.util.Map.Entry) item;
-                String key = entry.getKey() != null ? entry.getKey().toString() : DASH;
-                String value = entry.getValue() != null ? entry.getValue().toString() : DASH;
-                addTableRow(sb, key, value);
-            }
+            formatEntryCollection(sb, name, collection);
             return;
         }
-        
+
         addSectionHeader(sb, formatFeatureName(name) + " (" + collection.size() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 
         boolean first = true;
@@ -510,7 +528,6 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
         {
             if (item instanceof MdObject)
             {
-                MdObject mdObj = (MdObject) item;
                 if (first)
                 {
                     startTable(sb, "FQN", SYNONYM); //$NON-NLS-1$
@@ -521,36 +538,18 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
                     mdOmitted++;
                     continue;
                 }
-                // Show full FQN: Type.Name (e.g. Catalog.Products)
-                String fqn = mdObj.eClass().getName() + "." + mdObj.getName(); //$NON-NLS-1$
-                addTableRow(sb, fqn, getSynonym(mdObj.getSynonym(), language));
+                appendMdObjectRow(sb, (MdObject) item, language);
                 mdRendered++;
             }
             else if (item instanceof EObject)
             {
-                if (first)
-                {
-                    sb.append("- "); //$NON-NLS-1$
-                    first = false;
-                }
-                else
-                {
-                    sb.append(", "); //$NON-NLS-1$
-                }
-                sb.append(formatEObjectReference((EObject) item));
+                appendInlineReference(sb, first, formatEObjectReference((EObject) item));
+                first = false;
             }
             else if (item != null)
             {
-                if (first)
-                {
-                    sb.append("- "); //$NON-NLS-1$
-                    first = false;
-                }
-                else
-                {
-                    sb.append(", "); //$NON-NLS-1$
-                }
-                sb.append(item.toString());
+                appendInlineReference(sb, first, item.toString());
+                first = false;
             }
         }
         if (mdOmitted > 0)
@@ -561,6 +560,71 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
         {
             sb.append("\n\n"); //$NON-NLS-1$
         }
+    }
+
+    /**
+     * Renders an {@code EMap}-style collection of {@link java.util.Map.Entry} items
+     * (such as Synonym or ObjectPresentation) as a Language/Value table, exactly as
+     * the inline EMap branch of {@link #formatReferenceCollection} did. Null keys and
+     * values are rendered as {@link #DASH}.
+     *
+     * @param sb the buffer being built
+     * @param name the raw feature name used for the section header
+     * @param collection the entry collection (must be non-empty with Map.Entry items)
+     */
+    @SuppressWarnings("rawtypes")
+    private void formatEntryCollection(StringBuilder sb, String name, Collection<?> collection)
+    {
+        // For EMap collections like Synonym, ObjectPresentation - format as key-value table
+        addSectionHeader(sb, formatFeatureName(name) + " (" + collection.size() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+        startTable(sb, "Language", VALUE); //$NON-NLS-1$
+        for (Object item : collection)
+        {
+            java.util.Map.Entry entry = (java.util.Map.Entry) item;
+            String key = entry.getKey() != null ? entry.getKey().toString() : DASH;
+            String value = entry.getValue() != null ? entry.getValue().toString() : DASH;
+            addTableRow(sb, key, value);
+        }
+    }
+
+    /**
+     * Appends a single FQN/Synonym table row for a referencing {@link MdObject}, using
+     * its {@code Type.Name} fully-qualified name (e.g. {@code Catalog.Products}) and
+     * localized synonym. Matches the MdObject branch of
+     * {@link #formatReferenceCollection}.
+     *
+     * @param sb the table being built
+     * @param mdObj the referencing metadata object
+     * @param language language for synonym rendering
+     */
+    private void appendMdObjectRow(StringBuilder sb, MdObject mdObj, String language)
+    {
+        // Show full FQN: Type.Name (e.g. Catalog.Products)
+        String fqn = mdObj.eClass().getName() + "." + mdObj.getName(); //$NON-NLS-1$
+        addTableRow(sb, fqn, getSynonym(mdObj.getSynonym(), language));
+    }
+
+    /**
+     * Appends one item to the inline, comma-separated reference list used for
+     * non-{@link MdObject} entries in {@link #formatReferenceCollection}: the first
+     * rendered item is prefixed with {@code "- "} and subsequent items with
+     * {@code ", "}.
+     *
+     * @param sb the buffer being built
+     * @param first {@code true} if no inline item has been emitted yet
+     * @param text the already-formatted item text to append
+     */
+    private void appendInlineReference(StringBuilder sb, boolean first, String text)
+    {
+        if (first)
+        {
+            sb.append("- "); //$NON-NLS-1$
+        }
+        else
+        {
+            sb.append(", "); //$NON-NLS-1$
+        }
+        sb.append(text);
     }
     
     /**
@@ -608,79 +672,118 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
         // Handle EObject references using EObjectInspector
         if (value instanceof EObject)
         {
-            EObject eObj = (EObject) value;
-            
-            // Use EObjectInspector to determine the best format style
-            EObjectInspector.FormatStyle style = EObjectInspector.getFormatStyle(eObj);
-            
-            switch (style)
-            {
-                case SIMPLE_VALUE:
-                    // Simple wrapper (like StandardCommandGroup) - get primary value
-                    return EObjectInspector.getPrimaryValueAsString(eObj);
-                    
-                case REFERENCE:
-                    // MdObject reference - show as Type.Name
-                    return EObjectInspector.formatReference(eObj);
-                    
-                case EXPAND:
-                    // Complex object - show basic info (expansion handled elsewhere)
-                    return EObjectInspector.formatReference(eObj);
-                    
-                default:
-                    return EObjectInspector.formatReference(eObj);
-            }
+            return formatEObjectValue((EObject) value);
         }
-        
+
         // Handle collections
         if (value instanceof Collection)
         {
-            Collection<?> coll = (Collection<?>) value;
-            if (coll.isEmpty())
-            {
-                return DASH;
-            }
-            // For small collections, show inline
-            if (coll.size() <= 5)
-            {
-                StringBuilder sb = new StringBuilder();
-                for (Object item : coll)
-                {
-                    if (sb.length() > 0) sb.append(", "); //$NON-NLS-1$
-                    
-                    // Handle Map.Entry (LocalStringMapEntry, etc.)
-                    if (item instanceof java.util.Map.Entry)
-                    {
-                        java.util.Map.Entry<?, ?> entry = (java.util.Map.Entry<?, ?>) item;
-                        Object entryValue = entry.getValue();
-                        if (entryValue != null)
-                        {
-                            sb.append(entryValue.toString());
-                        }
-                    }
-                    else if (item instanceof MdObject)
-                    {
-                        // Show full FQN: Type.Name (e.g. Catalog.Products)
-                        MdObject mdObj = (MdObject) item;
-                        sb.append(mdObj.eClass().getName()).append(".").append(mdObj.getName()); //$NON-NLS-1$
-                    }
-                    else if (item instanceof EObject)
-                    {
-                        sb.append(formatEObjectReference((EObject) item));
-                    }
-                    else if (item != null)
-                    {
-                        sb.append(item.toString());
-                    }
-                }
-                return sb.toString();
-            }
-            // For larger collections, just show count
-            return "[" + coll.size() + " items]"; //$NON-NLS-1$ //$NON-NLS-2$
+            return formatCollectionValue((Collection<?>) value);
         }
-        
+
         // Default: toString
         return value.toString();
+    }
+
+    /**
+     * Formats a single {@link EObject} value via {@link EObjectInspector}, choosing the
+     * rendering by its detected {@code FormatStyle}: a simple wrapper yields its primary
+     * value, every other style (reference, expand, default) yields the formatted
+     * reference. Matches the inline EObject switch of {@link #formatDynamicValue}.
+     *
+     * @param eObj the object to render (non-{@code null})
+     * @return the formatted value string
+     */
+    private static String formatEObjectValue(EObject eObj)
+    {
+        // Use EObjectInspector to determine the best format style
+        EObjectInspector.FormatStyle style = EObjectInspector.getFormatStyle(eObj);
+
+        switch (style)
+        {
+            case SIMPLE_VALUE:
+                // Simple wrapper (like StandardCommandGroup) - get primary value
+                return EObjectInspector.getPrimaryValueAsString(eObj);
+
+            case REFERENCE:
+                // MdObject reference - show as Type.Name
+                return EObjectInspector.formatReference(eObj);
+
+            case EXPAND:
+                // Complex object - show basic info (expansion handled elsewhere)
+                return EObjectInspector.formatReference(eObj);
+
+            default:
+                return EObjectInspector.formatReference(eObj);
+        }
+    }
+
+    /**
+     * Formats a collection value for {@link #formatDynamicValue}: empty yields
+     * {@link #DASH}; up to five items are joined inline (per-item via
+     * {@link #formatCollectionItem}); larger collections collapse to an
+     * {@code [N items]} count. Behavior is identical to the inline collection branch.
+     *
+     * @param coll the collection to render (non-{@code null})
+     * @return the formatted value string
+     */
+    private String formatCollectionValue(Collection<?> coll)
+    {
+        if (coll.isEmpty())
+        {
+            return DASH;
+        }
+        // For small collections, show inline
+        if (coll.size() <= 5)
+        {
+            StringBuilder sb = new StringBuilder();
+            for (Object item : coll)
+            {
+                if (sb.length() > 0) sb.append(", "); //$NON-NLS-1$
+                formatCollectionItem(sb, item);
+            }
+            return sb.toString();
+        }
+        // For larger collections, just show count
+        return "[" + coll.size() + " items]"; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Appends one inline-collection item to {@code sb}, dispatching on its runtime type
+     * exactly as the inner loop of {@link #formatDynamicValue} did: a {@link java.util.Map.Entry}
+     * contributes its non-null value, an {@link MdObject} its {@code Type.Name} FQN, any
+     * other {@link EObject} its formatted reference, and any other non-null item its
+     * {@code toString()}. The leading separator is the caller's responsibility.
+     *
+     * @param sb the buffer being built
+     * @param item the item to render (may be {@code null}, in which case nothing is appended)
+     */
+    private void formatCollectionItem(StringBuilder sb, Object item)
+    {
+        // Handle Map.Entry (LocalStringMapEntry, etc.)
+        if (item instanceof java.util.Map.Entry)
+        {
+            java.util.Map.Entry<?, ?> entry = (java.util.Map.Entry<?, ?>) item;
+            Object entryValue = entry.getValue();
+            if (entryValue != null)
+            {
+                sb.append(entryValue.toString());
+            }
+        }
+        else if (item instanceof MdObject)
+        {
+            // Show full FQN: Type.Name (e.g. Catalog.Products)
+            MdObject mdObj = (MdObject) item;
+            sb.append(mdObj.eClass().getName()).append(".").append(mdObj.getName()); //$NON-NLS-1$
+        }
+        else if (item instanceof EObject)
+        {
+            sb.append(formatEObjectReference((EObject) item));
+        }
+        else if (item != null)
+        {
+            sb.append(item.toString());
+        }
     }
     
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/EObjectInspector.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/EObjectInspector.java
@@ -222,25 +222,75 @@ public final class EObjectInspector
         {
             return null;
         }
-        
+
         EClass eClass = eObj.eClass();
-        
+
         // 1. Look for enum attributes first (highest priority)
+        Object enumValue = findEnumAttributeValue(eObj, eClass);
+        if (enumValue != null)
+        {
+            return enumValue;
+        }
+
+        // 2. Look for known primary value feature names
+        Object namedFeatureValue = findNamedPrimaryFeatureValue(eObj, eClass);
+        if (namedFeatureValue != null)
+        {
+            return namedFeatureValue;
+        }
+
+        // 3. Try 'name' feature
+        Object nameValue = findNameFeatureValue(eObj, eClass);
+        if (nameValue != null)
+        {
+            return nameValue;
+        }
+
+        // 4. First non-derived, non-name attribute that is set
+        Object firstSetAttr = findFirstSetNonNameAttribute(eObj, eClass);
+        if (firstSetAttr != null)
+        {
+            return firstSetAttr;
+        }
+
+        // 5. Fallback to class name
+        return eClass.getName();
+    }
+
+    /**
+     * Find the value of the first non-derived enum attribute that is set.
+     *
+     * @param eObj the owning EObject
+     * @param eClass the EObject's class
+     * @return the enum value, or {@code null} if no enum attribute holds a value
+     */
+    private static Object findEnumAttributeValue(EObject eObj, EClass eClass)
+    {
         for (EAttribute attr : eClass.getEAllAttributes())
         {
             if (attr.isDerived() || attr.isTransient())
             {
                 continue;
             }
-            
+
             Object value = eObj.eGet(attr);
             if (value != null && value.getClass().isEnum())
             {
                 return value;
             }
         }
-        
-        // 2. Look for known primary value feature names
+        return null;
+    }
+
+    /**
+     * Find the value of the first known primary-value feature (category, group, type, value).
+     *
+     * @param eObj the owning EObject
+     * @param eClass the EObject's class
+     * @return the feature value, or {@code null} if none of the known features is set
+     */
+    private static Object findNamedPrimaryFeatureValue(EObject eObj, EClass eClass)
+    {
         for (String featureName : PRIMARY_VALUE_FEATURE_NAMES)
         {
             EStructuralFeature f = eClass.getEStructuralFeature(featureName);
@@ -253,8 +303,18 @@ public final class EObjectInspector
                 }
             }
         }
-        
-        // 3. Try 'name' feature
+        return null;
+    }
+
+    /**
+     * Find the value of the 'name' feature when it is set and non-empty.
+     *
+     * @param eObj the owning EObject
+     * @param eClass the EObject's class
+     * @return the name value, or {@code null} if the feature is absent, unset, or empty
+     */
+    private static Object findNameFeatureValue(EObject eObj, EClass eClass)
+    {
         EStructuralFeature nameFeature = eClass.getEStructuralFeature("name"); //$NON-NLS-1$
         if (nameFeature != null && eObj.eIsSet(nameFeature))
         {
@@ -264,8 +324,18 @@ public final class EObjectInspector
                 return name;
             }
         }
-        
-        // 4. First non-derived, non-name attribute that is set
+        return null;
+    }
+
+    /**
+     * Find the value of the first set, non-derived attribute that is not a name attribute.
+     *
+     * @param eObj the owning EObject
+     * @param eClass the EObject's class
+     * @return the attribute value, or {@code null} if no such attribute holds a value
+     */
+    private static Object findFirstSetNonNameAttribute(EObject eObj, EClass eClass)
+    {
         for (EAttribute attr : eClass.getEAllAttributes())
         {
             if (attr.isDerived() || attr.isTransient())
@@ -286,9 +356,7 @@ public final class EObjectInspector
                 }
             }
         }
-        
-        // 5. Fallback to class name
-        return eClass.getName();
+        return null;
     }
     
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
@@ -469,91 +469,108 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
     private void formatTabularSectionsExtended(StringBuilder sb, String name, Collection<?> items, boolean full, String language)
     {
         addSectionHeader(sb, name);
-        
+
         for (Object item : items)
         {
             if (item instanceof BasicTabularSection)
             {
                 BasicTabularSection ts = (BasicTabularSection) item;
-                
+
                 // Sub-header for this tabular section
                 sb.append("\n#### ").append(ts.getName()).append("\n\n");
-                
-                // Properties table for the TS itself
-                startTable(sb, "Property", VALUE_TOKEN);
-                addPropertyRow(sb, "Name", ts.getName());
-                addPropertyRow(sb, SYNONYM_TOKEN, getSynonym(ts.getSynonym(), language));
-                
-                String comment = ts.getComment();
-                if (comment != null && !comment.isEmpty())
+
+                formatTabularSectionProperties(sb, ts, language);
+                formatTabularSectionAttributes(sb, ts, full, language);
+            }
+        }
+    }
+
+    /**
+     * Renders the properties table of a single tabular section (Name, Synonym, optional Comment /
+     * Tool Tip, Fill Checking, and the reflective Use / Line Number Length rows).
+     */
+    private void formatTabularSectionProperties(StringBuilder sb, BasicTabularSection ts, String language)
+    {
+        // Properties table for the TS itself
+        startTable(sb, "Property", VALUE_TOKEN);
+        addPropertyRow(sb, "Name", ts.getName());
+        addPropertyRow(sb, SYNONYM_TOKEN, getSynonym(ts.getSynonym(), language));
+
+        String comment = ts.getComment();
+        if (comment != null && !comment.isEmpty())
+        {
+            addPropertyRow(sb, "Comment", comment);
+        }
+
+        // Tool Tip
+        String toolTip = getSynonym(ts.getToolTip(), language);
+        if (toolTip != null && !toolTip.isEmpty())
+        {
+            addPropertyRow(sb, "Tool Tip", toolTip);
+        }
+
+        // Fill Checking
+        addPropertyRow(sb, "Fill Checking", formatEnum(ts.getFillChecking()));
+
+        // Use (via reflection, available in HierarchicalDbObjectTabularSection)
+        try
+        {
+            java.lang.reflect.Method method = ts.getClass().getMethod("getUse");
+            Object use = method.invoke(ts);
+            if (use != null)
+            {
+                addPropertyRow(sb, "Use", formatEnum(use));
+            }
+        }
+        catch (Exception e)
+        {
+            // Method doesn't exist - skip
+        }
+
+        // LineNumberLength (via reflection)
+        try
+        {
+            java.lang.reflect.Method method = ts.getClass().getMethod("getLineNumberLength");
+            Object lineNumLen = method.invoke(ts);
+            if (lineNumLen != null)
+            {
+                addPropertyRow(sb, "Line Number Length", lineNumLen.toString());
+            }
+        }
+        catch (Exception e)
+        {
+            // Method doesn't exist - skip
+        }
+    }
+
+    /**
+     * Renders the attributes sub-table of a single tabular section, resolving the attributes
+     * collection via EMF reflection. No output is produced when the section has no attributes.
+     */
+    private void formatTabularSectionAttributes(StringBuilder sb, BasicTabularSection ts, boolean full, String language)
+    {
+        // Get attributes collection via EMF reflection
+        try
+        {
+            EObject eObj = (EObject) ts;
+            EStructuralFeature attrFeature = eObj.eClass().getEStructuralFeature("attributes");
+            if (attrFeature != null)
+            {
+                Object attrValue = eObj.eGet(attrFeature);
+                if (attrValue instanceof Collection && !((Collection<?>) attrValue).isEmpty())
                 {
-                    addPropertyRow(sb, "Comment", comment);
-                }
-                
-                // Tool Tip
-                String toolTip = getSynonym(ts.getToolTip(), language);
-                if (toolTip != null && !toolTip.isEmpty())
-                {
-                    addPropertyRow(sb, "Tool Tip", toolTip);
-                }
-                
-                // Fill Checking
-                addPropertyRow(sb, "Fill Checking", formatEnum(ts.getFillChecking()));
-                
-                // Use (via reflection, available in HierarchicalDbObjectTabularSection)
-                try
-                {
-                    java.lang.reflect.Method method = ts.getClass().getMethod("getUse");
-                    Object use = method.invoke(ts);
-                    if (use != null)
-                    {
-                        addPropertyRow(sb, "Use", formatEnum(use));
-                    }
-                }
-                catch (Exception e)
-                {
-                    // Method doesn't exist - skip
-                }
-                
-                // LineNumberLength (via reflection)
-                try
-                {
-                    java.lang.reflect.Method method = ts.getClass().getMethod("getLineNumberLength");
-                    Object lineNumLen = method.invoke(ts);
-                    if (lineNumLen != null)
-                    {
-                        addPropertyRow(sb, "Line Number Length", lineNumLen.toString());
-                    }
-                }
-                catch (Exception e)
-                {
-                    // Method doesn't exist - skip
-                }
-                
-                // Get attributes collection via EMF reflection
-                try
-                {
-                    EObject eObj = (EObject) ts;
-                    EStructuralFeature attrFeature = eObj.eClass().getEStructuralFeature("attributes");
-                    if (attrFeature != null)
-                    {
-                        Object attrValue = eObj.eGet(attrFeature);
-                        if (attrValue instanceof Collection && !((Collection<?>) attrValue).isEmpty())
-                        {
-                            Collection<?> attributes = (Collection<?>) attrValue;
-                            
-                            // Format attributes of this tabular section
-                            sb.append("\n**Attributes:**\n\n");
-                            formatAttributesCollection(sb, "", attributes, full, language);
-                        }
-                    }
-                }
-                catch (Exception e)
-                {
-                    // Error getting attributes - skip
-                    System.err.println("Error formatting tabular section attributes: " + e.getMessage());
+                    Collection<?> attributes = (Collection<?>) attrValue;
+
+                    // Format attributes of this tabular section
+                    sb.append("\n**Attributes:**\n\n");
+                    formatAttributesCollection(sb, "", attributes, full, language);
                 }
             }
+        }
+        catch (Exception e)
+        {
+            // Error getting attributes - skip
+            System.err.println("Error formatting tabular section attributes: " + e.getMessage());
         }
     }
     

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/reference/MetadataReferenceService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/reference/MetadataReferenceService.java
@@ -167,7 +167,29 @@ public class MetadataReferenceService
         // Separate BSL and metadata references
         java.util.Map<String, List<Integer>> bslModuleLines = new java.util.TreeMap<>();
         List<ReferenceInfo> metadataRefs = new ArrayList<>();
+        partitionReferences(allRefs, bslModuleLines, metadataRefs);
 
+        // Sort metadata references by sourcePath
+        metadataRefs.sort((a, b) -> {
+            String pathA = a.sourcePath != null ? a.sourcePath : ""; //$NON-NLS-1$
+            String pathB = b.sourcePath != null ? b.sourcePath : ""; //$NON-NLS-1$
+            return pathA.compareToIgnoreCase(pathB);
+        });
+
+        appendMetadataRefs(sb, metadataRefs);
+        appendBslModules(sb, bslModuleLines);
+
+        return sb.toString();
+    }
+
+    /**
+     * Splits the flat reference list into BSL lines grouped by module path (into
+     * {@code bslModuleLines}) and metadata references (into {@code metadataRefs}), preserving the
+     * original iteration order. Pure helper extracted from {@link #formatOutput}.
+     */
+    private static void partitionReferences(List<ReferenceInfo> allRefs,
+        java.util.Map<String, List<Integer>> bslModuleLines, List<ReferenceInfo> metadataRefs)
+    {
         for (ReferenceInfo ref : allRefs)
         {
             if (ref.isBslReference)
@@ -181,15 +203,15 @@ public class MetadataReferenceService
                 metadataRefs.add(ref);
             }
         }
+    }
 
-        // Sort metadata references by sourcePath
-        metadataRefs.sort((a, b) -> {
-            String pathA = a.sourcePath != null ? a.sourcePath : ""; //$NON-NLS-1$
-            String pathB = b.sourcePath != null ? b.sourcePath : ""; //$NON-NLS-1$
-            return pathA.compareToIgnoreCase(pathB);
-        });
-
-        // Output metadata references
+    /**
+     * Appends the (already sorted) metadata references to {@code sb} as a markdown bullet list,
+     * stripping a leading slash from the display path and adding the feature when present. Pure
+     * helper extracted from {@link #formatOutput}.
+     */
+    private static void appendMetadataRefs(StringBuilder sb, List<ReferenceInfo> metadataRefs)
+    {
         for (ReferenceInfo ref : metadataRefs)
         {
             String displayPath = ref.sourcePath;
@@ -205,47 +227,65 @@ public class MetadataReferenceService
             }
             sb.append("\n"); //$NON-NLS-1$
         }
+    }
 
-        // Output BSL references grouped by module
-        if (!bslModuleLines.isEmpty())
+    /**
+     * Appends the BSL references grouped by module (the "### BSL Modules" section) to {@code sb}:
+     * for each module path it sorts the line numbers, strips a leading slash, and renders them as
+     * {@code [Line X; Line Y; ...]}. Does nothing when there are no BSL references. Pure helper
+     * extracted from {@link #formatOutput}.
+     */
+    private static void appendBslModules(StringBuilder sb,
+        java.util.Map<String, List<Integer>> bslModuleLines)
+    {
+        if (bslModuleLines.isEmpty())
         {
-            sb.append("\n### BSL Modules\n\n"); //$NON-NLS-1$
-
-            for (java.util.Map.Entry<String, List<Integer>> entry : bslModuleLines.entrySet())
-            {
-                String modulePath = entry.getKey();
-                List<Integer> lines = entry.getValue();
-
-                // Sort lines
-                lines.sort(Integer::compareTo);
-
-                // Remove leading slash if present
-                if (modulePath != null && modulePath.startsWith("/")) //$NON-NLS-1$
-                {
-                    modulePath = modulePath.substring(1);
-                }
-
-                sb.append("- ").append(modulePath); //$NON-NLS-1$
-
-                // Format lines as [Line X; Line Y; ...]
-                if (!lines.isEmpty())
-                {
-                    sb.append(" ["); //$NON-NLS-1$
-                    for (int i = 0; i < lines.size(); i++)
-                    {
-                        if (i > 0)
-                        {
-                            sb.append("; "); //$NON-NLS-1$
-                        }
-                        sb.append("Line ").append(lines.get(i)); //$NON-NLS-1$
-                    }
-                    sb.append("]"); //$NON-NLS-1$
-                }
-                sb.append("\n"); //$NON-NLS-1$
-            }
+            return;
         }
+        sb.append("\n### BSL Modules\n\n"); //$NON-NLS-1$
 
-        return sb.toString();
+        for (java.util.Map.Entry<String, List<Integer>> entry : bslModuleLines.entrySet())
+        {
+            String modulePath = entry.getKey();
+            List<Integer> lines = entry.getValue();
+
+            // Sort lines
+            lines.sort(Integer::compareTo);
+
+            // Remove leading slash if present
+            if (modulePath != null && modulePath.startsWith("/")) //$NON-NLS-1$
+            {
+                modulePath = modulePath.substring(1);
+            }
+
+            sb.append("- ").append(modulePath); //$NON-NLS-1$
+
+            // Format lines as [Line X; Line Y; ...]
+            appendBslLines(sb, lines);
+            sb.append("\n"); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Appends a module's line numbers as {@code [Line X; Line Y; ...]} to {@code sb}, or nothing
+     * when the list is empty. Pure helper extracted from {@link #formatOutput}.
+     */
+    private static void appendBslLines(StringBuilder sb, List<Integer> lines)
+    {
+        if (lines.isEmpty())
+        {
+            return;
+        }
+        sb.append(" ["); //$NON-NLS-1$
+        for (int i = 0; i < lines.size(); i++)
+        {
+            if (i > 0)
+            {
+                sb.append("; "); //$NON-NLS-1$
+            }
+            sb.append("Line ").append(lines.get(i)); //$NON-NLS-1$
+        }
+        sb.append("]"); //$NON-NLS-1$
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
@@ -1423,34 +1423,7 @@ public class MetadataRenameService
         // Apply disableIndices by traversing items and their native changes
         if (!disableIndices.isEmpty())
         {
-            int[] indexCounter = {0};
-            for (IRefactoring refactoring : refactorings)
-            {
-                Collection<IRefactoringItem> items = refactoring.getItems();
-                if (items == null)
-                    continue;
-                for (IRefactoringItem item : items)
-                {
-                    if (item instanceof INativeChangeRefactoringItem nativeItem)
-                    {
-                        Change nativeChange = nativeItem.getNativeChange();
-                        if (nativeChange != null)
-                        {
-                            applyDisableToChange(nativeChange, disableIndices, indexCounter);
-                        }
-                        // If all leaf changes under this native item are disabled, uncheck the item itself
-                        if (nativeChange != null && nativeItem.isOptional() && isCompletelyDisabled(nativeChange))
-                        {
-                            nativeItem.setChecked(false);
-                        }
-                    }
-                    else
-                    {
-                        // Regular rename item — not skippable (non-optional), just advance index
-                        indexCounter[0]++;
-                    }
-                }
-            }
+            applyDisableIndices(refactorings, disableIndices);
         }
 
         List<String> performed = new ArrayList<>();
@@ -1470,6 +1443,58 @@ public class MetadataRenameService
             }
         }
 
+        return renderExecutedReport(objectFqn, newName, disableIndices, performed, errors);
+    }
+
+    /**
+     * Toggles the LTK change-tree flags for the requested {@code disableIndices} BEFORE the rename is
+     * performed: walks every refactoring item, disables the matching leaf changes (via
+     * {@link #applyDisableToChange}) and unchecks an optional native item whose leaves are all
+     * disabled. Mutates the in-memory refactoring objects' enabled/checked state only - it does NOT
+     * perform the rename. Extracted verbatim from {@link #performRename} so it runs at the same point
+     * under the same {@code !disableIndices.isEmpty()} guard.
+     */
+    private void applyDisableIndices(Collection<IRefactoring> refactorings,
+        java.util.Set<Integer> disableIndices)
+    {
+        int[] indexCounter = {0};
+        for (IRefactoring refactoring : refactorings)
+        {
+            Collection<IRefactoringItem> items = refactoring.getItems();
+            if (items == null)
+                continue;
+            for (IRefactoringItem item : items)
+            {
+                if (item instanceof INativeChangeRefactoringItem nativeItem)
+                {
+                    Change nativeChange = nativeItem.getNativeChange();
+                    if (nativeChange != null)
+                    {
+                        applyDisableToChange(nativeChange, disableIndices, indexCounter);
+                    }
+                    // If all leaf changes under this native item are disabled, uncheck the item itself
+                    if (nativeChange != null && nativeItem.isOptional() && isCompletelyDisabled(nativeChange))
+                    {
+                        nativeItem.setChecked(false);
+                    }
+                }
+                else
+                {
+                    // Regular rename item — not skippable (non-optional), just advance index
+                    indexCounter[0]++;
+                }
+            }
+        }
+    }
+
+    /**
+     * Renders the markdown report for a performed rename: the YAML front matter (counts), the
+     * "Rename Completed" header, the performed-titles and error lists, and the skipped-change-points
+     * note. Pure string building with no side effects; extracted verbatim from {@link #performRename}.
+     */
+    private static String renderExecutedReport(String objectFqn, String newName,
+        java.util.Set<Integer> disableIndices, List<String> performed, List<String> errors)
+    {
         StringBuilder sb = new StringBuilder();
         sb.append("---\n"); //$NON-NLS-1$
         sb.append("action: executed\n"); //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/symbol/SymbolInfoService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/symbol/SymbolInfoService.java
@@ -553,91 +553,23 @@ public class SymbolInfoService
 
         if (element instanceof Method)
         {
-            Method method = (Method) element;
-            boolean isFunction = element instanceof Function;
-
-            sb.append(codeCell(SYMBOL, method.getName()));
-            sb.append("| **Kind** | ").append(isFunction ? "Function" : "Procedure").append(" |\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-            sb.append(codeCell("Signature", BslModuleUtils.buildSignature(method))); //$NON-NLS-1$
-            sb.append("| **Export** | ").append(method.isExport() ? "Yes" : "No").append(" |\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-
-            int startLine = BslModuleUtils.getStartLine(method);
-            int endLine = BslModuleUtils.getEndLine(method);
-            if (startLine > 0)
-            {
-                sb.append("| **Lines** | ").append(startLine); //$NON-NLS-1$
-                if (endLine > startLine)
-                {
-                    sb.append(" - ").append(endLine); //$NON-NLS-1$
-                }
-                sb.append(" |\n"); //$NON-NLS-1$
-            }
-
-            // Parameters
-            String params = BslModuleUtils.buildParamsString(method);
-            if (params != null && !params.isEmpty())
-            {
-                sb.append(cell("Parameters", params)); //$NON-NLS-1$
-            }
+            appendMethodInfo(sb, (Method) element);
         }
         else if (element instanceof FormalParam)
         {
-            FormalParam param = (FormalParam) element;
-            sb.append(codeCell(SYMBOL, param.getName()));
-            sb.append("| **Kind** | Parameter |\n"); //$NON-NLS-1$
-            sb.append("| **ByValue** | ").append(param.isByValue() ? "Yes" : "No").append(" |\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-
-            // Show containing method
-            EObject container = param.eContainer();
-            if (container instanceof Method)
-            {
-                sb.append(codeCell(IN_METHOD, ((Method) container).getName()));
-            }
+            appendFormalParamInfo(sb, (FormalParam) element);
         }
         else if (element instanceof StaticFeatureAccess)
         {
-            StaticFeatureAccess sfa = (StaticFeatureAccess) element;
-            sb.append(codeCell(SYMBOL, sfa.getName()));
-            sb.append("| **Kind** | StaticFeatureAccess |\n"); //$NON-NLS-1$
-            sb.append(cell(EMF_TYPE, sfa.eClass().getName()));
-
-            // Show containing method
-            EObject container = findContainingMethod(sfa);
-            if (container instanceof Method)
-            {
-                sb.append(codeCell(IN_METHOD, ((Method) container).getName()));
-            }
+            appendStaticFeatureAccessInfo(sb, (StaticFeatureAccess) element);
         }
         else if (element instanceof DynamicFeatureAccess)
         {
-            DynamicFeatureAccess dfa = (DynamicFeatureAccess) element;
-            sb.append(codeCell(SYMBOL, dfa.getName()));
-            sb.append("| **Kind** | DynamicFeatureAccess |\n"); //$NON-NLS-1$
-            sb.append(cell(EMF_TYPE, dfa.eClass().getName()));
-
-            // Show containing method
-            EObject container = findContainingMethod(dfa);
-            if (container instanceof Method)
-            {
-                sb.append(codeCell(IN_METHOD, ((Method) container).getName()));
-            }
+            appendDynamicFeatureAccessInfo(sb, (DynamicFeatureAccess) element);
         }
         else if (element instanceof Invocation)
         {
-            Invocation invocation = (Invocation) element;
-            sb.append("| **Kind** | Invocation |\n"); //$NON-NLS-1$
-            sb.append(cell(EMF_TYPE, invocation.eClass().getName()));
-
-            // Try to get the method name from the feature access
-            EObject methodAccess = invocation.getMethodAccess();
-            if (methodAccess instanceof StaticFeatureAccess)
-            {
-                sb.append(codeCell(SYMBOL, ((StaticFeatureAccess) methodAccess).getName()));
-            }
-            else if (methodAccess instanceof DynamicFeatureAccess)
-            {
-                sb.append(codeCell(SYMBOL, ((DynamicFeatureAccess) methodAccess).getName()));
-            }
+            appendInvocationInfo(sb, (Invocation) element);
         }
         else if (element instanceof Module)
         {
@@ -646,38 +578,161 @@ public class SymbolInfoService
         }
         else
         {
-            // Generic EObject info
-            sb.append(cell("Kind", element.eClass().getName())); //$NON-NLS-1$
-
-            // Try to get name via reflection
-            try
-            {
-                Object name = ReflectionUtils.invokeMethod(element, "getName"); //$NON-NLS-1$
-                if (name instanceof String && !((String) name).isEmpty())
-                {
-                    sb.append(codeCell(SYMBOL, (String) name));
-                }
-            }
-            catch (Exception e)
-            {
-                // No getName method — that's OK
-            }
-
-            // Show containing method
-            EObject container = findContainingMethod(element);
-            if (container instanceof Method)
-            {
-                sb.append(codeCell(IN_METHOD, ((Method) container).getName()));
-            }
-
-            int startLine = BslModuleUtils.getStartLine(element);
-            if (startLine > 0)
-            {
-                sb.append("| **Line** | ").append(startLine).append(" |\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            }
+            appendGenericInfo(sb, element);
         }
 
         return sb.toString();
+    }
+
+    /**
+     * Appends the {@link Method}-specific rows (symbol, kind, signature, export,
+     * lines, parameters) to {@code sb}. Extracted verbatim from the
+     * {@code instanceof Method} branch of {@link #buildEObjectInfo}.
+     */
+    private void appendMethodInfo(StringBuilder sb, Method method)
+    {
+        boolean isFunction = method instanceof Function;
+
+        sb.append(codeCell(SYMBOL, method.getName()));
+        sb.append("| **Kind** | ").append(isFunction ? "Function" : "Procedure").append(" |\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        sb.append(codeCell("Signature", BslModuleUtils.buildSignature(method))); //$NON-NLS-1$
+        sb.append("| **Export** | ").append(method.isExport() ? "Yes" : "No").append(" |\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+        int startLine = BslModuleUtils.getStartLine(method);
+        int endLine = BslModuleUtils.getEndLine(method);
+        if (startLine > 0)
+        {
+            sb.append("| **Lines** | ").append(startLine); //$NON-NLS-1$
+            if (endLine > startLine)
+            {
+                sb.append(" - ").append(endLine); //$NON-NLS-1$
+            }
+            sb.append(" |\n"); //$NON-NLS-1$
+        }
+
+        // Parameters
+        String params = BslModuleUtils.buildParamsString(method);
+        if (params != null && !params.isEmpty())
+        {
+            sb.append(cell("Parameters", params)); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Appends the {@link FormalParam}-specific rows (symbol, kind, by-value, containing
+     * method) to {@code sb}. Extracted verbatim from the {@code instanceof FormalParam}
+     * branch of {@link #buildEObjectInfo}.
+     */
+    private void appendFormalParamInfo(StringBuilder sb, FormalParam param)
+    {
+        sb.append(codeCell(SYMBOL, param.getName()));
+        sb.append("| **Kind** | Parameter |\n"); //$NON-NLS-1$
+        sb.append("| **ByValue** | ").append(param.isByValue() ? "Yes" : "No").append(" |\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+        // Show containing method
+        EObject container = param.eContainer();
+        if (container instanceof Method)
+        {
+            sb.append(codeCell(IN_METHOD, ((Method) container).getName()));
+        }
+    }
+
+    /**
+     * Appends the {@link StaticFeatureAccess}-specific rows (symbol, kind, EMF type,
+     * containing method) to {@code sb}. Extracted verbatim from the
+     * {@code instanceof StaticFeatureAccess} branch of {@link #buildEObjectInfo}.
+     */
+    private void appendStaticFeatureAccessInfo(StringBuilder sb, StaticFeatureAccess sfa)
+    {
+        sb.append(codeCell(SYMBOL, sfa.getName()));
+        sb.append("| **Kind** | StaticFeatureAccess |\n"); //$NON-NLS-1$
+        sb.append(cell(EMF_TYPE, sfa.eClass().getName()));
+
+        // Show containing method
+        EObject container = findContainingMethod(sfa);
+        if (container instanceof Method)
+        {
+            sb.append(codeCell(IN_METHOD, ((Method) container).getName()));
+        }
+    }
+
+    /**
+     * Appends the {@link DynamicFeatureAccess}-specific rows (symbol, kind, EMF type,
+     * containing method) to {@code sb}. Extracted verbatim from the
+     * {@code instanceof DynamicFeatureAccess} branch of {@link #buildEObjectInfo}.
+     */
+    private void appendDynamicFeatureAccessInfo(StringBuilder sb, DynamicFeatureAccess dfa)
+    {
+        sb.append(codeCell(SYMBOL, dfa.getName()));
+        sb.append("| **Kind** | DynamicFeatureAccess |\n"); //$NON-NLS-1$
+        sb.append(cell(EMF_TYPE, dfa.eClass().getName()));
+
+        // Show containing method
+        EObject container = findContainingMethod(dfa);
+        if (container instanceof Method)
+        {
+            sb.append(codeCell(IN_METHOD, ((Method) container).getName()));
+        }
+    }
+
+    /**
+     * Appends the {@link Invocation}-specific rows (kind, EMF type, and the invoked
+     * symbol name resolved from the method access) to {@code sb}. Extracted verbatim
+     * from the {@code instanceof Invocation} branch of {@link #buildEObjectInfo}.
+     */
+    private void appendInvocationInfo(StringBuilder sb, Invocation invocation)
+    {
+        sb.append("| **Kind** | Invocation |\n"); //$NON-NLS-1$
+        sb.append(cell(EMF_TYPE, invocation.eClass().getName()));
+
+        // Try to get the method name from the feature access
+        EObject methodAccess = invocation.getMethodAccess();
+        if (methodAccess instanceof StaticFeatureAccess)
+        {
+            sb.append(codeCell(SYMBOL, ((StaticFeatureAccess) methodAccess).getName()));
+        }
+        else if (methodAccess instanceof DynamicFeatureAccess)
+        {
+            sb.append(codeCell(SYMBOL, ((DynamicFeatureAccess) methodAccess).getName()));
+        }
+    }
+
+    /**
+     * Appends the generic-EObject rows (kind, reflective name, containing method,
+     * line) to {@code sb} for any element not matched by a specific branch. Extracted
+     * verbatim from the {@code else} branch of {@link #buildEObjectInfo}.
+     */
+    private void appendGenericInfo(StringBuilder sb, EObject element)
+    {
+        // Generic EObject info
+        sb.append(cell("Kind", element.eClass().getName())); //$NON-NLS-1$
+
+        // Try to get name via reflection
+        try
+        {
+            Object name = ReflectionUtils.invokeMethod(element, "getName"); //$NON-NLS-1$
+            if (name instanceof String && !((String) name).isEmpty())
+            {
+                sb.append(codeCell(SYMBOL, (String) name));
+            }
+        }
+        catch (Exception e)
+        {
+            // No getName method — that's OK
+        }
+
+        // Show containing method
+        EObject container = findContainingMethod(element);
+        if (container instanceof Method)
+        {
+            sb.append(codeCell(IN_METHOD, ((Method) container).getName()));
+        }
+
+        int startLine = BslModuleUtils.getStartLine(element);
+        if (startLine > 0)
+        {
+            sb.append("| **Line** | ").append(startLine).append(" |\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslSyntaxChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslSyntaxChecker.java
@@ -121,106 +121,165 @@ public final class BslSyntaxChecker
 
         for (int i = 0; i < lines.size(); i++)
         {
-            String line = lines.get(i);
             int lineNum = i + 1;
 
-            // Skip empty lines
-            if (line.trim().isEmpty())
+            String trimmed = preprocessLine(lines.get(i));
+            if (trimmed == null)
             {
                 continue;
-            }
-
-            // Skip lines that are entirely a comment
-            String trimmed = line.trim();
-            if (trimmed.startsWith("//")) //$NON-NLS-1$
-            {
-                continue;
-            }
-
-            // Skip multiline string continuation lines (start with |)
-            if (trimmed.startsWith("|")) //$NON-NLS-1$
-            {
-                continue;
-            }
-
-            // Remove inline comment (everything after //)
-            // Known limitation: // inside string literals (e.g. URLs like "https://...")
-            // will be treated as a comment start. This is acceptable because keywords
-            // are matched at line start (^\s*keyword\b), so truncation does not affect results.
-            int commentIdx = trimmed.indexOf("//"); //$NON-NLS-1$
-            if (commentIdx > 0)
-            {
-                trimmed = trimmed.substring(0, commentIdx);
             }
 
             // Check closing keywords FIRST
-            if (END_PROCEDURE.matcher(trimmed).find())
+            if (handleClosingKeyword(trimmed, lineNum, stack, errors))
             {
-                popAndCheck(stack, TAG_PROCEDURE, "\u041A\u043E\u043D\u0435\u0446\u041F\u0440\u043E\u0446\u0435\u0434\u0443\u0440\u044B/EndProcedure", lineNum, errors); //$NON-NLS-1$
-                continue;
-            }
-            if (END_FUNCTION.matcher(trimmed).find())
-            {
-                popAndCheck(stack, TAG_FUNCTION, "\u041A\u043E\u043D\u0435\u0446\u0424\u0443\u043D\u043A\u0446\u0438\u0438/EndFunction", lineNum, errors); //$NON-NLS-1$
-                continue;
-            }
-            if (END_IF.matcher(trimmed).find())
-            {
-                popAndCheck(stack, TAG_IF, "\u041A\u043E\u043D\u0435\u0446\u0415\u0441\u043B\u0438/EndIf", lineNum, errors); //$NON-NLS-1$
-                continue;
-            }
-            if (END_DO.matcher(trimmed).find())
-            {
-                popAndCheck(stack, TAG_LOOP, "\u041A\u043E\u043D\u0435\u0446\u0426\u0438\u043A\u043B\u0430/EndDo", lineNum, errors); //$NON-NLS-1$
-                continue;
-            }
-            if (END_TRY.matcher(trimmed).find())
-            {
-                popAndCheck(stack, TAG_TRY, "\u041A\u043E\u043D\u0435\u0446\u041F\u043E\u043F\u044B\u0442\u043A\u0438/EndTry", lineNum, errors); //$NON-NLS-1$
                 continue;
             }
 
             // Check opening keywords
-            if (PROCEDURE_START.matcher(trimmed).find())
-            {
-                stack.push(new String[] { TAG_PROCEDURE, String.valueOf(lineNum) });
-                continue;
-            }
-            if (FUNCTION_START.matcher(trimmed).find())
-            {
-                stack.push(new String[] { TAG_FUNCTION, String.valueOf(lineNum) });
-                continue;
-            }
-            // If but NOT ElsIf
-            if (IF_START.matcher(trimmed).find() && !ELSIF_PATTERN.matcher(trimmed).find())
-            {
-                stack.push(new String[] { TAG_IF, String.valueOf(lineNum) });
-                continue;
-            }
-            if (WHILE_START.matcher(trimmed).find())
-            {
-                stack.push(new String[] { TAG_LOOP, String.valueOf(lineNum) });
-                continue;
-            }
-            if (FOR_START.matcher(trimmed).find())
-            {
-                stack.push(new String[] { TAG_LOOP, String.valueOf(lineNum) });
-                continue;
-            }
-            if (TRY_START.matcher(trimmed).find())
-            {
-                stack.push(new String[] { TAG_TRY, String.valueOf(lineNum) });
-            }
+            handleOpeningKeyword(trimmed, lineNum, stack);
         }
 
-        // Report unclosed blocks
+        reportUnclosedBlocks(stack, errors);
+
+        return new CheckResult(errors.isEmpty(), errors);
+    }
+
+    /**
+     * Normalize a source line for keyword matching: trims it, skips blank/comment/string
+     * continuation lines, and strips any inline comment.
+     *
+     * @param line the raw source line
+     * @return the trimmed line ready for matching, or {@code null} if the line must be skipped
+     */
+    private static String preprocessLine(String line)
+    {
+        // Skip empty lines
+        if (line.trim().isEmpty())
+        {
+            return null;
+        }
+
+        // Skip lines that are entirely a comment
+        String trimmed = line.trim();
+        if (trimmed.startsWith("//")) //$NON-NLS-1$
+        {
+            return null;
+        }
+
+        // Skip multiline string continuation lines (start with |)
+        if (trimmed.startsWith("|")) //$NON-NLS-1$
+        {
+            return null;
+        }
+
+        // Remove inline comment (everything after //)
+        // Known limitation: // inside string literals (e.g. URLs like "https://...")
+        // will be treated as a comment start. This is acceptable because keywords
+        // are matched at line start (^\s*keyword\b), so truncation does not affect results.
+        int commentIdx = trimmed.indexOf("//"); //$NON-NLS-1$
+        if (commentIdx > 0)
+        {
+            trimmed = trimmed.substring(0, commentIdx);
+        }
+        return trimmed;
+    }
+
+    /**
+     * Match a closing block keyword on the line and, if found, pop the matching opening
+     * block from the stack (recording any mismatch).
+     *
+     * @param trimmed the preprocessed line
+     * @param lineNum the 1-based line number
+     * @param stack the open-block stack
+     * @param errors the accumulated error messages
+     * @return true if a closing keyword was matched and handled
+     */
+    private static boolean handleClosingKeyword(String trimmed, int lineNum,
+        Deque<String[]> stack, List<String> errors)
+    {
+        if (END_PROCEDURE.matcher(trimmed).find())
+        {
+            popAndCheck(stack, TAG_PROCEDURE, "\u041A\u043E\u043D\u0435\u0446\u041F\u0440\u043E\u0446\u0435\u0434\u0443\u0440\u044B/EndProcedure", lineNum, errors); //$NON-NLS-1$
+            return true;
+        }
+        if (END_FUNCTION.matcher(trimmed).find())
+        {
+            popAndCheck(stack, TAG_FUNCTION, "\u041A\u043E\u043D\u0435\u0446\u0424\u0443\u043D\u043A\u0446\u0438\u0438/EndFunction", lineNum, errors); //$NON-NLS-1$
+            return true;
+        }
+        if (END_IF.matcher(trimmed).find())
+        {
+            popAndCheck(stack, TAG_IF, "\u041A\u043E\u043D\u0435\u0446\u0415\u0441\u043B\u0438/EndIf", lineNum, errors); //$NON-NLS-1$
+            return true;
+        }
+        if (END_DO.matcher(trimmed).find())
+        {
+            popAndCheck(stack, TAG_LOOP, "\u041A\u043E\u043D\u0435\u0446\u0426\u0438\u043A\u043B\u0430/EndDo", lineNum, errors); //$NON-NLS-1$
+            return true;
+        }
+        if (END_TRY.matcher(trimmed).find())
+        {
+            popAndCheck(stack, TAG_TRY, "\u041A\u043E\u043D\u0435\u0446\u041F\u043E\u043F\u044B\u0442\u043A\u0438/EndTry", lineNum, errors); //$NON-NLS-1$
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Match an opening block keyword on the line and, if found, push the corresponding
+     * open block onto the stack.
+     *
+     * @param trimmed the preprocessed line
+     * @param lineNum the 1-based line number
+     * @param stack the open-block stack
+     */
+    private static void handleOpeningKeyword(String trimmed, int lineNum, Deque<String[]> stack)
+    {
+        if (PROCEDURE_START.matcher(trimmed).find())
+        {
+            stack.push(new String[] { TAG_PROCEDURE, String.valueOf(lineNum) });
+            return;
+        }
+        if (FUNCTION_START.matcher(trimmed).find())
+        {
+            stack.push(new String[] { TAG_FUNCTION, String.valueOf(lineNum) });
+            return;
+        }
+        // If but NOT ElsIf
+        if (IF_START.matcher(trimmed).find() && !ELSIF_PATTERN.matcher(trimmed).find())
+        {
+            stack.push(new String[] { TAG_IF, String.valueOf(lineNum) });
+            return;
+        }
+        if (WHILE_START.matcher(trimmed).find())
+        {
+            stack.push(new String[] { TAG_LOOP, String.valueOf(lineNum) });
+            return;
+        }
+        if (FOR_START.matcher(trimmed).find())
+        {
+            stack.push(new String[] { TAG_LOOP, String.valueOf(lineNum) });
+            return;
+        }
+        if (TRY_START.matcher(trimmed).find())
+        {
+            stack.push(new String[] { TAG_TRY, String.valueOf(lineNum) });
+        }
+    }
+
+    /**
+     * Drain the open-block stack, appending an "unclosed" error for each remaining block.
+     *
+     * @param stack the open-block stack
+     * @param errors the accumulated error messages
+     */
+    private static void reportUnclosedBlocks(Deque<String[]> stack, List<String> errors)
+    {
         while (!stack.isEmpty())
         {
             String[] entry = stack.pop();
             errors.add("Unclosed " + tagToKeyword(entry[0]) + " from line " + entry[1]); //$NON-NLS-1$ //$NON-NLS-2$
         }
-
-        return new CheckResult(errors.isEmpty(), errors);
     }
 
     private static void popAndCheck(Deque<String[]> stack, String expectedTag,


### PR DESCRIPTION
Band C of the SonarCloud code-smell cleanup (#164): the **cc 31-40** band of S3776, branched from current master (post-#173). **25 methods** reduced under the limit of 15, each via 2-4 coherent Extract-Method refactors. Same rigorous pipeline as #167-173/#176: deep-study implement (8 file-disjoint agents) → **8 INDEPENDENT adversarial verify agents** (every diff reviewed) → `mvn clean verify` (2202 tests). All confirmed behaviour-identical. Early-returns inside extracted blocks were threaded out via a small **holder** object / nullable error-String so the parent re-checks and returns the SAME value in the SAME cases. **Destructive / mutating tools handled with extra care** — only side-effect-free blocks (validation, navigation, formatting, result-building) extracted; the delete/update/write-transaction/rename-perform/Job action stays inline under the same confirm-gate (CreateMetadataTool, CreateInfobaseTool, ModifyMetadataTool, MetadataRenameService, CreateProjectTool, GroupServiceImpl). Checked-exception correctness verified (ResumeTool→DebugException, GetFormScreenshotTool→Exception, GetProfilingResultsTool→Exception). No behaviour change. Follows #166-173, #176.