### PR TITLE
Reduce cognitive complexity via Extract Method, part 6 — the 5 god-methods (S3776 cc 64-108)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/doc/PlatformDocumentationService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/doc/PlatformDocumentationService.java
@@ -250,7 +250,36 @@ public class PlatformDocumentationService
     {
         StringBuilder sb = new StringBuilder();
 
-        // Type header
+        appendTypeHeader(sb, type, useRussian);
+        appendTypeInfo(sb, type);
+        appendCollectionElementTypes(sb, type, useRussian);
+
+        int count = 0;
+        count = appendConstructorsSection(sb, type, memberType, limit, count, useRussian);
+
+        // Get context def for methods and properties
+        ContextDef contextDef = type.getContextDef();
+        if (contextDef != null)
+        {
+            count = appendMethodsSection(sb, contextDef, memberName, memberType, limit, count, useRussian);
+            count = appendPropertiesSection(sb, contextDef, memberName, memberType, limit, count, useRussian);
+        }
+
+        count = appendEventsSection(sb, type, memberName, memberType, limit, count, useRussian);
+
+        if (count >= limit)
+        {
+            sb.append("\n*Results limited to ").append(limit).append(" items.*\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Appends the type header line (localized name plus optional alternate name).
+     */
+    private void appendTypeHeader(StringBuilder sb, Type type, boolean useRussian)
+    {
         String displayName = useRussian ? type.getNameRu() : type.getName();
         String altName = useRussian ? type.getName() : type.getNameRu();
 
@@ -260,137 +289,187 @@ public class PlatformDocumentationService
             sb.append(" / ").append(altName); //$NON-NLS-1$
         }
         sb.append("\n\n"); //$NON-NLS-1$
+    }
 
-        // Type properties
+    /**
+     * Appends the "Type Info" block (iterable / index accessible / created by New flags).
+     */
+    private void appendTypeInfo(StringBuilder sb, Type type)
+    {
         sb.append("**Type Info:**\n"); //$NON-NLS-1$
         sb.append("- Iterable: ").append(type.isIterable() ? "Yes" : "No").append("\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
         sb.append("- Index accessible: ").append(type.isIndexAccessible() ? "Yes" : "No").append("\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
         sb.append("- Created by New: ").append(type.isCreatedByNewOperator() ? "Yes" : "No").append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+    }
 
-        // Collection element types
+    /**
+     * Appends the "Collection element types" line, when the type exposes any.
+     */
+    private void appendCollectionElementTypes(StringBuilder sb, Type type, boolean useRussian)
+    {
         TypeContainer elementTypes = type.getCollectionElementTypes();
-        if (elementTypes != null)
+        if (elementTypes == null)
         {
-            EList<TypeItem> elemTypesList = elementTypes.allTypes();
-            if (elemTypesList != null && !elemTypesList.isEmpty())
+            return;
+        }
+        EList<TypeItem> elemTypesList = elementTypes.allTypes();
+        if (elemTypesList == null || elemTypesList.isEmpty())
+        {
+            return;
+        }
+        sb.append("**Collection element types:** "); //$NON-NLS-1$
+        List<String> typeNames = new ArrayList<>();
+        for (TypeItem elemType : elemTypesList)
+        {
+            String name = useRussian ? elemType.getNameRu() : elemType.getName();
+            if (name != null)
             {
-                sb.append("**Collection element types:** "); //$NON-NLS-1$
-                List<String> typeNames = new ArrayList<>();
-                for (TypeItem elemType : elemTypesList)
-                {
-                    String name = useRussian ? elemType.getNameRu() : elemType.getName();
-                    if (name != null)
-                    {
-                        typeNames.add(name);
-                    }
-                }
-                sb.append(String.join(", ", typeNames)).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+                typeNames.add(name);
             }
         }
+        sb.append(String.join(", ", typeNames)).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
 
-        int count = 0;
-
-        // Constructors
-        if (shouldIncludeMemberType(memberType, MEMBER_CONSTRUCTOR))
+    /**
+     * Appends the "Constructors" section, honoring the member-type filter and the
+     * running item limit. Returns the updated running item count.
+     */
+    private int appendConstructorsSection(StringBuilder sb, Type type, String memberType,
+                                          int limit, int count, boolean useRussian)
+    {
+        if (!shouldIncludeMemberType(memberType, MEMBER_CONSTRUCTOR))
         {
-            EList<Ctor> ctors = type.getCtors();
-            if (ctors != null && !ctors.isEmpty())
+            return count;
+        }
+        EList<Ctor> ctors = type.getCtors();
+        if (ctors == null || ctors.isEmpty())
+        {
+            return count;
+        }
+        sb.append("## Constructors\n\n"); //$NON-NLS-1$
+        for (int i = 0; i < ctors.size(); i++)
+        {
+            Ctor ctor = ctors.get(i);
+            if (count >= limit)
+                break;
+            appendCtorDocumentation(sb, ctor, i + 1, useRussian);
+            count++;
+        }
+        sb.append("\n"); //$NON-NLS-1$
+        return count;
+    }
+
+    /**
+     * Appends the "Methods" section, honoring the member-name/type filters and the
+     * running item limit. Returns the updated running item count.
+     */
+    private int appendMethodsSection(StringBuilder sb, ContextDef contextDef, String memberName,
+                                     String memberType, int limit, int count, boolean useRussian)
+    {
+        if (!shouldIncludeMemberType(memberType, MEMBER_METHOD))
+        {
+            return count;
+        }
+        EList<Method> methods = contextDef.allMethods();
+        if (methods == null || methods.isEmpty())
+        {
+            return count;
+        }
+        sb.append("## Methods\n\n"); //$NON-NLS-1$
+        for (Method method : methods)
+        {
+            if (count >= limit)
+                break;
+            String methodName = useRussian ? method.getNameRu() : method.getName();
+            if (memberNameMatches(methodName, method.getName(), method.getNameRu(), memberName))
             {
-                sb.append("## Constructors\n\n"); //$NON-NLS-1$
-                for (int i = 0; i < ctors.size(); i++)
-                {
-                    Ctor ctor = ctors.get(i);
-                    if (count >= limit)
-                        break;
-                    appendCtorDocumentation(sb, ctor, i + 1, useRussian);
-                    count++;
-                }
-                sb.append("\n"); //$NON-NLS-1$
+                appendMethodDocumentation(sb, method, useRussian);
+                count++;
             }
         }
+        sb.append("\n"); //$NON-NLS-1$
+        return count;
+    }
 
-        // Get context def for methods and properties
-        ContextDef contextDef = type.getContextDef();
-        if (contextDef != null)
+    /**
+     * Appends the "Properties" section, honoring the member-name/type filters and the
+     * running item limit. Returns the updated running item count.
+     */
+    private int appendPropertiesSection(StringBuilder sb, ContextDef contextDef, String memberName,
+                                        String memberType, int limit, int count, boolean useRussian)
+    {
+        if (!shouldIncludeMemberType(memberType, MEMBER_PROPERTY))
         {
-            // Methods
-            if (shouldIncludeMemberType(memberType, MEMBER_METHOD))
+            return count;
+        }
+        EList<Property> properties = contextDef.allProperties();
+        if (properties == null || properties.isEmpty())
+        {
+            return count;
+        }
+        sb.append("## Properties\n\n"); //$NON-NLS-1$
+        for (Property prop : properties)
+        {
+            if (count >= limit)
+                break;
+            String propName = useRussian ? prop.getNameRu() : prop.getName();
+            if (memberNameMatches(propName, prop.getName(), prop.getNameRu(), memberName))
             {
-                EList<Method> methods = contextDef.allMethods();
-                if (methods != null && !methods.isEmpty())
-                {
-                    sb.append("## Methods\n\n"); //$NON-NLS-1$
-                    for (Method method : methods)
-                    {
-                        if (count >= limit)
-                            break;
-                        String methodName = useRussian ? method.getNameRu() : method.getName();
-                        if (memberName == null || matchesMemberName(methodName, memberName) ||
-                            matchesMemberName(method.getName(), memberName) ||
-                            matchesMemberName(method.getNameRu(), memberName))
-                        {
-                            appendMethodDocumentation(sb, method, useRussian);
-                            count++;
-                        }
-                    }
-                    sb.append("\n"); //$NON-NLS-1$
-                }
-            }
-
-            // Properties
-            if (shouldIncludeMemberType(memberType, MEMBER_PROPERTY))
-            {
-                EList<Property> properties = contextDef.allProperties();
-                if (properties != null && !properties.isEmpty())
-                {
-                    sb.append("## Properties\n\n"); //$NON-NLS-1$
-                    for (Property prop : properties)
-                    {
-                        if (count >= limit)
-                            break;
-                        String propName = useRussian ? prop.getNameRu() : prop.getName();
-                        if (memberName == null || matchesMemberName(propName, memberName) ||
-                            matchesMemberName(prop.getName(), memberName) ||
-                            matchesMemberName(prop.getNameRu(), memberName))
-                        {
-                            appendPropertyDocumentation(sb, prop, useRussian);
-                            count++;
-                        }
-                    }
-                    sb.append("\n"); //$NON-NLS-1$
-                }
+                appendPropertyDocumentation(sb, prop, useRussian);
+                count++;
             }
         }
+        sb.append("\n"); //$NON-NLS-1$
+        return count;
+    }
 
-        // Events
-        if (shouldIncludeMemberType(memberType, MEMBER_EVENT))
+    /**
+     * Appends the "Events" section, honoring the member-name/type filters and the
+     * running item limit. Returns the updated running item count.
+     */
+    private int appendEventsSection(StringBuilder sb, Type type, String memberName,
+                                    String memberType, int limit, int count, boolean useRussian)
+    {
+        if (!shouldIncludeMemberType(memberType, MEMBER_EVENT))
         {
-            EList<Event> events = type.getEvents();
-            if (events != null && !events.isEmpty())
+            return count;
+        }
+        EList<Event> events = type.getEvents();
+        if (events == null || events.isEmpty())
+        {
+            return count;
+        }
+        sb.append("## Events\n\n"); //$NON-NLS-1$
+        for (Event event : events)
+        {
+            if (count >= limit)
+                break;
+            String eventName = useRussian ? event.getNameRu() : event.getName();
+            if (memberNameMatches(eventName, event.getName(), event.getNameRu(), memberName))
             {
-                sb.append("## Events\n\n"); //$NON-NLS-1$
-                for (Event event : events)
-                {
-                    if (count >= limit)
-                        break;
-                    String eventName = useRussian ? event.getNameRu() : event.getName();
-                    if (memberName == null || matchesMemberName(eventName, memberName) ||
-                        matchesMemberName(event.getName(), memberName) ||
-                        matchesMemberName(event.getNameRu(), memberName))
-                    {
-                        appendEventDocumentation(sb, event, useRussian);
-                        count++;
-                    }
-                }
+                appendEventDocumentation(sb, event, useRussian);
+                count++;
             }
         }
+        return count;
+    }
 
-        if (count >= limit)
-        {
-            sb.append("\n*Results limited to ").append(limit).append(" items.*\n"); //$NON-NLS-1$ //$NON-NLS-2$
-        }
-
-        return sb.toString();
+    /**
+     * Tells whether a member should be emitted given the optional member-name filter.
+     * A {@code null} filter always matches; otherwise the filter is matched (case-insensitive,
+     * partial) against the localized name and the explicit English/Russian names, in that order.
+     *
+     * @param localizedName the name already resolved for the requested language
+     * @param enName the English name of the member
+     * @param ruName the Russian name of the member
+     * @param filter the optional member-name filter ({@code null} to accept all)
+     * @return {@code true} when the member passes the filter
+     */
+    private boolean memberNameMatches(String localizedName, String enName, String ruName, String filter)
+    {
+        return filter == null || matchesMemberName(localizedName, filter) ||
+            matchesMemberName(enName, filter) ||
+            matchesMemberName(ruName, filter);
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateProjectTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateProjectTool.java
@@ -442,173 +442,43 @@ public class CreateProjectTool implements IMcpTool
         String prefix, String synonym, String comment, String purposeStr, String compatModeStr,
         boolean standardChecks, boolean commonChecks)
     {
-        // baseProjectName required for extension
-        if (baseProjectName == null || baseProjectName.trim().isEmpty())
+        // Validate the base project and new project name (read-only)
+        BaseProjectResolution baseResolution = validateExtensionBaseProject(configName, projectName, baseProjectName);
+        if (baseResolution.error != null)
         {
-            return ToolResult.error(
-                "'baseProjectName' is required for projectKind=extension. " //$NON-NLS-1$
-                    + "Use list_projects to find the base configuration project name.").toJson(); //$NON-NLS-1$
+            return baseResolution.error;
         }
-        baseProjectName = baseProjectName.trim();
+        baseProjectName = baseResolution.baseProjectName;
+        String effectiveProjectName = baseResolution.effectiveProjectName;
+        IProject baseIProject = baseResolution.baseIProject;
 
-        // Derive default EDT project name: <baseProjectName>.<configName>
-        String effectiveProjectName = (projectName != null) ? projectName
-            : baseProjectName + "." + configName; //$NON-NLS-1$
-
-        // Check the new project name does not already exist
-        if (ProjectContext.of(effectiveProjectName).exists())
+        // Resolve services and base-configuration model handles (read-only)
+        ExtensionServices services = resolveExtensionServices(baseIProject, baseProjectName);
+        if (services.error != null)
         {
-            return ToolResult.error(ERR_PROJECT_EXISTS_PREFIX + effectiveProjectName
-                + ERR_PROJECT_EXISTS_SUFFIX).toJson();
+            return services.error;
         }
-
-        // Validate the base project
-        ProjectContext baseCtx = ProjectContext.of(baseProjectName);
-        if (!baseCtx.exists())
-        {
-            return ToolResult.error(ProjectContext.notFoundMessage(baseProjectName)).toJson();
-        }
-        if (!baseCtx.isOpen())
-        {
-            return ToolResult.error("Base project '" + baseProjectName //$NON-NLS-1$
-                + "' exists but is not open. Open it first.").toJson(); //$NON-NLS-1$
-        }
-        IProject baseIProject = baseCtx.project();
-
-        // Validate the base project has V8ConfigurationNature (not an extension itself)
-        try
-        {
-            if (!baseIProject.hasNature(NATURE_CONFIGURATION))
-            {
-                return ToolResult.error("'" + baseProjectName //$NON-NLS-1$
-                    + "' is not a configuration project (V8ConfigurationNature). " //$NON-NLS-1$
-                    + "Pass the BASE configuration's project name, not an extension.").toJson(); //$NON-NLS-1$
-            }
-        }
-        catch (Exception e)
-        {
-            Activator.logError(LOG_PREFIX + "error checking nature for " + baseProjectName, e); //$NON-NLS-1$
-            return ToolResult.error("Failed to inspect base project nature: " + e.getMessage()).toJson(); //$NON-NLS-1$
-        }
-
-        // Resolve services
-        IExtensionProjectManager extMgr = Activator.getDefault().getExtensionProjectManager();
-        if (extMgr == null)
-        {
-            return ToolResult.error(
-                "IExtensionProjectManager service not available. The EDT platform may not be ready.").toJson(); //$NON-NLS-1$
-        }
-
-        IV8ProjectManager v8ProjectManager = Activator.getDefault().getV8ProjectManager();
-        if (v8ProjectManager == null)
-        {
-            return ToolResult.error("IV8ProjectManager service not available.").toJson(); //$NON-NLS-1$
-        }
-
-        IV8Project baseV8Project = v8ProjectManager.getProject(baseIProject);
-        if (baseV8Project == null)
-        {
-            return ToolResult.error("Could not obtain IV8Project for base project '" //$NON-NLS-1$
-                + baseProjectName + "'. Ensure the project is fully loaded.").toJson(); //$NON-NLS-1$
-        }
-
-        Version version = baseV8Project.getVersion();
-
-        IModelObjectFactory factory = Activator.getDefault().getModelObjectFactory();
-        if (factory == null)
-        {
-            return ToolResult.error("IModelObjectFactory (MD) not available. MdPlugin may not be ready.").toJson(); //$NON-NLS-1$
-        }
-
-        // Resolve the base configuration for ScriptVariant and synonym language
-        IConfigurationProvider configProvider = Activator.getDefault().getConfigurationProvider();
-        Configuration baseConfig = (configProvider != null)
-            ? configProvider.getConfiguration(baseIProject)
-            : null;
-
-        if (baseConfig == null)
-        {
-            return ToolResult.error("The configuration model of base project '" + baseProjectName //$NON-NLS-1$
-                + "' is not loaded yet (the project may still be indexing). " //$NON-NLS-1$
-                + "Wait until the project is ready and retry.").toJson(); //$NON-NLS-1$
-        }
-        ScriptVariant scriptVariant = baseConfig.getScriptVariant();
-        if (scriptVariant == null)
-        {
-            scriptVariant = ScriptVariant.RUSSIAN;
-        }
+        IExtensionProjectManager extMgr = services.extMgr;
+        IModelObjectFactory factory = services.factory;
+        Configuration baseConfig = services.baseConfig;
+        Version version = services.version;
+        ScriptVariant scriptVariant = services.scriptVariant;
 
         // Validate purpose
-        ConfigurationExtensionPurpose purpose = ConfigurationExtensionPurpose.CUSTOMIZATION;
-        if (purposeStr != null && !purposeStr.isEmpty())
+        PurposeResolution purposeResolution = resolveExtensionPurpose(purposeStr);
+        if (purposeResolution.error != null)
         {
-            switch (purposeStr)
-            {
-                case "Customization": //$NON-NLS-1$
-                    purpose = ConfigurationExtensionPurpose.CUSTOMIZATION;
-                    break;
-                case "AddOn": //$NON-NLS-1$
-                    purpose = ConfigurationExtensionPurpose.ADD_ON;
-                    break;
-                case "Patch": //$NON-NLS-1$
-                    purpose = ConfigurationExtensionPurpose.PATCH;
-                    break;
-                default:
-                    return ToolResult.error("Unknown purpose value: '" + purposeStr //$NON-NLS-1$
-                        + "'. Allowed values: Customization, AddOn, Patch.").toJson(); //$NON-NLS-1$
-            }
+            return purposeResolution.error;
         }
+        ConfigurationExtensionPurpose purpose = purposeResolution.purpose;
 
         // Validate CompatibilityMode if supplied
-        CompatibilityMode compatMode = null;
-        if (compatModeStr != null)
+        CompatModeResolution compatModeResolution = resolveCompatibilityMode(compatModeStr);
+        if (compatModeResolution.error != null)
         {
-            compatMode = CompatibilityMode.get(compatModeStr);
-            if (compatMode == null)
-            {
-                String normalizedInput = compatModeStr.replaceAll(RE_NON_ALNUM, "").toLowerCase(); //$NON-NLS-1$
-                for (CompatibilityMode candidate : CompatibilityMode.VALUES)
-                {
-                    String normalizedCandidate = candidate.getLiteral()
-                        .replaceAll(RE_NON_ALNUM, "").toLowerCase(); //$NON-NLS-1$
-                    if (normalizedInput.equals(normalizedCandidate))
-                    {
-                        compatMode = candidate;
-                        break;
-                    }
-                    String normalizedName = candidate.getName()
-                        .replaceAll(RE_NON_ALNUM, "").toLowerCase(); //$NON-NLS-1$
-                    if (normalizedInput.equals(normalizedName))
-                    {
-                        compatMode = candidate;
-                        break;
-                    }
-                }
-            }
-            if (compatMode == null)
-            {
-                StringBuilder examples = new StringBuilder();
-                int shown = 0;
-                for (CompatibilityMode candidate : CompatibilityMode.VALUES)
-                {
-                    if (shown > 0)
-                    {
-                        examples.append(", "); //$NON-NLS-1$
-                    }
-                    examples.append("'").append(candidate.getLiteral()).append("'"); //$NON-NLS-1$ //$NON-NLS-2$
-                    shown++;
-                    if (shown >= 3)
-                    {
-                        break;
-                    }
-                }
-                int total = CompatibilityMode.VALUES.size();
-                return ToolResult.error("Unknown compatibilityMode value: '" + compatModeStr //$NON-NLS-1$
-                    + "'. Use a CompatibilityMode enum literal (e.g. " + examples //$NON-NLS-1$
-                    + (total > 3 ? " and " + (total - 3) + " more" : "") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-                    + "), or omit for the factory default.").toJson(); //$NON-NLS-1$
-            }
+            return compatModeResolution.error;
         }
+        CompatibilityMode compatMode = compatModeResolution.compatMode;
 
         // Build the extension Configuration model object
         Configuration config = (Configuration) factory.create(MdClassPackage.Literals.CONFIGURATION, version);
@@ -630,22 +500,7 @@ public class CreateProjectTool implements IMcpTool
         }
 
         // Set synonym via language-code-keyed EMap
-        String synonymValue = (synonym != null && !synonym.isEmpty()) ? synonym : configName;
-        String langCode = MetadataLanguageUtils.resolveLanguageCode(baseConfig, null);
-        if (langCode == null)
-        {
-            langCode = MetadataLanguageUtils.resolveLanguageCode(config, null);
-        }
-        boolean synonymApplied = false;
-        if (langCode != null)
-        {
-            EMap<String, String> synonymMap = config.getSynonym();
-            if (synonymMap != null)
-            {
-                synonymMap.put(langCode, synonymValue);
-                synonymApplied = true;
-            }
-        }
+        boolean synonymApplied = applyExtensionSynonym(config, baseConfig, configName, synonym);
 
         // Create the extension project in a background Job
         final IProject[] createdHolder = new IProject[1];
@@ -680,30 +535,8 @@ public class CreateProjectTool implements IMcpTool
         if (jobResult.status == CreateStatus.SLOW_EXISTS)
         {
             // Creation completed past the wait window — build the full extension response
-            ToolResult slowResult = ToolResult.success()
-                .put(McpKeys.ACTION, VAL_CREATED)
-                .put(McpKeys.PROJECT, finalEffectiveProjectName)
-                .put(KEY_PROJECT_KIND, KIND_EXTENSION)
-                .put("name", configName) //$NON-NLS-1$
-                .put(KEY_BASE_PROJECT, baseProjectName)
-                .put(KEY_PREFIX, prefix)
-                .put(KEY_PURPOSE, finalPurpose.getLiteral())
-                .put(KEY_SCRIPT_VARIANT, finalScriptVariant.getLiteral())
-                .put(KEY_VERSION, version.toString())
-                .put(KEY_STATE, VAL_CREATED)
-                .put(KEY_CODESTYLE, slowPathCodestyleMap())
-                .put(McpKeys.MESSAGE, "Extension project '" + finalEffectiveProjectName //$NON-NLS-1$
-                    + "' created and bound to '" + baseProjectName //$NON-NLS-1$
-                    + "' (creation completed past the " //$NON-NLS-1$
-                    + (CREATE_TIMEOUT_MS / 1000) + MSG_WAIT_WINDOW_SUFFIX);
-            // Mirror the normal success path: report when the synonym could not be applied.
-            if (!synonymApplied)
-            {
-                slowResult.put(KEY_SYNONYM_NOTE,
-                    "Synonym was not applied: could not determine a language code from " //$NON-NLS-1$
-                        + "the base configuration or the new extension configuration."); //$NON-NLS-1$
-            }
-            return slowResult.toJson();
+            return buildExtensionSlowResponse(finalEffectiveProjectName, configName, baseProjectName, prefix,
+                finalPurpose, finalScriptVariant, version, synonymApplied);
         }
         if (jobResult.errorJson != null)
         {
@@ -727,27 +560,8 @@ public class CreateProjectTool implements IMcpTool
         // Apply v8codestyle preferences
         Map<String, Object> codestyleMap = applyCodestylePrefs(finalEffectiveProjectName, standardChecks, commonChecks);
 
-        ToolResult result = ToolResult.success()
-            .put(McpKeys.ACTION, VAL_CREATED)
-            .put(McpKeys.PROJECT, finalEffectiveProjectName)
-            .put(KEY_PROJECT_KIND, KIND_EXTENSION)
-            .put("name", configName) //$NON-NLS-1$
-            .put(KEY_BASE_PROJECT, baseProjectName)
-            .put(KEY_PREFIX, prefix)
-            .put(KEY_PURPOSE, finalPurpose.getLiteral())
-            .put(KEY_SCRIPT_VARIANT, finalScriptVariant.getLiteral())
-            .put(KEY_VERSION, version.toString())
-            .put(KEY_STATE, projectState)
-            .put(KEY_CODESTYLE, codestyleMap)
-            .put(McpKeys.MESSAGE, "Extension project '" + finalEffectiveProjectName //$NON-NLS-1$
-                + "' created and bound to '" + baseProjectName + "'."); //$NON-NLS-1$ //$NON-NLS-2$
-        if (!synonymApplied)
-        {
-            result.put(KEY_SYNONYM_NOTE,
-                "Synonym was not applied: could not determine a language code from " //$NON-NLS-1$
-                    + "the base configuration or the new extension configuration."); //$NON-NLS-1$
-        }
-        return result.toJson();
+        return buildExtensionSuccessResponse(finalEffectiveProjectName, configName, baseProjectName, prefix,
+            finalPurpose, finalScriptVariant, version, projectState, codestyleMap, synonymApplied);
     }
 
     // ─────────────────────── CONFIGURATION path ──────────────────────────────
@@ -1149,6 +963,452 @@ public class CreateProjectTool implements IMcpTool
             this.status = status;
             this.errorJson = errorJson;
         }
+    }
+
+    /**
+     * Outcome of {@link #validateExtensionBaseProject}: either a ready-to-return JSON
+     * {@code error}, or the validated base-project handles. Exactly one of {@code error}
+     * and {@code baseIProject} is non-null on success/failure respectively.
+     */
+    private static final class BaseProjectResolution
+    {
+        /** Ready-to-return JSON error, or {@code null} when validation passed. */
+        final String error;
+        /** Trimmed base project name (non-null when {@code error} is null). */
+        final String baseProjectName;
+        /** Derived EDT project name for the new extension (non-null when {@code error} is null). */
+        final String effectiveProjectName;
+        /** The validated, open base {@link IProject} (non-null when {@code error} is null). */
+        final IProject baseIProject;
+
+        private BaseProjectResolution(String error, String baseProjectName, String effectiveProjectName,
+            IProject baseIProject)
+        {
+            this.error = error;
+            this.baseProjectName = baseProjectName;
+            this.effectiveProjectName = effectiveProjectName;
+            this.baseIProject = baseIProject;
+        }
+
+        static BaseProjectResolution failure(String error)
+        {
+            return new BaseProjectResolution(error, null, null, null);
+        }
+
+        static BaseProjectResolution ok(String baseProjectName, String effectiveProjectName, IProject baseIProject)
+        {
+            return new BaseProjectResolution(null, baseProjectName, effectiveProjectName, baseIProject);
+        }
+    }
+
+    /**
+     * Outcome of {@link #resolveExtensionServices}: either a ready-to-return JSON {@code error},
+     * or the platform services/model handles needed to build the extension Configuration. All
+     * value fields are non-null exactly when {@code error} is null.
+     */
+    private static final class ExtensionServices
+    {
+        /** Ready-to-return JSON error, or {@code null} when resolution succeeded. */
+        final String error;
+        final IExtensionProjectManager extMgr;
+        final IModelObjectFactory factory;
+        final Configuration baseConfig;
+        final Version version;
+        final ScriptVariant scriptVariant;
+
+        private ExtensionServices(String error, IExtensionProjectManager extMgr, IModelObjectFactory factory,
+            Configuration baseConfig, Version version, ScriptVariant scriptVariant)
+        {
+            this.error = error;
+            this.extMgr = extMgr;
+            this.factory = factory;
+            this.baseConfig = baseConfig;
+            this.version = version;
+            this.scriptVariant = scriptVariant;
+        }
+
+        static ExtensionServices failure(String error)
+        {
+            return new ExtensionServices(error, null, null, null, null, null);
+        }
+
+        static ExtensionServices ok(IExtensionProjectManager extMgr, IModelObjectFactory factory,
+            Configuration baseConfig, Version version, ScriptVariant scriptVariant)
+        {
+            return new ExtensionServices(null, extMgr, factory, baseConfig, version, scriptVariant);
+        }
+    }
+
+    /**
+     * Outcome of {@link #resolveExtensionPurpose}: either a ready-to-return JSON {@code error},
+     * or the resolved {@link ConfigurationExtensionPurpose}. Exactly one field is non-null.
+     */
+    private static final class PurposeResolution
+    {
+        final String error;
+        final ConfigurationExtensionPurpose purpose;
+
+        private PurposeResolution(String error, ConfigurationExtensionPurpose purpose)
+        {
+            this.error = error;
+            this.purpose = purpose;
+        }
+    }
+
+    /**
+     * Outcome of {@link #resolveCompatibilityMode}: either a ready-to-return JSON {@code error},
+     * or the resolved {@link CompatibilityMode} (which may legitimately be {@code null} when no
+     * value was supplied). The {@code error} field disambiguates the two null cases.
+     */
+    private static final class CompatModeResolution
+    {
+        final String error;
+        final CompatibilityMode compatMode;
+
+        private CompatModeResolution(String error, CompatibilityMode compatMode)
+        {
+            this.error = error;
+            this.compatMode = compatMode;
+        }
+    }
+
+    /**
+     * Validates the extension's base project and the new project name (read-only). Trims
+     * {@code baseProjectName}, requires it to be non-blank, derives the EDT project name
+     * ({@code projectName} or {@code <baseProjectName>.<configName>}), and verifies that the
+     * new project does not already exist and that the base project exists, is open and carries
+     * {@code V8ConfigurationNature}.
+     *
+     * @return {@link BaseProjectResolution#ok} with the validated handles, or
+     *     {@link BaseProjectResolution#failure} carrying a ready-to-return JSON error
+     */
+    private BaseProjectResolution validateExtensionBaseProject(String configName, String projectName,
+        String baseProjectName)
+    {
+        // baseProjectName required for extension
+        if (baseProjectName == null || baseProjectName.trim().isEmpty())
+        {
+            return BaseProjectResolution.failure(ToolResult.error(
+                "'baseProjectName' is required for projectKind=extension. " //$NON-NLS-1$
+                    + "Use list_projects to find the base configuration project name.").toJson()); //$NON-NLS-1$
+        }
+        baseProjectName = baseProjectName.trim();
+
+        // Derive default EDT project name: <baseProjectName>.<configName>
+        String effectiveProjectName = (projectName != null) ? projectName
+            : baseProjectName + "." + configName; //$NON-NLS-1$
+
+        // Check the new project name does not already exist
+        if (ProjectContext.of(effectiveProjectName).exists())
+        {
+            return BaseProjectResolution.failure(ToolResult.error(ERR_PROJECT_EXISTS_PREFIX + effectiveProjectName
+                + ERR_PROJECT_EXISTS_SUFFIX).toJson());
+        }
+
+        // Validate the base project
+        ProjectContext baseCtx = ProjectContext.of(baseProjectName);
+        if (!baseCtx.exists())
+        {
+            return BaseProjectResolution.failure(ToolResult.error(ProjectContext.notFoundMessage(baseProjectName)).toJson());
+        }
+        if (!baseCtx.isOpen())
+        {
+            return BaseProjectResolution.failure(ToolResult.error("Base project '" + baseProjectName //$NON-NLS-1$
+                + "' exists but is not open. Open it first.").toJson()); //$NON-NLS-1$
+        }
+        IProject baseIProject = baseCtx.project();
+
+        // Validate the base project has V8ConfigurationNature (not an extension itself)
+        try
+        {
+            if (!baseIProject.hasNature(NATURE_CONFIGURATION))
+            {
+                return BaseProjectResolution.failure(ToolResult.error("'" + baseProjectName //$NON-NLS-1$
+                    + "' is not a configuration project (V8ConfigurationNature). " //$NON-NLS-1$
+                    + "Pass the BASE configuration's project name, not an extension.").toJson()); //$NON-NLS-1$
+            }
+        }
+        catch (Exception e)
+        {
+            Activator.logError(LOG_PREFIX + "error checking nature for " + baseProjectName, e); //$NON-NLS-1$
+            return BaseProjectResolution.failure(
+                ToolResult.error("Failed to inspect base project nature: " + e.getMessage()).toJson()); //$NON-NLS-1$
+        }
+
+        return BaseProjectResolution.ok(baseProjectName, effectiveProjectName, baseIProject);
+    }
+
+    /**
+     * Resolves the platform services and base-configuration model handles needed to build the
+     * extension Configuration (read-only lookups). Resolves {@link IExtensionProjectManager},
+     * {@link IV8ProjectManager} (to read the base {@link Version}), {@link IModelObjectFactory},
+     * the base {@link Configuration} and its {@link ScriptVariant} (defaulting to
+     * {@link ScriptVariant#RUSSIAN} when unset).
+     *
+     * @return {@link ExtensionServices#ok} with the resolved handles, or
+     *     {@link ExtensionServices#failure} carrying a ready-to-return JSON error
+     */
+    private ExtensionServices resolveExtensionServices(IProject baseIProject, String baseProjectName)
+    {
+        IExtensionProjectManager extMgr = Activator.getDefault().getExtensionProjectManager();
+        if (extMgr == null)
+        {
+            return ExtensionServices.failure(ToolResult.error(
+                "IExtensionProjectManager service not available. The EDT platform may not be ready.").toJson()); //$NON-NLS-1$
+        }
+
+        IV8ProjectManager v8ProjectManager = Activator.getDefault().getV8ProjectManager();
+        if (v8ProjectManager == null)
+        {
+            return ExtensionServices.failure(ToolResult.error("IV8ProjectManager service not available.").toJson()); //$NON-NLS-1$
+        }
+
+        IV8Project baseV8Project = v8ProjectManager.getProject(baseIProject);
+        if (baseV8Project == null)
+        {
+            return ExtensionServices.failure(ToolResult.error("Could not obtain IV8Project for base project '" //$NON-NLS-1$
+                + baseProjectName + "'. Ensure the project is fully loaded.").toJson()); //$NON-NLS-1$
+        }
+
+        Version version = baseV8Project.getVersion();
+
+        IModelObjectFactory factory = Activator.getDefault().getModelObjectFactory();
+        if (factory == null)
+        {
+            return ExtensionServices.failure(
+                ToolResult.error("IModelObjectFactory (MD) not available. MdPlugin may not be ready.").toJson()); //$NON-NLS-1$
+        }
+
+        // Resolve the base configuration for ScriptVariant and synonym language
+        IConfigurationProvider configProvider = Activator.getDefault().getConfigurationProvider();
+        Configuration baseConfig = (configProvider != null)
+            ? configProvider.getConfiguration(baseIProject)
+            : null;
+
+        if (baseConfig == null)
+        {
+            return ExtensionServices.failure(ToolResult.error("The configuration model of base project '" + baseProjectName //$NON-NLS-1$
+                + "' is not loaded yet (the project may still be indexing). " //$NON-NLS-1$
+                + "Wait until the project is ready and retry.").toJson()); //$NON-NLS-1$
+        }
+        ScriptVariant scriptVariant = baseConfig.getScriptVariant();
+        if (scriptVariant == null)
+        {
+            scriptVariant = ScriptVariant.RUSSIAN;
+        }
+
+        return ExtensionServices.ok(extMgr, factory, baseConfig, version, scriptVariant);
+    }
+
+    /**
+     * Maps the {@code purpose} parameter string to a {@link ConfigurationExtensionPurpose}
+     * (read-only). Defaults to {@link ConfigurationExtensionPurpose#CUSTOMIZATION} when blank.
+     *
+     * @return a {@link PurposeResolution} carrying the resolved purpose, or a ready-to-return
+     *     JSON error for an unknown value
+     */
+    private static PurposeResolution resolveExtensionPurpose(String purposeStr)
+    {
+        ConfigurationExtensionPurpose purpose = ConfigurationExtensionPurpose.CUSTOMIZATION;
+        if (purposeStr != null && !purposeStr.isEmpty())
+        {
+            switch (purposeStr)
+            {
+                case "Customization": //$NON-NLS-1$
+                    purpose = ConfigurationExtensionPurpose.CUSTOMIZATION;
+                    break;
+                case "AddOn": //$NON-NLS-1$
+                    purpose = ConfigurationExtensionPurpose.ADD_ON;
+                    break;
+                case "Patch": //$NON-NLS-1$
+                    purpose = ConfigurationExtensionPurpose.PATCH;
+                    break;
+                default:
+                    return new PurposeResolution(ToolResult.error("Unknown purpose value: '" + purposeStr //$NON-NLS-1$
+                        + "'. Allowed values: Customization, AddOn, Patch.").toJson(), null); //$NON-NLS-1$
+            }
+        }
+        return new PurposeResolution(null, purpose);
+    }
+
+    /**
+     * Resolves the optional {@code compatibilityMode} string to a {@link CompatibilityMode}
+     * (read-only). Tries an exact {@link CompatibilityMode#get} first, then a normalized
+     * (alphanumeric, lower-cased) match against each candidate's literal and name. A {@code null}
+     * {@code compatModeStr} yields a {@code null} mode with no error.
+     *
+     * @return a {@link CompatModeResolution} carrying the resolved mode (possibly {@code null}),
+     *     or a ready-to-return JSON error for an unknown value
+     */
+    private static CompatModeResolution resolveCompatibilityMode(String compatModeStr)
+    {
+        CompatibilityMode compatMode = null;
+        if (compatModeStr != null)
+        {
+            compatMode = CompatibilityMode.get(compatModeStr);
+            if (compatMode == null)
+            {
+                compatMode = matchCompatibilityModeByNormalizedName(compatModeStr);
+            }
+            if (compatMode == null)
+            {
+                return new CompatModeResolution(buildUnknownCompatModeError(compatModeStr), null);
+            }
+        }
+        return new CompatModeResolution(null, compatMode);
+    }
+
+    /**
+     * Finds the {@link CompatibilityMode} whose literal or name matches {@code compatModeStr}
+     * after stripping non-alphanumerics and lower-casing both sides (read-only).
+     *
+     * @return the matching mode, or {@code null} when none matches
+     */
+    private static CompatibilityMode matchCompatibilityModeByNormalizedName(String compatModeStr)
+    {
+        String normalizedInput = compatModeStr.replaceAll(RE_NON_ALNUM, "").toLowerCase(); //$NON-NLS-1$
+        for (CompatibilityMode candidate : CompatibilityMode.VALUES)
+        {
+            String normalizedCandidate = candidate.getLiteral()
+                .replaceAll(RE_NON_ALNUM, "").toLowerCase(); //$NON-NLS-1$
+            if (normalizedInput.equals(normalizedCandidate))
+            {
+                return candidate;
+            }
+            String normalizedName = candidate.getName()
+                .replaceAll(RE_NON_ALNUM, "").toLowerCase(); //$NON-NLS-1$
+            if (normalizedInput.equals(normalizedName))
+            {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Builds the ready-to-return JSON error for an unrecognized {@code compatibilityMode} value,
+     * listing up to the first three known literals as examples (read-only).
+     */
+    private static String buildUnknownCompatModeError(String compatModeStr)
+    {
+        StringBuilder examples = new StringBuilder();
+        int shown = 0;
+        for (CompatibilityMode candidate : CompatibilityMode.VALUES)
+        {
+            if (shown > 0)
+            {
+                examples.append(", "); //$NON-NLS-1$
+            }
+            examples.append("'").append(candidate.getLiteral()).append("'"); //$NON-NLS-1$ //$NON-NLS-2$
+            shown++;
+            if (shown >= 3)
+            {
+                break;
+            }
+        }
+        int total = CompatibilityMode.VALUES.size();
+        return ToolResult.error("Unknown compatibilityMode value: '" + compatModeStr //$NON-NLS-1$
+            + "'. Use a CompatibilityMode enum literal (e.g. " + examples //$NON-NLS-1$
+            + (total > 3 ? " and " + (total - 3) + " more" : "") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            + "), or omit for the factory default.").toJson(); //$NON-NLS-1$
+    }
+
+    /**
+     * Applies the synonym to the in-memory extension {@link Configuration} via its
+     * language-code-keyed {@code synonym} EMap (in-memory model mutation only — no workspace
+     * side effects). The synonym value defaults to {@code configName} when {@code synonym} is
+     * blank; the language code is resolved from the base configuration, falling back to the new
+     * configuration.
+     *
+     * @return {@code true} when the synonym was applied; {@code false} when no language code or
+     *     synonym map was available
+     */
+    private static boolean applyExtensionSynonym(Configuration config, Configuration baseConfig,
+        String configName, String synonym)
+    {
+        String synonymValue = (synonym != null && !synonym.isEmpty()) ? synonym : configName;
+        String langCode = MetadataLanguageUtils.resolveLanguageCode(baseConfig, null);
+        if (langCode == null)
+        {
+            langCode = MetadataLanguageUtils.resolveLanguageCode(config, null);
+        }
+        if (langCode != null)
+        {
+            EMap<String, String> synonymMap = config.getSynonym();
+            if (synonymMap != null)
+            {
+                synonymMap.put(langCode, synonymValue);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Builds the slow-path JSON response for a created extension project (read-only): creation
+     * completed past the wait window, so {@code state="created"} and {@code codestyle.applied=false}.
+     * Mirrors the normal success response, adding {@code synonymNote} when the synonym could not
+     * be applied.
+     */
+    private static String buildExtensionSlowResponse(String effectiveProjectName, String configName,
+        String baseProjectName, String prefix, ConfigurationExtensionPurpose purpose, ScriptVariant scriptVariant,
+        Version version, boolean synonymApplied)
+    {
+        ToolResult slowResult = ToolResult.success()
+            .put(McpKeys.ACTION, VAL_CREATED)
+            .put(McpKeys.PROJECT, effectiveProjectName)
+            .put(KEY_PROJECT_KIND, KIND_EXTENSION)
+            .put("name", configName) //$NON-NLS-1$
+            .put(KEY_BASE_PROJECT, baseProjectName)
+            .put(KEY_PREFIX, prefix)
+            .put(KEY_PURPOSE, purpose.getLiteral())
+            .put(KEY_SCRIPT_VARIANT, scriptVariant.getLiteral())
+            .put(KEY_VERSION, version.toString())
+            .put(KEY_STATE, VAL_CREATED)
+            .put(KEY_CODESTYLE, slowPathCodestyleMap())
+            .put(McpKeys.MESSAGE, "Extension project '" + effectiveProjectName //$NON-NLS-1$
+                + "' created and bound to '" + baseProjectName //$NON-NLS-1$
+                + "' (creation completed past the " //$NON-NLS-1$
+                + (CREATE_TIMEOUT_MS / 1000) + MSG_WAIT_WINDOW_SUFFIX);
+        // Mirror the normal success path: report when the synonym could not be applied.
+        if (!synonymApplied)
+        {
+            slowResult.put(KEY_SYNONYM_NOTE,
+                "Synonym was not applied: could not determine a language code from " //$NON-NLS-1$
+                    + "the base configuration or the new extension configuration."); //$NON-NLS-1$
+        }
+        return slowResult.toJson();
+    }
+
+    /**
+     * Builds the normal success JSON response for a created extension project (read-only),
+     * adding {@code synonymNote} when the synonym could not be applied.
+     */
+    private static String buildExtensionSuccessResponse(String effectiveProjectName, String configName,
+        String baseProjectName, String prefix, ConfigurationExtensionPurpose purpose, ScriptVariant scriptVariant,
+        Version version, String projectState, Map<String, Object> codestyleMap, boolean synonymApplied)
+    {
+        ToolResult result = ToolResult.success()
+            .put(McpKeys.ACTION, VAL_CREATED)
+            .put(McpKeys.PROJECT, effectiveProjectName)
+            .put(KEY_PROJECT_KIND, KIND_EXTENSION)
+            .put("name", configName) //$NON-NLS-1$
+            .put(KEY_BASE_PROJECT, baseProjectName)
+            .put(KEY_PREFIX, prefix)
+            .put(KEY_PURPOSE, purpose.getLiteral())
+            .put(KEY_SCRIPT_VARIANT, scriptVariant.getLiteral())
+            .put(KEY_VERSION, version.toString())
+            .put(KEY_STATE, projectState)
+            .put(KEY_CODESTYLE, codestyleMap)
+            .put(McpKeys.MESSAGE, "Extension project '" + effectiveProjectName //$NON-NLS-1$
+                + "' created and bound to '" + baseProjectName + "'."); //$NON-NLS-1$ //$NON-NLS-2$
+        if (!synonymApplied)
+        {
+            result.put(KEY_SYNONYM_NOTE,
+                "Synonym was not applied: could not determine a language code from " //$NON-NLS-1$
+                    + "the base configuration or the new extension configuration."); //$NON-NLS-1$
+        }
+        return result.toJson();
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -185,63 +185,30 @@ public class GetProjectErrorsTool implements IMcpTool
         try
         {
             IMarkerManager markerManager = Activator.getDefault().getMarkerManager();
-            
+
             if (markerManager == null)
             {
                 return ToolResult.error("IMarkerManager service is not available").toJson(); //$NON-NLS-1$
             }
-            
+
             final ICheckRepository checkRepository = Activator.getDefault().getCheckRepository();
             IBmModelManager bmModelManager = Activator.getDefault().getBmModelManager();
 
             // Parse severity filter
             final MarkerSeverity finalSeverityFilter = parseSeverityFilter(severity);
             final String finalCheckId = checkId;
-            
+
             // Validate project if specified
-            if (projectName != null && !projectName.isEmpty())
+            String projectNotFound = projectNotFoundErrorOrNull(projectName);
+            if (projectNotFound != null)
             {
-                ProjectContext ctx = ProjectContext.of(projectName);
-                if (!ctx.exists())
-                {
-                    return ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson();
-                }
+                return projectNotFound;
             }
-            
-            // Normalize object FQNs to support both English and Russian metadata type names.
-            // For each input FQN, generate all variants (original + English + Russian, lowercased)
-            // so we can match markers regardless of the configuration language.
-            // Using Set for deduplication of variants.
-            final Set<String> finalObjects = new HashSet<>();
-            if (objects != null)
-            {
-                for (String fqn : objects)
-                {
-                    finalObjects.addAll(MetadataTypeUtils.getAllFqnVariants(fqn));
-                }
-            }
-            
-            // Group markers by project in a single pass. getProject() does not touch
-            // resolvedDataCache, so this is safe outside a BM transaction. Grouping once avoids
-            // re-streaming all markers per project (previously O(markers x projects)).
-            // Marker presentation must still be resolved inside a BM read transaction bound to
-            // a single project's model, so processing below stays project by project.
-            Map<IProject, List<Marker>> markersByProject = new LinkedHashMap<>();
-            markerManager.markers().forEach(marker -> {
-                IProject markerProject = marker.getProject();
-                if (markerProject == null || !markerProject.exists())
-                {
-                    return;
-                }
-                if (projectName != null && !projectName.isEmpty()
-                    && !projectName.equals(markerProject.getName()))
-                {
-                    return;
-                }
-                markersByProject.computeIfAbsent(markerProject, k -> new ArrayList<>()).add(marker);
-            });
-            
-            final List<ErrorInfo> errors = new ArrayList<>();
+
+            final Set<String> finalObjects = buildObjectFilterVariants(objects);
+
+            Map<IProject, List<Marker>> markersByProject = groupMarkersByProject(markerManager, projectName);
+
             // Markers whose presentation could not be resolved even inside a transaction.
             // They are NOT dropped, but they are surfaced differently depending on context,
             // so we track the two cases separately to keep the warning text honest:
@@ -250,140 +217,309 @@ public class GetProjectErrorsTool implements IMcpTool
             //    filter is active and the location could not be resolved to test membership.
             final int[] unresolvedShown = {0};
             final int[] unresolvedFilteredOut = {0};
-            
-            for (Map.Entry<IProject, List<Marker>> entry : markersByProject.entrySet())
-            {
-                if (errors.size() >= limit)
-                {
-                    break;
-                }
-                
-                final List<Marker> projectMarkers = entry.getValue();
-                final int remaining = limit - errors.size();
-                
-                // Resolve the project's BM model so getObjectPresentation() can lazily
-                // resolve the marker target inside a read transaction. The getModel(IProject)
-                // overload is the idiomatic path used across the plugin (FindReferencesTool,
-                // CreateMetadataTool, tag tools), so no IDtProjectManager is needed.
-                IBmModel bmModel = bmModelManager != null ? bmModelManager.getModel(entry.getKey()) : null;
-                
-                Runnable collector = () -> projectMarkers.stream()
-                    .map(marker -> buildIfMatches(marker, finalSeverityFilter, finalCheckId,
-                        finalObjects, checkRepository, unresolvedShown, unresolvedFilteredOut))
-                    .filter(error -> error != null)
-                    .limit(remaining)
-                    .forEach(errors::add);
-                
-                if (bmModel != null)
-                {
-                    BmTransactions.<Void>read(bmModel, "CollectProjectErrors", (tx, pm) -> { //$NON-NLS-1$
-                        collector.run();
-                        return null;
-                    });
-                }
-                else
-                {
-                    // Not an EDT project (no BM model): best effort. Per-marker access is
-                    // still guarded, so an unresolved marker is reported, never dropped.
-                    collector.run();
-                }
-            }
-            
+
+            final List<ErrorInfo> errors = collectErrors(markersByProject, bmModelManager,
+                finalSeverityFilter, finalCheckId, finalObjects, checkRepository, limit,
+                unresolvedShown, unresolvedFilteredOut);
+
             // Build Markdown response for better readability and context efficiency
             StringBuilder md = new StringBuilder();
-            
+
             if (errors.isEmpty())
             {
-                md.append("# No Errors Found\n\n"); //$NON-NLS-1$
-                if (projectName != null && !projectName.isEmpty())
-                {
-                    md.append("Project: **").append(projectName).append("**\n"); //$NON-NLS-1$ //$NON-NLS-2$
-                }
-                if (severity != null && !severity.isEmpty())
-                {
-                    md.append("Severity filter: ").append(severity).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-                }
-                if (objects != null && !objects.isEmpty())
-                {
-                    md.append("Objects filter: ").append(String.join(", ", objects)).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-                }
-                md.append("\nNo configuration problems match the specified criteria."); //$NON-NLS-1$
+                appendNoErrorsSection(md, projectName, severity, objects);
             }
             else
             {
-                md.append("# Configuration Problems\n\n"); //$NON-NLS-1$
-                md.append("**Found:** ").append(errors.size()); //$NON-NLS-1$
-                if (errors.size() >= limit)
-                {
-                    md.append(Pagination.limitReachedNotice(limit));
-                }
-                md.append("\n\n"); //$NON-NLS-1$
-                
-                // Build table matching EDT's Configuration Problems view, plus a structural
-                // locator (Module path + Line) that feeds read_module_source / set_breakpoint.
-                // Built via the shared MarkdownUtils table builder so every cell is escaped.
-                // concise (default) drops the secondary 'Has docs' column to save tokens;
-                // detailed keeps the full historical set of columns. Every essential /
-                // actionable column (Description, Location, Module path, Line, Check code)
-                // is present in BOTH modes.
-                if (detailed)
-                {
-                    md.append(MarkdownUtils.tableHeader("Description", "Location", //$NON-NLS-1$ //$NON-NLS-2$
-                        "Module path", "Line", "Check code", "Has docs")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-                }
-                else
-                {
-                    md.append(MarkdownUtils.tableHeader("Description", "Location", //$NON-NLS-1$ //$NON-NLS-2$
-                        "Module path", "Line", "Check code")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-                }
+                appendProblemsTable(md, errors, limit, detailed);
+            }
 
-                for (ErrorInfo error : errors)
-                {
-                    // Show symbolic check ID if available, otherwise show check code
-                    String displayCheckId = error.checkId != null && !error.checkId.isEmpty()
-                        ? error.checkId
-                        : error.checkCode;
-                    // Wrap the check code in backticks; tableRow escapes the cell, so do NOT
-                    // pre-escape here (double-escaping would mangle a pipe in the id).
-                    String checkCell = "`" + (displayCheckId != null ? displayCheckId : "") + "`"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-                    String modulePathCell = error.modulePath != null ? error.modulePath : ""; //$NON-NLS-1$
-                    String lineCell = error.line != null ? error.line.toString() : ""; //$NON-NLS-1$
+            appendUnresolvedWarnings(md, unresolvedShown, unresolvedFilteredOut);
 
-                    if (detailed)
-                    {
-                        md.append(MarkdownUtils.tableRow(error.message, error.objectPresentation,
-                            modulePathCell, lineCell, checkCell,
-                            error.hasDocumentation ? "true" : "false")); //$NON-NLS-1$ //$NON-NLS-2$
-                    }
-                    else
-                    {
-                        md.append(MarkdownUtils.tableRow(error.message, error.objectPresentation,
-                            modulePathCell, lineCell, checkCell));
-                    }
-                }
-            }
-            
-            // Surface unresolved markers explicitly instead of silently dropping them.
-            // Two distinct cases, reported separately so each warning matches reality.
-            if (unresolvedShown[0] > 0)
-            {
-                md.append("\n> ⚠️ ").append(unresolvedShown[0]) //$NON-NLS-1$
-                  .append(" marker(s) could not be resolved and are shown with a placeholder location. ") //$NON-NLS-1$
-                  .append("Run clean_project / revalidate_objects to refresh them."); //$NON-NLS-1$
-            }
-            if (unresolvedFilteredOut[0] > 0)
-            {
-                md.append("\n> ⚠️ ").append(unresolvedFilteredOut[0]) //$NON-NLS-1$
-                  .append(" marker(s) were excluded from the object filter because their location could not be resolved. ") //$NON-NLS-1$
-                  .append("Run clean_project / revalidate_objects, or remove the objects filter, to include them."); //$NON-NLS-1$
-            }
-            
             return md.toString();
         }
         catch (Exception e)
         {
             Activator.logError("Error getting project errors", e); //$NON-NLS-1$
             return ToolResult.error("Failed to get project errors: " + e.getMessage()).toJson(); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Validates an explicit {@code projectName} filter. Returns the ready-to-return JSON error
+     * payload when the project is specified but does not exist, or {@code null} when no project
+     * was specified or it exists (in which case processing continues).
+     *
+     * @param projectName the project name filter, may be {@code null}/empty
+     * @return the JSON error string to return, or {@code null} to continue
+     */
+    private static String projectNotFoundErrorOrNull(String projectName)
+    {
+        if (projectName != null && !projectName.isEmpty())
+        {
+            ProjectContext ctx = ProjectContext.of(projectName);
+            if (!ctx.exists())
+            {
+                return ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Normalizes the input object FQNs to support both English and Russian metadata type names.
+     * For each input FQN, generates all variants (original + English + Russian, lowercased) so
+     * markers can be matched regardless of the configuration language. A {@link Set} is used to
+     * deduplicate the variants. A {@code null} input yields an empty set.
+     *
+     * @param objects the requested object FQN filters, may be {@code null}
+     * @return the deduplicated, lowercased FQN variants (never {@code null})
+     */
+    private static Set<String> buildObjectFilterVariants(List<String> objects)
+    {
+        final Set<String> finalObjects = new HashSet<>();
+        if (objects != null)
+        {
+            for (String fqn : objects)
+            {
+                finalObjects.addAll(MetadataTypeUtils.getAllFqnVariants(fqn));
+            }
+        }
+        return finalObjects;
+    }
+
+    /**
+     * Groups all markers by their owning project in a single pass, honoring an optional
+     * {@code projectName} filter. {@link Marker#getProject()} does not touch
+     * {@code resolvedDataCache}, so this is safe outside a BM transaction. Grouping once avoids
+     * re-streaming all markers per project (previously O(markers x projects)). Marker
+     * presentation must still be resolved inside a BM read transaction bound to a single
+     * project's model, so the subsequent processing stays project by project.
+     *
+     * @param markerManager the marker manager supplying the markers
+     * @param projectName the project name filter, may be {@code null}/empty for all projects
+     * @return markers grouped by project, in encounter order
+     */
+    private static Map<IProject, List<Marker>> groupMarkersByProject(IMarkerManager markerManager,
+        String projectName)
+    {
+        Map<IProject, List<Marker>> markersByProject = new LinkedHashMap<>();
+        markerManager.markers().forEach(marker -> {
+            IProject markerProject = marker.getProject();
+            if (markerProject == null || !markerProject.exists())
+            {
+                return;
+            }
+            if (projectName != null && !projectName.isEmpty()
+                && !projectName.equals(markerProject.getName()))
+            {
+                return;
+            }
+            markersByProject.computeIfAbsent(markerProject, k -> new ArrayList<>()).add(marker);
+        });
+        return markersByProject;
+    }
+
+    /**
+     * Collects matching {@link ErrorInfo} entries from the per-project markers, applying the
+     * severity/checkId/objects filters and respecting {@code limit}. Each project's markers are
+     * processed inside a BM read transaction (when a model is available) so that
+     * {@link Marker#getObjectPresentation()} can resolve lazily; projects without a BM model are
+     * processed best-effort. The {@code unresolvedShown}/{@code unresolvedFilteredOut} holders
+     * are advanced as markers fail to resolve.
+     *
+     * @param markersByProject the markers grouped by project, in processing order
+     * @param bmModelManager the BM model manager, may be {@code null}
+     * @param severityFilter the severity filter, or {@code null} for all severities
+     * @param checkId the checkId substring filter, may be {@code null}/empty
+     * @param objects the normalized object FQN variants (empty for no object filter)
+     * @param checkRepository the check repository for symbolic id resolution, may be {@code null}
+     * @param limit the maximum number of collected errors
+     * @param unresolvedShown out-counter for markers reported with a placeholder location
+     * @param unresolvedFilteredOut out-counter for markers excluded by an active object filter
+     * @return the collected errors, capped at {@code limit}
+     */
+    private static List<ErrorInfo> collectErrors(Map<IProject, List<Marker>> markersByProject,
+        IBmModelManager bmModelManager, MarkerSeverity severityFilter, String checkId,
+        Set<String> objects, ICheckRepository checkRepository, int limit,
+        int[] unresolvedShown, int[] unresolvedFilteredOut)
+    {
+        final List<ErrorInfo> errors = new ArrayList<>();
+        for (Map.Entry<IProject, List<Marker>> entry : markersByProject.entrySet())
+        {
+            if (errors.size() >= limit)
+            {
+                break;
+            }
+
+            final List<Marker> projectMarkers = entry.getValue();
+            final int remaining = limit - errors.size();
+
+            // Resolve the project's BM model so getObjectPresentation() can lazily
+            // resolve the marker target inside a read transaction. The getModel(IProject)
+            // overload is the idiomatic path used across the plugin (FindReferencesTool,
+            // CreateMetadataTool, tag tools), so no IDtProjectManager is needed.
+            IBmModel bmModel = bmModelManager != null ? bmModelManager.getModel(entry.getKey()) : null;
+
+            Runnable collector = () -> projectMarkers.stream()
+                .map(marker -> buildIfMatches(marker, severityFilter, checkId,
+                    objects, checkRepository, unresolvedShown, unresolvedFilteredOut))
+                .filter(error -> error != null)
+                .limit(remaining)
+                .forEach(errors::add);
+
+            if (bmModel != null)
+            {
+                BmTransactions.<Void>read(bmModel, "CollectProjectErrors", (tx, pm) -> { //$NON-NLS-1$
+                    collector.run();
+                    return null;
+                });
+            }
+            else
+            {
+                // Not an EDT project (no BM model): best effort. Per-marker access is
+                // still guarded, so an unresolved marker is reported, never dropped.
+                collector.run();
+            }
+        }
+        return errors;
+    }
+
+    /**
+     * Appends the "No Errors Found" Markdown section, echoing whichever filters were applied
+     * (project, severity, objects), to {@code md}.
+     *
+     * @param md the Markdown builder to append to
+     * @param projectName the project filter, may be {@code null}/empty
+     * @param severity the severity filter, may be {@code null}/empty
+     * @param objects the object filters, may be {@code null}/empty
+     */
+    private static void appendNoErrorsSection(StringBuilder md, String projectName, String severity,
+        List<String> objects)
+    {
+        md.append("# No Errors Found\n\n"); //$NON-NLS-1$
+        if (projectName != null && !projectName.isEmpty())
+        {
+            md.append("Project: **").append(projectName).append("**\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        if (severity != null && !severity.isEmpty())
+        {
+            md.append("Severity filter: ").append(severity).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        if (objects != null && !objects.isEmpty())
+        {
+            md.append("Objects filter: ").append(String.join(", ", objects)).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        md.append("\nNo configuration problems match the specified criteria."); //$NON-NLS-1$
+    }
+
+    /**
+     * Appends the "Configuration Problems" Markdown section — the found-count header, the
+     * table header and one row per error — to {@code md}.
+     *
+     * @param md the Markdown builder to append to
+     * @param errors the collected errors (must be non-empty)
+     * @param limit the result limit (drives the "limit reached" notice)
+     * @param detailed when {@code true} include the secondary {@code Has docs} column
+     */
+    private static void appendProblemsTable(StringBuilder md, List<ErrorInfo> errors, int limit,
+        boolean detailed)
+    {
+        md.append("# Configuration Problems\n\n"); //$NON-NLS-1$
+        md.append("**Found:** ").append(errors.size()); //$NON-NLS-1$
+        if (errors.size() >= limit)
+        {
+            md.append(Pagination.limitReachedNotice(limit));
+        }
+        md.append("\n\n"); //$NON-NLS-1$
+
+        appendProblemsTableHeader(md, detailed);
+        for (ErrorInfo error : errors)
+        {
+            appendProblemRow(md, error, detailed);
+        }
+    }
+
+    /**
+     * Appends the Configuration Problems table header to {@code md}. Built via the shared
+     * {@link MarkdownUtils} table builder so every cell is escaped. concise (default) drops the
+     * secondary 'Has docs' column to save tokens; detailed keeps the full historical set of
+     * columns. Every essential / actionable column (Description, Location, Module path, Line,
+     * Check code) is present in BOTH modes.
+     *
+     * @param md the Markdown builder to append to
+     * @param detailed when {@code true} include the secondary {@code Has docs} column
+     */
+    private static void appendProblemsTableHeader(StringBuilder md, boolean detailed)
+    {
+        if (detailed)
+        {
+            md.append(MarkdownUtils.tableHeader("Description", "Location", //$NON-NLS-1$ //$NON-NLS-2$
+                "Module path", "Line", "Check code", "Has docs")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        }
+        else
+        {
+            md.append(MarkdownUtils.tableHeader("Description", "Location", //$NON-NLS-1$ //$NON-NLS-2$
+                "Module path", "Line", "Check code")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        }
+    }
+
+    /**
+     * Appends a single Configuration Problems table row for {@code error} to {@code md},
+     * matching the column set selected by {@code detailed}.
+     *
+     * @param md the Markdown builder to append to
+     * @param error the error to render
+     * @param detailed when {@code true} include the secondary {@code Has docs} cell
+     */
+    private static void appendProblemRow(StringBuilder md, ErrorInfo error, boolean detailed)
+    {
+        // Show symbolic check ID if available, otherwise show check code
+        String displayCheckId = error.checkId != null && !error.checkId.isEmpty()
+            ? error.checkId
+            : error.checkCode;
+        // Wrap the check code in backticks; tableRow escapes the cell, so do NOT
+        // pre-escape here (double-escaping would mangle a pipe in the id).
+        String checkCell = "`" + (displayCheckId != null ? displayCheckId : "") + "`"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        String modulePathCell = error.modulePath != null ? error.modulePath : ""; //$NON-NLS-1$
+        String lineCell = error.line != null ? error.line.toString() : ""; //$NON-NLS-1$
+
+        if (detailed)
+        {
+            md.append(MarkdownUtils.tableRow(error.message, error.objectPresentation,
+                modulePathCell, lineCell, checkCell,
+                error.hasDocumentation ? "true" : "false")); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        else
+        {
+            md.append(MarkdownUtils.tableRow(error.message, error.objectPresentation,
+                modulePathCell, lineCell, checkCell));
+        }
+    }
+
+    /**
+     * Surfaces unresolved markers explicitly instead of silently dropping them, appending the
+     * two distinct warning blocks to {@code md} when their counters are positive. They are
+     * reported separately so each warning matches reality.
+     *
+     * @param md the Markdown builder to append to
+     * @param unresolvedShown count of markers reported with a placeholder location
+     * @param unresolvedFilteredOut count of markers excluded by an active object filter
+     */
+    private static void appendUnresolvedWarnings(StringBuilder md, int[] unresolvedShown,
+        int[] unresolvedFilteredOut)
+    {
+        if (unresolvedShown[0] > 0)
+        {
+            md.append("\n> ⚠️ ").append(unresolvedShown[0]) //$NON-NLS-1$
+              .append(" marker(s) could not be resolved and are shown with a placeholder location. ") //$NON-NLS-1$
+              .append("Run clean_project / revalidate_objects to refresh them."); //$NON-NLS-1$
+        }
+        if (unresolvedFilteredOut[0] > 0)
+        {
+            md.append("\n> ⚠️ ").append(unresolvedFilteredOut[0]) //$NON-NLS-1$
+              .append(" marker(s) were excluded from the object filter because their location could not be resolved. ") //$NON-NLS-1$
+              .append("Run clean_project / revalidate_objects, or remove the objects filter, to include them."); //$NON-NLS-1$
         }
     }
     

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
@@ -151,68 +151,7 @@ public class MetadataRenameService
         // Phase 1: collect all changes and problems
         List<ChangePoint> allChanges = new ArrayList<>();
         List<String> allProblems = new ArrayList<>();
-        int[] indexCounter = {0};
-
-        for (IRefactoring refactoring : refactorings)
-        {
-            String title = refactoring.getTitle();
-
-            Collection<IRefactoringItem> items = refactoring.getItems();
-            if (items != null)
-            {
-                for (IRefactoringItem item : items)
-                {
-                    if (item instanceof INativeChangeRefactoringItem nativeItem)
-                    {
-                        Change nativeChange = nativeItem.getNativeChange();
-                        if (nativeChange != null)
-                        {
-                            collectFlatChanges(nativeChange, null, null, exactMatches, allChanges, indexCounter, title,
-                                item.isOptional(), oldName);
-                        }
-                    }
-                    else
-                    {
-                        allChanges.add(new ChangePoint(
-                            indexCounter[0]++, "rename", null, null, //$NON-NLS-1$
-                            item.getName(), item.isOptional(), item.isChecked(), title));
-                    }
-                }
-            }
-
-            RefactoringStatus status = refactoring.getStatus();
-            if (status != null)
-            {
-                Collection<IRefactoringProblem> problems = status.getProblems();
-                if (problems != null)
-                {
-                    for (IRefactoringProblem problem : problems)
-                    {
-                        StringBuilder pb = new StringBuilder();
-                        if (problem instanceof CleanReferenceProblem crp)
-                        {
-                            org.eclipse.emf.ecore.EObject refObj = crp.getReferencingObject();
-                            if (refObj instanceof IBmObject bmObj)
-                            {
-                                pb.append(bmObj.bmGetFqn());
-                            }
-                            org.eclipse.emf.ecore.EStructuralFeature feat = crp.getReference();
-                            if (feat != null)
-                            {
-                                pb.append(" \u2192 ").append(feat.getName()); //$NON-NLS-1$
-                            }
-                        }
-                        org.eclipse.emf.ecore.EObject obj = problem.getObject();
-                        if (obj instanceof IBmObject bmObj)
-                        {
-                            if (pb.length() > 0) pb.append(" | "); //$NON-NLS-1$
-                            pb.append(bmObj.bmGetFqn());
-                        }
-                        allProblems.add(pb.toString());
-                    }
-                }
-            }
-        }
+        collectChangesAndProblems(refactorings, exactMatches, oldName, allChanges, allProblems);
 
         applyEdtBslPreviewData(allChanges, edtBslPreviewChanges);
 
@@ -221,6 +160,117 @@ public class MetadataRenameService
 
         // Phase 2: build markdown with YAML frontmatter
         StringBuilder sb = new StringBuilder();
+        appendFrontmatter(sb, objectFqn, newName, allChanges, allProblems, exactMatches, enabledCount, shown);
+        appendChangePointsTable(sb, allChanges, shown);
+        appendCodeContext(sb, allChanges, shown);
+        appendProblemsSection(sb, allProblems);
+        appendFooter(sb);
+
+        return sb.toString();
+    }
+
+    /**
+     * Phase 1 of the preview: walks every refactoring, flattening its items into change points and
+     * accumulating its status problems, preserving the original collection (and index) ordering.
+     */
+    private void collectChangesAndProblems(Collection<IRefactoring> refactorings,
+        Map<String, ExactMatchInfo> exactMatches, String oldName, List<ChangePoint> allChanges,
+        List<String> allProblems)
+    {
+        int[] indexCounter = {0};
+        for (IRefactoring refactoring : refactorings)
+        {
+            String title = refactoring.getTitle();
+            collectRefactoringItems(refactoring, title, exactMatches, oldName, allChanges, indexCounter);
+            collectRefactoringProblems(refactoring, allProblems);
+        }
+    }
+
+    /**
+     * Flattens one refactoring's items into change points: native items recurse through the LTK change
+     * tree, while plain rename items each consume one global index. Preserves the original ordering.
+     */
+    private void collectRefactoringItems(IRefactoring refactoring, String title,
+        Map<String, ExactMatchInfo> exactMatches, String oldName, List<ChangePoint> allChanges, int[] indexCounter)
+    {
+        Collection<IRefactoringItem> items = refactoring.getItems();
+        if (items == null)
+        {
+            return;
+        }
+        for (IRefactoringItem item : items)
+        {
+            if (item instanceof INativeChangeRefactoringItem nativeItem)
+            {
+                Change nativeChange = nativeItem.getNativeChange();
+                if (nativeChange != null)
+                {
+                    collectFlatChanges(nativeChange, null, null, exactMatches, allChanges, indexCounter, title,
+                        item.isOptional(), oldName);
+                }
+            }
+            else
+            {
+                allChanges.add(new ChangePoint(
+                    indexCounter[0]++, "rename", null, null, //$NON-NLS-1$
+                    item.getName(), item.isOptional(), item.isChecked(), title));
+            }
+        }
+    }
+
+    /** Appends one formatted problem line per problem in the refactoring's status (if any). */
+    private void collectRefactoringProblems(IRefactoring refactoring, List<String> allProblems)
+    {
+        RefactoringStatus status = refactoring.getStatus();
+        if (status == null)
+        {
+            return;
+        }
+        Collection<IRefactoringProblem> problems = status.getProblems();
+        if (problems == null)
+        {
+            return;
+        }
+        for (IRefactoringProblem problem : problems)
+        {
+            allProblems.add(formatProblem(problem));
+        }
+    }
+
+    /**
+     * Formats a single refactoring problem as a one-line string: clean-reference source/feature
+     * (when applicable) joined with the problem object's FQN, matching the original rendering.
+     */
+    private static String formatProblem(IRefactoringProblem problem)
+    {
+        StringBuilder pb = new StringBuilder();
+        if (problem instanceof CleanReferenceProblem crp)
+        {
+            org.eclipse.emf.ecore.EObject refObj = crp.getReferencingObject();
+            if (refObj instanceof IBmObject bmObj)
+            {
+                pb.append(bmObj.bmGetFqn());
+            }
+            org.eclipse.emf.ecore.EStructuralFeature feat = crp.getReference();
+            if (feat != null)
+            {
+                pb.append(" \u2192 ").append(feat.getName()); //$NON-NLS-1$
+            }
+        }
+        org.eclipse.emf.ecore.EObject obj = problem.getObject();
+        if (obj instanceof IBmObject bmObj)
+        {
+            if (pb.length() > 0) pb.append(" | "); //$NON-NLS-1$
+            pb.append(bmObj.bmGetFqn());
+        }
+        return pb.toString();
+    }
+
+    /** Appends the YAML frontmatter, title, totals and (when truncated) the "showing N of M" note. */
+    private void appendFrontmatter(StringBuilder sb, String objectFqn, String newName,
+        List<ChangePoint> allChanges, List<String> allProblems, Map<String, ExactMatchInfo> exactMatches,
+        long enabledCount, int shown)
+    {
         sb.append("---\n"); //$NON-NLS-1$
         sb.append("action: preview\n"); //$NON-NLS-1$
         sb.append("objectFqn: ").append(objectFqn).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -243,31 +293,17 @@ public class MetadataRenameService
               .append(" changes. Pass `maxResults=").append(allChanges.size()) //$NON-NLS-1$
               .append("` to see all._\n\n"); //$NON-NLS-1$
         }
+    }
 
-        // Change points table
+    /** Appends the change-points markdown table (header, the first {@code shown} rows, and the overflow row). */
+    private void appendChangePointsTable(StringBuilder sb, List<ChangePoint> allChanges, int shown)
+    {
         sb.append("## Change Points\n\n"); //$NON-NLS-1$
                 sb.append("| # | Type | Description | Line | Col | Default | Skippable | Project | FQN |\n"); //$NON-NLS-1$
                 sb.append("|---|------|-------------|------|-----|---------|-----------|---------|-----|\n"); //$NON-NLS-1$
         for (int i = 0; i < shown; i++)
         {
-            ChangePoint cp = allChanges.get(i);
-            String enabledMark = cp.enabled ? "\u2705" : "\u274c"; //$NON-NLS-1$ //$NON-NLS-2$
-            String optionalMark = cp.optional ? "yes" : "no"; //$NON-NLS-1$ //$NON-NLS-2$
-            String fqnCell = cp.fqn != null ? escapeMarkdownCell(cp.fqn) : DASH;
-            String projectCell = cp.project != null ? escapeMarkdownCell(cp.project) : DASH;
-            String line = cp.lineNumber > 0 ? String.valueOf(cp.lineNumber) : DASH;
-                        String column = cp.columnNumber > 0 ? String.valueOf(cp.columnNumber) : DASH;
-            String description = cp.description != null ? escapeMarkdownCell(cp.description) : DASH;
-            sb.append("| ").append(cp.index) //$NON-NLS-1$
-              .append(" | ").append(cp.type) //$NON-NLS-1$
-              .append(" | ").append(description) //$NON-NLS-1$
-              .append(" | ").append(line) //$NON-NLS-1$
-                            .append(" | ").append(column) //$NON-NLS-1$
-              .append(" | ").append(enabledMark) //$NON-NLS-1$
-              .append(" | ").append(optionalMark) //$NON-NLS-1$
-              .append(" | ").append(projectCell) //$NON-NLS-1$
-              .append(" | ").append(fqnCell) //$NON-NLS-1$
-              .append(" |\n"); //$NON-NLS-1$
+            appendChangePointRow(sb, allChanges.get(i));
         }
         if (allChanges.size() > shown)
         {
@@ -275,8 +311,36 @@ public class MetadataRenameService
               .append(" more_ |\n"); //$NON-NLS-1$
         }
         sb.append("\n"); //$NON-NLS-1$
+    }
 
-        // Code context section
+    /** Appends one markdown table row for a single change point, rendering empty cells as an em dash. */
+    private void appendChangePointRow(StringBuilder sb, ChangePoint cp)
+    {
+        String enabledMark = cp.enabled ? "\u2705" : "\u274c"; //$NON-NLS-1$ //$NON-NLS-2$
+        String optionalMark = cp.optional ? "yes" : "no"; //$NON-NLS-1$ //$NON-NLS-2$
+        String fqnCell = cp.fqn != null ? escapeMarkdownCell(cp.fqn) : DASH;
+        String projectCell = cp.project != null ? escapeMarkdownCell(cp.project) : DASH;
+        String line = cp.lineNumber > 0 ? String.valueOf(cp.lineNumber) : DASH;
+                    String column = cp.columnNumber > 0 ? String.valueOf(cp.columnNumber) : DASH;
+        String description = cp.description != null ? escapeMarkdownCell(cp.description) : DASH;
+        sb.append("| ").append(cp.index) //$NON-NLS-1$
+          .append(" | ").append(cp.type) //$NON-NLS-1$
+          .append(" | ").append(description) //$NON-NLS-1$
+          .append(" | ").append(line) //$NON-NLS-1$
+                        .append(" | ").append(column) //$NON-NLS-1$
+          .append(" | ").append(enabledMark) //$NON-NLS-1$
+          .append(" | ").append(optionalMark) //$NON-NLS-1$
+          .append(" | ").append(projectCell) //$NON-NLS-1$
+          .append(" | ").append(fqnCell) //$NON-NLS-1$
+          .append(" |\n"); //$NON-NLS-1$
+    }
+
+    /**
+     * Appends the code-context section (one block per shown change point that carries a snippet),
+     * but only when at least one of the shown change points actually has a code context.
+     */
+    private void appendCodeContext(StringBuilder sb, List<ChangePoint> allChanges, int shown)
+    {
         boolean hasContext = false;
         for (int i = 0; i < shown; i++)
         {
@@ -286,40 +350,47 @@ public class MetadataRenameService
                 break;
             }
         }
-        if (hasContext)
+        if (!hasContext)
         {
-            sb.append("## Code Context\n\n"); //$NON-NLS-1$
-            for (int i = 0; i < shown; i++)
-            {
-                ChangePoint cp = allChanges.get(i);
-                if (cp.codeContext == null)
-                    continue;
-                sb.append("### #").append(cp.index); //$NON-NLS-1$
-                if (cp.methodName != null)
-                    sb.append(" \u2014 `").append(escapeMarkdownCell(cp.methodName)).append("`"); //$NON-NLS-1$ //$NON-NLS-2$
-                if (cp.fqn != null && cp.lineNumber > 0)
-                    sb.append(" \u00b7 ").append(escapeMarkdownCell(cp.fqn)) //$NON-NLS-1$
-                      .append(":").append(cp.lineNumber); //$NON-NLS-1$
-                sb.append("\n```bsl\n").append(cp.codeContext).append("```\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            }
+            return;
         }
-
-        // Problems section
-        if (!allProblems.isEmpty())
+        sb.append("## Code Context\n\n"); //$NON-NLS-1$
+        for (int i = 0; i < shown; i++)
         {
-            sb.append("## Problems\n\n"); //$NON-NLS-1$
-            for (String p : allProblems)
-            {
-                sb.append("- ").append(p).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            }
-            sb.append("\n"); //$NON-NLS-1$
+            ChangePoint cp = allChanges.get(i);
+            if (cp.codeContext == null)
+                continue;
+            sb.append("### #").append(cp.index); //$NON-NLS-1$
+            if (cp.methodName != null)
+                sb.append(" \u2014 `").append(escapeMarkdownCell(cp.methodName)).append("`"); //$NON-NLS-1$ //$NON-NLS-2$
+            if (cp.fqn != null && cp.lineNumber > 0)
+                sb.append(" \u00b7 ").append(escapeMarkdownCell(cp.fqn)) //$NON-NLS-1$
+                  .append(":").append(cp.lineNumber); //$NON-NLS-1$
+            sb.append("\n```bsl\n").append(cp.codeContext).append("```\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
         }
+    }
 
+    /** Appends the problems section (one bullet per problem) when any problems were collected. */
+    private void appendProblemsSection(StringBuilder sb, List<String> allProblems)
+    {
+        if (allProblems.isEmpty())
+        {
+            return;
+        }
+        sb.append("## Problems\n\n"); //$NON-NLS-1$
+        for (String p : allProblems)
+        {
+            sb.append("- ").append(p).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        sb.append("\n"); //$NON-NLS-1$
+    }
+
+    /** Appends the trailing usage hint (confirm/disableIndices) shared by every preview. */
+    private void appendFooter(StringBuilder sb)
+    {
         sb.append("> To execute, call with `confirm=true`.\n"); //$NON-NLS-1$
         sb.append("> Use `disableIndices='1,2,3'` to skip change points by their `#` index " //$NON-NLS-1$
             + "(optional only; one index may span several context rows - skipping it skips them all).\n"); //$NON-NLS-1$
-
-        return sb.toString();
     }
 
     /** Simple data holder for a single change point in preview. */
@@ -393,6 +464,24 @@ public class MetadataRenameService
     }
 
     /**
+     * Mutable accumulator threaded through the per-leaf scan helpers so they can
+     * report back the resolved {@code fqn}/{@code project} (refined from the change
+     * itself) and whether they already added one or more change points for the leaf.
+     */
+    private static final class LeafScan
+    {
+        String fqn;
+        String project;
+        boolean addedFallbackChange;
+
+        LeafScan(String fqn, String project)
+        {
+            this.fqn = fqn;
+            this.project = project;
+        }
+    }
+
+    /**
      * Recursively collects leaf changes from LTK change tree into a flat list with global indices.
      * Extracts line number and code context (±3 lines + containing method) for TextChange leaves.
      */
@@ -411,161 +500,210 @@ public class MetadataRenameService
         }
         if (change instanceof CompositeChange composite)
         {
-            Change[] children = composite.getChildren();
-            if (children != null && children.length > 0)
-            {
-                for (Change child : children)
-                {
-                    collectFlatChanges(child, currentFqn, currentProject, exactMatches, result, indexCounter,
-                        refactoringTitle, optional, oldName);
-                }
-            }
+            recurseComposite(composite, currentFqn, currentProject, exactMatches, result, indexCounter,
+                refactoringTitle, optional, oldName);
         }
         else
         {
-            // One index per leaf change - this MUST match the leaf numbering in
-            // walkLeafChanges()/applyDisableToChange() so a preview index stays a
-            // stable cross-call handle for disableIndices. A leaf may render as
-            // several display rows (multiple exact matches / text edits) or none
-            // (suppressed), but it always consumes exactly one index. (card A2)
-            int leafIndex = indexCounter[0]++;
-            boolean hasExactMatches = exactMatches != null && !exactMatches.isEmpty();
-            boolean isBslReferenceChange = isBslReferenceChange(change, currentFqn);
-            boolean isFullTextSearchChange = isFullTextSearchSourceFileChange(change);
-            boolean addedFallbackChange = false;
-            int lineNumber = -1;
-            int columnNumber = -1;
-            String codeContext = null;
-            String methodName = null;
-            String fqn = currentFqn;
-            String project = currentProject;
-            List<ExactMatchInfo> exactMatchInfos = findExactMatchInfos(change, exactMatches);
-            logPreviewMapping(change, fqn, project, exactMatchInfos.size());
-            if (!exactMatchInfos.isEmpty())
-            {
-                for (ExactMatchInfo exactMatch : exactMatchInfos)
-                {
-                    String exactFqn = exactMatch.fqn != null ? exactMatch.fqn : fqn;
-                    String exactProject = exactMatch.project != null ? exactMatch.project : project;
-                    result.add(new ChangePoint(
-                        leafIndex, BSL_REF, exactFqn, exactProject,
-                        change.getName(), optional, change.isEnabled(), refactoringTitle,
-                        exactMatch.lineNumber, exactMatch.columnNumber, exactMatch.codeContext, exactMatch.methodName));
-                }
-                return;
-            }
-            else if (change instanceof BmObjectTextContentChange<?> bmChange)
-            {
-                try
-                {
-                    project = bmChange.getProjectName();
-                    Object modifiedElement = bmChange.getModifiedElement();
-                    EObject bmObj = modifiedElement instanceof EObject ? (EObject) modifiedElement : null;
-                    if (modifiedElement instanceof IBmObject ibm)
-                    {
-                        fqn = ibm.bmGetFqn();
-                    }
-                    String content = bmChange.getCurrentContent(new NullProgressMonitor());
-                    TextEdit edit = bmChange.getEdit();
-                    if (content != null && !content.isEmpty() && edit != null)
-                    {
-                        List<TextEdit> leafEdits = getLeafEdits(edit);
-                        if (!leafEdits.isEmpty())
-                        {
-                            for (TextEdit leafEdit : leafEdits)
-                            {
-                                int matchedLineNumber = computeLineNumber(content, leafEdit.getOffset());
-                                int matchedColumnNumber = computeColumnNumber(content, leafEdit.getOffset());
-                                String matchedCodeContext = extractContext(content, matchedLineNumber);
-                                String matchedMethodName = null;
-                                if (bmObj instanceof Module module)
-                                {
-                                    matchedMethodName = findContainingMethodAst(module, matchedLineNumber);
-                                }
-                                if (matchedMethodName == null)
-                                {
-                                    matchedMethodName = findContainingMethodText(content, matchedLineNumber);
-                                }
-                                result.add(new ChangePoint(
-                                    leafIndex, BSL_REF, fqn, project,
-                                    change.getName(), optional, change.isEnabled(), refactoringTitle,
-                                    matchedLineNumber, matchedColumnNumber, matchedCodeContext, matchedMethodName));
-                            }
-                            addedFallbackChange = true;
-                        }
-                    }
-                }
-                catch (Exception e)
-                {
-                    Activator.logError("Error extracting BSL change location", e); //$NON-NLS-1$
-                }
-            }
-            else
-            {
-                try
-                {
-                    IFile file = getIFile(change);
-                    if (file != null)
-                    {
-                        project = file.getProject().getName();
-                        String resolvedFqn = getBslFqn(file);
-                        if (resolvedFqn != null && !resolvedFqn.isEmpty())
-                        {
-                            fqn = resolvedFqn;
-                        }
-                        String content = BslModuleUtils.readFileText(file);
-                        TextEdit edit = getChangeEdit(change);
-                        if (content != null && !content.isEmpty() && edit != null)
-                        {
-                            List<TextEdit> leafEdits = getLeafEdits(edit);
-                            if (!leafEdits.isEmpty())
-                            {
-                                Module module = BslModuleUtils.loadModule(file.getProject(), BslModuleUtils.extractModulePath(file.getFullPath().toString()));
-                                for (TextEdit leafEdit : leafEdits)
-                                {
-                                    int matchedLineNumber = computeLineNumber(content, leafEdit.getOffset());
-                                    int matchedColumnNumber = computeColumnNumber(content, leafEdit.getOffset());
-                                    String matchedCodeContext = extractContext(content, matchedLineNumber);
-                                    String matchedMethodName = null;
-                                    if (module != null)
-                                    {
-                                        matchedMethodName = findContainingMethodAst(module, matchedLineNumber);
-                                    }
-                                    if (matchedMethodName == null)
-                                    {
-                                        matchedMethodName = findContainingMethodText(content, matchedLineNumber);
-                                    }
-                                    result.add(new ChangePoint(
-                                        leafIndex, BSL_REF, fqn, project,
-                                        change.getName(), optional, change.isEnabled(), refactoringTitle,
-                                        matchedLineNumber, matchedColumnNumber, matchedCodeContext, matchedMethodName));
-                                }
-                                addedFallbackChange = true;
-                            }
-                        }
-                    }
-                }
-                catch (Exception e)
-                {
-                    Activator.logError("Error extracting source file change location", e); //$NON-NLS-1$
-                }
-            }
-
-            if (addedFallbackChange)
-            {
-                return;
-            }
-
-            if (hasExactMatches && isBslReferenceChange && isFullTextSearchChange)
-            {
-                return;
-            }
-
-            result.add(new ChangePoint(
-                indexCounter[0]++, BSL_REF, fqn, project,
-                change.getName(), optional, change.isEnabled(), refactoringTitle,
-                lineNumber, columnNumber, codeContext, methodName));
+            collectLeafChange(change, currentFqn, currentProject, exactMatches, result, indexCounter,
+                refactoringTitle, optional);
         }
+    }
+
+    /** Recurses into the children of a composite change, preserving the inherited fqn/project context. */
+    private void recurseComposite(CompositeChange composite, String currentFqn, String currentProject,
+        Map<String, ExactMatchInfo> exactMatches, List<ChangePoint> result, int[] indexCounter,
+        String refactoringTitle, boolean optional, String oldName)
+    {
+        Change[] children = composite.getChildren();
+        if (children != null && children.length > 0)
+        {
+            for (Change child : children)
+            {
+                collectFlatChanges(child, currentFqn, currentProject, exactMatches, result, indexCounter,
+                    refactoringTitle, optional, oldName);
+            }
+        }
+    }
+
+    /**
+     * Handles a single leaf (non-composite) change: consumes exactly one global index, then renders
+     * either the exact-match rows, the BSL/source extracted rows, or the bare fallback row. Mirrors
+     * the leaf numbering of {@link #walkLeafChanges} so a preview {@code #index} stays a stable handle.
+     */
+    private void collectLeafChange(Change change, String currentFqn, String currentProject,
+        Map<String, ExactMatchInfo> exactMatches, List<ChangePoint> result, int[] indexCounter,
+        String refactoringTitle, boolean optional)
+    {
+        // One index per leaf change - this MUST match the leaf numbering in
+        // walkLeafChanges()/applyDisableToChange() so a preview index stays a
+        // stable cross-call handle for disableIndices. A leaf may render as
+        // several display rows (multiple exact matches / text edits) or none
+        // (suppressed), but it always consumes exactly one index. (card A2)
+        int leafIndex = indexCounter[0]++;
+        boolean hasExactMatches = exactMatches != null && !exactMatches.isEmpty();
+        boolean isBslReferenceChange = isBslReferenceChange(change, currentFqn);
+        boolean isFullTextSearchChange = isFullTextSearchSourceFileChange(change);
+        LeafScan scan = new LeafScan(currentFqn, currentProject);
+        List<ExactMatchInfo> exactMatchInfos = findExactMatchInfos(change, exactMatches);
+        logPreviewMapping(change, scan.fqn, scan.project, exactMatchInfos.size());
+        if (!exactMatchInfos.isEmpty())
+        {
+            addExactMatchChangePoints(change, leafIndex, scan, exactMatchInfos, result, refactoringTitle, optional);
+            return;
+        }
+        else if (change instanceof BmObjectTextContentChange<?> bmChange)
+        {
+            scanBmTextContentChange(change, bmChange, leafIndex, scan, result, refactoringTitle, optional);
+        }
+        else
+        {
+            scanSourceFileChange(change, leafIndex, scan, result, refactoringTitle, optional);
+        }
+
+        if (scan.addedFallbackChange)
+        {
+            return;
+        }
+
+        if (hasExactMatches && isBslReferenceChange && isFullTextSearchChange)
+        {
+            return;
+        }
+
+        result.add(new ChangePoint(
+            indexCounter[0]++, BSL_REF, scan.fqn, scan.project,
+            change.getName(), optional, change.isEnabled(), refactoringTitle,
+            -1, -1, null, null));
+    }
+
+    /** Emits one change point per resolved exact-match, defaulting fqn/project to the leaf context. */
+    private void addExactMatchChangePoints(Change change, int leafIndex, LeafScan scan,
+        List<ExactMatchInfo> exactMatchInfos, List<ChangePoint> result, String refactoringTitle, boolean optional)
+    {
+        for (ExactMatchInfo exactMatch : exactMatchInfos)
+        {
+            String exactFqn = exactMatch.fqn != null ? exactMatch.fqn : scan.fqn;
+            String exactProject = exactMatch.project != null ? exactMatch.project : scan.project;
+            result.add(new ChangePoint(
+                leafIndex, BSL_REF, exactFqn, exactProject,
+                change.getName(), optional, change.isEnabled(), refactoringTitle,
+                exactMatch.lineNumber, exactMatch.columnNumber, exactMatch.codeContext, exactMatch.methodName));
+        }
+    }
+
+    /**
+     * Extracts line/column/context for a BM model text-content change, refining scan.fqn/project and
+     * adding one change point per leaf edit. Swallows extraction errors exactly as before (logs only).
+     */
+    private void scanBmTextContentChange(Change change, BmObjectTextContentChange<?> bmChange, int leafIndex,
+        LeafScan scan, List<ChangePoint> result, String refactoringTitle, boolean optional)
+    {
+        try
+        {
+            scan.project = bmChange.getProjectName();
+            Object modifiedElement = bmChange.getModifiedElement();
+            EObject bmObj = modifiedElement instanceof EObject ? (EObject) modifiedElement : null;
+            if (modifiedElement instanceof IBmObject ibm)
+            {
+                scan.fqn = ibm.bmGetFqn();
+            }
+            String content = bmChange.getCurrentContent(new NullProgressMonitor());
+            TextEdit edit = bmChange.getEdit();
+            if (content != null && !content.isEmpty() && edit != null)
+            {
+                List<TextEdit> leafEdits = getLeafEdits(edit);
+                if (!leafEdits.isEmpty())
+                {
+                    Module module = bmObj instanceof Module bslModule ? bslModule : null;
+                    addLeafEditChangePoints(change, leafIndex, scan, leafEdits, content, module, result,
+                        refactoringTitle, optional);
+                    scan.addedFallbackChange = true;
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Activator.logError("Error extracting BSL change location", e); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Extracts line/column/context for a source-file change, refining scan.fqn/project and adding one
+     * change point per leaf edit. Swallows extraction errors exactly as before (logs only).
+     */
+    private void scanSourceFileChange(Change change, int leafIndex, LeafScan scan, List<ChangePoint> result,
+        String refactoringTitle, boolean optional)
+    {
+        try
+        {
+            IFile file = getIFile(change);
+            if (file != null)
+            {
+                scan.project = file.getProject().getName();
+                String resolvedFqn = getBslFqn(file);
+                if (resolvedFqn != null && !resolvedFqn.isEmpty())
+                {
+                    scan.fqn = resolvedFqn;
+                }
+                String content = BslModuleUtils.readFileText(file);
+                TextEdit edit = getChangeEdit(change);
+                if (content != null && !content.isEmpty() && edit != null)
+                {
+                    List<TextEdit> leafEdits = getLeafEdits(edit);
+                    if (!leafEdits.isEmpty())
+                    {
+                        Module module = BslModuleUtils.loadModule(file.getProject(),
+                            BslModuleUtils.extractModulePath(file.getFullPath().toString()));
+                        addLeafEditChangePoints(change, leafIndex, scan, leafEdits, content, module, result,
+                            refactoringTitle, optional);
+                        scan.addedFallbackChange = true;
+                    }
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Activator.logError("Error extracting source file change location", e); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Shared leaf-edit loop: for each edit computes line/column/context and the containing method, then
+     * appends a change point carrying the leaf's shared global index and the refined fqn/project.
+     */
+    private void addLeafEditChangePoints(Change change, int leafIndex, LeafScan scan, List<TextEdit> leafEdits,
+        String content, Module module, List<ChangePoint> result, String refactoringTitle, boolean optional)
+    {
+        for (TextEdit leafEdit : leafEdits)
+        {
+            int matchedLineNumber = computeLineNumber(content, leafEdit.getOffset());
+            int matchedColumnNumber = computeColumnNumber(content, leafEdit.getOffset());
+            String matchedCodeContext = extractContext(content, matchedLineNumber);
+            String matchedMethodName = resolveContainingMethod(module, content, matchedLineNumber);
+            result.add(new ChangePoint(
+                leafIndex, BSL_REF, scan.fqn, scan.project,
+                change.getName(), optional, change.isEnabled(), refactoringTitle,
+                matchedLineNumber, matchedColumnNumber, matchedCodeContext, matchedMethodName));
+        }
+    }
+
+    /**
+     * Resolves the containing method name for a line, preferring the BSL AST (when a module is
+     * available) and falling back to the regex-based text search, matching the original order.
+     */
+    private static String resolveContainingMethod(Module module, String content, int lineNumber)
+    {
+        String methodName = null;
+        if (module != null)
+        {
+            methodName = findContainingMethodAst(module, lineNumber);
+        }
+        if (methodName == null)
+        {
+            methodName = findContainingMethodText(content, lineNumber);
+        }
+        return methodName;
     }
 
     private Map<String, ExactMatchInfo> buildExactMatchInfo(IProject project, MdObject targetObject, String newName)


### PR DESCRIPTION
Band A — the **final** band of the SonarCloud S3776 cleanup (#164): the **5 heaviest methods** in the codebase (cc **64-108**), branched from current master. Each reduced under the limit of 15 via deep Extract-Method decomposition (one focused agent per method, 7-15 coherent helpers each). With this, the whole S3776 ladder is covered: cc16-18 (#172), 19-22 (#173), 23-30 (#176), 31-40 (#179), 41-60 (#180), 64-108 (this). Same rigorous pipeline: deep-study implement → **independent adversarial verify per method** → `mvn clean verify` (2202 tests). All behaviour-identical.\n\n**Methods:**\n- `PlatformDocumentationService.buildTypeDocumentation` (cc ~108→~2) — read-only markdown formatter; one helper per doc section, running item-limit count threaded via return values; **byte-identical output** verified (incl. the eager-vs-short-circuit nuance on pure EAttribute getters).\n- `MetadataRenameService.collectFlatChanges` (cc ~107→~4) and `buildPreview` (cc ~90→~3) — both **READ-ONLY** (preview / change-tree scanning); the mutating `performRename`/`refactoring.perform()` is a different method, untouched; global change-index consumption order preserved exactly.\n- `CreateProjectTool.executeExtension` (cc ~66→~9) — **MUTATING**; only validation / service resolution / compatibility-mode / response building extracted (each via a holder with a nullable error field); `factory.create`/`fillDefaultReferences`/extension-create Job/`runCreateJob` stay **inline** at the same point under the same guards (verified).\n- `GetProjectErrorsTool.getProjectErrors` (cc ~64→~9) — read-only; marker grouping, error collection (read transaction), result building split out; int[] counters threaded as before.\n\nNo behaviour change. Follows #166-173, #176, #179, #180.