### PR TITLE
Reduce cognitive complexity via Extract Method, part 5 (S3776 cc 41-60, 18 methods)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/AddToGroupHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/AddToGroupHandler.java
@@ -69,16 +69,72 @@ public class AddToGroupHandler extends AbstractHandler {
     public Object execute(ExecutionEvent event) throws ExecutionException {
         Shell shell = HandlerUtil.getActiveShell(event);
         ISelection selection = HandlerUtil.getCurrentSelection(event);
-        
+
         if (!(selection instanceof IStructuredSelection structuredSelection)) {
             return null;
         }
-        
+
         // Collect selected top-level objects and determine their type
+        Selected selected = collectSelectedTopLevelObjects(structuredSelection);
+
+        if (selected.objects.isEmpty() || selected.project == null || selected.objectType == null) {
+            MessageDialog.openWarning(shell, ADD_TO_GROUP,
+                "Please select one or more top-level metadata objects to add to a group.");
+            return null;
+        }
+
+        // Get groups filtered by object type
+        IGroupService service = Activator.getGroupServiceStatic();
+        List<Group> matchingGroups = findMatchingGroups(service, selected.project, selected.objectType);
+
+        if (matchingGroups.isEmpty()) {
+            MessageDialog.openInformation(shell, ADD_TO_GROUP,
+                "No groups exist for " + selected.objectType + ".\n" +
+                "Create a group first using 'New Group...' on the " + selected.objectType + " folder.");
+            return null;
+        }
+
+        Group targetGroup = chooseTargetGroup(shell, matchingGroups, selected.objectType);
+        if (targetGroup == null) {
+            return null;
+        }
+
+        // Add all selected objects to the group
+        int successCount = 0;
+        int failCount = 0;
+
+        for (EObject eObject : selected.objects) {
+            String fqn = TagUtils.extractFqn(eObject);
+            if (fqn != null) {
+                try {
+                    boolean added = service.addObjectToGroup(selected.project, fqn, targetGroup.getFullPath());
+                    if (added) {
+                        successCount++;
+                    } else {
+                        failCount++;
+                    }
+                } catch (Exception e) {
+                    Activator.logError("Failed to add " + fqn + " to group", e);
+                    failCount++;
+                }
+            }
+        }
+
+        showResult(shell, targetGroup, successCount, failCount);
+
+        return null;
+    }
+
+    /**
+     * Parses the structured selection into the top-level metadata objects (FQN like
+     * {@code Type.Name}), the owning project, and the common object type. Pure, no
+     * side effects.
+     */
+    private static Selected collectSelectedTopLevelObjects(IStructuredSelection structuredSelection) {
         List<EObject> selectedObjects = new ArrayList<>();
         IProject project = null;
         String objectType = null; // e.g., "Catalog", "CommonModule"
-        
+
         for (Object element : structuredSelection.toList()) {
             if (element instanceof EObject eObject) {
                 String fqn = TagUtils.extractFqn(eObject);
@@ -97,27 +153,23 @@ public class AddToGroupHandler extends AbstractHandler {
                 }
             }
         }
-        
-        if (selectedObjects.isEmpty() || project == null || objectType == null) {
-            MessageDialog.openWarning(shell, ADD_TO_GROUP,
-                "Please select one or more top-level metadata objects to add to a group.");
-            return null;
-        }
-        
-        // Get groups filtered by object type
-        IGroupService service = Activator.getGroupServiceStatic();
+
+        return new Selected(selectedObjects, project, objectType);
+    }
+
+    /** Read-only query: the groups whose path matches the given object type. */
+    private static List<Group> findMatchingGroups(IGroupService service, IProject project, String objectType) {
         final String filterPath = objectType;
-        List<Group> matchingGroups = service.getAllGroups(project).stream()
+        return service.getAllGroups(project).stream()
             .filter(g -> filterPath.equals(g.getPath()))
             .toList();
-        
-        if (matchingGroups.isEmpty()) {
-            MessageDialog.openInformation(shell, ADD_TO_GROUP,
-                "No groups exist for " + objectType + ".\n" +
-                "Create a group first using 'New Group...' on the " + objectType + " folder.");
-            return null;
-        }
-        
+    }
+
+    /**
+     * Shows the group-selection dialog and returns the chosen group, or {@code null}
+     * if the dialog was cancelled or yielded no group. Does not mutate group state.
+     */
+    private static Group chooseTargetGroup(Shell shell, List<Group> matchingGroups, String objectType) {
         // Show group selection dialog with group names only
         ElementListSelectionDialog dialog = new ElementListSelectionDialog(shell, new LabelProvider() {
             @Override
@@ -132,38 +184,20 @@ public class AddToGroupHandler extends AbstractHandler {
         dialog.setMessage("Select target group for " + objectType + ":");
         dialog.setElements(matchingGroups.toArray());
         dialog.setMultipleSelection(false);
-        
+
         if (dialog.open() != Window.OK) {
             return null;
         }
-        
+
         Object[] result = dialog.getResult();
         if (result == null || result.length == 0 || !(result[0] instanceof Group targetGroup)) {
             return null;
         }
-        
-        // Add all selected objects to the group
-        int successCount = 0;
-        int failCount = 0;
-        
-        for (EObject eObject : selectedObjects) {
-            String fqn = TagUtils.extractFqn(eObject);
-            if (fqn != null) {
-                try {
-                    boolean added = service.addObjectToGroup(project, fqn, targetGroup.getFullPath());
-                    if (added) {
-                        successCount++;
-                    } else {
-                        failCount++;
-                    }
-                } catch (Exception e) {
-                    Activator.logError("Failed to add " + fqn + " to group", e);
-                    failCount++;
-                }
-            }
-        }
-        
-        // Show result
+        return targetGroup;
+    }
+
+    /** Reports the outcome of the add operation to the user via a message dialog. */
+    private static void showResult(Shell shell, Group targetGroup, int successCount, int failCount) {
         if (successCount > 0) {
             MessageDialog.openInformation(shell, ADD_TO_GROUP,
                 "Added " + successCount + " object(s) to group '" + targetGroup.getName() + "'.");
@@ -171,7 +205,18 @@ public class AddToGroupHandler extends AbstractHandler {
             MessageDialog.openWarning(shell, ADD_TO_GROUP,
                 "Failed to add objects. They may already be in the group.");
         }
-        
-        return null;
+    }
+
+    /** Holder for the parsed selection: top-level objects, owning project and common type. */
+    private static final class Selected {
+        final List<EObject> objects;
+        final IProject project;
+        final String objectType;
+
+        Selected(List<EObject> objects, IProject project, String objectType) {
+            this.objects = objects;
+            this.project = project;
+            this.objectType = objectType;
+        }
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagFilterView.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagFilterView.java
@@ -232,25 +232,7 @@ public class TagFilterView extends ViewPart implements ITagChangeListener {
         countColumn.setLabelProvider(new ColumnLabelProvider() {
             @Override
             public String getText(Object element) {
-                if (element instanceof TagEntry entry) {
-                    Set<String> objects = tagService.findObjectsByTag(entry.project(), entry.tag().getName());
-                    if (searchPattern != null) {
-                        int filteredCount = 0;
-                        int totalCount = objects.size();
-                        for (String fqn : objects) {
-                            if (matchesSearch(fqn)) {
-                                filteredCount++;
-                            }
-                        }
-                        return filteredCount + "/" + totalCount;
-                    }
-                    return String.valueOf(objects.size());
-                } else if (element instanceof IProject project) {
-                    // Show total tags count for project
-                    List<Tag> tags = tagService.getTags(project);
-                    return "(" + tags.size() + " tags)";
-                }
-                return "";
+                return countColumnText(element);
             }
         });
         
@@ -261,40 +243,7 @@ public class TagFilterView extends ViewPart implements ITagChangeListener {
         tagsTreeViewer.addCheckStateListener(new ICheckStateListener() {
             @Override
             public void checkStateChanged(CheckStateChangedEvent event) {
-                Object element = event.getElement();
-                boolean checked = event.getChecked();
-                
-                if (element instanceof IProject project) {
-                    // Check/uncheck all tags in this project
-                    List<Tag> tags = tagService.getTags(project);
-                    Set<String> projectTags = selectedTagsByProject.computeIfAbsent(project, p -> new HashSet<>());
-                    
-                    if (checked) {
-                        for (Tag tag : tags) {
-                            projectTags.add(tag.getName());
-                            tagsTreeViewer.setChecked(new TagEntry(project, tag), true);
-                        }
-                    } else {
-                        projectTags.clear();
-                        for (Tag tag : tags) {
-                            tagsTreeViewer.setChecked(new TagEntry(project, tag), false);
-                        }
-                    }
-                    // Reset grayed state when explicitly checking/unchecking project
-                    tagsTreeViewer.setGrayed(project, false);
-                    
-                } else if (element instanceof TagEntry entry) {
-                    Set<String> projectTags = selectedTagsByProject.computeIfAbsent(entry.project(), p -> new HashSet<>());
-                    if (checked) {
-                        projectTags.add(entry.tag().getName());
-                    } else {
-                        projectTags.remove(entry.tag().getName());
-                    }
-                    // Update parent project checkbox state
-                    updateProjectCheckState(entry.project());
-                }
-                
-                updateFilteredResults();
+                handleCheckStateChanged(event.getElement(), event.getChecked());
             }
         });
         
@@ -302,7 +251,87 @@ public class TagFilterView extends ViewPart implements ITagChangeListener {
         tagsTreeViewer.setInput(ResourcesPlugin.getWorkspace().getRoot());
         tagsTreeViewer.expandAll();
     }
-    
+
+    /**
+     * Computes the text for the count column of the tags tree: for a tag entry
+     * the (optionally search-filtered) object count, for a project the number of
+     * tags it has.
+     */
+    private String countColumnText(Object element) {
+        if (element instanceof TagEntry entry) {
+            Set<String> objects = tagService.findObjectsByTag(entry.project(), entry.tag().getName());
+            if (searchPattern != null) {
+                int filteredCount = 0;
+                int totalCount = objects.size();
+                for (String fqn : objects) {
+                    if (matchesSearch(fqn)) {
+                        filteredCount++;
+                    }
+                }
+                return filteredCount + "/" + totalCount;
+            }
+            return String.valueOf(objects.size());
+        } else if (element instanceof IProject project) {
+            // Show total tags count for project
+            List<Tag> tags = tagService.getTags(project);
+            return "(" + tags.size() + " tags)";
+        }
+        return "";
+    }
+
+    /**
+     * Handles a checkbox state change in the tags tree, then refreshes the
+     * filtered results. Runs on the UI thread (invoked from the check-state
+     * listener).
+     */
+    private void handleCheckStateChanged(Object element, boolean checked) {
+        if (element instanceof IProject project) {
+            applyProjectCheck(project, checked);
+        } else if (element instanceof TagEntry entry) {
+            applyTagEntryCheck(entry, checked);
+        }
+
+        updateFilteredResults();
+    }
+
+    /**
+     * Checks or unchecks all tags of a project and resets its grayed state.
+     */
+    private void applyProjectCheck(IProject project, boolean checked) {
+        // Check/uncheck all tags in this project
+        List<Tag> tags = tagService.getTags(project);
+        Set<String> projectTags = selectedTagsByProject.computeIfAbsent(project, p -> new HashSet<>());
+
+        if (checked) {
+            for (Tag tag : tags) {
+                projectTags.add(tag.getName());
+                tagsTreeViewer.setChecked(new TagEntry(project, tag), true);
+            }
+        } else {
+            projectTags.clear();
+            for (Tag tag : tags) {
+                tagsTreeViewer.setChecked(new TagEntry(project, tag), false);
+            }
+        }
+        // Reset grayed state when explicitly checking/unchecking project
+        tagsTreeViewer.setGrayed(project, false);
+    }
+
+    /**
+     * Checks or unchecks a single tag entry and updates its parent project's
+     * checkbox state.
+     */
+    private void applyTagEntryCheck(TagEntry entry, boolean checked) {
+        Set<String> projectTags = selectedTagsByProject.computeIfAbsent(entry.project(), p -> new HashSet<>());
+        if (checked) {
+            projectTags.add(entry.tag().getName());
+        } else {
+            projectTags.remove(entry.tag().getName());
+        }
+        // Update parent project checkbox state
+        updateProjectCheckState(entry.project());
+    }
+
     /**
      * Create context menu for the tags tree.
      */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagTrieStateProvider.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagTrieStateProvider.java
@@ -153,87 +153,125 @@ public class TagTrieStateProvider implements INavigatorContentProviderStateProvi
                     EObjectTrie trie = new EObjectTrie();
 
                     for (String fqn : matchingFqns) {
-                        try {
-                            // FQN format: TypeName.ObjectName or TypeName.ObjectName.SubTypeName.SubName
-                            // e.g., "Document.SalesOrder", "CommonModule.Common", "Catalog.Products.Attribute.Name"
-                            
-                            String[] parts = fqn.split("\\.");
-                            if (parts.length < 2) {
-                                continue;
-                            }
-                            
-                            // Get top-level object FQN (TypeName.ObjectName)
-                            String topFqn = parts[0] + "." + parts[1];
-                            QualifiedName topQualifiedName = QualifiedName.create(parts[0], parts[1]);
-                            
-                            // Add path to Trie - this creates both the type folder and object node
-                            trie.addPath(topQualifiedName);
-                            
-                            // Resolve top object and set it in the Trie
-                            EObject topObject = null;
-                            
-                            // Special handling for Subsystems - they are not top-level BM objects
-                            // They are contained in Configuration.getSubsystems()
-                            // Using hardcoded "Subsystem" as the EClass name
-                            if ("Subsystem".equals(parts[0])) {
-                                topObject = resolveSubsystem(project, parts[1]);
-                                if (topObject != null) {
-                                    trie.setEObject(topQualifiedName, topObject);
-                                }
-                            } else {
-                                // Standard top-level object resolution
-                                IBmObject bmObject = transaction.getTopObjectByFqn(topFqn);
-                                if (bmObject != null) {
-                                    topObject = (EObject) bmObject;
-                                    trie.setEObject(topQualifiedName, topObject);
-                                }
-                            }
-                            
-                            // If FQN has more parts (nested objects), add those paths too
-                            if (parts.length > 2) {
-                                // Add the full path for nested objects
-                                QualifiedName fullQualifiedName = QualifiedName.create(parts);
-                                trie.addPath(fullQualifiedName);
-                                
-                                // Try to resolve nested object
-                                if (topObject != null) {
-                                    EObject nestedObject = EObjectFqnNavigator.resolveNestedObject((EObject) topObject, parts, 2);
-                                    if (nestedObject != null) {
-                                        trie.setEObject(fullQualifiedName, nestedObject);
-                                    }
-                                }
-                            }
-                        } catch (Exception e) {
-                            Activator.logError("Error adding FQN to Trie: " + fqn, e);
-                        }
+                        addFqnToTrie(trie, fqn, project, transaction);
                     }
-                    
-                    // Add Configuration to make the tree traversable
-                    try {
-                        com._1c.g5.v8.dt.core.platform.IV8ProjectManager v8ProjectManager = 
-                            Activator.getDefault().getV8ProjectManager();
-                        if (v8ProjectManager != null) {
-                            com._1c.g5.v8.dt.core.platform.IV8Project v8Project = 
-                                v8ProjectManager.getProject(project);
-                            if (v8Project instanceof com._1c.g5.v8.dt.core.platform.IConfigurationAware) {
-                                com._1c.g5.v8.dt.metadata.mdclass.Configuration configuration = 
-                                    ((com._1c.g5.v8.dt.core.platform.IConfigurationAware) v8Project).getConfiguration();
-                                if (configuration != null) {
-                                    QualifiedName configQName = QualifiedName.create("Configuration", configuration.getName());
-                                    trie.addPath(configQName);
-                                    trie.setEObject(configQName, (EObject) configuration);
-                                }
-                            }
-                        }
-                    } catch (Exception e) {
-                        Activator.logError("Error adding Configuration to Trie", e);
-                    }
-                    
+
+                    addConfigurationToTrie(trie, project);
+
                     return trie;
             });
         } catch (Exception e) {
             Activator.logError("Error building Trie", e);
             return null;
+        }
+    }
+
+    /**
+     * Adds a single tagged FQN to the Trie, creating the type folder and object
+     * node and resolving the top (and any nested) object. Errors are logged and
+     * swallowed so one bad FQN does not abort the whole build.
+     */
+    private void addFqnToTrie(EObjectTrie trie, String fqn, IProject project,
+            com._1c.g5.v8.bm.core.IBmTransaction transaction) {
+        try {
+            // FQN format: TypeName.ObjectName or TypeName.ObjectName.SubTypeName.SubName
+            // e.g., "Document.SalesOrder", "CommonModule.Common", "Catalog.Products.Attribute.Name"
+
+            String[] parts = fqn.split("\\.");
+            if (parts.length < 2) {
+                return;
+            }
+
+            // Get top-level object FQN (TypeName.ObjectName)
+            String topFqn = parts[0] + "." + parts[1];
+            QualifiedName topQualifiedName = QualifiedName.create(parts[0], parts[1]);
+
+            // Add path to Trie - this creates both the type folder and object node
+            trie.addPath(topQualifiedName);
+
+            // Resolve top object and set it in the Trie
+            EObject topObject = resolveAndSetTopObject(trie, parts, topFqn, topQualifiedName, project, transaction);
+
+            // If FQN has more parts (nested objects), add those paths too
+            if (parts.length > 2) {
+                addNestedObjectToTrie(trie, parts, topObject);
+            }
+        } catch (Exception e) {
+            Activator.logError("Error adding FQN to Trie: " + fqn, e);
+        }
+    }
+
+    /**
+     * Resolves the top-level object for the given FQN parts and, when found,
+     * sets it on the Trie node.
+     *
+     * @return the resolved top object, or {@code null} if it could not be resolved
+     */
+    private EObject resolveAndSetTopObject(EObjectTrie trie, String[] parts, String topFqn,
+            QualifiedName topQualifiedName, IProject project,
+            com._1c.g5.v8.bm.core.IBmTransaction transaction) {
+        EObject topObject = null;
+
+        // Special handling for Subsystems - they are not top-level BM objects
+        // They are contained in Configuration.getSubsystems()
+        // Using hardcoded "Subsystem" as the EClass name
+        if ("Subsystem".equals(parts[0])) {
+            topObject = resolveSubsystem(project, parts[1]);
+            if (topObject != null) {
+                trie.setEObject(topQualifiedName, topObject);
+            }
+        } else {
+            // Standard top-level object resolution
+            IBmObject bmObject = transaction.getTopObjectByFqn(topFqn);
+            if (bmObject != null) {
+                topObject = (EObject) bmObject;
+                trie.setEObject(topQualifiedName, topObject);
+            }
+        }
+        return topObject;
+    }
+
+    /**
+     * Adds the full nested-object path to the Trie and, when the top object is
+     * available, resolves and sets the nested object on its node.
+     */
+    private void addNestedObjectToTrie(EObjectTrie trie, String[] parts, EObject topObject) {
+        // Add the full path for nested objects
+        QualifiedName fullQualifiedName = QualifiedName.create(parts);
+        trie.addPath(fullQualifiedName);
+
+        // Try to resolve nested object
+        if (topObject != null) {
+            EObject nestedObject = EObjectFqnNavigator.resolveNestedObject(topObject, parts, 2);
+            if (nestedObject != null) {
+                trie.setEObject(fullQualifiedName, nestedObject);
+            }
+        }
+    }
+
+    /**
+     * Adds the project's Configuration node to the Trie so the resulting tree is
+     * traversable. Errors are logged and swallowed.
+     */
+    private void addConfigurationToTrie(EObjectTrie trie, IProject project) {
+        try {
+            com._1c.g5.v8.dt.core.platform.IV8ProjectManager v8ProjectManager =
+                Activator.getDefault().getV8ProjectManager();
+            if (v8ProjectManager != null) {
+                com._1c.g5.v8.dt.core.platform.IV8Project v8Project =
+                    v8ProjectManager.getProject(project);
+                if (v8Project instanceof com._1c.g5.v8.dt.core.platform.IConfigurationAware) {
+                    com._1c.g5.v8.dt.metadata.mdclass.Configuration configuration =
+                        ((com._1c.g5.v8.dt.core.platform.IConfigurationAware) v8Project).getConfiguration();
+                    if (configuration != null) {
+                        QualifiedName configQName = QualifiedName.create("Configuration", configuration.getName());
+                        trie.addPath(configQName);
+                        trie.setEObject(configQName, (EObject) configuration);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            Activator.logError("Error adding Configuration to Trie", e);
         }
     }
     

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/doc/PlatformDocumentationService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/doc/PlatformDocumentationService.java
@@ -132,6 +132,34 @@ public class PlatformDocumentationService
         // Note: For platform types like Array, ValueTable, the types are
         // directly available from IEObjectDescription without needing project ResourceSet.
 
+        IEObjectProvider typeProvider = selectTypeProvider(version);
+        if (typeProvider == null)
+        {
+            return ToolResult.error("Could not get type provider. Make sure EDT workspace is open.").toJson(); //$NON-NLS-1$
+        }
+
+        // Find type by iterating through all type descriptions
+        List<String> availableTypes = new ArrayList<>();
+        Type foundType = findType(typeProvider, typeName, availableTypes);
+
+        // If not found, show available types
+        if (foundType == null)
+        {
+            return buildNotFoundBanner("Type not found: ", typeName, "types", availableTypes); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+
+        // Build documentation from resolved Type
+        return buildTypeDocumentation(foundType, memberName, memberType, limit, useRussian);
+    }
+
+    /**
+     * Selects the type provider for the given version: prefers TYPE (platform types like Array,
+     * ValueTable) and falls back to TYPE_ITEM when the TYPE provider is empty (some EDT versions).
+     *
+     * @return the selected provider, or {@code null} when neither is available
+     */
+    private IEObjectProvider selectTypeProvider(Version version)
+    {
         // Get type provider using TYPE (not TYPE_ITEM - TYPE gives us platform types like ValueTable)
         IEObjectProvider.Registry registry = IEObjectProvider.Registry.INSTANCE;
 
@@ -155,91 +183,118 @@ public class PlatformDocumentationService
         {
             typeProvider = typeItemProvider; // Fall back to TYPE_ITEM
         }
+        return typeProvider;
+    }
 
-        if (typeProvider == null)
-        {
-            return ToolResult.error("Could not get type provider. Make sure EDT workspace is open.").toJson(); //$NON-NLS-1$
-        }
-
-        // Find type by iterating through all type descriptions
-        Type foundType = null;
-        List<String> availableTypes = new ArrayList<>();
-
+    /**
+     * Iterates the provider's descriptions looking for {@code typeName} (case-insensitive, matching
+     * either the full qualified name or its last segment), collecting up to the first 30 names into
+     * {@code availableTypes} for the not-found banner.
+     *
+     * @param availableTypes out-param populated with up to 30 candidate names, in iteration order
+     * @return the resolved (non-proxy) {@link Type}, or {@code null} when not found
+     */
+    private Type findType(IEObjectProvider typeProvider, String typeName, List<String> availableTypes)
+    {
         Iterable<IEObjectDescription> descriptions = typeProvider.getEObjectDescriptions(null);
-        if (descriptions != null)
+        if (descriptions == null)
         {
-            for (IEObjectDescription desc : descriptions)
+            return null;
+        }
+        for (IEObjectDescription desc : descriptions)
+        {
+            // Get last segment of qualified name (e.g., "DocumentRef" from "some.package.DocumentRef")
+            String fullName = desc.getName().toString();
+            String lastSegment = desc.getName().getLastSegment();
+
+            // Collect first 30 types for debugging (show full name)
+            if (availableTypes.size() < 30)
             {
-                // Get last segment of qualified name (e.g., "DocumentRef" from "some.package.DocumentRef")
-                String fullName = desc.getName().toString();
-                String lastSegment = desc.getName().getLastSegment();
+                availableTypes.add(lastSegment != null ? lastSegment : fullName);
+            }
 
-                // Collect first 30 types for debugging (show full name)
-                if (availableTypes.size() < 30)
+            // Check if this is the type we're looking for (case-insensitive, check both full and last segment)
+            if (fullName.equalsIgnoreCase(typeName) ||
+                (lastSegment != null && lastSegment.equalsIgnoreCase(typeName)))
+            {
+                Type resolvedType = resolveDescriptionAsType(desc);
+                if (resolvedType != null)
                 {
-                    availableTypes.add(lastSegment != null ? lastSegment : fullName);
-                }
-
-                // Check if this is the type we're looking for (case-insensitive, check both full and last segment)
-                if (fullName.equalsIgnoreCase(typeName) ||
-                    (lastSegment != null && lastSegment.equalsIgnoreCase(typeName)))
-                {
-                    // Get the object - for platform types from TYPE provider,
-                    // these should be fully resolved objects, not proxies
-                    EObject resolved = desc.getEObjectOrProxy();
-
-                    if (resolved instanceof Type)
-                    {
-                        // If still a proxy, we can use the EcoreUtil registry to resolve
-                        if (resolved.eIsProxy())
-                        {
-                            org.eclipse.emf.common.util.URI uri = desc.getEObjectURI();
-                            try
-                            {
-                                // Try to resolve via platform resource
-                                org.eclipse.emf.ecore.resource.impl.ResourceSetImpl tempResourceSet =
-                                    new org.eclipse.emf.ecore.resource.impl.ResourceSetImpl();
-                                resolved = EcoreUtil.resolve(resolved, tempResourceSet);
-                            }
-                            catch (Exception e)
-                            {
-                                Activator.logError("Error resolving type proxy: " + uri, e); //$NON-NLS-1$
-                            }
-                        }
-
-                        if (!resolved.eIsProxy())
-                        {
-                            foundType = (Type) resolved;
-                            break;
-                        }
-                    }
+                    return resolvedType;
                 }
             }
         }
+        return null;
+    }
 
-        // If not found, show available types
-        if (foundType == null)
+    /**
+     * Resolves a matched description to a non-proxy {@link Type}, attempting EcoreUtil proxy
+     * resolution via a temporary resource set when needed (errors are logged, not thrown).
+     *
+     * @return the resolved {@link Type}, or {@code null} when the object is not a Type or stays a proxy
+     */
+    private Type resolveDescriptionAsType(IEObjectDescription desc)
+    {
+        // Get the object - for platform types from TYPE provider,
+        // these should be fully resolved objects, not proxies
+        EObject resolved = desc.getEObjectOrProxy();
+
+        if (resolved instanceof Type)
         {
-            StringBuilder sb = new StringBuilder();
-            sb.append("Error: Type not found: ").append(typeName).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            sb.append("Available types (first ").append(availableTypes.size()).append("):\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            for (String availType : availableTypes)
+            // If still a proxy, we can use the EcoreUtil registry to resolve
+            if (resolved.eIsProxy())
             {
-                sb.append("- ").append(availType).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+                org.eclipse.emf.common.util.URI uri = desc.getEObjectURI();
+                try
+                {
+                    // Try to resolve via platform resource
+                    org.eclipse.emf.ecore.resource.impl.ResourceSetImpl tempResourceSet =
+                        new org.eclipse.emf.ecore.resource.impl.ResourceSetImpl();
+                    resolved = EcoreUtil.resolve(resolved, tempResourceSet);
+                }
+                catch (Exception e)
+                {
+                    Activator.logError("Error resolving type proxy: " + uri, e); //$NON-NLS-1$
+                }
             }
-            if (availableTypes.isEmpty())
-            {
-                sb.append("(no types found - provider may be empty)\n"); //$NON-NLS-1$
-            }
-            else if (availableTypes.size() >= 30)
-            {
-                sb.append("... (more available)\n"); //$NON-NLS-1$
-            }
-            return sb.toString();
-        }
 
-        // Build documentation from resolved Type
-        return buildTypeDocumentation(foundType, memberName, memberType, limit, useRussian);
+            if (!resolved.eIsProxy())
+            {
+                return (Type) resolved;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Builds the soft "not found" banner: an {@code "Error: <subject><name>"} line followed by the
+     * collected available items (or an empty-provider note / "more available" hint). The exact text
+     * matches the previous inline builders so {@link #isNotFoundBanner} still recognises it.
+     *
+     * @param subject the not-found phrase incl. trailing separator (e.g. {@code "Type not found: "})
+     * @param name the looked-up name appended after {@code subject}
+     * @param itemsLabel the plural noun used in the "Available &lt;itemsLabel&gt; (first N)" heading
+     * @param available the collected candidate names
+     * @return the rendered banner string
+     */
+    private String buildNotFoundBanner(String subject, String name, String itemsLabel, List<String> available)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Error: ").append(subject).append(name).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("Available ").append(itemsLabel).append(" (first ").append(available.size()).append("):\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        for (String item : available)
+        {
+            sb.append("- ").append(item).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        if (available.isEmpty())
+        {
+            sb.append("(no ").append(itemsLabel).append(" found - provider may be empty)\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        else if (available.size() >= 30)
+        {
+            sb.append("... (more available)\n"); //$NON-NLS-1$
+        }
+        return sb.toString();
     }
 
     /**
@@ -739,6 +794,28 @@ public class PlatformDocumentationService
             return ToolResult.error("Could not get method provider. Make sure EDT workspace is open.").toJson(); //$NON-NLS-1$
         }
 
+        ResourceSet resourceSet = findAnyProjectResourceSet();
+
+        // Search for the function
+        List<String> availableMethods = new ArrayList<>();
+        Method foundMethod = findBuiltinMethod(methodProvider, functionName, resourceSet, availableMethods);
+
+        // If not found, show available methods
+        if (foundMethod == null)
+        {
+            return buildBuiltinNotFoundBanner(functionName, availableMethods);
+        }
+
+        // Build documentation for the found method
+        return buildBuiltinMethodDocumentation(foundMethod, useRussian);
+    }
+
+    /**
+     * Finds the first non-{@code null} project {@link ResourceSet} (used to resolve proxies),
+     * iterating the open V8 projects. Returns {@code null} when no provider / project yields one.
+     */
+    private ResourceSet findAnyProjectResourceSet()
+    {
         // Get ResourceSet for resolving proxies
         ResourceSet resourceSet = null;
         BmAwareResourceSetProvider resourceSetProvider = Activator.getDefault().getResourceSetProvider();
@@ -754,80 +831,114 @@ public class PlatformDocumentationService
                 }
             }
         }
+        return resourceSet;
+    }
 
-        // Search for the function
-        Method foundMethod = null;
-        List<String> availableMethods = new ArrayList<>();
-
+    /**
+     * Iterates the provider's descriptions looking for a global method named {@code functionName}
+     * (case-insensitive, by last segment), collecting up to the first 30 names into
+     * {@code availableMethods} for the not-found banner.
+     *
+     * @param resourceSet resource set used to resolve a matched proxy (may be {@code null})
+     * @param availableMethods out-param populated with up to 30 candidate names, in iteration order
+     * @return the resolved (non-proxy) {@link Method}, or {@code null} when not found
+     */
+    private Method findBuiltinMethod(IEObjectProvider methodProvider, String functionName,
+                                     ResourceSet resourceSet, List<String> availableMethods)
+    {
         Iterable<IEObjectDescription> descriptions = methodProvider.getEObjectDescriptions(null);
-        if (descriptions != null)
+        if (descriptions == null)
         {
-            for (IEObjectDescription desc : descriptions)
+            return null;
+        }
+        for (IEObjectDescription desc : descriptions)
+        {
+            String methodName = desc.getName().getLastSegment();
+            if (methodName == null)
             {
-                String methodName = desc.getName().getLastSegment();
-                if (methodName == null)
-                {
-                    methodName = desc.getName().toString();
-                }
+                methodName = desc.getName().toString();
+            }
 
-                // Collect some methods for suggestions
-                if (availableMethods.size() < 30)
-                {
-                    availableMethods.add(methodName);
-                }
+            // Collect some methods for suggestions
+            if (availableMethods.size() < 30)
+            {
+                availableMethods.add(methodName);
+            }
 
-                // Check if this is the function we're looking for (case-insensitive)
-                if (methodName.equalsIgnoreCase(functionName))
+            // Check if this is the function we're looking for (case-insensitive)
+            if (methodName.equalsIgnoreCase(functionName))
+            {
+                Method resolvedMethod = resolveDescriptionAsMethod(desc, resourceSet);
+                if (resolvedMethod != null)
                 {
-                    EObject resolved = desc.getEObjectOrProxy();
-                    if (resolved != null)
-                    {
-                        // Try to resolve proxy
-                        if (resolved.eIsProxy() && resourceSet != null)
-                        {
-                            resolved = EcoreUtil.resolve(resolved, resourceSet);
-                        }
-                        else if (resolved.eIsProxy())
-                        {
-                            // Try with temp resource set
-                            org.eclipse.emf.ecore.resource.impl.ResourceSetImpl tempResourceSet =
-                                new org.eclipse.emf.ecore.resource.impl.ResourceSetImpl();
-                            resolved = EcoreUtil.resolve(resolved, tempResourceSet);
-                        }
-
-                        if (resolved instanceof Method && !resolved.eIsProxy())
-                        {
-                            foundMethod = (Method) resolved;
-                            break;
-                        }
-                    }
+                    return resolvedMethod;
                 }
             }
         }
+        return null;
+    }
 
-        // If not found, show available methods
-        if (foundMethod == null)
+    /**
+     * Resolves a matched description to a non-proxy {@link Method}, preferring the given
+     * {@code resourceSet} and otherwise a temporary one for proxy resolution.
+     *
+     * @return the resolved {@link Method}, or {@code null} when the object is absent, not a Method,
+     *         or stays a proxy
+     */
+    private Method resolveDescriptionAsMethod(IEObjectDescription desc, ResourceSet resourceSet)
+    {
+        EObject resolved = desc.getEObjectOrProxy();
+        if (resolved == null)
         {
-            StringBuilder sb = new StringBuilder();
-            sb.append("Error: Built-in function not found: ").append(functionName).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            sb.append("Available global methods (first ").append(availableMethods.size()).append("):\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            for (String availMethod : availableMethods)
-            {
-                sb.append("- ").append(availMethod).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            }
-            if (availableMethods.isEmpty())
-            {
-                sb.append("(no methods found - provider may be empty)\n"); //$NON-NLS-1$
-            }
-            else if (availableMethods.size() >= 30)
-            {
-                sb.append("... (more available)\n"); //$NON-NLS-1$
-            }
-            return sb.toString();
+            return null;
+        }
+        // Try to resolve proxy
+        if (resolved.eIsProxy() && resourceSet != null)
+        {
+            resolved = EcoreUtil.resolve(resolved, resourceSet);
+        }
+        else if (resolved.eIsProxy())
+        {
+            // Try with temp resource set
+            org.eclipse.emf.ecore.resource.impl.ResourceSetImpl tempResourceSet =
+                new org.eclipse.emf.ecore.resource.impl.ResourceSetImpl();
+            resolved = EcoreUtil.resolve(resolved, tempResourceSet);
         }
 
-        // Build documentation for the found method
-        return buildBuiltinMethodDocumentation(foundMethod, useRussian);
+        if (resolved instanceof Method && !resolved.eIsProxy())
+        {
+            return (Method) resolved;
+        }
+        return null;
+    }
+
+    /**
+     * Builds the built-in-function not-found banner. Mirrors the previous inline text exactly: the
+     * heading reads "Available global methods" while the empty-provider note reads "(no methods
+     * found ...)", so it cannot reuse {@link #buildNotFoundBanner} (single label).
+     *
+     * @param functionName the looked-up function name
+     * @param available the collected candidate global-method names
+     * @return the rendered banner string
+     */
+    private String buildBuiltinNotFoundBanner(String functionName, List<String> available)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Error: Built-in function not found: ").append(functionName).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("Available global methods (first ").append(available.size()).append("):\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        for (String availMethod : available)
+        {
+            sb.append("- ").append(availMethod).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        if (available.isEmpty())
+        {
+            sb.append("(no methods found - provider may be empty)\n"); //$NON-NLS-1$
+        }
+        else if (available.size() >= 30)
+        {
+            sb.append("... (more available)\n"); //$NON-NLS-1$
+        }
+        return sb.toString();
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
@@ -322,64 +322,31 @@ public class CreateInfobaseTool implements IMcpTool
     private String createInfobase(String projectName, Path infobaseDir,
             String infobaseName, String platform, boolean setDefault, boolean register)
     {
-        // --- 1. Resolve project ---
-        ProjectContext ctx = ProjectContext.of(projectName);
-        if (!ctx.exists())
+        // --- 1-2. Resolve project + services ---
+        CreateContext context = resolveCreateContext(projectName);
+        if (context.error != null)
         {
-            return ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson();
+            return context.error;
         }
-        if (!ctx.isOpen())
-        {
-            return ToolResult.error("Project is closed: " + projectName //$NON-NLS-1$
-                + ". Open the project in EDT first.").toJson(); //$NON-NLS-1$
-        }
-        IProject project = ctx.project();
-
-        // --- 2. Acquire services ---
-        IApplicationManager appManager = Activator.getDefault().getApplicationManager();
-        if (appManager == null)
-        {
-            return ToolResult.error("IApplicationManager service is not available").toJson(); //$NON-NLS-1$
-        }
-
-        IInfobaseManager ibManager = Activator.getDefault().getInfobaseManager();
-        if (ibManager == null)
-        {
-            return ToolResult.error("IInfobaseManager service is not available. " //$NON-NLS-1$
-                + "Ensure EDT platform-services are running.").toJson(); //$NON-NLS-1$
-        }
-
-        IInfobaseAssociationManager assocManager =
-            Activator.getDefault().getInfobaseAssociationManager();
-        if (assocManager == null)
-        {
-            return ToolResult.error("IInfobaseAssociationManager service is not available. " //$NON-NLS-1$
-                + "Ensure EDT platform-services are running.").toJson(); //$NON-NLS-1$
-        }
+        IProject project = context.project;
+        IApplicationManager appManager = context.appManager;
+        IInfobaseManager ibManager = context.ibManager;
+        IInfobaseAssociationManager assocManager = context.assocManager;
 
         // --- 3. Auto-generate infobase name if omitted ---
         if (infobaseName == null || infobaseName.isEmpty())
         {
-            try
-            {
-                infobaseName = ibManager.generateInfobaseName();
-            }
-            catch (Exception e)
-            {
-                infobaseName = projectName + "_infobase"; //$NON-NLS-1$
-            }
+            infobaseName = generateDefaultInfobaseName(ibManager, projectName);
         }
 
         // --- 4. Prepare the directory ---
         if (register)
         {
             // mode=register: the infobase must already exist on disk; do NOT create it.
-            if (!Files.isDirectory(infobaseDir)
-                || !Files.isRegularFile(infobaseDir.resolve("1Cv8.1CD"))) //$NON-NLS-1$
+            String registerError = validateRegisterPath(infobaseDir);
+            if (registerError != null)
             {
-                return ToolResult.error("No file infobase found at '" + infobaseDir //$NON-NLS-1$
-                    + "' (expected a 1Cv8.1CD file). For mode='register' the path must point to an " //$NON-NLS-1$
-                    + "existing file infobase; use mode='create' to make a new one.").toJson(); //$NON-NLS-1$
+                return registerError;
             }
         }
         else
@@ -397,12 +364,7 @@ public class CreateInfobaseTool implements IMcpTool
         }
 
         // --- 5. Build the FILE infobase reference ---
-        InfobaseReference ibRef =
-            InfobaseReferences.newFileInfobaseReference(infobaseDir.toAbsolutePath().toString());
-        ibRef.setName(infobaseName);
-        // The reference MUST carry a UUID before perform(): the creation operation locks the
-        // infobase by its UUID very early (LockManager.getLock), which NPEs on a null id.
-        ibRef.setUuid(java.util.UUID.randomUUID());
+        InfobaseReference ibRef = buildInfobaseReference(infobaseDir, infobaseName);
 
         // --- 6. Create the database (create) or register the existing one (register) ---
         if (register)
@@ -436,16 +398,8 @@ public class CreateInfobaseTool implements IMcpTool
                     + "or use mode='register' for an existing infobase.").toJson(); //$NON-NLS-1$
             }
 
-            IInfobaseCreationOperation.Builder builder = new IInfobaseCreationOperation.Builder()
-                .infobaseReference(ibRef)
-                .createNew(true)
-                .addReference(true)
-                .arguments(ModelFactory.eINSTANCE.createCreateInfobaseArguments());
-            if (platform != null && !platform.isEmpty())
-            {
-                builder.platform(platform);
-            }
-            final IInfobaseCreationOperation.Descriptor descriptor = builder.build();
+            final IInfobaseCreationOperation.Descriptor descriptor =
+                buildCreationDescriptor(ibRef, platform);
 
             final IInfobaseCreationOperation finalOp = creationOp;
             final AtomicReference<Exception> jobError = new AtomicReference<>();
@@ -548,6 +502,156 @@ public class CreateInfobaseTool implements IMcpTool
         // --- 9. Read back and return ---
         return buildSuccessResult(projectName, infobaseDir, infobaseName,
             appManager, project, ibRef, setDefaultNote, register);
+    }
+
+    /**
+     * Resolves the configuration project and the platform services needed for a file-infobase
+     * creation (read-only). Returns a {@link CreateContext} whose {@code error} field carries the
+     * tool-result JSON for the SAME early-return cases the inline code produced (project missing /
+     * closed; {@code IApplicationManager} / {@code IInfobaseManager} / {@code IInfobaseAssociationManager}
+     * unavailable); otherwise {@code error} is {@code null} and the service fields are populated.
+     */
+    private static CreateContext resolveCreateContext(String projectName)
+    {
+        ProjectContext ctx = ProjectContext.of(projectName);
+        if (!ctx.exists())
+        {
+            return CreateContext.error(
+                ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson());
+        }
+        if (!ctx.isOpen())
+        {
+            return CreateContext.error(ToolResult.error("Project is closed: " + projectName //$NON-NLS-1$
+                + ". Open the project in EDT first.").toJson()); //$NON-NLS-1$
+        }
+
+        IApplicationManager appManager = Activator.getDefault().getApplicationManager();
+        if (appManager == null)
+        {
+            return CreateContext.error(
+                ToolResult.error("IApplicationManager service is not available").toJson()); //$NON-NLS-1$
+        }
+
+        IInfobaseManager ibManager = Activator.getDefault().getInfobaseManager();
+        if (ibManager == null)
+        {
+            return CreateContext.error(ToolResult.error("IInfobaseManager service is not available. " //$NON-NLS-1$
+                + "Ensure EDT platform-services are running.").toJson()); //$NON-NLS-1$
+        }
+
+        IInfobaseAssociationManager assocManager =
+            Activator.getDefault().getInfobaseAssociationManager();
+        if (assocManager == null)
+        {
+            return CreateContext.error(ToolResult.error(
+                "IInfobaseAssociationManager service is not available. " //$NON-NLS-1$
+                + "Ensure EDT platform-services are running.").toJson()); //$NON-NLS-1$
+        }
+
+        return CreateContext.of(ctx.project(), appManager, ibManager, assocManager);
+    }
+
+    /**
+     * Auto-generates a display name for a new infobase when none was supplied: EDT's
+     * {@code IInfobaseManager.generateInfobaseName()}, falling back to {@code <projectName>_infobase}
+     * on any failure. Read-only — name generation has no side effect on the infobase.
+     */
+    private static String generateDefaultInfobaseName(IInfobaseManager ibManager, String projectName)
+    {
+        try
+        {
+            return ibManager.generateInfobaseName();
+        }
+        catch (Exception e)
+        {
+            return projectName + "_infobase"; //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Validates (read-only) that {@code infobaseDir} already contains a file infobase, for
+     * mode='register'. Returns the SAME error tool-result JSON the inline check produced when no
+     * {@code 1Cv8.1CD} is present, or {@code null} when the path is a valid existing file infobase.
+     */
+    private static String validateRegisterPath(Path infobaseDir)
+    {
+        if (!Files.isDirectory(infobaseDir)
+            || !Files.isRegularFile(infobaseDir.resolve("1Cv8.1CD"))) //$NON-NLS-1$
+        {
+            return ToolResult.error("No file infobase found at '" + infobaseDir //$NON-NLS-1$
+                + "' (expected a 1Cv8.1CD file). For mode='register' the path must point to an " //$NON-NLS-1$
+                + "existing file infobase; use mode='create' to make a new one.").toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Builds the FILE {@link InfobaseReference} for the new infobase (read-only construction). The
+     * reference MUST carry a UUID before {@code perform()}: the creation operation locks the infobase
+     * by its UUID very early ({@code LockManager.getLock}), which NPEs on a null id.
+     */
+    private static InfobaseReference buildInfobaseReference(Path infobaseDir, String infobaseName)
+    {
+        InfobaseReference ibRef =
+            InfobaseReferences.newFileInfobaseReference(infobaseDir.toAbsolutePath().toString());
+        ibRef.setName(infobaseName);
+        ibRef.setUuid(java.util.UUID.randomUUID());
+        return ibRef;
+    }
+
+    /**
+     * Builds the {@link IInfobaseCreationOperation.Descriptor} for the create Job (read-only
+     * construction — no platform call is made here). The optional platform mask is applied only when
+     * non-empty, identical to the inline builder.
+     */
+    private static IInfobaseCreationOperation.Descriptor buildCreationDescriptor(InfobaseReference ibRef,
+            String platform)
+    {
+        IInfobaseCreationOperation.Builder builder = new IInfobaseCreationOperation.Builder()
+            .infobaseReference(ibRef)
+            .createNew(true)
+            .addReference(true)
+            .arguments(ModelFactory.eINSTANCE.createCreateInfobaseArguments());
+        if (platform != null && !platform.isEmpty())
+        {
+            builder.platform(platform);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Holder for the project + platform services resolved by {@link #resolveCreateContext(String)}.
+     * When {@code error} is non-null it carries a ready tool-result JSON and the other fields are unset;
+     * otherwise {@code error} is {@code null} and the fields are populated.
+     */
+    private static final class CreateContext
+    {
+        final String error;
+        final IProject project;
+        final IApplicationManager appManager;
+        final IInfobaseManager ibManager;
+        final IInfobaseAssociationManager assocManager;
+
+        private CreateContext(String error, IProject project, IApplicationManager appManager,
+                IInfobaseManager ibManager, IInfobaseAssociationManager assocManager)
+        {
+            this.error = error;
+            this.project = project;
+            this.appManager = appManager;
+            this.ibManager = ibManager;
+            this.assocManager = assocManager;
+        }
+
+        static CreateContext error(String error)
+        {
+            return new CreateContext(error, null, null, null, null);
+        }
+
+        static CreateContext of(IProject project, IApplicationManager appManager,
+                IInfobaseManager ibManager, IInfobaseAssociationManager assocManager)
+        {
+            return new CreateContext(null, project, appManager, ibManager, assocManager);
+        }
     }
 
     /**
@@ -1025,69 +1129,11 @@ public class CreateInfobaseTool implements IMcpTool
             String infobaseName, int actualPort, String webUrl, boolean setDefault,
             IApplicationManager appManager, IProject project)
     {
-        JsonArray appsArray = new JsonArray();
-        String newAppId = null;
-        IApplication newApp = null;
-
-        for (int poll = 0; poll < READ_BACK_MAX_POLLS; poll++)
-        {
-            appsArray = new JsonArray();
-            newAppId = null;
-            newApp = null;
-
-            try
-            {
-                List<IApplication> applications = appManager.getApplications(project);
-                if (applications != null)
-                {
-                    for (IApplication app : applications)
-                    {
-                        JsonObject appObj = new JsonObject();
-                        appObj.addProperty("id", app.getId()); //$NON-NLS-1$
-                        appObj.addProperty("name", app.getName()); //$NON-NLS-1$
-                        String typeId = app.getType() != null ? app.getType().getId() : null;
-                        if (typeId != null)
-                        {
-                            appObj.addProperty("type", typeId); //$NON-NLS-1$
-                        }
-                        addUpdateState(appObj, appManager, app);
-                        // Identify the JUST-created standalone server by its name (a wst-server app whose
-                        // name matches the new infobase) — NOT merely the first wst-server app, which could
-                        // be a pre-existing standalone server already bound to this project.
-                        if (newAppId == null && StandaloneServerSupport.WST_SERVER_APP_TYPE.equals(typeId)
-                            && infobaseName.equals(app.getName()))
-                        {
-                            newAppId = app.getId();
-                            newApp = app;
-                        }
-                        appsArray.add(appObj);
-                    }
-                }
-            }
-            catch (ApplicationException e)
-            {
-                Activator.logError("create_infobase: error reading back applications", e); //$NON-NLS-1$
-                break;
-            }
-
-            if (newAppId != null)
-            {
-                break;
-            }
-
-            if (poll < READ_BACK_MAX_POLLS - 1)
-            {
-                try
-                {
-                    Thread.sleep(READ_BACK_POLL_DELAY_MS);
-                }
-                catch (InterruptedException ie)
-                {
-                    Thread.currentThread().interrupt();
-                    break;
-                }
-            }
-        }
+        // Read back the applications (bounded re-poll) and locate the just-created wst-server.
+        ServerReadBack readBack = pollForNewServerApplication(appManager, project, infobaseName);
+        JsonArray appsArray = readBack.appsArray;
+        String newAppId = readBack.newAppId;
+        IApplication newApp = readBack.newApp;
 
         // Optionally set the new standalone server as the project's default application. A wst-server
         // application is an ordinary IApplication, so the same setDefaultApplication API the file path
@@ -1140,7 +1186,108 @@ public class CreateInfobaseTool implements IMcpTool
             result.put(McpKeys.APPLICATION_ID, newAppId);
         }
 
-        String message = "Standalone server for infobase '" + infobaseName //$NON-NLS-1$
+        result.put(McpKeys.MESSAGE, buildStandaloneServerMessage(projectName, infobaseDir,
+            infobaseName, actualPort, webUrl, setDefaultNote));
+
+        return result.toJson();
+    }
+
+    /**
+     * Reads back the project's applications with the same short bounded re-poll the file path uses
+     * (to absorb the provision-delegate listener race) and locates the JUST-created standalone server
+     * — a {@code wst-server} application whose name matches {@code infobaseName} (NOT merely the first
+     * wst-server, which could be a pre-existing one). Read-only: it only reads applications and builds
+     * the {@code appsArray} echo. Returns a {@link ServerReadBack} carrying the JSON array plus the new
+     * application id/handle ({@code null} when not found within the poll budget).
+     */
+    private static ServerReadBack pollForNewServerApplication(IApplicationManager appManager,
+            IProject project, String infobaseName)
+    {
+        JsonArray appsArray = new JsonArray();
+        String newAppId = null;
+        IApplication newApp = null;
+
+        for (int poll = 0; poll < READ_BACK_MAX_POLLS; poll++)
+        {
+            appsArray = new JsonArray();
+            newAppId = null;
+            newApp = null;
+
+            try
+            {
+                List<IApplication> applications = appManager.getApplications(project);
+                if (applications != null)
+                {
+                    for (IApplication app : applications)
+                    {
+                        appsArray.add(toApplicationJson(appManager, app));
+                        // Identify the JUST-created standalone server by its name (a wst-server app whose
+                        // name matches the new infobase) — NOT merely the first wst-server app, which could
+                        // be a pre-existing standalone server already bound to this project.
+                        String typeId = app.getType() != null ? app.getType().getId() : null;
+                        if (newAppId == null && StandaloneServerSupport.WST_SERVER_APP_TYPE.equals(typeId)
+                            && infobaseName.equals(app.getName()))
+                        {
+                            newAppId = app.getId();
+                            newApp = app;
+                        }
+                    }
+                }
+            }
+            catch (ApplicationException e)
+            {
+                Activator.logError("create_infobase: error reading back applications", e); //$NON-NLS-1$
+                break;
+            }
+
+            if (newAppId != null)
+            {
+                break;
+            }
+
+            if (poll < READ_BACK_MAX_POLLS - 1)
+            {
+                try
+                {
+                    Thread.sleep(READ_BACK_POLL_DELAY_MS);
+                }
+                catch (InterruptedException ie)
+                {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+        return new ServerReadBack(appsArray, newAppId, newApp);
+    }
+
+    /**
+     * Builds the {@code applications} echo entry for a single application: id, name, optional type and
+     * update state — the same shape as {@code get_applications}. Read-only.
+     */
+    private static JsonObject toApplicationJson(IApplicationManager appManager, IApplication app)
+    {
+        JsonObject appObj = new JsonObject();
+        appObj.addProperty("id", app.getId()); //$NON-NLS-1$
+        appObj.addProperty("name", app.getName()); //$NON-NLS-1$
+        String typeId = app.getType() != null ? app.getType().getId() : null;
+        if (typeId != null)
+        {
+            appObj.addProperty("type", typeId); //$NON-NLS-1$
+        }
+        addUpdateState(appObj, appManager, app);
+        return appObj;
+    }
+
+    /**
+     * Builds the human-readable status message for the standalone-server success result (read-only
+     * string assembly). Byte-for-byte identical to the inline message; appends {@code setDefaultNote}
+     * when non-null.
+     */
+    private static String buildStandaloneServerMessage(String projectName, Path infobaseDir,
+            String infobaseName, int actualPort, String webUrl, String setDefaultNote)
+    {
+        return "Standalone server for infobase '" + infobaseName //$NON-NLS-1$
             + "' created at '" + infobaseDir.toAbsolutePath() //$NON-NLS-1$
             + "' and bound to project '" + projectName + "'" //$NON-NLS-1$ //$NON-NLS-2$
             + (actualPort > 0 ? " (web port " + actualPort + ")" : "") + "." //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -1149,9 +1296,24 @@ public class CreateInfobaseTool implements IMcpTool
             + "run_yaxunit_tests with updateBeforeLaunch=true) rather than a bare update_database, " //$NON-NLS-1$
             + "which would start the server in RUN mode." //$NON-NLS-1$
             + (setDefaultNote != null ? setDefaultNote : ""); //$NON-NLS-1$
-        result.put(McpKeys.MESSAGE, message);
+    }
 
-        return result.toJson();
+    /**
+     * Holder for the standalone-server read-back: the {@code applications} JSON echo plus the
+     * just-created server's id/handle ({@code null} when it was not found within the poll budget).
+     */
+    private static final class ServerReadBack
+    {
+        final JsonArray appsArray;
+        final String newAppId;
+        final IApplication newApp;
+
+        ServerReadBack(JsonArray appsArray, String newAppId, IApplication newApp)
+        {
+            this.appsArray = appsArray;
+            this.newAppId = newAppId;
+            this.newApp = newApp;
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugStatusTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugStatusTool.java
@@ -120,80 +120,7 @@ public class DebugStatusTool implements IMcpTool
                     continue;
                 }
 
-                Map<String, Object> entry = new LinkedHashMap<>();
-                entry.put(APPLICATION_ID, appId);
-                entry.put("mode", launch.getLaunchMode()); //$NON-NLS-1$
-                entry.put("debug", ILaunchManager.DEBUG_MODE.equals(launch.getLaunchMode())); //$NON-NLS-1$
-
-                ILaunchConfiguration config = launch.getLaunchConfiguration();
-                if (config != null)
-                {
-                    entry.put("launchConfiguration", config.getName()); //$NON-NLS-1$
-                    String typeId = LaunchConfigUtils.getConfigTypeId(config);
-                    entry.put("configurationType", typeId); //$NON-NLS-1$
-                    entry.put("attach", LaunchConfigUtils.isAttachConfigTypeId(typeId)); //$NON-NLS-1$
-                    String project = LaunchConfigUtils.readAttribute(config,
-                        LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
-                    if (!project.isEmpty())
-                    {
-                        entry.put("project", project); //$NON-NLS-1$
-                    }
-                    String alias = LaunchConfigUtils.readAttribute(config,
-                        LaunchConfigUtils.ATTR_DEBUG_INFOBASE_ALIAS, ""); //$NON-NLS-1$
-                    if (!alias.isEmpty())
-                    {
-                        entry.put("infobaseAlias", alias); //$NON-NLS-1$
-                    }
-                    String url = LaunchConfigUtils.readAttribute(config,
-                        LaunchConfigUtils.ATTR_DEBUG_SERVER_URL, ""); //$NON-NLS-1$
-                    if (!url.isEmpty())
-                    {
-                        entry.put("debugServerUrl", url); //$NON-NLS-1$
-                    }
-                }
-
-                IDebugTarget[] targets = launch.getDebugTargets();
-                int threadCount = 0;
-                boolean anySuspended = false;
-                String suspendedAt = null;
-                for (IDebugTarget t : targets)
-                {
-                    if (t == null || t.isTerminated())
-                    {
-                        continue;
-                    }
-                    try
-                    {
-                        for (IThread th : t.getThreads())
-                        {
-                            threadCount++;
-                            if (th.isSuspended())
-                            {
-                                anySuspended = true;
-                                if (suspendedAt == null)
-                                {
-                                    IStackFrame top = th.getTopStackFrame();
-                                    if (top != null)
-                                    {
-                                        suspendedAt = top.getName() + " @ " + top.getLineNumber(); //$NON-NLS-1$
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        // best-effort
-                    }
-                }
-                entry.put("threadCount", threadCount); //$NON-NLS-1$
-                entry.put("suspended", anySuspended); //$NON-NLS-1$
-                if (suspendedAt != null)
-                {
-                    entry.put("suspendedAt", suspendedAt); //$NON-NLS-1$
-                }
-                entry.put("registered", DebugSessionRegistry.get().hasSnapshot(appId)); //$NON-NLS-1$
-                launches.add(entry);
+                launches.add(buildLaunchEntry(launch, appId));
             }
 
             Map<String, Object> registryInfo = DebugSessionRegistry.get().snapshotInfo();
@@ -211,6 +138,120 @@ public class DebugStatusTool implements IMcpTool
         {
             Activator.logError("Error in debug_status", e); //$NON-NLS-1$
             return ToolResult.error(e.getMessage()).toJson(); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Builds the descriptor map for a single (non-terminated, EDT) debug launch in the
+     * exact field order/shape the JSON response expects: applicationId, mode/debug,
+     * launch-configuration attributes (when a config is present), thread count, suspend
+     * state and the registered flag.
+     *
+     * @param launch the live launch
+     * @param appId the resolved (real or synthetic) application id for the launch
+     * @return the launch entry map
+     */
+    private static Map<String, Object> buildLaunchEntry(ILaunch launch, String appId)
+    {
+        Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put(APPLICATION_ID, appId);
+        entry.put("mode", launch.getLaunchMode()); //$NON-NLS-1$
+        entry.put("debug", ILaunchManager.DEBUG_MODE.equals(launch.getLaunchMode())); //$NON-NLS-1$
+
+        ILaunchConfiguration config = launch.getLaunchConfiguration();
+        if (config != null)
+        {
+            appendLaunchConfigInfo(entry, config);
+        }
+
+        appendSuspendState(entry, launch.getDebugTargets());
+        entry.put("registered", DebugSessionRegistry.get().hasSnapshot(appId)); //$NON-NLS-1$
+        return entry;
+    }
+
+    /**
+     * Adds the launch-configuration-derived fields to the entry: configuration name,
+     * type id and attach flag (always), plus project/infobaseAlias/debugServerUrl only
+     * when those attributes are non-empty (matching the original conditional emission).
+     *
+     * @param entry the launch entry being populated
+     * @param config the launch configuration (non-null)
+     */
+    private static void appendLaunchConfigInfo(Map<String, Object> entry, ILaunchConfiguration config)
+    {
+        entry.put("launchConfiguration", config.getName()); //$NON-NLS-1$
+        String typeId = LaunchConfigUtils.getConfigTypeId(config);
+        entry.put("configurationType", typeId); //$NON-NLS-1$
+        entry.put("attach", LaunchConfigUtils.isAttachConfigTypeId(typeId)); //$NON-NLS-1$
+        String project = LaunchConfigUtils.readAttribute(config,
+            LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+        if (!project.isEmpty())
+        {
+            entry.put("project", project); //$NON-NLS-1$
+        }
+        String alias = LaunchConfigUtils.readAttribute(config,
+            LaunchConfigUtils.ATTR_DEBUG_INFOBASE_ALIAS, ""); //$NON-NLS-1$
+        if (!alias.isEmpty())
+        {
+            entry.put("infobaseAlias", alias); //$NON-NLS-1$
+        }
+        String url = LaunchConfigUtils.readAttribute(config,
+            LaunchConfigUtils.ATTR_DEBUG_SERVER_URL, ""); //$NON-NLS-1$
+        if (!url.isEmpty())
+        {
+            entry.put("debugServerUrl", url); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Walks the launch's debug targets/threads (best-effort, swallowing per-target
+     * exceptions as before) and adds threadCount, suspended and — when a suspended
+     * thread with a top frame is found — suspendedAt to the entry. The first suspended
+     * top frame seen wins suspendedAt, matching the original iteration order.
+     *
+     * @param entry the launch entry being populated
+     * @param targets the launch's debug targets
+     */
+    private static void appendSuspendState(Map<String, Object> entry, IDebugTarget[] targets)
+    {
+        int threadCount = 0;
+        boolean anySuspended = false;
+        String suspendedAt = null;
+        for (IDebugTarget t : targets)
+        {
+            if (t == null || t.isTerminated())
+            {
+                continue;
+            }
+            try
+            {
+                for (IThread th : t.getThreads())
+                {
+                    threadCount++;
+                    if (th.isSuspended())
+                    {
+                        anySuspended = true;
+                        if (suspendedAt == null)
+                        {
+                            IStackFrame top = th.getTopStackFrame();
+                            if (top != null)
+                            {
+                                suspendedAt = top.getName() + " @ " + top.getLineNumber(); //$NON-NLS-1$
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // best-effort
+            }
+        }
+        entry.put("threadCount", threadCount); //$NON-NLS-1$
+        entry.put("suspended", anySuspended); //$NON-NLS-1$
+        if (suspendedAt != null)
+        {
+            entry.put("suspendedAt", suspendedAt); //$NON-NLS-1$
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteInfobaseTool.java
@@ -200,82 +200,25 @@ public class DeleteInfobaseTool implements IMcpTool
     private String deleteInfobase(String projectName, String applicationId, String infobaseName,
             boolean deleteRegistration, boolean deleteDatabaseFiles, boolean confirm)
     {
-        // --- Resolve project ---
-        ProjectContext ctx = ProjectContext.of(projectName);
-        if (!ctx.exists())
+        // --- Resolve project + services ---
+        DeleteContext context = resolveContext(projectName);
+        if (context.error != null)
         {
-            return ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson();
+            return context.error;
         }
-        if (!ctx.isOpen())
-        {
-            return ToolResult.error("Project is closed: " + projectName).toJson(); //$NON-NLS-1$
-        }
-        IProject project = ctx.project();
-
-        // --- Acquire services ---
-        IApplicationManager appManager = Activator.getDefault().getApplicationManager();
-        if (appManager == null)
-        {
-            return ToolResult.error("IApplicationManager service is not available").toJson(); //$NON-NLS-1$
-        }
-
-        IInfobaseAssociationManager assocManager =
-            Activator.getDefault().getInfobaseAssociationManager();
-        if (assocManager == null)
-        {
-            return ToolResult.error("IInfobaseAssociationManager service is not available.").toJson(); //$NON-NLS-1$
-        }
-
-        IInfobaseManager ibManager = Activator.getDefault().getInfobaseManager();
-        // ibManager is optional — only needed for deleteRegistration=true; null checked below.
+        IProject project = context.project;
+        IApplicationManager appManager = context.appManager;
+        IInfobaseAssociationManager assocManager = context.assocManager;
+        IInfobaseManager ibManager = context.ibManager;
 
         // --- Find the target application ---
-        IApplication targetApp = null;
-
-        if (applicationId != null && !applicationId.isEmpty())
+        TargetApplication target =
+            resolveTargetApplication(appManager, project, projectName, applicationId, infobaseName);
+        if (target.error != null)
         {
-            Optional<IApplication> found =
-                appManager.getApplication(project, applicationId);
-            if (!found.isPresent())
-            {
-                return ToolResult.error("Application not found: '" + applicationId //$NON-NLS-1$
-                    + "' for project '" + projectName //$NON-NLS-1$
-                    + "'. Use get_applications to list available application IDs.").toJson(); //$NON-NLS-1$
-            }
-            targetApp = found.get();
+            return target.error;
         }
-        else
-        {
-            // Find by display name among the project's infobase-type OR standalone-server applications.
-            try
-            {
-                List<IApplication> apps = appManager.getApplications(project);
-                if (apps != null)
-                {
-                    for (IApplication app : apps)
-                    {
-                        String appTypeId = app.getType() != null ? app.getType().getId() : null;
-                        if (infobaseName.equals(app.getName())
-                            && (INFOBASE_APP_TYPE.equals(appTypeId)
-                                || StandaloneServerSupport.WST_SERVER_APP_TYPE.equals(appTypeId)))
-                        {
-                            targetApp = app;
-                            break;
-                        }
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                return ToolResult.error("Error listing applications: " + e.getMessage()).toJson(); //$NON-NLS-1$
-            }
-            if (targetApp == null)
-            {
-                return ToolResult.error("Infobase with name '" + infobaseName //$NON-NLS-1$
-                    + "' not found in project '" + projectName //$NON-NLS-1$
-                    + "'. Use get_applications to list available infobases.").toJson(); //$NON-NLS-1$
-            }
-        }
+        IApplication targetApp = target.app;
 
         // Standalone-server (wst-server) applications: the inverse of
         // create_infobase applicationKind=standaloneServer. Handled by a dedicated path.
@@ -310,21 +253,8 @@ public class DeleteInfobaseTool implements IMcpTool
         // --- Confirm-preview gate ---
         if (!confirm)
         {
-            return ToolResult.success()
-                .put(McpKeys.ACTION, "preview") //$NON-NLS-1$
-                .put(KEY_CONFIRMATION_REQUIRED, true)
-                .put(McpKeys.PROJECT, projectName)
-                .put(McpKeys.APPLICATION_ID, resolvedId)
-                .put(KEY_INFOBASE_NAME, resolvedName)
-                .put(KEY_DELETE_REGISTRATION, deleteRegistration)
-                .put(McpKeys.MESSAGE, "PREVIEW: this would dissociate infobase '" + resolvedName //$NON-NLS-1$
-                    + "' from project '" + projectName + "'" //$NON-NLS-1$ //$NON-NLS-2$
-                    + (deleteRegistration
-                        ? " AND deregister it from the EDT infobases list" //$NON-NLS-1$
-                        : " (EDT infobases list entry kept)") //$NON-NLS-1$
-                    + databasePreviewNote(deleteDatabaseFiles, dbDir, dbSharedWithOthers)
-                    + ". Re-call with confirm=true to apply.") //$NON-NLS-1$
-                .toJson();
+            return buildPreviewResult(projectName, resolvedId, resolvedName, deleteRegistration,
+                deleteDatabaseFiles, dbDir, dbSharedWithOthers);
         }
 
         // --- Perform deletion ---
@@ -366,23 +296,8 @@ public class DeleteInfobaseTool implements IMcpTool
                     // Non-fatal: return success but note the partial deletion. We deliberately do NOT
                     // delete the database files here even if requested — deregistration failed, so the
                     // safe choice is to leave the data and say so explicitly (schema-consistent).
-                    return ToolResult.success()
-                        .put(McpKeys.ACTION, VAL_DELETED)
-                        .put(McpKeys.PROJECT, projectName)
-                        .put(McpKeys.APPLICATION_ID, resolvedId)
-                        .put(KEY_INFOBASE_NAME, resolvedName)
-                        .put(KEY_DELETE_REGISTRATION, false)
-                        .put(KEY_DATABASE_FILES_DELETED, false)
-                        .put(McpKeys.MESSAGE, "Infobase '" + resolvedName //$NON-NLS-1$
-                            + "' was dissociated from project '" + projectName //$NON-NLS-1$
-                            + "' but could not be deregistered from the EDT list: " //$NON-NLS-1$
-                            + e.getMessage()
-                            + ". You can remove it manually from the Infobases view in EDT." //$NON-NLS-1$
-                            + (deleteDatabaseFiles
-                                ? " The database files on disk were KEPT (deregistration failed); " //$NON-NLS-1$
-                                    + "remove the directory manually if intended." //$NON-NLS-1$
-                                : "")) //$NON-NLS-1$
-                        .toJson();
+                    return buildDeregisterFailedResult(projectName, resolvedId, resolvedName,
+                        deleteDatabaseFiles, e);
                 }
             }
         }
@@ -399,6 +314,171 @@ public class DeleteInfobaseTool implements IMcpTool
         Activator.logInfo("delete_infobase: done, resolvedId=" + resolvedId //$NON-NLS-1$
             + " (dbFilesDeleted=" + dbFilesDeleted + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 
+        return buildDeleteSuccessResult(projectName, resolvedId, resolvedName, deleteRegistration,
+            deleteDatabaseFiles, dbDir, dbFilesDeleted, dbSharedWithOthers);
+    }
+
+    /**
+     * Resolves the configuration project and the platform services needed for a file-infobase
+     * deletion (read-only). Returns a {@link DeleteContext} whose {@code error} field carries the
+     * tool-result JSON for the SAME early-return cases the inline code produced (project missing /
+     * closed, {@code IApplicationManager} / {@code IInfobaseAssociationManager} unavailable);
+     * otherwise {@code error} is {@code null} and the service fields are populated. The optional
+     * {@code ibManager} (only needed for deleteRegistration) may be {@code null} with no error.
+     */
+    private static DeleteContext resolveContext(String projectName)
+    {
+        ProjectContext ctx = ProjectContext.of(projectName);
+        if (!ctx.exists())
+        {
+            return DeleteContext.error(ToolResult.error(
+                ProjectContext.notFoundMessage(projectName)).toJson());
+        }
+        if (!ctx.isOpen())
+        {
+            return DeleteContext.error(
+                ToolResult.error("Project is closed: " + projectName).toJson()); //$NON-NLS-1$
+        }
+
+        IApplicationManager appManager = Activator.getDefault().getApplicationManager();
+        if (appManager == null)
+        {
+            return DeleteContext.error(
+                ToolResult.error("IApplicationManager service is not available").toJson()); //$NON-NLS-1$
+        }
+
+        IInfobaseAssociationManager assocManager =
+            Activator.getDefault().getInfobaseAssociationManager();
+        if (assocManager == null)
+        {
+            return DeleteContext.error(ToolResult.error(
+                "IInfobaseAssociationManager service is not available.").toJson()); //$NON-NLS-1$
+        }
+
+        // ibManager is optional — only needed for deleteRegistration=true; null checked at use.
+        IInfobaseManager ibManager = Activator.getDefault().getInfobaseManager();
+
+        return DeleteContext.of(ctx.project(), appManager, assocManager, ibManager);
+    }
+
+    /**
+     * Finds the application to remove (read-only) either by {@code applicationId} (exact lookup) or,
+     * when no id is given, by {@code infobaseName} among the project's file-infobase OR
+     * standalone-server applications. Returns a {@link TargetApplication} whose {@code error} field
+     * carries the tool-result JSON for the SAME early-return cases the inline code produced
+     * (application id not found, error listing applications, name not found); otherwise {@code error}
+     * is {@code null} and {@code app} is the resolved application.
+     */
+    private static TargetApplication resolveTargetApplication(IApplicationManager appManager,
+            IProject project, String projectName, String applicationId, String infobaseName)
+    {
+        if (applicationId != null && !applicationId.isEmpty())
+        {
+            Optional<IApplication> found = appManager.getApplication(project, applicationId);
+            if (!found.isPresent())
+            {
+                return TargetApplication.error(ToolResult.error("Application not found: '" //$NON-NLS-1$
+                    + applicationId + "' for project '" + projectName //$NON-NLS-1$
+                    + "'. Use get_applications to list available application IDs.").toJson()); //$NON-NLS-1$
+            }
+            return TargetApplication.of(found.get());
+        }
+
+        // Find by display name among the project's infobase-type OR standalone-server applications.
+        IApplication targetApp = null;
+        try
+        {
+            List<IApplication> apps = appManager.getApplications(project);
+            if (apps != null)
+            {
+                for (IApplication app : apps)
+                {
+                    String appTypeId = app.getType() != null ? app.getType().getId() : null;
+                    if (infobaseName.equals(app.getName())
+                        && (INFOBASE_APP_TYPE.equals(appTypeId)
+                            || StandaloneServerSupport.WST_SERVER_APP_TYPE.equals(appTypeId)))
+                    {
+                        targetApp = app;
+                        break;
+                    }
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            return TargetApplication.error(
+                ToolResult.error("Error listing applications: " + e.getMessage()).toJson()); //$NON-NLS-1$
+        }
+        if (targetApp == null)
+        {
+            return TargetApplication.error(ToolResult.error("Infobase with name '" + infobaseName //$NON-NLS-1$
+                + "' not found in project '" + projectName //$NON-NLS-1$
+                + "'. Use get_applications to list available infobases.").toJson()); //$NON-NLS-1$
+        }
+        return TargetApplication.of(targetApp);
+    }
+
+    /**
+     * Builds the confirm-preview tool-result JSON for a file infobase (no change is made). Byte-for-byte
+     * identical to the inline preview the {@code !confirm} gate produced.
+     */
+    private static String buildPreviewResult(String projectName, String resolvedId, String resolvedName,
+            boolean deleteRegistration, boolean deleteDatabaseFiles, Path dbDir, boolean dbSharedWithOthers)
+    {
+        return ToolResult.success()
+            .put(McpKeys.ACTION, "preview") //$NON-NLS-1$
+            .put(KEY_CONFIRMATION_REQUIRED, true)
+            .put(McpKeys.PROJECT, projectName)
+            .put(McpKeys.APPLICATION_ID, resolvedId)
+            .put(KEY_INFOBASE_NAME, resolvedName)
+            .put(KEY_DELETE_REGISTRATION, deleteRegistration)
+            .put(McpKeys.MESSAGE, "PREVIEW: this would dissociate infobase '" + resolvedName //$NON-NLS-1$
+                + "' from project '" + projectName + "'" //$NON-NLS-1$ //$NON-NLS-2$
+                + (deleteRegistration
+                    ? " AND deregister it from the EDT infobases list" //$NON-NLS-1$
+                    : " (EDT infobases list entry kept)") //$NON-NLS-1$
+                + databasePreviewNote(deleteDatabaseFiles, dbDir, dbSharedWithOthers)
+                + ". Re-call with confirm=true to apply.") //$NON-NLS-1$
+            .toJson();
+    }
+
+    /**
+     * Builds the tool-result JSON for the partial-success case where the infobase was dissociated but
+     * could NOT be deregistered from the EDT list. Byte-for-byte identical to the inline result the
+     * deregister-failure catch produced; the database files are reported as KEPT (the safe choice when
+     * deregistration failed). Read-only — the dissociation has already happened at the call site.
+     */
+    private static String buildDeregisterFailedResult(String projectName, String resolvedId,
+            String resolvedName, boolean deleteDatabaseFiles, Exception e)
+    {
+        return ToolResult.success()
+            .put(McpKeys.ACTION, VAL_DELETED)
+            .put(McpKeys.PROJECT, projectName)
+            .put(McpKeys.APPLICATION_ID, resolvedId)
+            .put(KEY_INFOBASE_NAME, resolvedName)
+            .put(KEY_DELETE_REGISTRATION, false)
+            .put(KEY_DATABASE_FILES_DELETED, false)
+            .put(McpKeys.MESSAGE, "Infobase '" + resolvedName //$NON-NLS-1$
+                + "' was dissociated from project '" + projectName //$NON-NLS-1$
+                + "' but could not be deregistered from the EDT list: " //$NON-NLS-1$
+                + e.getMessage()
+                + ". You can remove it manually from the Infobases view in EDT." //$NON-NLS-1$
+                + (deleteDatabaseFiles
+                    ? " The database files on disk were KEPT (deregistration failed); " //$NON-NLS-1$
+                        + "remove the directory manually if intended." //$NON-NLS-1$
+                    : "")) //$NON-NLS-1$
+            .toJson();
+    }
+
+    /**
+     * Builds the final success tool-result JSON after a file infobase was removed. Byte-for-byte
+     * identical to the inline result the success path produced. Read-only — all mutations
+     * (dissociate / deregister / file deletion) have already happened at the call site.
+     */
+    private static String buildDeleteSuccessResult(String projectName, String resolvedId,
+            String resolvedName, boolean deleteRegistration, boolean deleteDatabaseFiles, Path dbDir,
+            boolean dbFilesDeleted, boolean dbSharedWithOthers)
+    {
         return ToolResult.success()
             .put(McpKeys.ACTION, VAL_DELETED)
             .put(McpKeys.PROJECT, projectName)
@@ -410,8 +490,71 @@ public class DeleteInfobaseTool implements IMcpTool
                 + "' removed from project '" + projectName + "'" //$NON-NLS-1$ //$NON-NLS-2$
                 + (deleteRegistration ? " and deregistered from the EDT infobases list." //$NON-NLS-1$
                     : " (EDT infobases list entry kept).") //$NON-NLS-1$
-                + databaseResultNote(deleteDatabaseFiles, dbDir, dbFilesDeleted, dbSharedWithOthers)) //$NON-NLS-1$
+                + databaseResultNote(deleteDatabaseFiles, dbDir, dbFilesDeleted, dbSharedWithOthers))
             .toJson();
+    }
+
+    /**
+     * Holder for the project + platform services resolved by {@link #resolveContext(String)}. When
+     * {@code error} is non-null it carries a ready tool-result JSON and the other fields are unset;
+     * otherwise {@code error} is {@code null} and the fields are populated (ibManager may be null).
+     */
+    private static final class DeleteContext
+    {
+        final String error;
+        final IProject project;
+        final IApplicationManager appManager;
+        final IInfobaseAssociationManager assocManager;
+        final IInfobaseManager ibManager;
+
+        private DeleteContext(String error, IProject project, IApplicationManager appManager,
+                IInfobaseAssociationManager assocManager, IInfobaseManager ibManager)
+        {
+            this.error = error;
+            this.project = project;
+            this.appManager = appManager;
+            this.assocManager = assocManager;
+            this.ibManager = ibManager;
+        }
+
+        static DeleteContext error(String error)
+        {
+            return new DeleteContext(error, null, null, null, null);
+        }
+
+        static DeleteContext of(IProject project, IApplicationManager appManager,
+                IInfobaseAssociationManager assocManager, IInfobaseManager ibManager)
+        {
+            return new DeleteContext(null, project, appManager, assocManager, ibManager);
+        }
+    }
+
+    /**
+     * Holder for the application resolved by
+     * {@link #resolveTargetApplication(IApplicationManager, IProject, String, String, String)}. When
+     * {@code error} is non-null it carries a ready tool-result JSON and {@code app} is {@code null};
+     * otherwise {@code error} is {@code null} and {@code app} is the resolved application.
+     */
+    private static final class TargetApplication
+    {
+        final String error;
+        final IApplication app;
+
+        private TargetApplication(String error, IApplication app)
+        {
+            this.error = error;
+            this.app = app;
+        }
+
+        static TargetApplication error(String error)
+        {
+            return new TargetApplication(error, null);
+        }
+
+        static TargetApplication of(IApplication app)
+        {
+            return new TargetApplication(null, app);
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetConfigurationPropertiesTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetConfigurationPropertiesTool.java
@@ -121,12 +121,12 @@ public class GetConfigurationPropertiesTool implements IMcpTool
     private static String getConfigurationPropertiesInternal(String projectName)
     {
         Activator.logInfo("getConfigurationPropertiesInternal: Starting..."); //$NON-NLS-1$
-        
+
         try
         {
             IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
             IV8ProjectManager v8ProjectManager = Activator.getDefault().getV8ProjectManager();
-            
+
             if (dtProjectManager == null || v8ProjectManager == null)
             {
                 Activator.logInfo("getConfigurationProperties: Project managers not available"); //$NON-NLS-1$
@@ -137,80 +137,16 @@ public class GetConfigurationPropertiesTool implements IMcpTool
             // are IConfigurationAware and expose getConfiguration(), so resolve against
             // that shared interface (NOT the narrower IConfigurationProject, which
             // excludes extensions and made this tool error on a valid extension).
-            IConfigurationAware configProject = null;
-            IProject matchedProject = null;
-            boolean matchedIsExtension = false;
+            MatchedConfiguration matched = resolveConfigurationProject(projectName,
+                dtProjectManager, v8ProjectManager);
 
-            // Find project by name or get first configuration project
-            IWorkspace workspace = ResourcesPlugin.getWorkspace();
-            IProject[] projects = workspace.getRoot().getProjects();
-
-            for (IProject project : projects)
+            if (matched.configProject == null)
             {
-                if (!project.isOpen())
-                {
-                    continue;
-                }
-
-                IDtProject dtProject = dtProjectManager.getDtProject(project);
-                if (dtProject == null)
-                {
-                    continue;
-                }
-
-                IV8Project v8Project = v8ProjectManager.getProject(dtProject);
-                if (!(v8Project instanceof IConfigurationAware))
-                {
-                    continue;
-                }
-
-                if (projectName == null || projectName.isEmpty())
-                {
-                    // Default (no name given): the first base CONFIGURATION project — an
-                    // extension is not a sensible "default configuration", so skip it here.
-                    if (v8Project instanceof IConfigurationProject)
-                    {
-                        configProject = (IConfigurationAware) v8Project;
-                        matchedProject = project;
-                        break;
-                    }
-                }
-                else if (project.getName().equals(projectName))
-                {
-                    // Explicit name: accept a base configuration OR an extension.
-                    configProject = (IConfigurationAware) v8Project;
-                    matchedProject = project;
-                    matchedIsExtension = v8Project instanceof IExtensionProject;
-                    break;
-                }
-            }
-            
-            if (configProject == null)
-            {
-                if (projectName != null && !projectName.isEmpty())
-                {
-                    // Distinguish "no such project" from "exists but is not a
-                    // configuration project" so the message is accurate; both name
-                    // the value and point at list_projects as the next step.
-                    if (!ProjectContext.of(projectName).exists())
-                    {
-                        return ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson();
-                    }
-                    // Exists but exposes no 1C configuration — neither a base
-                    // configuration nor an extension (both are IConfigurationAware).
-                    return ToolResult.error("Project '" + projectName //$NON-NLS-1$
-                        + "' does not expose a 1C configuration (not a configuration or extension project). " //$NON-NLS-1$
-                        + "Use list_projects to see available projects.").toJson(); //$NON-NLS-1$
-                }
-                // No projectName given and the workspace holds no configuration
-                // project at all — nothing to name; keep the message clear and tell
-                // the caller how to discover projects.
-                return ToolResult.error("No configuration project found in the workspace. " //$NON-NLS-1$
-                    + "Use list_projects to see available projects.").toJson(); //$NON-NLS-1$
+                return configProjectNotFoundError(projectName);
             }
 
             // Get configuration object
-            Configuration configuration = configProject.getConfiguration();
+            Configuration configuration = matched.configProject.getConfiguration();
             if (configuration == null)
             {
                 return ToolResult.error("Configuration object not available").toJson(); //$NON-NLS-1$
@@ -222,90 +158,17 @@ public class GetConfigurationPropertiesTool implements IMcpTool
             // ToolResult.error(...).toJson() above and are delivered as structured
             // JSON via the protocol diversion, independent of this YAML body.
             StringBuilder yaml = new StringBuilder();
-            appendScalar(yaml, "name", configuration.getName()); //$NON-NLS-1$
-            appendMap(yaml, "synonym", toLocalizedMap(configuration.getSynonym())); //$NON-NLS-1$
-            appendScalar(yaml, "comment", configuration.getComment()); //$NON-NLS-1$
-
-            if (configuration.getScriptVariant() != null)
-            {
-                appendScalar(yaml, "scriptVariant", configuration.getScriptVariant().toString()); //$NON-NLS-1$
-            }
-            if (configuration.getDefaultRunMode() != null)
-            {
-                appendScalar(yaml, "defaultRunMode", configuration.getDefaultRunMode().toString()); //$NON-NLS-1$
-            }
-            if (configuration.getDataLockControlMode() != null)
-            {
-                appendScalar(yaml, "dataLockControlMode", configuration.getDataLockControlMode().toString()); //$NON-NLS-1$
-            }
-            if (configuration.getCompatibilityMode() != null)
-            {
-                appendScalar(yaml, "compatibilityMode", configuration.getCompatibilityMode().toString()); //$NON-NLS-1$
-            }
-            if (configuration.getModalityUseMode() != null)
-            {
-                appendScalar(yaml, "modalityUseMode", configuration.getModalityUseMode().toString()); //$NON-NLS-1$
-            }
-            if (configuration.getInterfaceCompatibilityMode() != null)
-            {
-                appendScalar(yaml, "interfaceCompatibilityMode", configuration.getInterfaceCompatibilityMode().toString()); //$NON-NLS-1$
-            }
-            if (configuration.getObjectAutonumerationMode() != null)
-            {
-                appendScalar(yaml, "objectAutonumerationMode", configuration.getObjectAutonumerationMode().toString()); //$NON-NLS-1$
-            }
-
-            // Use purposes (list)
-            List<String> usePurposes = new ArrayList<>();
-            if (configuration.getUsePurposes() != null)
-            {
-                for (Object purpose : configuration.getUsePurposes())
-                {
-                    usePurposes.add(purpose.toString());
-                }
-            }
-            appendList(yaml, "usePurposes", usePurposes); //$NON-NLS-1$
-
-            // Localized / vendor fields (empty maps omitted)
-            appendMap(yaml, "briefInformation", toLocalizedMap(configuration.getBriefInformation())); //$NON-NLS-1$
-            appendMap(yaml, "detailedInformation", toLocalizedMap(configuration.getDetailedInformation())); //$NON-NLS-1$
-            appendScalar(yaml, "vendor", configuration.getVendor()); //$NON-NLS-1$
-            appendScalar(yaml, "version", configuration.getVersion()); //$NON-NLS-1$
-            appendMap(yaml, "copyright", toLocalizedMap(configuration.getCopyright())); //$NON-NLS-1$
-            appendMap(yaml, "vendorInformationAddress", toLocalizedMap(configuration.getVendorInformationAddress())); //$NON-NLS-1$
-            appendMap(yaml, "configurationInformationAddress", toLocalizedMap(configuration.getConfigurationInformationAddress())); //$NON-NLS-1$
-
-            // Default language: report the language CODE (ru/en — the synonym map key)
-            // plus its human-readable name.
-            if (configuration.getDefaultLanguage() != null)
-            {
-                appendScalar(yaml, "defaultLanguage", configuration.getDefaultLanguage().getLanguageCode()); //$NON-NLS-1$
-                appendScalar(yaml, "defaultLanguageName", configuration.getDefaultLanguage().getName()); //$NON-NLS-1$
-            }
+            appendConfigurationProperties(yaml, configuration);
 
             // Extension-specific properties — emitted only for a configuration
             // EXTENSION (a base configuration has no name prefix / purpose / extension
             // compatibility mode), so a base config's output is unchanged.
-            if (matchedIsExtension)
+            if (matched.isExtension)
             {
-                // A synthetic marker that this project is a configuration EXTENSION.
-                // NB this is NOT the EMF MdObject.getObjectBelonging() property (that
-                // returns Adopted/Native per object) — it is a project-kind hint.
-                appendScalar(yaml, "projectKind", "Extension"); //$NON-NLS-1$ //$NON-NLS-2$
-                appendScalar(yaml, "namePrefix", configuration.getNamePrefix()); //$NON-NLS-1$
-                if (configuration.getConfigurationExtensionPurpose() != null)
-                {
-                    appendScalar(yaml, "configurationExtensionPurpose", //$NON-NLS-1$
-                        configuration.getConfigurationExtensionPurpose().toString());
-                }
-                if (configuration.getConfigurationExtensionCompatibilityMode() != null)
-                {
-                    appendScalar(yaml, "configurationExtensionCompatibilityMode", //$NON-NLS-1$
-                        configuration.getConfigurationExtensionCompatibilityMode().toString());
-                }
+                appendExtensionProperties(yaml, configuration);
             }
 
-            appendScalar(yaml, McpKeys.PROJECT_NAME, matchedProject.getName());
+            appendScalar(yaml, McpKeys.PROJECT_NAME, matched.project.getName());
 
             return yaml.toString();
         }
@@ -313,6 +176,214 @@ public class GetConfigurationPropertiesTool implements IMcpTool
         {
             Activator.logError("Failed to get configuration properties", e); //$NON-NLS-1$
             return ToolResult.error(e.getMessage()).toJson();
+        }
+    }
+
+    /**
+     * Holder threading the resolved configuration project, its workspace project and
+     * whether the match is a configuration EXTENSION out of {@link #resolveConfigurationProject}.
+     * When no project matched, {@link #configProject} is {@code null}.
+     */
+    private static final class MatchedConfiguration
+    {
+        private final IConfigurationAware configProject;
+        private final IProject project;
+        private final boolean isExtension;
+
+        private MatchedConfiguration(IConfigurationAware configProject, IProject project, boolean isExtension)
+        {
+            this.configProject = configProject;
+            this.project = project;
+            this.isExtension = isExtension;
+        }
+    }
+
+    /**
+     * Resolves the configuration project to report. With no name, returns the first base
+     * CONFIGURATION project (extensions are skipped — an extension is not a sensible
+     * "default configuration"). With a name, accepts a base configuration OR an extension
+     * whose project name matches. Returns a holder with a {@code null} configProject when
+     * nothing matched (the caller turns that into the appropriate error).
+     *
+     * @param projectName optional project name filter
+     * @param dtProjectManager the DT project manager
+     * @param v8ProjectManager the V8 project manager
+     * @return the matched-configuration holder (never null; configProject may be null)
+     */
+    private static MatchedConfiguration resolveConfigurationProject(String projectName,
+        IDtProjectManager dtProjectManager, IV8ProjectManager v8ProjectManager)
+    {
+        IWorkspace workspace = ResourcesPlugin.getWorkspace();
+        IProject[] projects = workspace.getRoot().getProjects();
+
+        for (IProject project : projects)
+        {
+            if (!project.isOpen())
+            {
+                continue;
+            }
+
+            IDtProject dtProject = dtProjectManager.getDtProject(project);
+            if (dtProject == null)
+            {
+                continue;
+            }
+
+            IV8Project v8Project = v8ProjectManager.getProject(dtProject);
+            if (!(v8Project instanceof IConfigurationAware))
+            {
+                continue;
+            }
+
+            if (projectName == null || projectName.isEmpty())
+            {
+                // Default (no name given): the first base CONFIGURATION project — an
+                // extension is not a sensible "default configuration", so skip it here.
+                if (v8Project instanceof IConfigurationProject)
+                {
+                    return new MatchedConfiguration((IConfigurationAware) v8Project, project, false);
+                }
+            }
+            else if (project.getName().equals(projectName))
+            {
+                // Explicit name: accept a base configuration OR an extension.
+                return new MatchedConfiguration((IConfigurationAware) v8Project, project,
+                    v8Project instanceof IExtensionProject);
+            }
+        }
+
+        return new MatchedConfiguration(null, null, false);
+    }
+
+    /**
+     * Builds the error returned when no configuration project resolved, distinguishing
+     * "no such project", "exists but exposes no 1C configuration" and "workspace has no
+     * configuration project at all" so the message is accurate. Always travels as
+     * structured JSON via {@link ToolResult#error}.
+     *
+     * @param projectName the requested project name (may be null/empty)
+     * @return the JSON error payload
+     */
+    private static String configProjectNotFoundError(String projectName)
+    {
+        if (projectName != null && !projectName.isEmpty())
+        {
+            // Distinguish "no such project" from "exists but is not a
+            // configuration project" so the message is accurate; both name
+            // the value and point at list_projects as the next step.
+            if (!ProjectContext.of(projectName).exists())
+            {
+                return ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson();
+            }
+            // Exists but exposes no 1C configuration — neither a base
+            // configuration nor an extension (both are IConfigurationAware).
+            return ToolResult.error("Project '" + projectName //$NON-NLS-1$
+                + "' does not expose a 1C configuration (not a configuration or extension project). " //$NON-NLS-1$
+                + "Use list_projects to see available projects.").toJson(); //$NON-NLS-1$
+        }
+        // No projectName given and the workspace holds no configuration
+        // project at all — nothing to name; keep the message clear and tell
+        // the caller how to discover projects.
+        return ToolResult.error("No configuration project found in the workspace. " //$NON-NLS-1$
+            + "Use list_projects to see available projects.").toJson(); //$NON-NLS-1$
+    }
+
+    /**
+     * Appends the common (non-extension) configuration properties to the YAML body in
+     * the exact order/format used for both base configurations and extensions. Null
+     * scalars and empty localized maps are omitted by the append* helpers.
+     *
+     * @param yaml the YAML accumulator
+     * @param configuration the configuration object to read from
+     */
+    private static void appendConfigurationProperties(StringBuilder yaml, Configuration configuration)
+    {
+        appendScalar(yaml, "name", configuration.getName()); //$NON-NLS-1$
+        appendMap(yaml, "synonym", toLocalizedMap(configuration.getSynonym())); //$NON-NLS-1$
+        appendScalar(yaml, "comment", configuration.getComment()); //$NON-NLS-1$
+
+        if (configuration.getScriptVariant() != null)
+        {
+            appendScalar(yaml, "scriptVariant", configuration.getScriptVariant().toString()); //$NON-NLS-1$
+        }
+        if (configuration.getDefaultRunMode() != null)
+        {
+            appendScalar(yaml, "defaultRunMode", configuration.getDefaultRunMode().toString()); //$NON-NLS-1$
+        }
+        if (configuration.getDataLockControlMode() != null)
+        {
+            appendScalar(yaml, "dataLockControlMode", configuration.getDataLockControlMode().toString()); //$NON-NLS-1$
+        }
+        if (configuration.getCompatibilityMode() != null)
+        {
+            appendScalar(yaml, "compatibilityMode", configuration.getCompatibilityMode().toString()); //$NON-NLS-1$
+        }
+        if (configuration.getModalityUseMode() != null)
+        {
+            appendScalar(yaml, "modalityUseMode", configuration.getModalityUseMode().toString()); //$NON-NLS-1$
+        }
+        if (configuration.getInterfaceCompatibilityMode() != null)
+        {
+            appendScalar(yaml, "interfaceCompatibilityMode", configuration.getInterfaceCompatibilityMode().toString()); //$NON-NLS-1$
+        }
+        if (configuration.getObjectAutonumerationMode() != null)
+        {
+            appendScalar(yaml, "objectAutonumerationMode", configuration.getObjectAutonumerationMode().toString()); //$NON-NLS-1$
+        }
+
+        // Use purposes (list)
+        List<String> usePurposes = new ArrayList<>();
+        if (configuration.getUsePurposes() != null)
+        {
+            for (Object purpose : configuration.getUsePurposes())
+            {
+                usePurposes.add(purpose.toString());
+            }
+        }
+        appendList(yaml, "usePurposes", usePurposes); //$NON-NLS-1$
+
+        // Localized / vendor fields (empty maps omitted)
+        appendMap(yaml, "briefInformation", toLocalizedMap(configuration.getBriefInformation())); //$NON-NLS-1$
+        appendMap(yaml, "detailedInformation", toLocalizedMap(configuration.getDetailedInformation())); //$NON-NLS-1$
+        appendScalar(yaml, "vendor", configuration.getVendor()); //$NON-NLS-1$
+        appendScalar(yaml, "version", configuration.getVersion()); //$NON-NLS-1$
+        appendMap(yaml, "copyright", toLocalizedMap(configuration.getCopyright())); //$NON-NLS-1$
+        appendMap(yaml, "vendorInformationAddress", toLocalizedMap(configuration.getVendorInformationAddress())); //$NON-NLS-1$
+        appendMap(yaml, "configurationInformationAddress", toLocalizedMap(configuration.getConfigurationInformationAddress())); //$NON-NLS-1$
+
+        // Default language: report the language CODE (ru/en — the synonym map key)
+        // plus its human-readable name.
+        if (configuration.getDefaultLanguage() != null)
+        {
+            appendScalar(yaml, "defaultLanguage", configuration.getDefaultLanguage().getLanguageCode()); //$NON-NLS-1$
+            appendScalar(yaml, "defaultLanguageName", configuration.getDefaultLanguage().getName()); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Appends the configuration-EXTENSION-only properties (project-kind marker, name
+     * prefix, extension purpose and extension compatibility mode). Called only when the
+     * matched project is an extension, so base-configuration output is unchanged.
+     *
+     * @param yaml the YAML accumulator
+     * @param configuration the extension configuration object to read from
+     */
+    private static void appendExtensionProperties(StringBuilder yaml, Configuration configuration)
+    {
+        // A synthetic marker that this project is a configuration EXTENSION.
+        // NB this is NOT the EMF MdObject.getObjectBelonging() property (that
+        // returns Adopted/Native per object) — it is a project-kind hint.
+        appendScalar(yaml, "projectKind", "Extension"); //$NON-NLS-1$ //$NON-NLS-2$
+        appendScalar(yaml, "namePrefix", configuration.getNamePrefix()); //$NON-NLS-1$
+        if (configuration.getConfigurationExtensionPurpose() != null)
+        {
+            appendScalar(yaml, "configurationExtensionPurpose", //$NON-NLS-1$
+                configuration.getConfigurationExtensionPurpose().toString());
+        }
+        if (configuration.getConfigurationExtensionCompatibilityMode() != null)
+        {
+            appendScalar(yaml, "configurationExtensionCompatibilityMode", //$NON-NLS-1$
+                configuration.getConfigurationExtensionCompatibilityMode().toString());
         }
     }
     

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetContentAssistTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetContentAssistTool.java
@@ -598,15 +598,7 @@ public class GetContentAssistTool implements IMcpTool
         }
 
         // Parse contains filter into lowercase parts
-        String[] filterParts = null;
-        if (containsFilter != null && !containsFilter.isEmpty())
-        {
-            filterParts = containsFilter.toLowerCase().split(","); //$NON-NLS-1$
-            for (int i = 0; i < filterParts.length; i++)
-            {
-                filterParts[i] = filterParts[i].trim();
-            }
-        }
+        String[] filterParts = parseContainsFilter(containsFilter);
 
         List<Map<String, Object>> proposalList = new ArrayList<>();
         int count = 0;
@@ -620,23 +612,10 @@ public class GetContentAssistTool implements IMcpTool
                 String displayString = proposal.getDisplayString();
 
                 // Apply contains filter
-                if (filterParts != null)
+                if (filterParts != null && !matchesFilter(displayString, filterParts))
                 {
-                    boolean matches = false;
-                    String displayLower = displayString.toLowerCase();
-                    for (String part : filterParts)
-                    {
-                        if (!part.isEmpty() && displayLower.contains(part))
-                        {
-                            matches = true;
-                            break;
-                        }
-                    }
-                    if (!matches)
-                    {
-                        filteredOut++;
-                        continue;
-                    }
+                    filteredOut++;
+                    continue;
                 }
 
                 // Apply offset (skip first N matching proposals)
@@ -652,43 +631,7 @@ public class GetContentAssistTool implements IMcpTool
                     break;
                 }
 
-                // LinkedHashMap to keep a stable, readable field order per proposal.
-                Map<String, Object> proposalObj = new LinkedHashMap<>();
-                proposalObj.put("displayString", displayString); //$NON-NLS-1$
-
-                // Only get documentation if extendedDocumentation is true
-                if (extendedDocumentation)
-                {
-                    // Get additional info (documentation)
-                    // Use ICompletionProposalExtension5 for async-capable proposals
-                    String additionalInfo = null;
-                    if (proposal instanceof ICompletionProposalExtension5)
-                    {
-                        // Get documentation using progress monitor
-                        Object info = ((ICompletionProposalExtension5) proposal)
-                            .getAdditionalProposalInfo(new NullProgressMonitor());
-                        if (info != null)
-                        {
-                            additionalInfo = info.toString();
-                        }
-                    }
-                    else
-                    {
-                        additionalInfo = proposal.getAdditionalProposalInfo();
-                    }
-
-                    if (additionalInfo != null && !additionalInfo.isEmpty())
-                    {
-                        // Strip HTML tags and CSS styles for cleaner output
-                        String cleanInfo = cleanHtmlContent(additionalInfo);
-                        if (!cleanInfo.isEmpty())
-                        {
-                            proposalObj.put("documentation", cleanInfo); //$NON-NLS-1$
-                        }
-                    }
-                }
-
-                proposalList.add(proposalObj);
+                proposalList.add(buildProposalObject(proposal, displayString, extendedDocumentation));
                 count++;
             }
         }
@@ -705,7 +648,106 @@ public class GetContentAssistTool implements IMcpTool
             .put("proposals", proposalList) //$NON-NLS-1$
             .toJson();
     }
-    
+
+    /**
+     * Parses the comma-separated {@code contains} filter into trimmed, lowercased parts.
+     * Returns {@code null} when no filter is supplied (caller treats null as "no filter"),
+     * preserving the original behavior where an empty/absent filter keeps all proposals.
+     *
+     * @param containsFilter the raw comma-separated filter, possibly null/empty
+     * @return the lowercased trimmed parts, or null when no filter was supplied
+     */
+    private static String[] parseContainsFilter(String containsFilter)
+    {
+        if (containsFilter == null || containsFilter.isEmpty())
+        {
+            return null;
+        }
+        String[] filterParts = containsFilter.toLowerCase().split(","); //$NON-NLS-1$
+        for (int i = 0; i < filterParts.length; i++)
+        {
+            filterParts[i] = filterParts[i].trim();
+        }
+        return filterParts;
+    }
+
+    /**
+     * Returns true when the display string contains any non-empty filter part
+     * (case-insensitive), matching the original inline filter loop.
+     *
+     * @param displayString the proposal display string
+     * @param filterParts the lowercased trimmed filter parts (non-null)
+     * @return true if at least one non-empty part is a substring of the display string
+     */
+    private static boolean matchesFilter(String displayString, String[] filterParts)
+    {
+        String displayLower = displayString.toLowerCase();
+        for (String part : filterParts)
+        {
+            if (!part.isEmpty() && displayLower.contains(part))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Builds the per-proposal map ({@code displayString} plus, when requested and
+     * available, cleaned {@code documentation}). Uses a LinkedHashMap to keep a stable,
+     * readable field order, exactly as the original inline block did.
+     *
+     * @param proposal the completion proposal
+     * @param displayString the proposal's already-read display string
+     * @param extendedDocumentation whether to include documentation
+     * @return the proposal object map
+     */
+    private static Map<String, Object> buildProposalObject(ICompletionProposal proposal,
+        String displayString, boolean extendedDocumentation)
+    {
+        // LinkedHashMap to keep a stable, readable field order per proposal.
+        Map<String, Object> proposalObj = new LinkedHashMap<>();
+        proposalObj.put("displayString", displayString); //$NON-NLS-1$
+
+        // Only get documentation if extendedDocumentation is true
+        if (extendedDocumentation)
+        {
+            String additionalInfo = extractAdditionalInfo(proposal);
+            if (additionalInfo != null && !additionalInfo.isEmpty())
+            {
+                // Strip HTML tags and CSS styles for cleaner output
+                String cleanInfo = cleanHtmlContent(additionalInfo);
+                if (!cleanInfo.isEmpty())
+                {
+                    proposalObj.put("documentation", cleanInfo); //$NON-NLS-1$
+                }
+            }
+        }
+        return proposalObj;
+    }
+
+    /**
+     * Reads a proposal's additional info (documentation), using
+     * {@link ICompletionProposalExtension5} with a {@link NullProgressMonitor} for
+     * async-capable proposals and the plain accessor otherwise. May return null.
+     *
+     * @param proposal the completion proposal
+     * @return the additional-info string, or null when none is available
+     */
+    private static String extractAdditionalInfo(ICompletionProposal proposal)
+    {
+        // Get additional info (documentation)
+        // Use ICompletionProposalExtension5 for async-capable proposals
+        if (proposal instanceof ICompletionProposalExtension5)
+        {
+            // Get documentation using progress monitor
+            Object info = ((ICompletionProposalExtension5) proposal)
+                .getAdditionalProposalInfo(new NullProgressMonitor());
+            return info != null ? info.toString() : null;
+        }
+        return proposal.getAdditionalProposalInfo();
+    }
+
     /**
      * Converts HTML content to Markdown format using CopyDown library.
      * 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -898,24 +898,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         switch (info.valueKind)
         {
             case LOCALIZED_STRING:
-            {
-                if (value == null || value.isEmpty())
-                {
-                    return requireValueError(name);
-                }
-                String code;
-                try
-                {
-                    code = MetadataLanguageUtils.resolveSynonymLanguage(config, value,
-                        asString(prop.get("language")), "'" + name + "'"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-                }
-                catch (IllegalArgumentException e)
-                {
-                    return ToolResult.error(e.getMessage()).toJson();
-                }
-                out.add(PreparedChange.localized(info.feature, code, normReport.apply(name, value)));
-                return null;
-            }
+                return prepareLocalized(config, name, value, prop, info, out, normReport);
             case ENUM:
             {
                 EEnumLiteral literal = MetadataPropertyIntrospector.resolveEnumLiteral(info.feature, value);
@@ -950,77 +933,13 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 return null;
             }
             case TYPE_DESCRIPTION:
-            {
-                if (version == null)
-                {
-                    return ToolResult.error("Cannot resolve the platform version needed to build a " //$NON-NLS-1$
-                        + "type for '" + name + "'.").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
-                }
-                MetadataTypeBuilder.Result tr =
-                    MetadataTypeBuilder.build(prop.get(KEY_VALUE), config, version);
-                if (tr.error != null)
-                {
-                    return ToolResult.error("Invalid 'type' for '" + name + "': " + tr.error).toJson(); //$NON-NLS-1$ //$NON-NLS-2$
-                }
-                out.add(PreparedChange.scalar(info.feature, tr.typeDescription));
-                return null;
-            }
+                return prepareTypeDescription(config, version, name, prop, info, out);
             case REFERENCE:
-            {
-                if (value == null || value.isEmpty())
-                {
-                    return requireValueError(name);
-                }
-                MdObject targetMd = resolveReferenceTarget(config, value);
-                String vErr = validateReferenceTarget(name, info.feature, targetMd, value);
-                if (vErr != null)
-                {
-                    return vErr;
-                }
-                out.add(PreparedChange.reference(info.feature, ((IBmObject)targetMd).bmGetId()));
-                return null;
-            }
+                return prepareReference(config, name, value, info, out);
             case MANY_REFERENCE:
-            {
-                JsonElement raw = prop.get(KEY_VALUE);
-                if (raw == null || !raw.isJsonArray())
-                {
-                    return ToolResult.error("'" + name + "' is a list reference: provide 'value' as an " //$NON-NLS-1$ //$NON-NLS-2$
-                        + "array of FQNs, e.g. [\"Catalog.Products\", \"Document.Order\"].").toJson(); //$NON-NLS-1$
-                }
-                List<Long> ids = new ArrayList<>();
-                for (JsonElement el : raw.getAsJsonArray())
-                {
-                    String fqn = (el != null && el.isJsonPrimitive()) ? el.getAsString() : null;
-                    if (fqn == null || fqn.isEmpty())
-                    {
-                        return ToolResult.error("Each entry of the '" + name + "' list must be a " //$NON-NLS-1$ //$NON-NLS-2$
-                            + "non-empty FQN string.").toJson(); //$NON-NLS-1$
-                    }
-                    MdObject t = resolveReferenceTarget(config, fqn);
-                    String vErr = validateReferenceTarget(name, info.feature, t, fqn);
-                    if (vErr != null)
-                    {
-                        return vErr;
-                    }
-                    ids.add(((IBmObject)t).bmGetId());
-                }
-                out.add(PreparedChange.manyReference(info.feature, ids));
-                return null;
-            }
+                return prepareManyReference(config, name, prop, info, out);
             case STYLE_VALUE:
-            {
-                StyleValueBuilder.Result sv = StyleValueBuilder.build(prop.get(KEY_VALUE));
-                if (sv.error != null)
-                {
-                    return ToolResult.error("Invalid StyleItem '" + name + "': " + sv.error).toJson(); //$NON-NLS-1$ //$NON-NLS-2$
-                }
-                // The style item's `type` (Color / Font) is kept consistent with the value it holds, so
-                // the change sets both the `value` and the sibling `type` feature in one shot.
-                EStructuralFeature typeFeature = target.eClass().getEStructuralFeature("type"); //$NON-NLS-1$
-                out.add(PreparedChange.styleValue(info.feature, typeFeature, sv.value, sv.type));
-                return null;
-            }
+                return prepareStyleValue(name, prop, target, info, out);
             case STRING:
             default:
                 if (value == null || value.isEmpty())
@@ -1031,6 +950,136 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                     normalizeStringPropertyValue(name, value, normReport)));
                 return null;
         }
+    }
+
+    /**
+     * Validates a {@code LOCALIZED_STRING} property (resolving its synonym language code) and, on
+     * success, appends the prepared localized change to {@code out}. Returns a JSON error on failure,
+     * or {@code null} on success. Read-only: it only builds and queues the change (no model mutation).
+     */
+    private String prepareLocalized(Configuration config, String name, String value, JsonObject prop,
+        PropertyInfo info, List<PreparedChange> out, MdNameNormalizer.Report normReport)
+    {
+        if (value == null || value.isEmpty())
+        {
+            return requireValueError(name);
+        }
+        String code;
+        try
+        {
+            code = MetadataLanguageUtils.resolveSynonymLanguage(config, value,
+                asString(prop.get("language")), "'" + name + "'"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        }
+        catch (IllegalArgumentException e)
+        {
+            return ToolResult.error(e.getMessage()).toJson();
+        }
+        out.add(PreparedChange.localized(info.feature, code, normReport.apply(name, value)));
+        return null;
+    }
+
+    /**
+     * Validates a {@code TYPE_DESCRIPTION} property (building the type description for the resolved
+     * platform version) and, on success, appends the prepared scalar change to {@code out}. Returns a
+     * JSON error on failure, or {@code null} on success. Read-only: it only builds and queues the
+     * change (no model mutation).
+     */
+    private String prepareTypeDescription(Configuration config, Version version, String name,
+        JsonObject prop, PropertyInfo info, List<PreparedChange> out)
+    {
+        if (version == null)
+        {
+            return ToolResult.error("Cannot resolve the platform version needed to build a " //$NON-NLS-1$
+                + "type for '" + name + "'.").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        MetadataTypeBuilder.Result tr =
+            MetadataTypeBuilder.build(prop.get(KEY_VALUE), config, version);
+        if (tr.error != null)
+        {
+            return ToolResult.error("Invalid 'type' for '" + name + "': " + tr.error).toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        out.add(PreparedChange.scalar(info.feature, tr.typeDescription));
+        return null;
+    }
+
+    /**
+     * Validates a single-valued {@code REFERENCE} property (resolving and type-checking its FQN target)
+     * and, on success, appends the prepared reference change to {@code out}. Returns a JSON error on
+     * failure, or {@code null} on success. Read-only: it only builds and queues the change (no model
+     * mutation).
+     */
+    private String prepareReference(Configuration config, String name, String value, PropertyInfo info,
+        List<PreparedChange> out)
+    {
+        if (value == null || value.isEmpty())
+        {
+            return requireValueError(name);
+        }
+        MdObject targetMd = resolveReferenceTarget(config, value);
+        String vErr = validateReferenceTarget(name, info.feature, targetMd, value);
+        if (vErr != null)
+        {
+            return vErr;
+        }
+        out.add(PreparedChange.reference(info.feature, ((IBmObject)targetMd).bmGetId()));
+        return null;
+    }
+
+    /**
+     * Validates a {@code MANY_REFERENCE} property (the value must be a JSON array of non-empty FQNs,
+     * each resolving and type-checking) and, on success, appends the prepared list-reference change to
+     * {@code out}. Returns a JSON error on failure, or {@code null} on success. Read-only: it only
+     * builds and queues the change (no model mutation).
+     */
+    private String prepareManyReference(Configuration config, String name, JsonObject prop,
+        PropertyInfo info, List<PreparedChange> out)
+    {
+        JsonElement raw = prop.get(KEY_VALUE);
+        if (raw == null || !raw.isJsonArray())
+        {
+            return ToolResult.error("'" + name + "' is a list reference: provide 'value' as an " //$NON-NLS-1$ //$NON-NLS-2$
+                + "array of FQNs, e.g. [\"Catalog.Products\", \"Document.Order\"].").toJson(); //$NON-NLS-1$
+        }
+        List<Long> ids = new ArrayList<>();
+        for (JsonElement el : raw.getAsJsonArray())
+        {
+            String fqn = (el != null && el.isJsonPrimitive()) ? el.getAsString() : null;
+            if (fqn == null || fqn.isEmpty())
+            {
+                return ToolResult.error("Each entry of the '" + name + "' list must be a " //$NON-NLS-1$ //$NON-NLS-2$
+                    + "non-empty FQN string.").toJson(); //$NON-NLS-1$
+            }
+            MdObject t = resolveReferenceTarget(config, fqn);
+            String vErr = validateReferenceTarget(name, info.feature, t, fqn);
+            if (vErr != null)
+            {
+                return vErr;
+            }
+            ids.add(((IBmObject)t).bmGetId());
+        }
+        out.add(PreparedChange.manyReference(info.feature, ids));
+        return null;
+    }
+
+    /**
+     * Validates a {@code STYLE_VALUE} property (building the StyleItem Color / Font value) and, on
+     * success, appends the prepared style-value change to {@code out} (which also keeps the sibling
+     * {@code type} feature consistent with the value). Returns a JSON error on failure, or {@code null}
+     * on success. Read-only: it only builds and queues the change (no model mutation).
+     */
+    private String prepareStyleValue(String name, JsonObject prop, EObject target, PropertyInfo info,
+        List<PreparedChange> out)
+    {
+        StyleValueBuilder.Result sv = StyleValueBuilder.build(prop.get(KEY_VALUE));
+        if (sv.error != null)
+        {
+            return ToolResult.error("Invalid StyleItem '" + name + "': " + sv.error).toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        // The style item's `type` (Color / Font) is kept consistent with the value it holds, so
+        // the change sets both the `value` and the sibling `type` feature in one shot.
+        EStructuralFeature typeFeature = target.eClass().getEStructuralFeature("type"); //$NON-NLS-1$
+        out.add(PreparedChange.styleValue(info.feature, typeFeature, sv.value, sv.type));
+        return null;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
@@ -300,104 +300,22 @@ public class RunYaxunitTestsTool implements IMcpTool
                 return ToolResult.error("Launch manager is not available").toJson(); //$NON-NLS-1$
             }
 
-            // updateScope is ARGUMENT-validated as early as possible: when the caller
-            // named the project directly, a typo'd extension name fails fast with the
-            // available names BEFORE launch-config resolution — so the validation is
-            // reachable (and e2e-testable) without a launch configuration or a live
-            // infobase. The same validation inside prepareForFreshLaunch stays as the
-            // backstop for the by-name call style, where the project is only known
-            // after the config resolves. Gated on updateBeforeLaunch because
-            // updateScope only applies to the auto-chain; gated on the project
-            // existing so an unknown project keeps its established no-config sentinel.
-            if (updateBeforeLaunch && projectName != null && !projectName.isEmpty())
+            String earlyScopeError = validateUpdateScopeEarly(projectName, updateScope, updateBeforeLaunch);
+            if (earlyScopeError != null)
             {
-                ProjectContext scopeCtx = ProjectContext.of(projectName);
-                if (scopeCtx.exists())
-                {
-                    String scopeError =
-                        LaunchLifecycleUtils.validateUpdateScope(scopeCtx.project(), updateScope);
-                    if (scopeError != null)
-                    {
-                        return ToolResult.error(scopeError).toJson();
-                    }
-                }
+                return earlyScopeError;
             }
 
-            ILaunchConfiguration matchingConfig = LaunchConfigUtils.resolveLaunchConfig(
-                    launchManager, configName, projectName, applicationId);
-            if (matchingConfig == null)
+            LaunchContext context = resolveLaunchContext(launchManager, configName, projectName, applicationId);
+            if (context.error != null)
             {
-                boolean hasName = configName != null && !configName.isEmpty();
-                return hasName
-                    ? ToolResult.error("Launch configuration not found: '" + configName + "'. " //$NON-NLS-1$ //$NON-NLS-2$
-                        + "Use list_configurations to see what's available.").toJson() //$NON-NLS-1$
-                    : buildNoConfigError(launchManager,
-                        launchManager.getLaunchConfigurationType(LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID),
-                        projectName, applicationId);
+                return context.error;
             }
-            if (!LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID.equals(LaunchConfigUtils.getConfigTypeId(matchingConfig)))
-            {
-                return ToolResult.error("Launch configuration '" + matchingConfig.getName() //$NON-NLS-1$
-                    + "' is not a runtime-client config — YAXUnit tests require one.").toJson(); //$NON-NLS-1$
-            }
-
-            // Derive effective project/application from the resolved config.
-            String effectiveProject = LaunchConfigUtils.readAttribute(matchingConfig,
-                LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
-            String effectiveAppId = LaunchConfigUtils.readAttribute(matchingConfig,
-                LaunchConfigUtils.ATTR_APPLICATION_ID, ""); //$NON-NLS-1$
-            if (projectName == null || projectName.isEmpty())
-            {
-                projectName = effectiveProject;
-            }
-            if (applicationId == null || applicationId.isEmpty())
-            {
-                applicationId = effectiveAppId;
-            }
-            if (projectName == null || projectName.isEmpty())
-            {
-                return ToolResult.error("Launch configuration '" + matchingConfig.getName() //$NON-NLS-1$
-                    + "' has no project attribute set").toJson(); //$NON-NLS-1$
-            }
-
-            String notReadyError = ProjectStateChecker.checkReadyOrError(projectName);
-            if (notReadyError != null)
-            {
-                return ToolResult.error(notReadyError).toJson();
-            }
-
-            ProjectContext ctx = ProjectContext.of(projectName);
-            if (!ctx.exists())
-            {
-                return ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson();
-            }
-
-            if (!ctx.isOpen())
-            {
-                return ToolResult.error("Project is closed: " + projectName).toJson(); //$NON-NLS-1$
-            }
-            IProject project = ctx.project();
-
-            IApplicationManager appManager = Activator.getDefault().getApplicationManager();
-            if (appManager == null)
-            {
-                return ToolResult.error("IApplicationManager service is not available").toJson(); //$NON-NLS-1$
-            }
-
-            // A runtime-client launch config may carry no applicationId (it was not
-            // bound to an application). Fall back to the project's default application
-            // so updateBeforeLaunch has a target and the EDT launch delegate does not
-            // pop its blocking "Update infobase before launch?" modal.
-            applicationId = LaunchLifecycleUtils.resolveDefaultApplicationId(project, applicationId, appManager);
-
-            if (applicationId != null && !applicationId.isEmpty())
-            {
-                String appError = validateApplicationExists(appManager, project, applicationId);
-                if (appError != null)
-                {
-                    return appError;
-                }
-            }
+            ILaunchConfiguration matchingConfig = context.config;
+            projectName = context.projectName;
+            applicationId = context.applicationId;
+            IProject project = context.project;
+            IApplicationManager appManager = context.appManager;
 
             // DEBUG mode shares the whole setup above (resolve/validate/effective
             // project+app), then spawns a DEBUG launch and returns at once for
@@ -419,83 +337,22 @@ public class RunYaxunitTestsTool implements IMcpTool
             ILaunch existing = ACTIVE_LAUNCHES.get(runKey);
             if (existing != null)
             {
-                if (existing.isTerminated())
-                {
-                    // Remove + read under the per-IB lock so remove-then-read is ATOMIC against a
-                    // concurrent identical call that falls through to a fresh launch: that path holds
-                    // the SAME lock for cleanupTempDir(reportDir) + spawn, so it cannot wipe reportDir
-                    // between this thread's remove and read. With the remove OUTSIDE the lock, a racer
-                    // could observe ACTIVE_LAUNCHES already empty, take the lock first, cleanupTempDir
-                    // the fresh run's dir and delete junit.xml before this thread reads it — a spurious
-                    // "no JUnit XML" error. pollLaunch's sibling read guards the same way (see there).
-                    // remove(runKey, existing) is by identity — it never drops a newer launch a racing
-                    // identical call may have put under the same runKey since the get() above. Worst
-                    // case still degrades from a torn parse to a clean null; findJunitXml + readResults
-                    // are fast (ms), so contention is negligible.
-                    synchronized (LaunchLifecycleUtils.lockFor(projectName, applicationId))
-                    {
-                        ACTIVE_LAUNCHES.remove(runKey, existing);
-                        PENDING_FETCH.remove(runKey);
-                        File junitXml = findJunitXml(reportDir);
-                        if (junitXml != null)
-                        {
-                            return readResults(junitXml);
-                        }
-                        return ToolResult.error("Previous launch finished but no JUnit XML found in " //$NON-NLS-1$
-                                + reportDir + ". Make sure YAXUnit extension is installed.").toJson(); //$NON-NLS-1$
-                    }
-                }
-                String pollResult = pollLaunch(existing, reportDir, timeout, runKey,
+                return handleExistingLaunch(existing, reportDir, timeout, runKey,
                         projectName, applicationId);
-                if (pollResult != null)
-                {
-                    // Result delivered — forget any Pending bookkeeping so the next call re-runs.
-                    PENDING_FETCH.remove(runKey);
-                    return pollResult;
-                }
-                // Still running past the window — remember the key so a re-call can fetch the result.
-                PENDING_FETCH.add(runKey);
-                return buildPendingMessage(reportDir);
             }
 
             // No active launch. Deliver a previously reported Pending result EXACTLY ONCE: a re-call
             // fetching the result of a run that finished after a Pending response gets the report;
             // any later call with the same key falls through to a fresh run. There is NO time-based
             // cache, so a genuine re-run always re-executes the tests.
-            // Consume + read under the per-IB lock so a concurrent identical call that falls through to
-            // a fresh launch cannot cleanupTempDir(reportDir) mid-read — the fresh-run path holds the
-            // SAME lock for cleanup+spawn. A racer blocked here finds PENDING_FETCH already drained and
-            // proceeds to a fresh run; worst case degrades from a torn parse to a clean null.
-            synchronized (LaunchLifecycleUtils.lockFor(projectName, applicationId))
+            String pendingResult = tryDeliverPendingResult(runKey, reportDir, projectName, applicationId);
+            if (pendingResult != null)
             {
-                if (PENDING_FETCH.remove(runKey))
-                {
-                    File pending = findJunitXml(reportDir);
-                    if (pending != null)
-                    {
-                        Activator.logInfo("Delivering completed YAXUnit result for pending runKey=" + runKey); //$NON-NLS-1$
-                        return readResults(pending);
-                    }
-                    // Pending was reported but no report materialised (the launch died without writing
-                    // junit.xml) — fall through and start a fresh run.
-                }
+                return pendingResult;
             }
 
             // Phase 1 (quick, JVM-wide): try to reuse an active launch for this runKey.
-            ILaunch launch = null;
-            synchronized (ACTIVE_LAUNCHES)
-            {
-                ILaunch concurrent = ACTIVE_LAUNCHES.get(runKey);
-                if (concurrent != null && !concurrent.isTerminated())
-                {
-                    Activator.logInfo("Reusing active YAXUnit launch for runKey=" + runKey); //$NON-NLS-1$
-                    launch = concurrent;
-                }
-                else if (concurrent != null)
-                {
-                    ACTIVE_LAUNCHES.remove(runKey);
-                }
-            }
+            ILaunch launch = reuseActiveLaunch(runKey);
 
             // Phase 2: pre-launch preparation (terminate stale launch + recompute
             // + DB update) runs in a background Job under a 25-second budget.
@@ -634,6 +491,289 @@ public class RunYaxunitTestsTool implements IMcpTool
             Activator.logError("Unexpected error running YAXUnit tests", e); //$NON-NLS-1$
             return ToolResult.error(e.getMessage()).toJson();
         }
+    }
+
+    /**
+     * Resolved launch context produced by {@link #resolveLaunchContext}: either a
+     * ready {@link ToolResult#error} JSON payload in {@link #error} (the caller
+     * returns it verbatim) or the fully derived launch inputs (config, effective
+     * project/application names, project handle and application manager).
+     */
+    private static final class LaunchContext
+    {
+        final String error;
+        final ILaunchConfiguration config;
+        final String projectName;
+        final String applicationId;
+        final IProject project;
+        final IApplicationManager appManager;
+
+        /** Failure result — only {@link #error} is meaningful. */
+        static LaunchContext failure(String error)
+        {
+            return new LaunchContext(error, null, null, null, null, null);
+        }
+
+        /** Success result — {@link #error} is {@code null}. */
+        static LaunchContext success(ILaunchConfiguration config, String projectName,
+                String applicationId, IProject project, IApplicationManager appManager)
+        {
+            return new LaunchContext(null, config, projectName, applicationId, project, appManager);
+        }
+
+        private LaunchContext(String error, ILaunchConfiguration config, String projectName,
+                String applicationId, IProject project, IApplicationManager appManager)
+        {
+            this.error = error;
+            this.config = config;
+            this.projectName = projectName;
+            this.applicationId = applicationId;
+            this.project = project;
+            this.appManager = appManager;
+        }
+    }
+
+    /**
+     * Argument-validates {@code updateScope} as early as possible: when the caller
+     * named the project directly a typo'd extension name fails fast with the
+     * available names BEFORE launch-config resolution, so the validation is
+     * reachable (and e2e-testable) without a launch configuration or a live
+     * infobase. The same validation inside {@code prepareForFreshLaunch} stays as
+     * the backstop for the by-name call style, where the project is only known
+     * after the config resolves. Gated on {@code updateBeforeLaunch} because
+     * {@code updateScope} only applies to the auto-chain; gated on the project
+     * existing so an unknown project keeps its established no-config sentinel.
+     *
+     * @return a ready {@link ToolResult#error} JSON payload to return verbatim, or
+     *         {@code null} when the scope is valid (or the guard does not apply)
+     */
+    private static String validateUpdateScopeEarly(String projectName, String updateScope,
+            boolean updateBeforeLaunch)
+    {
+        if (updateBeforeLaunch && projectName != null && !projectName.isEmpty())
+        {
+            ProjectContext scopeCtx = ProjectContext.of(projectName);
+            if (scopeCtx.exists())
+            {
+                String scopeError =
+                    LaunchLifecycleUtils.validateUpdateScope(scopeCtx.project(), updateScope);
+                if (scopeError != null)
+                {
+                    return ToolResult.error(scopeError).toJson();
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolves and validates the runtime-client launch configuration and derives
+     * the effective project/application from it (read-only — no launch is spawned).
+     * Mirrors the exact early-return errors the inline flow produced; on success the
+     * returned {@link LaunchContext} carries the resolved config, the possibly
+     * config-derived project/application names, the project handle and the
+     * application manager (with the project's default application substituted for a
+     * missing applicationId).
+     *
+     * @return a {@link LaunchContext} whose {@link LaunchContext#error} is non-{@code null}
+     *         when the caller must return that JSON payload, otherwise a populated success
+     */
+    private LaunchContext resolveLaunchContext(ILaunchManager launchManager, String configName,
+            String projectName, String applicationId)
+    {
+        ILaunchConfiguration matchingConfig = LaunchConfigUtils.resolveLaunchConfig(
+                launchManager, configName, projectName, applicationId);
+        if (matchingConfig == null)
+        {
+            boolean hasName = configName != null && !configName.isEmpty();
+            return LaunchContext.failure(hasName
+                ? ToolResult.error("Launch configuration not found: '" + configName + "'. " //$NON-NLS-1$ //$NON-NLS-2$
+                    + "Use list_configurations to see what's available.").toJson() //$NON-NLS-1$
+                : buildNoConfigError(launchManager,
+                    launchManager.getLaunchConfigurationType(LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID),
+                    projectName, applicationId));
+        }
+        if (!LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID.equals(LaunchConfigUtils.getConfigTypeId(matchingConfig)))
+        {
+            return LaunchContext.failure(ToolResult.error("Launch configuration '" + matchingConfig.getName() //$NON-NLS-1$
+                + "' is not a runtime-client config — YAXUnit tests require one.").toJson()); //$NON-NLS-1$
+        }
+
+        // Derive effective project/application from the resolved config.
+        String effectiveProject = LaunchConfigUtils.readAttribute(matchingConfig,
+            LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+        String effectiveAppId = LaunchConfigUtils.readAttribute(matchingConfig,
+            LaunchConfigUtils.ATTR_APPLICATION_ID, ""); //$NON-NLS-1$
+        if (projectName == null || projectName.isEmpty())
+        {
+            projectName = effectiveProject;
+        }
+        if (applicationId == null || applicationId.isEmpty())
+        {
+            applicationId = effectiveAppId;
+        }
+        if (projectName == null || projectName.isEmpty())
+        {
+            return LaunchContext.failure(ToolResult.error("Launch configuration '" + matchingConfig.getName() //$NON-NLS-1$
+                + "' has no project attribute set").toJson()); //$NON-NLS-1$
+        }
+
+        String notReadyError = ProjectStateChecker.checkReadyOrError(projectName);
+        if (notReadyError != null)
+        {
+            return LaunchContext.failure(ToolResult.error(notReadyError).toJson());
+        }
+
+        ProjectContext ctx = ProjectContext.of(projectName);
+        if (!ctx.exists())
+        {
+            return LaunchContext.failure(ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson());
+        }
+
+        if (!ctx.isOpen())
+        {
+            return LaunchContext.failure(ToolResult.error("Project is closed: " + projectName).toJson()); //$NON-NLS-1$
+        }
+        IProject project = ctx.project();
+
+        IApplicationManager appManager = Activator.getDefault().getApplicationManager();
+        if (appManager == null)
+        {
+            return LaunchContext.failure(
+                ToolResult.error("IApplicationManager service is not available").toJson()); //$NON-NLS-1$
+        }
+
+        // A runtime-client launch config may carry no applicationId (it was not
+        // bound to an application). Fall back to the project's default application
+        // so updateBeforeLaunch has a target and the EDT launch delegate does not
+        // pop its blocking "Update infobase before launch?" modal.
+        applicationId = LaunchLifecycleUtils.resolveDefaultApplicationId(project, applicationId, appManager);
+
+        if (applicationId != null && !applicationId.isEmpty())
+        {
+            String appError = validateApplicationExists(appManager, project, applicationId);
+            if (appError != null)
+            {
+                return LaunchContext.failure(appError);
+            }
+        }
+
+        return LaunchContext.success(matchingConfig, projectName, applicationId, project, appManager);
+    }
+
+    /**
+     * Handles a run-key that already has a launch tracked in {@link #ACTIVE_LAUNCHES}:
+     * if it terminated, evicts it and reads the report (or reports a missing one);
+     * otherwise polls up to {@code timeout}s and returns the parsed report or a
+     * Pending message. Does NOT spawn a launch — it only reads results and updates
+     * the {@link #ACTIVE_LAUNCHES}/{@link #PENDING_FETCH} tracking maps, exactly as
+     * the inline branch did.
+     * <p>
+     * The terminated remove + read runs under the per-IB lock so remove-then-read is
+     * ATOMIC against a concurrent identical call that falls through to a fresh launch:
+     * that path holds the SAME lock for cleanupTempDir(reportDir) + spawn, so it cannot
+     * wipe reportDir between this thread's remove and read. With the remove OUTSIDE the
+     * lock, a racer could observe ACTIVE_LAUNCHES already empty, take the lock first,
+     * cleanupTempDir the fresh run's dir and delete junit.xml before this thread reads it
+     * — a spurious "no JUnit XML" error. pollLaunch's sibling read guards the same way
+     * (see there). remove(runKey, existing) is by identity — it never drops a newer launch
+     * a racing identical call may have put under the same runKey since the get() above.
+     * Worst case still degrades from a torn parse to a clean null; findJunitXml + readResults
+     * are fast (ms), so contention is negligible.
+     *
+     * @return the Markdown report, a structured error, or a Pending message — always non-{@code null}
+     */
+    private String handleExistingLaunch(ILaunch existing, Path reportDir, int timeout, String runKey,
+            String projectName, String applicationId) throws InterruptedException
+    {
+        if (existing.isTerminated())
+        {
+            synchronized (LaunchLifecycleUtils.lockFor(projectName, applicationId))
+            {
+                ACTIVE_LAUNCHES.remove(runKey, existing);
+                PENDING_FETCH.remove(runKey);
+                File junitXml = findJunitXml(reportDir);
+                if (junitXml != null)
+                {
+                    return readResults(junitXml);
+                }
+                return ToolResult.error("Previous launch finished but no JUnit XML found in " //$NON-NLS-1$
+                        + reportDir + ". Make sure YAXUnit extension is installed.").toJson(); //$NON-NLS-1$
+            }
+        }
+        String pollResult = pollLaunch(existing, reportDir, timeout, runKey,
+                projectName, applicationId);
+        if (pollResult != null)
+        {
+            // Result delivered — forget any Pending bookkeeping so the next call re-runs.
+            PENDING_FETCH.remove(runKey);
+            return pollResult;
+        }
+        // Still running past the window — remember the key so a re-call can fetch the result.
+        PENDING_FETCH.add(runKey);
+        return buildPendingMessage(reportDir);
+    }
+
+    /**
+     * Delivers a previously reported Pending result EXACTLY ONCE: a re-call fetching
+     * the result of a run that finished after a Pending response gets the report;
+     * any later call with the same key falls through to a fresh run. Reads the report
+     * only (no launch is spawned) and consumes the {@link #PENDING_FETCH} entry.
+     * <p>
+     * Consume + read run under the per-IB lock so a concurrent identical call that falls
+     * through to a fresh launch cannot cleanupTempDir(reportDir) mid-read — the fresh-run
+     * path holds the SAME lock for cleanup+spawn. A racer blocked here finds PENDING_FETCH
+     * already drained and proceeds to a fresh run; worst case degrades from a torn parse to
+     * a clean null.
+     *
+     * @return the parsed report when a pending result was delivered, or {@code null}
+     *         when the caller should fall through and start a fresh run (no pending
+     *         entry, or the launch died without writing junit.xml)
+     */
+    private String tryDeliverPendingResult(String runKey, Path reportDir, String projectName,
+            String applicationId)
+    {
+        synchronized (LaunchLifecycleUtils.lockFor(projectName, applicationId))
+        {
+            if (PENDING_FETCH.remove(runKey))
+            {
+                File pending = findJunitXml(reportDir);
+                if (pending != null)
+                {
+                    Activator.logInfo("Delivering completed YAXUnit result for pending runKey=" + runKey); //$NON-NLS-1$
+                    return readResults(pending);
+                }
+                // Pending was reported but no report materialised (the launch died without writing
+                // junit.xml) — fall through and start a fresh run.
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Phase 1 reuse check (read-only — no launch is spawned): under JVM-wide sync,
+     * returns the active launch tracked for {@code runKey} when it is still running,
+     * or {@code null} when there is none. A tracked-but-terminated entry is evicted
+     * from {@link #ACTIVE_LAUNCHES} so the caller proceeds to a fresh launch.
+     *
+     * @return the reusable running launch, or {@code null} when none can be reused
+     */
+    private static ILaunch reuseActiveLaunch(String runKey)
+    {
+        synchronized (ACTIVE_LAUNCHES)
+        {
+            ILaunch concurrent = ACTIVE_LAUNCHES.get(runKey);
+            if (concurrent != null && !concurrent.isTerminated())
+            {
+                Activator.logInfo("Reusing active YAXUnit launch for runKey=" + runKey); //$NON-NLS-1$
+                return concurrent;
+            }
+            if (concurrent != null)
+            {
+                ACTIVE_LAUNCHES.remove(runKey);
+            }
+        }
+        return null;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
@@ -151,91 +151,24 @@ public class WriteModuleSourceTool implements IMcpTool
         String expectedHash = JsonUtils.extractStringArgument(params, "expectedHash"); //$NON-NLS-1$
 
         // 2. Validate required parameters
-        String err = JsonUtils.requireArgument(params, PROJECT_NAME);
-        if (err != null)
-        {
-            return err;
-        }
-        if (source == null)
-        {
-            return ToolResult.error("source is required").toJson(); //$NON-NLS-1$
-        }
-        if (source.length() > MAX_SOURCE_LENGTH)
-        {
-            return ToolResult.error("source exceeds maximum allowed length (" + MAX_SOURCE_LENGTH + " characters)").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
-        }
-
-        // Default mode
         if (mode == null || mode.isEmpty())
         {
             mode = MODE_SEARCH_REPLACE;
         }
-
-        // Validate mode
-        if (!MODE_REPLACE.equals(mode) && !MODE_APPEND.equals(mode)
-            && !MODE_SEARCH_REPLACE.equals(mode))
+        String argError = validateWriteArguments(params, source, mode, oldSource);
+        if (argError != null)
         {
-            return ToolResult.error("invalid mode '" + mode + "'. " + //$NON-NLS-1$ //$NON-NLS-2$
-                "Allowed: searchReplace, replace, append").toJson(); //$NON-NLS-1$
+            return argError;
         }
 
-        // Validate oldSource for searchReplace mode
-        if (MODE_SEARCH_REPLACE.equals(mode))
+        // 3. Resolve the module target.
+        ModuleTargetResult target = resolveModuleTarget(modulePath, objectName, moduleType,
+            formName, commandName);
+        if (target.error != null)
         {
-            if (oldSource == null || oldSource.isEmpty())
-            {
-                return ToolResult.error("oldSource is required for searchReplace mode").toJson(); //$NON-NLS-1$
-            }
+            return target.error;
         }
-
-        // 3. Resolve the module target. modulePath and objectName form an exclusive
-        // OR (a flat Map schema cannot express XOR, so it is enforced here): exactly
-        // one must be given. moduleType is a decorator on the objectName path only —
-        // it is meaningless with an explicit modulePath, so flag it instead of
-        // silently ignoring it. formName/commandName are validated deeper in
-        // resolveModulePath (they depend on the resolved moduleType).
-        boolean hasModulePath = modulePath != null && !modulePath.isEmpty();
-        boolean hasObjectName = objectName != null && !objectName.isEmpty();
-        boolean hasModuleType = moduleType != null && !moduleType.isEmpty();
-
-        if (hasModulePath && hasObjectName)
-        {
-            return ToolResult.error("modulePath and objectName are mutually exclusive; " + //$NON-NLS-1$
-                "pass only one (modulePath for a direct path, or objectName to resolve it)").toJson(); //$NON-NLS-1$
-        }
-        if (!hasModulePath && !hasObjectName)
-        {
-            return ToolResult.error("either modulePath or objectName is required").toJson(); //$NON-NLS-1$
-        }
-        if (hasModulePath && hasModuleType)
-        {
-            return ToolResult.error("moduleType applies only with objectName; " + //$NON-NLS-1$
-                "it is meaningless with an explicit modulePath, so drop one of them").toJson(); //$NON-NLS-1$
-        }
-
-        if (!hasModulePath)
-        {
-            String resolved = resolveModulePath(objectName, moduleType, formName, commandName);
-            if (isErrorJson(resolved))
-            {
-                // resolveModulePath signals failure by returning a ready
-                // ToolResult.error(...).toJson() payload; surface it as-is.
-                return resolved;
-            }
-            modulePath = resolved;
-        }
-
-        // Validate modulePath: prevent path traversal
-        if (modulePath.contains("..")) //$NON-NLS-1$
-        {
-            return ToolResult.error("modulePath must not contain '..'").toJson(); //$NON-NLS-1$
-        }
-
-        // Validate modulePath: only .bsl files allowed
-        if (!modulePath.endsWith(".bsl")) //$NON-NLS-1$
-        {
-            return ToolResult.error("only .bsl module files can be written").toJson(); //$NON-NLS-1$
-        }
+        modulePath = target.modulePath;
 
         // 4. Validate project
         ProjectContext ctx = ProjectContext.of(projectName);
@@ -291,121 +224,316 @@ public class WriteModuleSourceTool implements IMcpTool
             }
 
             // 7. Compute new content based on mode
-            List<String> newLines;
             int totalOriginal = originalLines.size();
-
-            switch (mode)
+            NewLinesResult computed = computeNewLines(mode, file, fileExists, originalLines,
+                source, oldSource, expectedHash, expectedSource, overwrite);
+            if (computed.error != null)
             {
-                case MODE_REPLACE:
-                {
-                    // Lost-update guard: overwriting an EXISTING module blindly
-                    // clobbers any edit made since the agent last read it. Creating a
-                    // NEW module is unconditional (nothing to lose).
-                    // A matching expectedHash is itself a valid lost-update precondition
-                    // (the whole-file token proves the agent saw the current state) and
-                    // was ALREADY validated at step 6b — so when one was supplied, the
-                    // expectedSource/overwrite precondition is satisfied and skipped.
-                    boolean hashGuardSatisfied = expectedHash != null && !expectedHash.isEmpty();
-                    if (fileExists && !hashGuardSatisfied)
-                    {
-                        String preconditionError =
-                            checkReplacePrecondition(file, expectedSource, overwrite);
-                        if (preconditionError != null)
-                        {
-                            return preconditionError;
-                        }
-                    }
-                    newLines = splitSourceLines(source);
-                    break;
-                }
-
-                case MODE_APPEND:
-                    newLines = new ArrayList<>(originalLines);
-                    newLines.addAll(splitSourceLines(source));
-                    break;
-
-                case MODE_SEARCH_REPLACE:
-                {
-                    // Normalize oldSource
-                    oldSource = oldSource.replace("\r\n", "\n"); //$NON-NLS-1$ //$NON-NLS-2$
-
-                    // Read the raw file content (preserves the trailing newline that
-                    // writeFile always adds). Reconstructing it from originalLines via
-                    // String.join dropped that final newline, so an oldSource fragment
-                    // that ended at EOF (including the final newline) was reported
-                    // "not found".
-                    String currentContent = BslModuleUtils.readFileText(file).replace("\r\n", "\n"); //$NON-NLS-1$ //$NON-NLS-2$
-
-                    SearchReplaceResult sr = applySearchReplace(currentContent, oldSource, source);
-                    if (sr.occurrences == 0)
-                    {
-                        return ToolResult.error("oldSource not found in current file content. " + //$NON-NLS-1$
-                            "The file may have changed since last read, or the oldSource text " + //$NON-NLS-1$
-                            "does not match exactly. Please read the file again with read_module_source.").toJson(); //$NON-NLS-1$
-                    }
-                    if (sr.occurrences > 1)
-                    {
-                        return ToolResult.error("oldSource found multiple times in the file (" + //$NON-NLS-1$
-                            sr.occurrences +
-                            " occurrences). Provide a larger, more specific oldSource fragment " + //$NON-NLS-1$
-                            "that matches exactly one location.").toJson(); //$NON-NLS-1$
-                    }
-
-                    newLines = splitSourceLines(sr.newContent);
-                    break;
-                }
-
-                default:
-                    return ToolResult.error("unsupported mode: " + mode).toJson(); //$NON-NLS-1$
+                return computed.error;
             }
+            List<String> newLines = computed.newLines;
 
             // 8. BSL syntax check
             if (!skipSyntaxCheck)
             {
-                BslSyntaxChecker.CheckResult checkResult = BslSyntaxChecker.check(newLines);
-                if (!checkResult.isValid())
+                String syntaxError = runSyntaxCheck(newLines);
+                if (syntaxError != null)
                 {
-                    StringBuilder sb = new StringBuilder();
-                    sb.append("BSL syntax check failed. Write blocked.\n\n"); //$NON-NLS-1$
-                    sb.append("Errors:\n"); //$NON-NLS-1$
-                    for (String error : checkResult.getErrors())
-                    {
-                        sb.append("- ").append(error).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-                    }
-                    sb.append("\nPass skipSyntaxCheck=true to force write."); //$NON-NLS-1$
-                    return ToolResult.error(sb.toString()).toJson();
+                    return syntaxError;
                 }
             }
 
             // 9. Write file
             writeFile(file, newLines, hasBom, fileExists);
 
-            // 10. Build frontmatter
-            FrontMatter fm = FrontMatter.create()
-                .put("tool", NAME) //$NON-NLS-1$
-                .put(PROJECT_NAME, projectName)
-                .put(MODULE_PATH, modulePath)
-                .put("mode", mode) //$NON-NLS-1$
-                .put("status", "success") //$NON-NLS-1$ //$NON-NLS-2$
-                .put("linesAfter", newLines.size()) //$NON-NLS-1$
-                .put("syntaxCheck", skipSyntaxCheck ? "skipped" : "passed"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-
-            if (fileExists)
-            {
-                fm.put("linesBefore", totalOriginal); //$NON-NLS-1$
-            }
-            else
-            {
-                fm.put("newFile", true); //$NON-NLS-1$
-            }
-
-            // 11. Return success
-            return fm.wrapContent("File written successfully"); //$NON-NLS-1$
+            // 10. Return success
+            return buildSuccessResponse(projectName, modulePath, mode, skipSyntaxCheck,
+                newLines, fileExists, totalOriginal);
         }
         catch (Exception e)
         {
             return ToolResult.error("Failed to write file: " + e.getMessage()).toJson(); //$NON-NLS-1$
         }
+    }
+
+    /**
+     * Validates the required and scalar write arguments in the SAME order the inline
+     * flow did: projectName presence, source presence + length, mode validity, and the
+     * oldSource requirement for searchReplace. {@code mode} is expected to have already
+     * been defaulted by the caller.
+     *
+     * @return a ready {@link ToolResult#error} JSON payload (or the {@code requireArgument}
+     *         error) to return verbatim, or {@code null} when all arguments are valid
+     */
+    private static String validateWriteArguments(Map<String, String> params, String source,
+        String mode, String oldSource)
+    {
+        String err = JsonUtils.requireArgument(params, PROJECT_NAME);
+        if (err != null)
+        {
+            return err;
+        }
+        if (source == null)
+        {
+            return ToolResult.error("source is required").toJson(); //$NON-NLS-1$
+        }
+        if (source.length() > MAX_SOURCE_LENGTH)
+        {
+            return ToolResult.error("source exceeds maximum allowed length (" + MAX_SOURCE_LENGTH + " characters)").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+
+        // Validate mode
+        if (!MODE_REPLACE.equals(mode) && !MODE_APPEND.equals(mode)
+            && !MODE_SEARCH_REPLACE.equals(mode))
+        {
+            return ToolResult.error("invalid mode '" + mode + "'. " + //$NON-NLS-1$ //$NON-NLS-2$
+                "Allowed: searchReplace, replace, append").toJson(); //$NON-NLS-1$
+        }
+
+        // Validate oldSource for searchReplace mode
+        if (MODE_SEARCH_REPLACE.equals(mode) && (oldSource == null || oldSource.isEmpty()))
+        {
+            return ToolResult.error("oldSource is required for searchReplace mode").toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Resolved module target produced by {@link #resolveModuleTarget}: either a ready
+     * {@link ToolResult#error} JSON payload in {@link #error} (the caller returns it
+     * verbatim) or the validated {@code src/}-relative {@link #modulePath}.
+     */
+    private static final class ModuleTargetResult
+    {
+        final String error;
+        final String modulePath;
+
+        private ModuleTargetResult(String error, String modulePath)
+        {
+            this.error = error;
+            this.modulePath = modulePath;
+        }
+    }
+
+    /**
+     * Resolves the module target (read-only — no file is written). modulePath and
+     * objectName form an exclusive OR (a flat Map schema cannot express XOR, so it is
+     * enforced here): exactly one must be given. moduleType is a decorator on the
+     * objectName path only — it is meaningless with an explicit modulePath, so it is
+     * flagged instead of being silently ignored. formName/commandName are validated
+     * deeper in {@link #resolveModulePath} (they depend on the resolved moduleType).
+     * The resolved path is then validated against path traversal and a {@code .bsl}
+     * extension, mirroring the inline checks exactly.
+     *
+     * @return a {@link ModuleTargetResult} whose {@link ModuleTargetResult#error} is
+     *         non-{@code null} when the caller must return that JSON payload, otherwise
+     *         the validated module path
+     */
+    private ModuleTargetResult resolveModuleTarget(String modulePath, String objectName,
+        String moduleType, String formName, String commandName)
+    {
+        boolean hasModulePath = modulePath != null && !modulePath.isEmpty();
+        boolean hasObjectName = objectName != null && !objectName.isEmpty();
+        boolean hasModuleType = moduleType != null && !moduleType.isEmpty();
+
+        if (hasModulePath && hasObjectName)
+        {
+            return new ModuleTargetResult(ToolResult.error("modulePath and objectName are mutually exclusive; " + //$NON-NLS-1$
+                "pass only one (modulePath for a direct path, or objectName to resolve it)").toJson(), null); //$NON-NLS-1$
+        }
+        if (!hasModulePath && !hasObjectName)
+        {
+            return new ModuleTargetResult(
+                ToolResult.error("either modulePath or objectName is required").toJson(), null); //$NON-NLS-1$
+        }
+        if (hasModulePath && hasModuleType)
+        {
+            return new ModuleTargetResult(ToolResult.error("moduleType applies only with objectName; " + //$NON-NLS-1$
+                "it is meaningless with an explicit modulePath, so drop one of them").toJson(), null); //$NON-NLS-1$
+        }
+
+        if (!hasModulePath)
+        {
+            String resolved = resolveModulePath(objectName, moduleType, formName, commandName);
+            if (isErrorJson(resolved))
+            {
+                // resolveModulePath signals failure by returning a ready
+                // ToolResult.error(...).toJson() payload; surface it as-is.
+                return new ModuleTargetResult(resolved, null);
+            }
+            modulePath = resolved;
+        }
+
+        // Validate modulePath: prevent path traversal
+        if (modulePath.contains("..")) //$NON-NLS-1$
+        {
+            return new ModuleTargetResult(ToolResult.error("modulePath must not contain '..'").toJson(), null); //$NON-NLS-1$
+        }
+
+        // Validate modulePath: only .bsl files allowed
+        if (!modulePath.endsWith(".bsl")) //$NON-NLS-1$
+        {
+            return new ModuleTargetResult(
+                ToolResult.error("only .bsl module files can be written").toJson(), null); //$NON-NLS-1$
+        }
+
+        return new ModuleTargetResult(null, modulePath);
+    }
+
+    /**
+     * Computed new module content produced by {@link #computeNewLines}: either a ready
+     * {@link ToolResult#error} JSON payload in {@link #error} (the caller returns it
+     * verbatim) or the {@link #newLines} to write.
+     */
+    private static final class NewLinesResult
+    {
+        final String error;
+        final List<String> newLines;
+
+        private NewLinesResult(String error, List<String> newLines)
+        {
+            this.error = error;
+            this.newLines = newLines;
+        }
+    }
+
+    /**
+     * Computes the new module content for the given mode (read-only — no file is
+     * written; only the already-read {@code file}/{@code originalLines} content is
+     * consulted). Mirrors the inline {@code switch} exactly, including the replace
+     * lost-update precondition and the searchReplace not-found / multiple-match errors.
+     * <p>
+     * Declares {@code throws Exception} because {@link #checkReplacePrecondition} does,
+     * so the same exceptions reach the SAME {@code catch (Exception)} in {@link #execute}
+     * as before.
+     *
+     * @return a {@link NewLinesResult} whose {@link NewLinesResult#error} is non-{@code null}
+     *         when the caller must return that JSON payload, otherwise the lines to write
+     */
+    private NewLinesResult computeNewLines(String mode, IFile file, boolean fileExists,
+        List<String> originalLines, String source, String oldSource, String expectedHash,
+        String expectedSource, boolean overwrite) throws Exception
+    {
+        switch (mode)
+        {
+            case MODE_REPLACE:
+            {
+                // Lost-update guard: overwriting an EXISTING module blindly
+                // clobbers any edit made since the agent last read it. Creating a
+                // NEW module is unconditional (nothing to lose).
+                // A matching expectedHash is itself a valid lost-update precondition
+                // (the whole-file token proves the agent saw the current state) and
+                // was ALREADY validated at step 6b — so when one was supplied, the
+                // expectedSource/overwrite precondition is satisfied and skipped.
+                boolean hashGuardSatisfied = expectedHash != null && !expectedHash.isEmpty();
+                if (fileExists && !hashGuardSatisfied)
+                {
+                    String preconditionError =
+                        checkReplacePrecondition(file, expectedSource, overwrite);
+                    if (preconditionError != null)
+                    {
+                        return new NewLinesResult(preconditionError, null);
+                    }
+                }
+                return new NewLinesResult(null, splitSourceLines(source));
+            }
+
+            case MODE_APPEND:
+            {
+                List<String> appended = new ArrayList<>(originalLines);
+                appended.addAll(splitSourceLines(source));
+                return new NewLinesResult(null, appended);
+            }
+
+            case MODE_SEARCH_REPLACE:
+            {
+                // Normalize oldSource
+                oldSource = oldSource.replace("\r\n", "\n"); //$NON-NLS-1$ //$NON-NLS-2$
+
+                // Read the raw file content (preserves the trailing newline that
+                // writeFile always adds). Reconstructing it from originalLines via
+                // String.join dropped that final newline, so an oldSource fragment
+                // that ended at EOF (including the final newline) was reported
+                // "not found".
+                String currentContent = BslModuleUtils.readFileText(file).replace("\r\n", "\n"); //$NON-NLS-1$ //$NON-NLS-2$
+
+                SearchReplaceResult sr = applySearchReplace(currentContent, oldSource, source);
+                if (sr.occurrences == 0)
+                {
+                    return new NewLinesResult(ToolResult.error("oldSource not found in current file content. " + //$NON-NLS-1$
+                        "The file may have changed since last read, or the oldSource text " + //$NON-NLS-1$
+                        "does not match exactly. Please read the file again with read_module_source.").toJson(), null); //$NON-NLS-1$
+                }
+                if (sr.occurrences > 1)
+                {
+                    return new NewLinesResult(ToolResult.error("oldSource found multiple times in the file (" + //$NON-NLS-1$
+                        sr.occurrences +
+                        " occurrences). Provide a larger, more specific oldSource fragment " + //$NON-NLS-1$
+                        "that matches exactly one location.").toJson(), null); //$NON-NLS-1$
+                }
+
+                return new NewLinesResult(null, splitSourceLines(sr.newContent));
+            }
+
+            default:
+                return new NewLinesResult(ToolResult.error("unsupported mode: " + mode).toJson(), null); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Runs the BSL syntax check (read-only) over the computed {@code newLines} and,
+     * on failure, formats the blocking error message exactly as the inline check did.
+     *
+     * @return a ready {@link ToolResult#error} JSON payload to return verbatim, or
+     *         {@code null} when the syntax check passes
+     */
+    private static String runSyntaxCheck(List<String> newLines)
+    {
+        BslSyntaxChecker.CheckResult checkResult = BslSyntaxChecker.check(newLines);
+        if (checkResult.isValid())
+        {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("BSL syntax check failed. Write blocked.\n\n"); //$NON-NLS-1$
+        sb.append("Errors:\n"); //$NON-NLS-1$
+        for (String error : checkResult.getErrors())
+        {
+            sb.append("- ").append(error).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        sb.append("\nPass skipSyntaxCheck=true to force write."); //$NON-NLS-1$
+        return ToolResult.error(sb.toString()).toJson();
+    }
+
+    /**
+     * Builds the success frontmatter + content returned after the module is written
+     * (pure string building — no side effects), preserving the exact keys and the
+     * {@code linesBefore}/{@code newFile} branch the inline flow used.
+     *
+     * @return the wrapped success response
+     */
+    private static String buildSuccessResponse(String projectName, String modulePath, String mode,
+        boolean skipSyntaxCheck, List<String> newLines, boolean fileExists, int totalOriginal)
+    {
+        FrontMatter fm = FrontMatter.create()
+            .put("tool", NAME) //$NON-NLS-1$
+            .put(PROJECT_NAME, projectName)
+            .put(MODULE_PATH, modulePath)
+            .put("mode", mode) //$NON-NLS-1$
+            .put("status", "success") //$NON-NLS-1$ //$NON-NLS-2$
+            .put("linesAfter", newLines.size()) //$NON-NLS-1$
+            .put("syntaxCheck", skipSyntaxCheck ? "skipped" : "passed"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+        if (fileExists)
+        {
+            fm.put("linesBefore", totalOriginal); //$NON-NLS-1$
+        }
+        else
+        {
+            fm.put("newFile", true); //$NON-NLS-1$
+        }
+
+        return fm.wrapContent("File written successfully"); //$NON-NLS-1$
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
@@ -340,7 +340,7 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
         {
             addSectionHeader(sb, name);
         }
-        
+
         // An Origin column is added only when at least one attribute is ADOPTED (an extension's
         // adopted object whose attribute(s) override the base) - marking which attribute is
         // overridden (core (adopted)) vs the extension's own (extension). A base configuration
@@ -348,112 +348,127 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
         boolean showOrigin = anyAdopted(items);
         if (full)
         {
-            // Extended format with 10 columns (+ Origin when adopted attributes are present)
-            java.util.List<String> headers = new java.util.ArrayList<>(java.util.Arrays.asList(
-                "Name", SYNONYM_TOKEN, "Type", "Indexing", "Fill Checking", "Full Text Search", "Password Mode", "Multi Line", "Quick Choice", "Create On Input")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$
-            if (showOrigin)
-            {
-                headers.add(ORIGIN_TOKEN);
-            }
-            startTable(sb, headers.toArray(new String[0]));
-
-            for (Object item : items)
-            {
-                if (item instanceof BasicFeature)
-                {
-                    BasicFeature attr = (BasicFeature) item;
-
-                    // Get indexing if it's DbObjectAttribute
-                    String indexing = DASH;
-                    if (attr instanceof DbObjectAttribute)
-                    {
-                        indexing = formatEnum(((DbObjectAttribute) attr).getIndexing());
-                    }
-
-                    // Get password mode using EMF reflection (it's in BasicFeature but not in interface)
-                    String passwordMode = NO;
-                    try
-                    {
-                        java.lang.reflect.Method method = attr.getClass().getMethod("isPasswordMode"); //$NON-NLS-1$
-                        Boolean pwdMode = (Boolean) method.invoke(attr);
-                        passwordMode = formatBoolean(pwdMode != null ? pwdMode : false);
-                    }
-                    catch (Exception e)
-                    {
-                        // Method doesn't exist or error - use default
-                    }
-
-                    // Get multiLine using EMF reflection
-                    String multiLine = NO;
-                    try
-                    {
-                        java.lang.reflect.Method method = attr.getClass().getMethod("isMultiLine"); //$NON-NLS-1$
-                        Boolean mlMode = (Boolean) method.invoke(attr);
-                        multiLine = formatBoolean(mlMode != null ? mlMode : false);
-                    }
-                    catch (Exception e)
-                    {
-                        // Method doesn't exist or error - use default
-                    }
-
-                    // Get fullTextSearch if it's DbObjectAttribute
-                    String fullTextSearch = DASH;
-                    if (attr instanceof DbObjectAttribute)
-                    {
-                        fullTextSearch = formatEnum(((DbObjectAttribute) attr).getFullTextSearch());
-                    }
-
-                    java.util.List<String> cells = new java.util.ArrayList<>(java.util.Arrays.asList(
-                        attr.getName(),
-                        getSynonym(attr.getSynonym(), language),
-                        formatType(attr.getType()),
-                        indexing,
-                        formatEnum(attr.getFillChecking()),
-                        fullTextSearch,
-                        passwordMode,
-                        multiLine,
-                        formatEnum(attr.getQuickChoice()),
-                        formatEnum(attr.getCreateOnInput())));
-                    if (showOrigin)
-                    {
-                        cells.add(originCell(attr));
-                    }
-                    addTableRow(sb, cells.toArray(new String[0]));
-                }
-            }
+            formatAttributesExtended(sb, items, showOrigin, language);
         }
         else
         {
-            // Compact format - Name, Synonym, Type (+ Origin when adopted attributes are present)
-            if (showOrigin)
-            {
-                startTable(sb, "Name", SYNONYM_TOKEN, "Type", ORIGIN_TOKEN); //$NON-NLS-1$ //$NON-NLS-2$
-            }
-            else
-            {
-                startTable(sb, "Name", SYNONYM_TOKEN, "Type"); //$NON-NLS-1$ //$NON-NLS-2$
-            }
+            formatAttributesCompact(sb, items, showOrigin, language);
+        }
+    }
 
-            for (Object item : items)
+    /**
+     * Renders the extended (full=true) attribute table: a 10-column layout (plus an Origin column
+     * when {@code showOrigin}). Header and per-row rendering match the original inline code exactly.
+     */
+    private void formatAttributesExtended(StringBuilder sb, Collection<?> items, boolean showOrigin, String language)
+    {
+        // Extended format with 10 columns (+ Origin when adopted attributes are present)
+        java.util.List<String> headers = new java.util.ArrayList<>(java.util.Arrays.asList(
+            "Name", SYNONYM_TOKEN, "Type", "Indexing", "Fill Checking", "Full Text Search", "Password Mode", "Multi Line", "Quick Choice", "Create On Input")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$
+        if (showOrigin)
+        {
+            headers.add(ORIGIN_TOKEN);
+        }
+        startTable(sb, headers.toArray(new String[0]));
+
+        for (Object item : items)
+        {
+            if (item instanceof BasicFeature)
             {
-                if (item instanceof BasicFeature)
+                BasicFeature attr = (BasicFeature) item;
+
+                // Get indexing if it's DbObjectAttribute
+                String indexing = DASH;
+                if (attr instanceof DbObjectAttribute)
                 {
-                    BasicFeature attr = (BasicFeature) item;
-                    if (showOrigin)
-                    {
-                        addTableRow(sb,
-                            attr.getName(),
-                            getSynonym(attr.getSynonym(), language),
-                            formatType(attr.getType()),
-                            originCell(attr));
-                    }
-                    else
-                    {
-                        addTableRow(sb,
-                            attr.getName(),
-                            getSynonym(attr.getSynonym(), language),
-                            formatType(attr.getType()));
-                    }
+                    indexing = formatEnum(((DbObjectAttribute) attr).getIndexing());
+                }
+
+                String passwordMode = formatReflectiveBoolean(attr, "isPasswordMode"); //$NON-NLS-1$
+                String multiLine = formatReflectiveBoolean(attr, "isMultiLine"); //$NON-NLS-1$
+
+                // Get fullTextSearch if it's DbObjectAttribute
+                String fullTextSearch = DASH;
+                if (attr instanceof DbObjectAttribute)
+                {
+                    fullTextSearch = formatEnum(((DbObjectAttribute) attr).getFullTextSearch());
+                }
+
+                java.util.List<String> cells = new java.util.ArrayList<>(java.util.Arrays.asList(
+                    attr.getName(),
+                    getSynonym(attr.getSynonym(), language),
+                    formatType(attr.getType()),
+                    indexing,
+                    formatEnum(attr.getFillChecking()),
+                    fullTextSearch,
+                    passwordMode,
+                    multiLine,
+                    formatEnum(attr.getQuickChoice()),
+                    formatEnum(attr.getCreateOnInput())));
+                if (showOrigin)
+                {
+                    cells.add(originCell(attr));
+                }
+                addTableRow(sb, cells.toArray(new String[0]));
+            }
+        }
+    }
+
+    /**
+     * Reads a boolean-returning method (e.g. {@code isPasswordMode} / {@code isMultiLine}) that lives
+     * in BasicFeature but not in the API interface, via reflection. Returns {@link #NO} when the
+     * method is absent or any error occurs, matching the original default. Never throws.
+     */
+    private String formatReflectiveBoolean(BasicFeature attr, String methodName)
+    {
+        try
+        {
+            java.lang.reflect.Method method = attr.getClass().getMethod(methodName);
+            Boolean flag = (Boolean) method.invoke(attr);
+            return formatBoolean(flag != null ? flag : false);
+        }
+        catch (Exception e)
+        {
+            // Method doesn't exist or error - use default
+            return NO;
+        }
+    }
+
+    /**
+     * Renders the compact (full=false) attribute table: Name, Synonym, Type (plus an Origin column
+     * when {@code showOrigin}). Output matches the original inline code exactly.
+     */
+    private void formatAttributesCompact(StringBuilder sb, Collection<?> items, boolean showOrigin, String language)
+    {
+        // Compact format - Name, Synonym, Type (+ Origin when adopted attributes are present)
+        if (showOrigin)
+        {
+            startTable(sb, "Name", SYNONYM_TOKEN, "Type", ORIGIN_TOKEN); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        else
+        {
+            startTable(sb, "Name", SYNONYM_TOKEN, "Type"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+
+        for (Object item : items)
+        {
+            if (item instanceof BasicFeature)
+            {
+                BasicFeature attr = (BasicFeature) item;
+                if (showOrigin)
+                {
+                    addTableRow(sb,
+                        attr.getName(),
+                        getSynonym(attr.getSynonym(), language),
+                        formatType(attr.getType()),
+                        originCell(attr));
+                }
+                else
+                {
+                    addTableRow(sb,
+                        attr.getName(),
+                        getSynonym(attr.getSynonym(), language),
+                        formatType(attr.getType()));
                 }
             }
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
@@ -879,64 +879,106 @@ public class MetadataRenameService
             Object modifiedElement = bmChange.getModifiedElement();
             if (modifiedElement instanceof IBmObject bmObject)
             {
-                EStructuralFeature feature = getBmChangeFeature(bmChange);
-                if (feature != null)
-                {
-                    for (TextEdit leafEdit : getLeafEdits(bmChange.getEdit()))
-                    {
-                        ExactMatchInfo info = exactMatches.get(getModelMatchKey(bmObject.bmGetId(), feature,
-                            leafEdit.getOffset(), leafEdit.getLength()));
-                        if (info != null)
-                        {
-                            matches.put(getExactMatchIdentity(info), info);
-                        }
-                    }
-                }
-
-                String projectName = bmChange.getProjectName();
-                String objectFqn = bmObject.bmGetFqn();
-                for (ExactMatchInfo info : exactMatches.values())
-                {
-                    if (info == null || info.filePath == null)
-                    {
-                        continue;
-                    }
-                    if (!Objects.equals(info.project, projectName) || !Objects.equals(info.fqn, objectFqn))
-                    {
-                        continue;
-                    }
-                    for (TextEdit leafEdit : getLeafEdits(bmChange.getEdit()))
-                    {
-                        if (containsOffset(leafEdit, info.matchOffset))
-                        {
-                            matches.put(getExactMatchIdentity(info), info);
-                            break;
-                        }
-                    }
-                }
+                collectBmChangeMatches(bmChange, bmObject, exactMatches, matches);
             }
         }
         IFile file = getIFile(change);
         TextEdit edit = getChangeEdit(change);
         if (file != null && edit != null)
         {
-            for (ExactMatchInfo info : exactMatches.values())
+            collectFileChangeMatches(file, edit, exactMatches, matches);
+        }
+        return new ArrayList<>(matches.values());
+    }
+
+    /**
+     * Collects the exact matches that belong to a {@link BmObjectTextContentChange}: model matches
+     * keyed by (object, feature, offset, length) and file-backed matches whose project / FQN equal the
+     * change's and whose offset falls inside one of the change's leaf edits. Pure lookup - adds the
+     * hits into {@code matches} keyed by their identity (no model mutation).
+     */
+    private void collectBmChangeMatches(BmObjectTextContentChange<?> bmChange, IBmObject bmObject,
+        Map<String, ExactMatchInfo> exactMatches, Map<String, ExactMatchInfo> matches)
+    {
+        EStructuralFeature feature = getBmChangeFeature(bmChange);
+        if (feature != null)
+        {
+            collectBmModelKeyMatches(bmChange, bmObject, feature, exactMatches, matches);
+        }
+        collectBmFileOffsetMatches(bmChange, bmObject, exactMatches, matches);
+    }
+
+    /**
+     * Adds the file-backed exact matches whose (object, feature, offset, length) key equals a leaf edit
+     * of the BM change. Pure lookup - no model mutation.
+     */
+    private void collectBmModelKeyMatches(BmObjectTextContentChange<?> bmChange, IBmObject bmObject,
+        EStructuralFeature feature, Map<String, ExactMatchInfo> exactMatches, Map<String, ExactMatchInfo> matches)
+    {
+        for (TextEdit leafEdit : getLeafEdits(bmChange.getEdit()))
+        {
+            ExactMatchInfo info = exactMatches.get(getModelMatchKey(bmObject.bmGetId(), feature,
+                leafEdit.getOffset(), leafEdit.getLength()));
+            if (info != null)
             {
-                if (info == null || info.filePath == null || !info.filePath.equals(file.getFullPath().toString()))
+                matches.put(getExactMatchIdentity(info), info);
+            }
+        }
+    }
+
+    /**
+     * Adds the file-backed exact matches whose project / FQN equal the BM change's and whose offset
+     * falls inside one of the change's leaf edits. Pure lookup - no model mutation.
+     */
+    private void collectBmFileOffsetMatches(BmObjectTextContentChange<?> bmChange, IBmObject bmObject,
+        Map<String, ExactMatchInfo> exactMatches, Map<String, ExactMatchInfo> matches)
+    {
+        String projectName = bmChange.getProjectName();
+        String objectFqn = bmObject.bmGetFqn();
+        for (ExactMatchInfo info : exactMatches.values())
+        {
+            if (info == null || info.filePath == null)
+            {
+                continue;
+            }
+            if (!Objects.equals(info.project, projectName) || !Objects.equals(info.fqn, objectFqn))
+            {
+                continue;
+            }
+            for (TextEdit leafEdit : getLeafEdits(bmChange.getEdit()))
+            {
+                if (containsOffset(leafEdit, info.matchOffset))
                 {
-                    continue;
-                }
-                for (TextEdit leafEdit : getLeafEdits(edit))
-                {
-                    if (containsOffset(leafEdit, info.matchOffset))
-                    {
-                        matches.put(getExactMatchIdentity(info), info);
-                        break;
-                    }
+                    matches.put(getExactMatchIdentity(info), info);
+                    break;
                 }
             }
         }
-        return new ArrayList<>(matches.values());
+    }
+
+    /**
+     * Collects the exact matches that belong to a plain source-file change: file-backed matches whose
+     * path equals {@code file} and whose offset falls inside one of the change's leaf edits. Pure
+     * lookup - adds the hits into {@code matches} keyed by their identity (no model mutation).
+     */
+    private void collectFileChangeMatches(IFile file, TextEdit edit,
+        Map<String, ExactMatchInfo> exactMatches, Map<String, ExactMatchInfo> matches)
+    {
+        for (ExactMatchInfo info : exactMatches.values())
+        {
+            if (info == null || info.filePath == null || !info.filePath.equals(file.getFullPath().toString()))
+            {
+                continue;
+            }
+            for (TextEdit leafEdit : getLeafEdits(edit))
+            {
+                if (containsOffset(leafEdit, info.matchOffset))
+                {
+                    matches.put(getExactMatchIdentity(info), info);
+                    break;
+                }
+            }
+        }
     }
 
     private void logPreviewMapping(Change change, String fqn, String project, int exactMatchesCount)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/ui/McpStatusContribution.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/ui/McpStatusContribution.java
@@ -520,21 +520,36 @@ public class McpStatusContribution extends WorkbenchWindowControlContribution
         {
             return;
         }
-        
-        McpServer server = Activator.getDefault() != null ? 
+
+        McpServer server = Activator.getDefault() != null ?
             Activator.getDefault().getMcpServer() : null;
-        
+
         boolean running = server != null && server.isRunning();
         long requestCount = server != null ? server.getRequestCount() : 0;
         int port = server != null ? server.getPort() : 0;
         String currentTool = server != null ? server.getCurrentToolName() : null;
         boolean isExecuting = currentTool != null;
         long executionSeconds = server != null ? server.getToolExecutionSeconds() : 0;
-        
+
         // Toggle blink state for animation effect
         blinkState = !blinkState;
-        
-        // Update circle image - yellow blinking when executing, green when running, grey when stopped
+
+        updateCircleImage(isExecuting, running);
+        updateStatusLabel(isExecuting, currentTool);
+        updateCounterLabel(isExecuting, executionSeconds, requestCount);
+
+        String tooltip = buildTooltip(isExecuting, running, currentTool, port, requestCount);
+        applyTooltip(tooltip);
+
+        container.layout(true);
+    }
+
+    /**
+     * Updates the circle indicator image: yellow blinking when executing, green
+     * when running, grey when stopped.
+     */
+    private void updateCircleImage(boolean isExecuting, boolean running)
+    {
         if (circleLabel != null && !circleLabel.isDisposed())
         {
             if (isExecuting)
@@ -547,14 +562,20 @@ public class McpStatusContribution extends WorkbenchWindowControlContribution
                 circleLabel.setImage(running ? greenImage : greyImage);
             }
         }
-        
-        // Update status label - show tool name when executing
+    }
+
+    /**
+     * Updates the status label: shows the (possibly truncated) tool name when
+     * executing, otherwise "MCP" with an optional new-release hint.
+     */
+    private void updateStatusLabel(boolean isExecuting, String currentTool)
+    {
         if (statusLabel != null && !statusLabel.isDisposed())
         {
             if (isExecuting)
             {
                 // Add MCP: prefix and truncate tool name if too long
-                String displayName = currentTool.length() > TOOL_NAME_MAX_LENGTH 
+                String displayName = currentTool.length() > TOOL_NAME_MAX_LENGTH
                     ? "MCP: " + currentTool.substring(0, TOOL_NAME_MAX_LENGTH - 3) + "..." //$NON-NLS-1$ //$NON-NLS-2$
                     : "MCP: " + currentTool; //$NON-NLS-1$
                 statusLabel.setText(displayName);
@@ -565,8 +586,14 @@ public class McpStatusContribution extends WorkbenchWindowControlContribution
                 statusLabel.setText(updateAvail ? "MCP New release" : "MCP"); //$NON-NLS-1$ //$NON-NLS-2$
             }
         }
-        
-        // Update counter - show elapsed time during execution, otherwise request count
+    }
+
+    /**
+     * Updates the counter label: elapsed time during execution, otherwise the
+     * request count in brackets.
+     */
+    private void updateCounterLabel(boolean isExecuting, long executionSeconds, long requestCount)
+    {
         if (counterLabel != null && !counterLabel.isDisposed())
         {
             if (isExecuting)
@@ -581,18 +608,25 @@ public class McpStatusContribution extends WorkbenchWindowControlContribution
                 counterLabel.setText("[" + requestCount + "]"); //$NON-NLS-1$ //$NON-NLS-2$
             }
         }
-        
-        // Update tooltip
+    }
+
+    /**
+     * Builds the status tooltip text for the current server state, appending an
+     * update notification when one is available. Pure: builds and returns text only.
+     */
+    private String buildTooltip(boolean isExecuting, boolean running, String currentTool,
+        int port, long requestCount)
+    {
         String tooltip;
         if (isExecuting)
         {
             tooltip = "MCP Server: Executing " + currentTool +
-                "\nPort: " + port + "\nRequests: " + requestCount + 
+                "\nPort: " + port + "\nRequests: " + requestCount +
                 "\nVersion: " + McpConstants.PLUGIN_VERSION + "\nAuthor: " + McpConstants.AUTHOR;
         }
         else if (running)
         {
-            tooltip = "MCP Server: Running on port " + port + "\nRequests: " + requestCount + 
+            tooltip = "MCP Server: Running on port " + port + "\nRequests: " + requestCount +
                 "\nVersion: " + McpConstants.PLUGIN_VERSION + "\nAuthor: " + McpConstants.AUTHOR +
                 "\nClick for options";
         }
@@ -608,7 +642,14 @@ public class McpStatusContribution extends WorkbenchWindowControlContribution
             tooltip += "\n\u26A0 New version available: " + latestVer //$NON-NLS-1$
                 + "\nClick circle \u2192 download option"; //$NON-NLS-1$
         }
-        
+        return tooltip;
+    }
+
+    /**
+     * Applies the given tooltip text to all status-bar labels that are alive.
+     */
+    private void applyTooltip(String tooltip)
+    {
         if (circleLabel != null && !circleLabel.isDisposed())
         {
             circleLabel.setToolTipText(tooltip);
@@ -621,8 +662,6 @@ public class McpStatusContribution extends WorkbenchWindowControlContribution
         {
             counterLabel.setToolTipText(tooltip);
         }
-        
-        container.layout(true);
     }
 
     @Override

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/InterceptionUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/InterceptionUtils.java
@@ -127,68 +127,99 @@ public final class InterceptionUtils
             Set<String> lines = new LinkedHashSet<>();
             if (svc.isExtensionModule(module))
             {
-                // This extension module -> the core methods its methods intercept.
-                for (Method method : module.getMethods())
-                {
-                    Map<Pragma, Method> sources = svc.getSourceMethod(method);
-                    if (sources == null)
-                    {
-                        continue;
-                    }
-                    for (Map.Entry<Pragma, Method> entry : sources.entrySet())
-                    {
-                        Method baseMethod = entry.getValue();
-                        String baseName = baseMethod != null ? baseMethod.getName() : pragmaTarget(entry.getKey());
-                        lines.add("`" + safeName(method) + "` -> intercepts core method `" + baseName //$NON-NLS-1$ //$NON-NLS-2$
-                            + VIA_SEPARATOR + annotation(entry.getKey()) + "`"); //$NON-NLS-1$
-                    }
-                }
+                collectModuleExtensionSide(svc, module, lines);
             }
             else
             {
-                // Inverse: every extension module that adopts this base module; list
-                // each of its methods that resolves back to a method here.
-                Collection<Module> extensionModules = svc.getExtensionModules(module);
-                if (extensionModules != null)
-                {
-                    for (Module extModule : extensionModules)
-                    {
-                        String extProject = projectName(extModule);
-                        for (Method extMethod : extModule.getMethods())
-                        {
-                            Map<Pragma, Method> sources = svc.getSourceMethod(extMethod);
-                            if (sources == null)
-                            {
-                                continue;
-                            }
-                            for (Map.Entry<Pragma, Method> entry : sources.entrySet())
-                            {
-                                Method baseMethod = entry.getValue();
-                                String baseName = baseMethod != null ? baseMethod.getName() : pragmaTarget(entry.getKey());
-                                lines.add("`" + baseName + "` <- intercepted by extension `" + extProject //$NON-NLS-1$ //$NON-NLS-2$
-                                    + "`: `" + safeName(extMethod) + VIA_SEPARATOR + annotation(entry.getKey()) + "`"); //$NON-NLS-1$ //$NON-NLS-2$
-                            }
-                        }
-                    }
-                }
+                collectModuleBaseSide(svc, module, lines);
             }
             if (lines.isEmpty())
             {
                 return null;
             }
-            StringBuilder sb = new StringBuilder();
-            sb.append("\n## Extension interception\n\n"); //$NON-NLS-1$
-            for (String line : lines)
-            {
-                sb.append("- ").append(line).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            }
-            return sb.toString();
+            return buildFooterSection(lines);
         }
         catch (RuntimeException e)
         {
             Activator.logWarning("module interception footer unavailable: " + e.getMessage()); //$NON-NLS-1$
             return null;
         }
+    }
+
+    /**
+     * Module extension-side: for an extension {@code module}, lists the core methods
+     * each of its methods intercepts (one line per resolving annotation pragma).
+     */
+    private static void collectModuleExtensionSide(IModuleExtensionService svc, Module module, Set<String> lines)
+    {
+        // This extension module -> the core methods its methods intercept.
+        for (Method method : module.getMethods())
+        {
+            Map<Pragma, Method> sources = svc.getSourceMethod(method);
+            if (sources == null)
+            {
+                continue;
+            }
+            for (Map.Entry<Pragma, Method> entry : sources.entrySet())
+            {
+                String baseName = baseMethodName(entry);
+                lines.add("`" + safeName(method) + "` -> intercepts core method `" + baseName //$NON-NLS-1$ //$NON-NLS-2$
+                    + VIA_SEPARATOR + annotation(entry.getKey()) + "`"); //$NON-NLS-1$
+            }
+        }
+    }
+
+    /**
+     * Module base-side (inverse): for a base {@code module}, lists every extension
+     * module that adopts it and each of its methods that resolves back to a method here.
+     */
+    private static void collectModuleBaseSide(IModuleExtensionService svc, Module module, Set<String> lines)
+    {
+        Collection<Module> extensionModules = svc.getExtensionModules(module);
+        if (extensionModules == null)
+        {
+            return;
+        }
+        for (Module extModule : extensionModules)
+        {
+            String extProject = projectName(extModule);
+            for (Method extMethod : extModule.getMethods())
+            {
+                Map<Pragma, Method> sources = svc.getSourceMethod(extMethod);
+                if (sources == null)
+                {
+                    continue;
+                }
+                for (Map.Entry<Pragma, Method> entry : sources.entrySet())
+                {
+                    String baseName = baseMethodName(entry);
+                    lines.add("`" + baseName + "` <- intercepted by extension `" + extProject //$NON-NLS-1$ //$NON-NLS-2$
+                        + "`: `" + safeName(extMethod) + VIA_SEPARATOR + annotation(entry.getKey()) + "`"); //$NON-NLS-1$ //$NON-NLS-2$
+                }
+            }
+        }
+    }
+
+    /**
+     * The resolved core-method name for a source-map entry: the target method's name
+     * when it resolved, otherwise the annotation pragma's quoted target.
+     */
+    private static String baseMethodName(Map.Entry<Pragma, Method> entry)
+    {
+        Method baseMethod = entry.getValue();
+        return baseMethod != null ? baseMethod.getName() : pragmaTarget(entry.getKey());
+    }
+
+    /** Assembles the {@code ## Extension interception} markdown section from collected lines. */
+    private static String buildFooterSection(Set<String> lines)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("\n## Extension interception\n\n"); //$NON-NLS-1$
+        for (String line : lines)
+        {
+            sb.append("- ").append(line).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return sb.toString();
     }
 
     /**
@@ -204,8 +235,7 @@ public final class InterceptionUtils
         }
         for (Map.Entry<Pragma, Method> entry : sources.entrySet())
         {
-            Method baseMethod = entry.getValue();
-            String baseName = baseMethod != null ? baseMethod.getName() : pragmaTarget(entry.getKey());
+            String baseName = baseMethodName(entry);
             lines.add("**Extension interception** — `" + safeName(extensionMethod) //$NON-NLS-1$
                 + "` intercepts core method `" + baseName + VIA_SEPARATOR + annotation(entry.getKey()) + "`"); //$NON-NLS-1$ //$NON-NLS-2$
         }


### PR DESCRIPTION
Band B of the SonarCloud code-smell cleanup (#164): the **cc 41-60** band of S3776, branched from current master. **18 methods** reduced under the limit of 15, each via 3-6 Extract-Method refactors. Same rigorous pipeline as #167-173/#176/#179: deep-study implement (7 file-disjoint agents) → **7 INDEPENDENT adversarial verify agents** (every diff reviewed for dropped/reordered branches, **lock-scope**, early-return threading, exception propagation, NLS markers) → `mvn clean verify` (2202 tests). All confirmed behaviour-identical. Early-returns threaded out via small **holder** objects / nullable error-Strings (parent re-checks, returns the SAME value in the SAME cases). **Destructive / mutating tools handled with extra care** — only side-effect-free blocks (validation, shared-infobase / register-path guards, navigation, formatting, result-building) extracted; the irreversible delete / DB-dir removal / infobase-create / Job / launch / module-write stays inline relative to the same confirm-gate (DeleteInfobaseTool, CreateInfobaseTool, RunYaxunitTestsTool, WriteModuleSourceTool, AddToGroupHandler). Checked-exception correctness verified (RunYaxunitTestsTool→InterruptedException, WriteModuleSourceTool→Exception). UI/state code keeps exact widget/listener order + UI-thread semantics. No behaviour change. Follows #166-173, #176, #179.