### PR TITLE
Raise unit-test coverage of the headless-testable surface (#171): +496 tests

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/symbol/SymbolInfoService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/symbol/SymbolInfoService.java
@@ -545,8 +545,13 @@ public class SymbolInfoService
 
     /**
      * Builds a markdown info table for the given EObject.
+     * <p>
+     * Package-private (not {@code private}) so the same-package unit test can drive the
+     * pure per-kind formatting branches with in-memory {@code BslFactory}-built objects,
+     * without a live workbench/editor. This mirrors the test seam used by
+     * {@code AbstractMetadataFormatter}'s protected helpers.
      */
-    private String buildEObjectInfo(EObject element)
+    String buildEObjectInfo(EObject element)
     {
         StringBuilder sb = new StringBuilder();
         sb.append(MarkdownUtils.tableHeader(PROPERTY, VALUE));

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/groups/model/GroupYamlSerializationTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/groups/model/GroupYamlSerializationTest.java
@@ -1,0 +1,406 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2026 Diversus23 (https://github.com/Diversus23)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.groups.model;
+
+import static org.junit.Assert.*;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.Test;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.introspector.Property;
+import org.yaml.snakeyaml.nodes.MappingNode;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+
+/**
+ * Pure, workspace-free tests for the YAML serialization surface of
+ * {@link GroupStorage} and {@link Group}.
+ *
+ * <p>These exercise the same SnakeYAML configuration that
+ * {@code YamlGroupRepository} uses on disk, but entirely in memory via a
+ * String round-trip, so no {@code IProject}/{@code ResourcesPlugin} is
+ * required. The intent is to cover the model beans' serialization-relevant
+ * accessor paths (getters/setters driven by SnakeYAML introspection) and the
+ * on-disk YAML contract.</p>
+ */
+public class GroupYamlSerializationTest
+{
+    // ==================== SnakeYAML config mirrored from YamlGroupRepository ====================
+
+    /**
+     * Serializes a {@link GroupStorage} to a YAML String using the same
+     * representer/tag configuration as the production repository's save path.
+     */
+    private static String dump(GroupStorage storage)
+    {
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setPrettyFlow(true);
+        options.setIndent(2);
+        options.setWidth(120);
+        options.setSplitLines(false);
+
+        Representer representer = new SortedKeysRepresenter(options);
+        representer.getPropertyUtils().setSkipMissingProperties(true);
+        representer.addClassTag(GroupStorage.class, Tag.MAP);
+        representer.addClassTag(Group.class, Tag.MAP);
+
+        Yaml yaml = new Yaml(representer, options);
+        StringWriter writer = new StringWriter();
+        yaml.dump(storage, writer);
+        return writer.toString();
+    }
+
+    /**
+     * Deserializes a {@link GroupStorage} from a YAML String using the same
+     * constructor configuration as the production repository's load path.
+     */
+    private static GroupStorage load(String text)
+    {
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setTagInspector(tag -> true);
+        Constructor constructor = new Constructor(GroupStorage.class, loaderOptions);
+        // The dump emits every readable JavaBean property, including derived,
+        // setter-less getters (Group#getFullPath / #isEmpty, GroupStorage#
+        // getGroupCount / #isEmpty). Tolerate those extra keys on load so the
+        // round-trip never trips over a property that has no setter.
+        constructor.getPropertyUtils().setSkipMissingProperties(true);
+        Yaml yaml = new Yaml(constructor);
+        return yaml.load(new StringReader(text));
+    }
+
+    /**
+     * Custom representer matching the production one: outputs bean keys in
+     * sorted order for Git-friendly diffs.
+     */
+    private static class SortedKeysRepresenter extends Representer
+    {
+        SortedKeysRepresenter(DumperOptions options)
+        {
+            super(options);
+        }
+
+        @Override
+        protected MappingNode representJavaBean(java.util.Set<Property> properties, Object javaBean)
+        {
+            List<Property> sorted = new java.util.ArrayList<>(properties);
+            sorted.sort(Comparator.comparing(Property::getName));
+            return super.representJavaBean(new java.util.LinkedHashSet<>(sorted), javaBean);
+        }
+    }
+
+    // ==================== Round-trip: empty / minimal ====================
+
+    @Test
+    public void testEmptyStorageRoundTrip()
+    {
+        GroupStorage original = new GroupStorage();
+        GroupStorage restored = load(dump(original));
+        assertNotNull(restored);
+        assertTrue(restored.isEmpty());
+        assertEquals(0, restored.getGroupCount());
+    }
+
+    @Test
+    public void testSingleGroupRoundTrip()
+    {
+        GroupStorage original = new GroupStorage();
+        original.addGroup(new Group("Server", "CommonModules")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        GroupStorage restored = load(dump(original));
+
+        assertEquals(1, restored.getGroupCount());
+        Group g = restored.getGroupByFullPath("CommonModules/Server"); //$NON-NLS-1$
+        assertNotNull(g);
+        assertEquals("Server", g.getName()); //$NON-NLS-1$
+        assertEquals("CommonModules", g.getPath()); //$NON-NLS-1$
+        assertTrue(g.isEmpty());
+    }
+
+    // ==================== Round-trip: full field coverage ====================
+
+    @Test
+    public void testAllFieldsRoundTrip()
+    {
+        Group group = new Group("Reports", "Catalogs"); //$NON-NLS-1$ //$NON-NLS-2$
+        group.setDescription("Grouped reports"); //$NON-NLS-1$
+        group.setOrder(7);
+        group.addChild("Catalog.A"); //$NON-NLS-1$
+        group.addChild("Catalog.B"); //$NON-NLS-1$
+        GroupStorage original = new GroupStorage();
+        original.addGroup(group);
+
+        GroupStorage restored = load(dump(original));
+
+        Group g = restored.getGroupByFullPath("Catalogs/Reports"); //$NON-NLS-1$
+        assertNotNull(g);
+        assertEquals("Reports", g.getName()); //$NON-NLS-1$
+        assertEquals("Catalogs", g.getPath()); //$NON-NLS-1$
+        assertEquals("Grouped reports", g.getDescription()); //$NON-NLS-1$
+        assertEquals(7, g.getOrder());
+        assertEquals(2, g.getChildren().size());
+        assertTrue(g.containsChild("Catalog.A")); //$NON-NLS-1$
+        assertTrue(g.containsChild("Catalog.B")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMultipleGroupsRoundTrip()
+    {
+        GroupStorage original = new GroupStorage();
+        Group g1 = new Group("Alpha", "CommonModules"); //$NON-NLS-1$ //$NON-NLS-2$
+        g1.setOrder(1);
+        g1.addChild("CommonModule.One"); //$NON-NLS-1$
+        Group g2 = new Group("Beta", "CommonModules"); //$NON-NLS-1$ //$NON-NLS-2$
+        g2.setOrder(2);
+        Group g3 = new Group("Root", null); //$NON-NLS-1$
+        original.addGroup(g1);
+        original.addGroup(g2);
+        original.addGroup(g3);
+
+        GroupStorage restored = load(dump(original));
+
+        assertEquals(3, restored.getGroupCount());
+        assertNotNull(restored.getGroupByFullPath("CommonModules/Alpha")); //$NON-NLS-1$
+        assertNotNull(restored.getGroupByFullPath("CommonModules/Beta")); //$NON-NLS-1$
+        assertNotNull(restored.getGroupByFullPath("Root")); //$NON-NLS-1$
+    }
+
+    // ==================== Nested / hierarchical groups ====================
+
+    @Test
+    public void testNestedGroupsRoundTrip()
+    {
+        GroupStorage original = new GroupStorage();
+        original.addGroup(new Group("Parent", "Root")); //$NON-NLS-1$ //$NON-NLS-2$
+        Group child = new Group("Child", "Root/Parent"); //$NON-NLS-1$ //$NON-NLS-2$
+        child.addChild("CommonModule.Nested"); //$NON-NLS-1$
+        original.addGroup(child);
+
+        GroupStorage restored = load(dump(original));
+
+        assertEquals(2, restored.getGroupCount());
+        Group restoredChild = restored.getGroupByFullPath("Root/Parent/Child"); //$NON-NLS-1$
+        assertNotNull(restoredChild);
+        assertTrue(restoredChild.containsChild("CommonModule.Nested")); //$NON-NLS-1$
+    }
+
+    // ==================== Null / default field handling ====================
+
+    @Test
+    public void testNullPathRoundTrip()
+    {
+        GroupStorage original = new GroupStorage();
+        Group group = new Group("TopLevel", null); //$NON-NLS-1$
+        original.addGroup(group);
+
+        GroupStorage restored = load(dump(original));
+
+        Group g = restored.getGroupByFullPath("TopLevel"); //$NON-NLS-1$
+        assertNotNull(g);
+        assertNull(g.getPath());
+        assertNull(g.getDescription());
+    }
+
+    @Test
+    public void testDefaultOrderIsZeroAfterRoundTrip()
+    {
+        GroupStorage original = new GroupStorage();
+        original.addGroup(new Group("G", "P")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        GroupStorage restored = load(dump(original));
+
+        assertEquals(0, restored.getGroupByFullPath("P/G").getOrder()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testEmptyChildrenRoundTrip()
+    {
+        GroupStorage original = new GroupStorage();
+        original.addGroup(new Group("Empty", "P")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        GroupStorage restored = load(dump(original));
+
+        Group g = restored.getGroupByFullPath("P/Empty"); //$NON-NLS-1$
+        assertNotNull(g);
+        assertNotNull("children must never be null after load", g.getChildren()); //$NON-NLS-1$
+        assertTrue(g.isEmpty());
+    }
+
+    // ==================== Unicode / Cyrillic payloads ====================
+
+    @Test
+    public void testCyrillicValuesRoundTrip()
+    {
+        GroupStorage original = new GroupStorage();
+        Group group = new Group(
+            "Сервер", //$NON-NLS-1$
+            "ОбщиеМодули"); //$NON-NLS-1$
+        group.setDescription("Описание"); //$NON-NLS-1$
+        group.addChild("CommonModule.Модуль"); //$NON-NLS-1$
+        original.addGroup(group);
+
+        GroupStorage restored = load(dump(original));
+
+        Group g = restored.getGroups().get(0);
+        assertEquals("Сервер", g.getName()); //$NON-NLS-1$
+        assertEquals("ОбщиеМодули", g.getPath()); //$NON-NLS-1$
+        assertEquals("Описание", g.getDescription()); //$NON-NLS-1$
+        assertTrue(g.containsChild("CommonModule.Модуль")); //$NON-NLS-1$
+    }
+
+    // ==================== Emitted YAML shape ====================
+
+    @Test
+    public void testDumpContainsExpectedKeys()
+    {
+        GroupStorage original = new GroupStorage();
+        Group group = new Group("Server", "CommonModules"); //$NON-NLS-1$ //$NON-NLS-2$
+        group.addChild("CommonModule.X"); //$NON-NLS-1$
+        original.addGroup(group);
+
+        String yaml = dump(original);
+
+        assertTrue(yaml.contains("groups")); //$NON-NLS-1$
+        assertTrue(yaml.contains("name")); //$NON-NLS-1$
+        assertTrue(yaml.contains("Server")); //$NON-NLS-1$
+        assertTrue(yaml.contains("CommonModules")); //$NON-NLS-1$
+        assertTrue(yaml.contains("CommonModule.X")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testDumpKeysAreSortedAlphabetically()
+    {
+        GroupStorage original = new GroupStorage();
+        Group group = new Group("Server", "CommonModules"); //$NON-NLS-1$ //$NON-NLS-2$
+        group.setDescription("d"); //$NON-NLS-1$
+        group.setOrder(3);
+        group.addChild("CommonModule.X"); //$NON-NLS-1$
+        original.addGroup(group);
+
+        String yaml = dump(original);
+
+        // SortedKeysRepresenter emits bean properties alphabetically:
+        // children < description < name < order < path
+        int children = yaml.indexOf("children"); //$NON-NLS-1$
+        int description = yaml.indexOf("description"); //$NON-NLS-1$
+        int name = yaml.indexOf("name"); //$NON-NLS-1$
+        int order = yaml.indexOf("order"); //$NON-NLS-1$
+        int path = yaml.indexOf("path"); //$NON-NLS-1$
+        assertTrue("children present", children >= 0); //$NON-NLS-1$
+        assertTrue("description present", description >= 0); //$NON-NLS-1$
+        assertTrue("name present", name >= 0); //$NON-NLS-1$
+        assertTrue("order present", order >= 0); //$NON-NLS-1$
+        assertTrue("path present", path >= 0); //$NON-NLS-1$
+        assertTrue(children < description);
+        assertTrue(description < name);
+        assertTrue(name < order);
+        assertTrue(order < path);
+    }
+
+    // ==================== Loading hand-written YAML ====================
+
+    @Test
+    public void testLoadHandWrittenYaml()
+    {
+        String yaml = String.join("\n", //$NON-NLS-1$
+            "groups:", //$NON-NLS-1$
+            "- name: ServerModules", //$NON-NLS-1$
+            "  path: CommonModules", //$NON-NLS-1$
+            "  description: Server-side modules", //$NON-NLS-1$
+            "  order: 5", //$NON-NLS-1$
+            "  children:", //$NON-NLS-1$
+            "  - CommonModule.A", //$NON-NLS-1$
+            "  - CommonModule.B"); //$NON-NLS-1$
+
+        GroupStorage storage = load(yaml);
+
+        assertEquals(1, storage.getGroupCount());
+        Group g = storage.getGroupByFullPath("CommonModules/ServerModules"); //$NON-NLS-1$
+        assertNotNull(g);
+        assertEquals("Server-side modules", g.getDescription()); //$NON-NLS-1$
+        assertEquals(5, g.getOrder());
+        assertEquals(2, g.getChildren().size());
+        assertTrue(g.containsChild("CommonModule.A")); //$NON-NLS-1$
+        assertTrue(g.containsChild("CommonModule.B")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testLoadEmptyDocumentReturnsNull()
+    {
+        // SnakeYAML returns null for an empty/blank document; the repository
+        // guards this by substituting an empty GroupStorage. Here we just
+        // pin the raw loader behaviour our model must tolerate.
+        assertNull(load("")); //$NON-NLS-1$
+    }
+
+    // ==================== Queries survive the round-trip ====================
+
+    @Test
+    public void testGroupedObjectsQueryAfterRoundTrip()
+    {
+        GroupStorage original = new GroupStorage();
+        Group g1 = new Group("G1", "CommonModules"); //$NON-NLS-1$ //$NON-NLS-2$
+        g1.addChild("CommonModule.Direct"); //$NON-NLS-1$
+        Group g2 = new Group("G2", "CommonModules/Sub"); //$NON-NLS-1$ //$NON-NLS-2$
+        g2.addChild("CommonModule.Nested"); //$NON-NLS-1$
+        original.addGroup(g1);
+        original.addGroup(g2);
+
+        GroupStorage restored = load(dump(original));
+
+        java.util.Set<String> objects = restored.getGroupedObjectsAtPath("CommonModules"); //$NON-NLS-1$
+        assertTrue(objects.contains("CommonModule.Direct")); //$NON-NLS-1$
+        assertTrue(objects.contains("CommonModule.Nested")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindGroupForObjectAfterRoundTrip()
+    {
+        GroupStorage original = new GroupStorage();
+        Group g = new Group("Server", "CommonModules"); //$NON-NLS-1$ //$NON-NLS-2$
+        g.addChild("CommonModule.Mod"); //$NON-NLS-1$
+        original.addGroup(g);
+
+        GroupStorage restored = load(dump(original));
+
+        Group found = restored.findGroupForObject("CommonModule.Mod"); //$NON-NLS-1$
+        assertNotNull(found);
+        assertEquals("Server", found.getName()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testManyChildrenRoundTrip()
+    {
+        GroupStorage original = new GroupStorage();
+        Group g = new Group("Big", "P"); //$NON-NLS-1$ //$NON-NLS-2$
+        List<String> fqns = Arrays.asList(
+            "Catalog.A", "Catalog.B", "Catalog.C", "Document.D", "Document.E"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+        for (String fqn : fqns)
+        {
+            g.addChild(fqn);
+        }
+        original.addGroup(g);
+
+        GroupStorage restored = load(dump(original));
+
+        Group rg = restored.getGroupByFullPath("P/Big"); //$NON-NLS-1$
+        assertNotNull(rg);
+        assertEquals(5, rg.getChildren().size());
+        for (String fqn : fqns)
+        {
+            assertTrue("Missing child after round-trip: " + fqn, rg.containsChild(fqn)); //$NON-NLS-1$
+        }
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tags/TagUtilsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tags/TagUtilsTest.java
@@ -1,0 +1,234 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tags;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Tests for the PURE, string/FQN-only helpers of {@link TagUtils}.
+ * <p>
+ * Only the methods that take Strings/primitives and return deterministically WITHOUT touching an
+ * {@code EObject}, {@code IProject}, an EDT model object or any platform service are covered here:
+ * {@link TagUtils#buildNewFqn(String, String)}, {@link TagUtils#isFqnOfType(String, String)},
+ * {@link TagUtils#getTypeFromFqn(String)} and {@link TagUtils#getTopNameFromFqn(String)}.
+ * <p>
+ * The EObject / IProject / service-based methods (extractFqn, getObjectName, getParentForFqn,
+ * extractProject, extractProjectFromElement, unwrapToEObject, extractMdObject) need a live EDT
+ * workspace / EMF model / OSGi platform and are exercised by the e2e suite, not here.
+ */
+public class TagUtilsTest
+{
+    // ==================== buildNewFqn ====================
+
+    @Test
+    public void testBuildNewFqnReplacesLastNameInTwoSegmentFqn()
+    {
+        assertEquals("Document.NewName", //$NON-NLS-1$
+            TagUtils.buildNewFqn("Document.OldName", "NewName")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testBuildNewFqnReplacesLastNameInNestedFqn()
+    {
+        // Only the trailing name component is replaced; the type prefix is preserved.
+        assertEquals("Catalog.Products.Attribute.NewName", //$NON-NLS-1$
+            TagUtils.buildNewFqn("Catalog.Products.Attribute.OldName", "NewName")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testBuildNewFqnWithNoDotReturnsNewNameOnly()
+    {
+        // No dot in the input -> there is no type prefix to keep, so just the new name is returned.
+        assertEquals("NewName", TagUtils.buildNewFqn("OldName", "NewName")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    @Test
+    public void testBuildNewFqnWithLeadingDotReturnsNewNameOnly()
+    {
+        // lastDot is at index 0 (not > 0), so the prefix branch is not taken.
+        assertEquals("NewName", TagUtils.buildNewFqn(".OldName", "NewName")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    @Test
+    public void testBuildNewFqnWithTrailingDotKeepsPrefix()
+    {
+        // The last dot is the trailing one; everything up to and including it is kept.
+        assertEquals("Document.NewName", //$NON-NLS-1$
+            TagUtils.buildNewFqn("Document.", "NewName")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testBuildNewFqnWithEmptyNewName()
+    {
+        assertEquals("Document.", TagUtils.buildNewFqn("Document.OldName", "")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    @Test
+    public void testBuildNewFqnWithNullOldFqnReturnsNull()
+    {
+        assertNull(TagUtils.buildNewFqn(null, "NewName")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBuildNewFqnWithNullNewNameReturnsNull()
+    {
+        assertNull(TagUtils.buildNewFqn("Document.OldName", null)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBuildNewFqnWithBothNullReturnsNull()
+    {
+        assertNull(TagUtils.buildNewFqn(null, null));
+    }
+
+    // ==================== isFqnOfType ====================
+
+    @Test
+    public void testIsFqnOfTypeMatching()
+    {
+        assertTrue(TagUtils.isFqnOfType("Document.SalesOrder", "Document")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testIsFqnOfTypeMatchingNestedFqn()
+    {
+        assertTrue(TagUtils.isFqnOfType("Catalog.Products.Attribute.Name", "Catalog")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testIsFqnOfTypeNotMatchingDifferentType()
+    {
+        assertFalse(TagUtils.isFqnOfType("Document.SalesOrder", "Catalog")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testIsFqnOfTypeRequiresTrailingDot()
+    {
+        // "Document" alone (no dot) must NOT match the type "Document": a separator is required.
+        assertFalse(TagUtils.isFqnOfType("Document", "Document")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testIsFqnOfTypePrefixWithoutDotIsNotAMatch()
+    {
+        // "DocumentSalesOrder" starts with "Document" but not "Document.", so it must not match.
+        assertFalse(TagUtils.isFqnOfType("DocumentSalesOrder", "Document")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testIsFqnOfTypeIsCaseSensitive()
+    {
+        // No normalization is performed; the comparison is a literal startsWith.
+        assertFalse(TagUtils.isFqnOfType("document.SalesOrder", "Document")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testIsFqnOfTypeWithNullFqnReturnsFalse()
+    {
+        assertFalse(TagUtils.isFqnOfType(null, "Document")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testIsFqnOfTypeWithNullTypeReturnsFalse()
+    {
+        assertFalse(TagUtils.isFqnOfType("Document.SalesOrder", null)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testIsFqnOfTypeWithBothNullReturnsFalse()
+    {
+        assertFalse(TagUtils.isFqnOfType(null, null));
+    }
+
+    // ==================== getTypeFromFqn ====================
+
+    @Test
+    public void testGetTypeFromFqnTwoSegments()
+    {
+        assertEquals("Document", TagUtils.getTypeFromFqn("Document.SalesOrder")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testGetTypeFromFqnNestedReturnsTopType()
+    {
+        // Only the segment before the FIRST dot is returned.
+        assertEquals("Document", //$NON-NLS-1$
+            TagUtils.getTypeFromFqn("Document.SalesOrder.Attribute.Name")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testGetTypeFromFqnNoDotReturnsNull()
+    {
+        assertNull(TagUtils.getTypeFromFqn("Document")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testGetTypeFromFqnLeadingDotReturnsNull()
+    {
+        // The first dot is at index 0 (not > 0), so no type is extracted.
+        assertNull(TagUtils.getTypeFromFqn(".SalesOrder")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testGetTypeFromFqnNullReturnsNull()
+    {
+        assertNull(TagUtils.getTypeFromFqn(null));
+    }
+
+    @Test
+    public void testGetTypeFromFqnEmptyReturnsNull()
+    {
+        assertNull(TagUtils.getTypeFromFqn("")); //$NON-NLS-1$
+    }
+
+    // ==================== getTopNameFromFqn ====================
+
+    @Test
+    public void testGetTopNameFromFqnTwoSegments()
+    {
+        assertEquals("SalesOrder", TagUtils.getTopNameFromFqn("Document.SalesOrder")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testGetTopNameFromFqnNestedReturnsSecondSegment()
+    {
+        // The second segment (the top object's name) is returned, ignoring deeper parts.
+        assertEquals("SalesOrder", //$NON-NLS-1$
+            TagUtils.getTopNameFromFqn("Document.SalesOrder.Attribute.Name")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testGetTopNameFromFqnSingleSegmentReturnsNull()
+    {
+        // Only one segment -> there is no top object name.
+        assertNull(TagUtils.getTopNameFromFqn("Document")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testGetTopNameFromFqnNullReturnsNull()
+    {
+        assertNull(TagUtils.getTopNameFromFqn(null));
+    }
+
+    @Test
+    public void testGetTopNameFromFqnEmptyReturnsNull()
+    {
+        assertNull(TagUtils.getTopNameFromFqn("")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testGetTopNameFromFqnTrailingDotYieldsTopName()
+    {
+        // String.split drops trailing empty strings, but the second segment is still present here.
+        assertEquals("SalesOrder", TagUtils.getTopNameFromFqn("Document.SalesOrder.")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchToolTest.java
@@ -746,4 +746,204 @@ public class DebugLaunchToolTest
         assertTrue("guide must document the coordinated launch flow performing the update",
             guide.contains("coordinated launch flow")); //$NON-NLS-1$
     }
+
+    // ==================== extractRestartIfRunning — full default/override matrix ====================
+    //
+    // extractRestartIfRunning is the pure (no-EDT) seam execute() reads. The two
+    // headline branches (absent->false, "true"->true) are pinned above; these add the
+    // remaining JsonUtils.extractBooleanArgument outcomes so the flag's parsing can't
+    // silently change: the OTHER truthy tokens, the explicit-false tokens, an empty
+    // value (falls back to the default), and an unrecognized token (also the default).
+
+    @Test
+    public void testExtractRestartIfRunningAlternateTruthyTokensAreTrue()
+    {
+        // "1" and "yes" are JsonUtils' other truthy spellings — they must flip the flag
+        // exactly like "true", so a non-canonical client value still restarts.
+        Map<String, String> one = new HashMap<>();
+        one.put("restartIfRunning", "1"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("restartIfRunning=1 must be true",
+            DebugLaunchTool.extractRestartIfRunning(one));
+        Map<String, String> yes = new HashMap<>();
+        yes.put("restartIfRunning", "YES"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("restartIfRunning=YES (case-insensitive) must be true",
+            DebugLaunchTool.extractRestartIfRunning(yes));
+    }
+
+    @Test
+    public void testExtractRestartIfRunningExplicitFalseTokensAreFalse()
+    {
+        // The explicit-false spellings must stay false (not flip to the true side).
+        Map<String, String> f = new HashMap<>();
+        f.put("restartIfRunning", "false"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("restartIfRunning=false must be false",
+            DebugLaunchTool.extractRestartIfRunning(f));
+        Map<String, String> zero = new HashMap<>();
+        zero.put("restartIfRunning", "0"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("restartIfRunning=0 must be false",
+            DebugLaunchTool.extractRestartIfRunning(zero));
+        Map<String, String> no = new HashMap<>();
+        no.put("restartIfRunning", "no"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("restartIfRunning=no must be false",
+            DebugLaunchTool.extractRestartIfRunning(no));
+    }
+
+    @Test
+    public void testExtractRestartIfRunningEmptyAndGarbageFallBackToDefault()
+    {
+        // An empty value and an unrecognized token both fall back to the documented
+        // default (false) — the safe non-destructive choice, never an accidental restart.
+        Map<String, String> empty = new HashMap<>();
+        empty.put("restartIfRunning", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("empty restartIfRunning must fall back to the false default",
+            DebugLaunchTool.extractRestartIfRunning(empty));
+        Map<String, String> garbage = new HashMap<>();
+        garbage.put("restartIfRunning", "maybe"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("unrecognized restartIfRunning token must fall back to the false default",
+            DebugLaunchTool.extractRestartIfRunning(garbage));
+    }
+
+    // ==================== execute() early-validation — empty-value branches ====================
+    //
+    // execute()'s required-argument guards test (value == null || value.isEmpty()), so a
+    // present-but-EMPTY value is a distinct branch from a missing key — and an empty
+    // launchConfigurationName must NOT enter mode 1 (the guard is also
+    // !configName.isEmpty()), so it falls through to mode 2's projectName guard. All
+    // three checks return BEFORE the first ProjectStateChecker/workspace access, so no
+    // live workbench is needed.
+
+    @Test
+    public void testEmptyProjectNameIsRequiredError()
+    {
+        // projectName present as "" (no launchConfigurationName) must hit the same
+        // "projectName is required" guard as a missing key, not slip past it.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new DebugLaunchTool().execute(params);
+        assertTrue("empty projectName must produce 'projectName is required'",
+            result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testEmptyLaunchConfigurationNameFallsThroughToProjectMode()
+    {
+        // launchConfigurationName="" must NOT enter the by-name mode (whose first
+        // statement touches the live launch manager); with no projectName it falls
+        // through to the project+application guard and reports projectName required.
+        Map<String, String> params = new HashMap<>();
+        params.put("launchConfigurationName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new DebugLaunchTool().execute(params);
+        assertTrue("empty launchConfigurationName must fall through to the projectName guard",
+            result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testEmptyApplicationIdIsRequiredError()
+    {
+        // projectName present, no launchConfigurationName, applicationId present as ""
+        // must hit the "applicationId is required" guard (the .isEmpty() half) before
+        // any workspace access.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("applicationId", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new DebugLaunchTool().execute(params);
+        assertTrue("empty applicationId must produce 'applicationId is required'",
+            result.contains("applicationId is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingProjectNameErrorSteersToLaunchConfigurationName()
+    {
+        // The projectName-required error must keep advertising the alternative
+        // (launchConfigurationName) so the caller can recover without guessing.
+        Map<String, String> params = new HashMap<>();
+        String result = new DebugLaunchTool().execute(params);
+        assertTrue("projectName error must mention the launchConfigurationName alternative",
+            result.contains("launchConfigurationName")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingApplicationIdErrorSteersToGetApplications()
+    {
+        // The applicationId-required error must point the caller at get_applications
+        // (the discovery source) and at the launchConfigurationName alternative.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new DebugLaunchTool().execute(params);
+        assertTrue("applicationId error must steer to get_applications",
+            result.contains("get_applications")); //$NON-NLS-1$
+        assertTrue("applicationId error must mention the launchConfigurationName alternative",
+            result.contains("launchConfigurationName")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testEarlyValidationErrorsAreSuccessFalseJson()
+    {
+        // The early-validation errors are well-formed error JSON: parseable and
+        // success:false — the wire shape every MCP client keys off.
+        JsonObject obj = JsonParser.parseString(new DebugLaunchTool().execute(new HashMap<>()))
+            .getAsJsonObject();
+        assertTrue("error result must carry success:false", obj.has("success")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("a validation failure must be success:false", obj.get("success").getAsBoolean()); //$NON-NLS-1$
+    }
+
+    // ==================== AlreadyRunningContext.buildAlreadyRunning — pure JSON shaping ====================
+    //
+    // The alreadyRunning payload builder is pure (Gson only) — exercise its branches
+    // without mocking any debug type. The set-all and unset-optional cases are pinned
+    // above; these add the EMPTY-STRING optional omissions, a null/empty applicationId,
+    // and the "run" mode value, so the omit-when-blank contract is fully covered.
+
+    @Test
+    public void testBuildAlreadyRunningOmitsEmptyStringOptionalFields()
+    {
+        // Optional identity fields set to "" (not just null) must be omitted too — the
+        // guard is (field != null && !field.isEmpty()). project="" must drop, and a "run"
+        // mode flows straight through to the mode field.
+        AlreadyRunningContext ctx = new AlreadyRunningContext("m"); //$NON-NLS-1$
+        ctx.launchConfiguration = ""; //$NON-NLS-1$
+        ctx.configurationType = ""; //$NON-NLS-1$
+        ctx.project = ""; //$NON-NLS-1$
+        JsonObject obj = JsonParser.parseString(
+            ctx.buildAlreadyRunning("run", "the-app").toJson()).getAsJsonObject(); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("empty launchConfiguration must be omitted", obj.has("launchConfiguration")); //$NON-NLS-1$
+        assertFalse("empty configurationType must be omitted", obj.has("configurationType")); //$NON-NLS-1$
+        assertFalse("empty project must be omitted", obj.has("project")); //$NON-NLS-1$
+        assertEquals("run", obj.get("mode").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("the-app", obj.get("applicationId").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testBuildAlreadyRunningOmitsNullAndEmptyApplicationId()
+    {
+        // applicationId is itself optional in the payload: a null or "" id is omitted,
+        // while the always-present alreadyRunning/mode/message stay.
+        AlreadyRunningContext ctx = new AlreadyRunningContext("the message"); //$NON-NLS-1$
+        JsonObject nullId = JsonParser.parseString(
+            ctx.buildAlreadyRunning("debug", null).toJson()).getAsJsonObject(); //$NON-NLS-1$
+        assertFalse("null applicationId must be omitted", nullId.has("applicationId")); //$NON-NLS-1$
+        assertTrue(nullId.get("alreadyRunning").getAsBoolean()); //$NON-NLS-1$
+        assertEquals("debug", nullId.get("mode").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("the message", nullId.get("message").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+
+        JsonObject emptyId = JsonParser.parseString(
+            ctx.buildAlreadyRunning("debug", "").toJson()).getAsJsonObject(); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("empty applicationId must be omitted", emptyId.has("applicationId")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBuildAlreadyRunningAlwaysCarriesCoreFieldsAndNoLaunchingStatus()
+    {
+        // The minimal payload (no optional identity fields supplied) still carries the
+        // three invariants — alreadyRunning:true, mode, message — and NEVER the
+        // status:"launching" field (that belongs only to the fresh-launch path).
+        AlreadyRunningContext ctx = new AlreadyRunningContext("running"); //$NON-NLS-1$
+        JsonObject obj = JsonParser.parseString(
+            ctx.buildAlreadyRunning("debug", "a").toJson()).getAsJsonObject(); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("alreadyRunning must be true", obj.get("alreadyRunning").getAsBoolean()); //$NON-NLS-1$
+        assertTrue("success must be true on a short-circuit", obj.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertFalse("the alreadyRunning short-circuit must never carry status:launching",
+            obj.has("status")); //$NON-NLS-1$
+        assertFalse("attach must be omitted when unset", obj.has("attach")); //$NON-NLS-1$
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataToolTest.java
@@ -239,4 +239,195 @@ public class DeleteMetadataToolTest
         // An unknown type cannot be mapped to a directory - no path, no blind delete.
         assertNull(DeleteMetadataTool.formResourceFolderPath("Bogus", "X", "Y")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
     }
+
+    /**
+     * The TYPE token is bilingual: a Russian type token resolves to the SAME English {@code src/}
+     * directory (the folder layout is language-neutral), while the owner / form NAME segments pass
+     * through verbatim - so a form addressed in Russian deletes the exact same on-disk folder.
+     */
+    @Test
+    public void testFormResourceFolderPathAcceptsRussianTypeToken()
+    {
+        // "Справочник" (Catalog, singular) -> Catalogs directory; the Cyrillic name parts are verbatim.
+        assertEquals("src/Catalogs/Товары/Forms/Форма", //$NON-NLS-1$
+            DeleteMetadataTool.formResourceFolderPath(
+                "Справочник", //$NON-NLS-1$
+                "Товары", "Форма")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * The folder mapping is not Catalog/Document-specific: any object family with an own {@code src/}
+     * type directory resolves (here an InformationRegister, whose directory is the plural form).
+     */
+    @Test
+    public void testFormResourceFolderPathResolvesOtherObjectFamilies()
+    {
+        assertEquals("src/InformationRegisters/Prices/Forms/ListForm", //$NON-NLS-1$
+            DeleteMetadataTool.formResourceFolderPath("InformationRegister", "Prices", "ListForm")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        // The plural type token resolves to the same directory as the singular one.
+        assertEquals("src/InformationRegisters/Prices/Forms/ListForm", //$NON-NLS-1$
+            DeleteMetadataTool.formResourceFolderPath("InformationRegisters", "Prices", "ListForm")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    /**
+     * A null or empty type token has no directory mapping, so no path is produced - the delete must
+     * never invent a folder to remove from a blank type.
+     */
+    @Test
+    public void testFormResourceFolderPathNullForBlankType()
+    {
+        assertNull(DeleteMetadataTool.formResourceFolderPath(null, "Products", "ItemForm")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNull(DeleteMetadataTool.formResourceFolderPath("", "Products", "ItemForm")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    // ---- putBlockingReferences: the single shared emitter feeding every response branch -----------
+
+    /**
+     * The shared emitter must count and emit MULTIPLE blocking references in order, under both the
+     * canonical {@code blocking*} keys and the legacy {@code affected*} aliases - the count equals the
+     * list size and the two arrays are element-for-element identical, so a caller reading either name
+     * sees the same N referencers in the same order.
+     */
+    @Test
+    public void testPutBlockingReferencesEmitsMultipleInOrder()
+    {
+        List<Map<String, Object>> blocking = new ArrayList<>();
+        blocking.add(reference("Catalog.Products", "type")); //$NON-NLS-1$ //$NON-NLS-2$
+        blocking.add(reference("Document.Order", "registerRecords")); //$NON-NLS-1$ //$NON-NLS-2$
+        blocking.add(reference("Report.Sales", "dataSource")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        String json = DeleteMetadataTool.putBlockingReferences(ToolResult.success(), blocking).toJson();
+        JsonObject obj = JsonParser.parseString(json).getAsJsonObject();
+
+        assertEquals(3, obj.get("blockingReferencesCount").getAsInt()); //$NON-NLS-1$
+        assertEquals("count and aliases must agree for N>1", //$NON-NLS-1$
+            obj.get("blockingReferencesCount"), obj.get("affectedReferencesCount")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("the alias array must mirror the canonical array exactly (order included)", //$NON-NLS-1$
+            obj.get("blockingReferences"), obj.get("affectedReferences")); //$NON-NLS-1$ //$NON-NLS-2$
+        // Order is preserved: the second referencer is the one inserted second.
+        assertEquals("Document.Order", obj.get("blockingReferences").getAsJsonArray() //$NON-NLS-1$ //$NON-NLS-2$
+            .get(1).getAsJsonObject().get("referencingObject").getAsString()); //$NON-NLS-1$
+    }
+
+    /**
+     * The emitter copies every field of a reference map verbatim into the JSON - the
+     * {@code referencingObject} / {@code reference} (feature) / {@code targetObject} a
+     * {@code CleanReferenceProblem} carries all survive, under both the canonical and the alias keys.
+     */
+    @Test
+    public void testPutBlockingReferencesPreservesAllFields()
+    {
+        List<Map<String, Object>> blocking = new ArrayList<>();
+        Map<String, Object> ref = new LinkedHashMap<>();
+        ref.put("problemType", "CleanReferenceProblem"); //$NON-NLS-1$ //$NON-NLS-2$
+        ref.put("referencingObject", "Document.Order"); //$NON-NLS-1$ //$NON-NLS-2$
+        ref.put("reference", "type"); //$NON-NLS-1$ //$NON-NLS-2$
+        ref.put("targetObject", "Catalog.Products"); //$NON-NLS-1$ //$NON-NLS-2$
+        blocking.add(ref);
+
+        String json = DeleteMetadataTool.putBlockingReferences(ToolResult.success(), blocking).toJson();
+        JsonObject obj = JsonParser.parseString(json).getAsJsonObject();
+
+        JsonObject canonical = obj.get("blockingReferences").getAsJsonArray() //$NON-NLS-1$
+            .get(0).getAsJsonObject();
+        assertEquals("CleanReferenceProblem", canonical.get("problemType").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("type", canonical.get("reference").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("Catalog.Products", canonical.get("targetObject").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+        // The legacy alias carries the SAME field set (it is the same list object).
+        assertEquals(obj.get("blockingReferences"), obj.get("affectedReferences")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * The emitter never drops the success flag the caller set on the result: emitting the
+     * blocking-reference block onto a {@code ToolResult.success()} leaves {@code success=true} - the
+     * preview / forced-execute branches rely on this (only the blocked branch flips success).
+     */
+    @Test
+    public void testPutBlockingReferencesKeepsSuccessFlag()
+    {
+        String json = DeleteMetadataTool
+            .putBlockingReferences(ToolResult.success(), new ArrayList<>()).toJson();
+        JsonObject obj = JsonParser.parseString(json).getAsJsonObject();
+        assertTrue("success must remain true after emitting an empty blocking block", //$NON-NLS-1$
+            obj.get("success").getAsBoolean()); //$NON-NLS-1$
+    }
+
+    // ---- additional metadata / schema facets ------------------------------------------------------
+
+    /**
+     * The description must advertise the full two-phase contract a caller keys off: the preview gate,
+     * the confirm step, the blocked outcome, and the force override that overrides it.
+     */
+    @Test
+    public void testDescriptionDocumentsTwoPhaseAndBlocking()
+    {
+        String desc = new DeleteMetadataTool().getDescription().toLowerCase();
+        assertTrue("description must mention the preview phase", desc.contains("preview")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("description must mention confirm", desc.contains("confirm")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("description must mention the blocked path", desc.contains("blocked")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("description must mention dangling references left by force", //$NON-NLS-1$
+            desc.contains("dangling")); //$NON-NLS-1$
+    }
+
+    /**
+     * The output schema must declare the full preview/blocked envelope a caller now receives, beyond
+     * the blocking* / affected* aliases already pinned above: action, fqn, refactoringTitle, items,
+     * the blocking flag, the blocking count and the human message.
+     */
+    @Test
+    public void testOutputSchemaDeclaresPreviewEnvelope()
+    {
+        String schema = new DeleteMetadataTool().getOutputSchema();
+        assertNotNull(schema);
+        assertTrue("outputSchema must declare action", schema.contains("\"action\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare fqn", schema.contains("\"fqn\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare refactoringTitle", //$NON-NLS-1$
+            schema.contains("\"refactoringTitle\"")); //$NON-NLS-1$
+        assertTrue("outputSchema must declare items", schema.contains("\"items\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare the blocking flag", schema.contains("\"blocking\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare blockingReferencesCount", //$NON-NLS-1$
+            schema.contains("\"blockingReferencesCount\"")); //$NON-NLS-1$
+        assertTrue("outputSchema must declare message", schema.contains("\"message\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * The output schema's {@code action} field must name all three terminal actions a caller can
+     * receive - {@code preview}, {@code executed} and {@code blocked} - so an agent can branch on them.
+     */
+    @Test
+    public void testOutputSchemaActionNamesAllThreeOutcomes()
+    {
+        String schema = new DeleteMetadataTool().getOutputSchema();
+        assertTrue("action must name 'preview'", schema.contains("preview")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("action must name 'executed'", schema.contains("executed")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("action must name 'blocked'", schema.contains("blocked")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * The guide must document the reference-blocking + force override (the safety mechanism reviewers
+     * check) and the two cross-model delete surfaces this tool also handles - form objects and form
+     * members - so a caller knows a 4-part / 6+-part form FQN is deletable too.
+     */
+    @Test
+    public void testGuideDocumentsForceAndFormSurfaces()
+    {
+        String guide = new DeleteMetadataTool().getGuide();
+        assertNotNull(guide);
+        assertTrue("guide must document the force override", guide.contains("force=true")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("guide must document the blocked outcome", guide.contains("action='blocked'")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("guide must document the form object surface", guide.contains("Form object")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("guide must document the form members surface", guide.contains("Form members")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("guide must note the deprecated affected* aliases", //$NON-NLS-1$
+            guide.contains("affectedReferences")); //$NON-NLS-1$
+    }
+
+    /** A {problemType, referencingObject, reference} blocking-reference map for the emitter tests. */
+    private static Map<String, Object> reference(String referencingObject, String feature)
+    {
+        Map<String, Object> ref = new LinkedHashMap<>();
+        ref.put("problemType", "CleanReferenceProblem"); //$NON-NLS-1$ //$NON-NLS-2$
+        ref.put("referencingObject", referencingObject); //$NON-NLS-1$
+        ref.put("reference", feature); //$NON-NLS-1$
+        return ref;
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/EvaluateExpressionToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/EvaluateExpressionToolTest.java
@@ -56,12 +56,44 @@ public class EvaluateExpressionToolTest
     }
 
     @Test
+    public void testDescriptionWarnsAboutArbitraryCodeExecution()
+    {
+        // The tool executes arbitrary BSL in the running application — the
+        // description must keep that WARNING so agents do not invoke it blindly.
+        String desc = new EvaluateExpressionTool().getDescription();
+        assertTrue(desc.contains("WARNING")); //$NON-NLS-1$
+        assertTrue(desc.toLowerCase().contains("arbitrary")); //$NON-NLS-1$
+    }
+
+    @Test
     public void testSchemaDeclaresParameters()
     {
         String schema = new EvaluateExpressionTool().getInputSchema();
         assertNotNull(schema);
         assertTrue(schema.contains("\"frameRef\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"expression\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testInputSchemaMarksBothParametersRequired()
+    {
+        String schema = new EvaluateExpressionTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        assertTrue("schema must declare a required array", requiredIdx >= 0); //$NON-NLS-1$
+        String tail = schema.substring(requiredIdx);
+        assertTrue("frameRef must be required", tail.contains("\"frameRef\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("expression must be required", tail.contains("\"expression\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testOutputSchemaDeclaresValueFields()
+    {
+        String schema = new EvaluateExpressionTool().getOutputSchema();
+        assertNotNull(schema);
+        assertTrue(schema.contains("\"type\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"value\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"truncated\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"fullLength\"")); //$NON-NLS-1$
     }
 
     // ==================== Argument validation (no live debug session needed) ====================
@@ -77,10 +109,44 @@ public class EvaluateExpressionToolTest
     }
 
     @Test
+    public void testZeroFrameRefIsRequiredError()
+    {
+        // frameRef is validated as <= 0 (not merely null/absent): an explicit 0 must
+        // hit the same "frameRef is required" guard before any registry lookup.
+        Map<String, String> params = new HashMap<>();
+        params.put("frameRef", "0"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("expression", "1 + 1"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new EvaluateExpressionTool().execute(params);
+        assertTrue(result.contains("frameRef is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNegativeFrameRefIsRequiredError()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("frameRef", "-5"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("expression", "1 + 1"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new EvaluateExpressionTool().execute(params);
+        assertTrue(result.contains("frameRef is required")); //$NON-NLS-1$
+    }
+
+    @Test
     public void testMissingExpression()
     {
         Map<String, String> params = new HashMap<>();
         params.put("frameRef", "1"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new EvaluateExpressionTool().execute(params);
+        assertTrue(result.contains("expression is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBlankExpression()
+    {
+        // A present-but-blank expression is rejected by requireArgument before the
+        // stale-frame lookup (frameRef > 0 here), exercising the required guard.
+        Map<String, String> params = new HashMap<>();
+        params.put("frameRef", "1"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("expression", ""); //$NON-NLS-1$ //$NON-NLS-2$
         String result = new EvaluateExpressionTool().execute(params);
         assertTrue(result.contains("expression is required")); //$NON-NLS-1$
     }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ExportConfigurationToXmlToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ExportConfigurationToXmlToolTest.java
@@ -8,13 +8,25 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.*;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 
 /**
- * Lightweight tests for {@link ExportConfigurationToXmlTool} that exercise
- * tool metadata and JSON schema without needing the Eclipse runtime.
+ * Lightweight tests for {@link ExportConfigurationToXmlTool} that exercise tool
+ * metadata, JSON schema, and the argument/path-validation guards that fire BEFORE
+ * any EDT CLI access — so they run headless.
+ * <p>
+ * {@code execute()} requires {@code projectName} + {@code outputPath} up front, then
+ * does a filesystem check ("outputPath exists but is not a directory") that touches
+ * only {@code java.nio.file}, not EDT. The real export needs a live workspace and is
+ * covered by the E2E suite.
  */
 public class ExportConfigurationToXmlToolTest
 {
@@ -59,5 +71,57 @@ public class ExportConfigurationToXmlToolTest
         String tail = schema.substring(requiredIdx);
         assertTrue("projectName must be required", tail.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("outputPath must be required", tail.contains("\"outputPath\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testGuideNotEmpty()
+    {
+        String guide = new ExportConfigurationToXmlTool().getGuide();
+        assertNotNull(guide);
+        assertFalse(guide.isEmpty());
+    }
+
+    // ==================== Argument & path validation (returns before any EDT access) ===========
+
+    @Test
+    public void testExecuteMissingProjectNameIsError()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("outputPath", "C:/tmp/out"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ExportConfigurationToXmlTool().execute(params);
+        assertTrue("missing projectName must produce 'projectName is required'", //$NON-NLS-1$
+            result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteMissingOutputPathIsError()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyConfig"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ExportConfigurationToXmlTool().execute(params);
+        assertTrue("missing outputPath must produce 'outputPath is required'", //$NON-NLS-1$
+            result.contains("outputPath is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteOutputPathIsAFileIsError() throws IOException
+    {
+        // The "exists but is not a directory" guard runs purely on java.nio.file,
+        // before any EDT CLI lookup — so it is reachable headless.
+        Path tempFile = Files.createTempFile("export-cfg-not-a-dir", ".tmp"); //$NON-NLS-1$ //$NON-NLS-2$
+        try
+        {
+            Map<String, String> params = new HashMap<>();
+            params.put("projectName", "MyConfig"); //$NON-NLS-1$ //$NON-NLS-2$
+            params.put("outputPath", tempFile.toString()); //$NON-NLS-1$
+            String result = new ExportConfigurationToXmlTool().execute(params);
+            assertTrue("a file outputPath must be rejected as not a directory", //$NON-NLS-1$
+                result.contains("is not a directory")); //$NON-NLS-1$
+            assertTrue("error payload must be JSON", result.trim().startsWith("{")); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        finally
+        {
+            Files.deleteIfExists(tempFile);
+        }
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GenerateTranslationStringsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GenerateTranslationStringsToolTest.java
@@ -9,6 +9,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -19,7 +20,12 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 
 /**
  * Lightweight tests for {@link GenerateTranslationStringsTool} that exercise
- * tool metadata and JSON schema without needing the Eclipse runtime.
+ * tool metadata, JSON schema, and the argument-validation guards that fire
+ * BEFORE any project resolution or LanguageTool access — so they run headless.
+ * <p>
+ * {@code execute()} checks {@code projectName}, {@code targetLanguages}, and the
+ * FROM_PROVIDER/{@code providerId} rule up front (before {@code ProjectContext.of});
+ * everything past that needs a live EDT workspace and is covered by the E2E suite.
  */
 public class GenerateTranslationStringsToolTest
 {
@@ -92,5 +98,64 @@ public class GenerateTranslationStringsToolTest
         assertNotNull("schema must declare required array", required); //$NON-NLS-1$
         assertEquals("required must be exactly [projectName, targetLanguages]", //$NON-NLS-1$
             Arrays.asList("projectName", "targetLanguages"), required); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== Argument validation (returns before any project/LangTool access) ===========
+
+    @Test
+    public void testExecuteMissingProjectNameIsError()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("targetLanguages", "[\"en\"]"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GenerateTranslationStringsTool().execute(params);
+        assertTrue("missing projectName must produce 'projectName is required'", //$NON-NLS-1$
+            result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteMissingTargetLanguagesIsError()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyConfig"); //$NON-NLS-1$ //$NON-NLS-2$
+        // No targetLanguages — the second guard fires before any project lookup.
+        String result = new GenerateTranslationStringsTool().execute(params);
+        assertTrue("missing targetLanguages must be reported as required", //$NON-NLS-1$
+            result.contains("targetLanguages is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteEmptyTargetLanguagesArrayIsError()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyConfig"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("targetLanguages", "[]"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GenerateTranslationStringsTool().execute(params);
+        assertTrue("an empty targetLanguages array must be reported as required", //$NON-NLS-1$
+            result.contains("targetLanguages is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteFromProviderWithoutProviderIdIsError()
+    {
+        // fillUpType=FROM_PROVIDER with no providerId is rejected up front, before
+        // the project is resolved — so this branch is reachable headless.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyConfig"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("targetLanguages", "[\"en\"]"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("fillUpType", "FROM_PROVIDER"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GenerateTranslationStringsTool().execute(params);
+        assertTrue("FROM_PROVIDER without providerId must mention providerId", //$NON-NLS-1$
+            result.contains("providerId is required")); //$NON-NLS-1$
+        assertTrue("the error must name FROM_PROVIDER", result.contains("FROM_PROVIDER")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testValidationErrorPayloadIsJson()
+    {
+        // The pre-flight guards return ToolResult.error(...).toJson(), delivered as a
+        // structured error regardless of the tool's MARKDOWN response type.
+        Map<String, String> params = new HashMap<>();
+        String result = new GenerateTranslationStringsTool().execute(params);
+        assertTrue("error payload must be JSON", result.trim().startsWith("{")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetApplicationsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetApplicationsToolTest.java
@@ -7,6 +7,7 @@
 package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -20,11 +21,15 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 /**
  * Tests for {@link GetApplicationsTool}.
  * <p>
- * Covers tool metadata, the input schema, and the pure {@code projectName}
- * required-argument validation that returns before the first
- * {@code ProjectStateChecker}/{@code ResourcesPlugin} access. Enumerating
- * applications needs a live project model and the application manager service
- * and is covered by the E2E suite.
+ * Covers tool metadata, the input and output schemas, and the pure
+ * {@code projectName} required-argument validation that returns before the
+ * first {@code ProjectStateChecker}/{@code ResourcesPlugin} access. The EDT
+ * boundary is {@code execute()}'s call to
+ * {@code ProjectStateChecker.buildingErrorOrNull(projectName)}, which touches
+ * {@code ResourcesPlugin.getWorkspace()}; only the missing/blank-projectName
+ * branch returns before that. Enumerating applications needs a live project
+ * model and the {@code IApplicationManager} service and is covered by the E2E
+ * suite.
  */
 public class GetApplicationsToolTest
 {
@@ -55,11 +60,56 @@ public class GetApplicationsToolTest
     }
 
     @Test
+    public void testResponseTypeJsonConstantSurface()
+    {
+        // The tool overrides getResponseType() explicitly to JSON; pin it so a future
+        // edit cannot silently drop to the MARKDOWN default of IMcpTool.
+        assertEquals(ResponseType.JSON, new GetApplicationsTool().getResponseType());
+    }
+
+    @Test
+    public void testDescriptionMentionsConsumingTools()
+    {
+        // The description must steer callers to the tools that consume the application id.
+        String desc = new GetApplicationsTool().getDescription();
+        assertTrue("description must point at update_database", desc.contains("update_database")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("description must point at debug_launch", desc.contains("debug_launch")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
     public void testSchemaDeclaresParameters()
     {
         String schema = new GetApplicationsTool().getInputSchema();
         assertNotNull(schema);
         assertTrue(schema.contains("\"projectName\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testInputSchemaMarksProjectNameRequired()
+    {
+        // projectName is the only input and it is mandatory.
+        String schema = new GetApplicationsTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        assertTrue("schema must declare a required array", requiredIdx >= 0); //$NON-NLS-1$
+        int open = schema.indexOf('[', requiredIdx);
+        int close = schema.indexOf(']', open);
+        assertTrue("required array must be well-formed", open >= 0 && close > open); //$NON-NLS-1$
+        String requiredBlock = schema.substring(open, close + 1);
+        assertTrue("projectName must be required", requiredBlock.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testOutputSchemaDeclaresAllFields()
+    {
+        String schema = new GetApplicationsTool().getOutputSchema();
+        assertNotNull(schema);
+        assertTrue("outputSchema must declare success", schema.contains("\"success\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare project", schema.contains("\"project\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare applications", schema.contains("\"applications\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare count", schema.contains("\"count\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare message", schema.contains("\"message\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare defaultApplicationId", //$NON-NLS-1$
+            schema.contains("\"defaultApplicationId\"")); //$NON-NLS-1$
     }
 
     // ==================== Argument validation (no live workbench needed) ====================
@@ -70,5 +120,38 @@ public class GetApplicationsToolTest
         Map<String, String> params = new HashMap<>();
         String result = new GetApplicationsTool().execute(params);
         assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingProjectNameCarriesDiscoveryHint()
+    {
+        // The shared required-argument guard appends the list_projects discovery hint.
+        String result = new GetApplicationsTool().execute(new HashMap<>());
+        assertTrue("missing projectName must steer to list_projects", //$NON-NLS-1$
+            result.contains("list_projects")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBlankProjectNameIsAlsoMissing()
+    {
+        // An empty value is treated as absent by requireArgument and hits the same branch
+        // BEFORE any ResourcesPlugin/workspace access.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetApplicationsTool().execute(params);
+        assertTrue("blank projectName must hit the required branch", //$NON-NLS-1$
+            result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingProjectNameIsStructuredErrorEnvelope()
+    {
+        // The validation error must be the structured {"success":false,...} envelope
+        // recognised by the protocol's error diversion, not a partial success body.
+        String result = new GetApplicationsTool().execute(new HashMap<>());
+        assertTrue("error must be a structured failure envelope", //$NON-NLS-1$
+            result.contains("\"success\":false")); //$NON-NLS-1$
+        assertFalse("a validation error must not emit a success envelope", //$NON-NLS-1$
+            result.contains("\"success\":true")); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetCheckDescriptionToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetCheckDescriptionToolTest.java
@@ -7,6 +7,7 @@
 package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -26,11 +27,17 @@ import com.e1c.g5.v8.dt.check.settings.ICheckRepository;
 /**
  * Tests for {@link GetCheckDescriptionTool}.
  * <p>
- * Covers tool metadata, the input schema, and the checkId required-argument
- * validation that returns before the configured-folder / preference-store
- * access. Reading the actual check document needs the configured docs folder and
- * is covered by the E2E suite. (Uses the {@code IMcpTool} default MARKDOWN
- * response type.)
+ * Covers tool metadata, the input schema, the {@code getResultFileName} naming
+ * helper, the {@code checkId} required-argument guard, the pure UID -> symbolic
+ * resolver, and the {@code hasCheckDocumentation} lookup. The headless boundary
+ * is {@code Activator.getDefault().getPreferenceStore()} (the configured
+ * check-descriptions folder): in the unit-test runtime the Activator is not
+ * started, so any document-reading path degrades to an error payload /
+ * {@code false} rather than returning content. {@code findCheckDocumentationFile}
+ * swallows that and yields {@code null}, so {@code hasCheckDocumentation} is
+ * headless-safe. Reading an actual check document needs the configured docs
+ * folder and is covered by the E2E suite. (Uses the {@code IMcpTool} default
+ * MARKDOWN response type.)
  */
 public class GetCheckDescriptionToolTest
 {
@@ -93,7 +100,37 @@ public class GetCheckDescriptionToolTest
             desc.contains("UID")); //$NON-NLS-1$
     }
 
-    // ==================== Argument validation (no configured folder needed) ====================
+    // ==================== getResultFileName (pure, no folder/Activator) ====================
+
+    @Test
+    public void testResultFileNameUsesCheckId()
+    {
+        // A supplied checkId names the result file <checkId>.md.
+        Map<String, String> params = new HashMap<>();
+        params.put("checkId", "begin-transaction"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("begin-transaction.md", //$NON-NLS-1$
+            new GetCheckDescriptionTool().getResultFileName(params));
+    }
+
+    @Test
+    public void testResultFileNameFallsBackToToolName()
+    {
+        // No checkId -> the file name falls back to "<toolName>.md".
+        assertEquals("get_check_description.md", //$NON-NLS-1$
+            new GetCheckDescriptionTool().getResultFileName(new HashMap<>()));
+    }
+
+    @Test
+    public void testResultFileNameEmptyCheckIdFallsBackToToolName()
+    {
+        // A blank checkId is treated as absent -> fall back to the tool name.
+        Map<String, String> params = new HashMap<>();
+        params.put("checkId", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("get_check_description.md", //$NON-NLS-1$
+            new GetCheckDescriptionTool().getResultFileName(params));
+    }
+
+    // ==================== checkId validation (no configured folder needed) ====================
 
     @Test
     public void testMissingCheckId()
@@ -101,6 +138,74 @@ public class GetCheckDescriptionToolTest
         Map<String, String> params = new HashMap<>();
         String result = new GetCheckDescriptionTool().execute(params);
         assertTrue(result.contains("checkId is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStaticGetCheckDescriptionNullCheckIdIsError()
+    {
+        // The static entry point shares the same required-checkId guard, which
+        // returns BEFORE any preference-store / folder access.
+        String result = GetCheckDescriptionTool.getCheckDescription(null);
+        assertTrue("null checkId must produce the checkId-required error", //$NON-NLS-1$
+            result.contains("checkId is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStaticGetCheckDescriptionEmptyCheckIdIsError()
+    {
+        String result = GetCheckDescriptionTool.getCheckDescription(""); //$NON-NLS-1$
+        assertTrue("empty checkId must produce the checkId-required error", //$NON-NLS-1$
+            result.contains("checkId is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStaticGetCheckDescriptionTwoArgEmptyCheckIdIsError()
+    {
+        // The projectName-aware overload applies the same guard first.
+        String result = GetCheckDescriptionTool.getCheckDescription("", "SomeProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("empty checkId must produce the checkId-required error", //$NON-NLS-1$
+            result.contains("checkId is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testGetCheckDescriptionForUnknownCheckIsError()
+    {
+        // A non-empty but unknown checkId can never resolve to a document
+        // (no configured folder in the unit-test runtime, and even if one were
+        // configured this id has no .md file): the tool yields an error payload,
+        // never content. A unique synthetic id keeps this independent of any
+        // packaged or configured check docs.
+        String result = GetCheckDescriptionTool.getCheckDescription("no-such-check-xyz-unit"); //$NON-NLS-1$
+        assertNotNull(result);
+        assertTrue("an unresolvable checkId must yield a structured error payload", //$NON-NLS-1$
+            result.contains("\"success\":false") || result.contains("\"success\": false")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== hasCheckDocumentation (headless-safe lookup) ====================
+
+    @Test
+    public void testHasCheckDocumentationNullCheckIdIsFalse()
+    {
+        // A null/empty checkId short-circuits to false before any folder access.
+        assertFalse(GetCheckDescriptionTool.hasCheckDocumentation(null));
+        assertFalse(GetCheckDescriptionTool.hasCheckDocumentation("")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testHasCheckDocumentationForUnknownCheckIsFalse()
+    {
+        // findCheckDocumentationFile swallows the missing-folder / absent-Activator
+        // condition and returns null, so the public probe is a safe false. A unique
+        // synthetic id also guarantees no packaged/configured doc can match.
+        assertFalse(GetCheckDescriptionTool.hasCheckDocumentation("no-such-check-xyz-unit")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testHasCheckDocumentationPathTraversalIsFalse()
+    {
+        // A checkId carrying path-traversal characters must never resolve a file;
+        // the lookup is null-safe and returns false (no exception).
+        assertFalse(GetCheckDescriptionTool.hasCheckDocumentation("../../etc/passwd")); //$NON-NLS-1$
     }
 
     // ==================== UID -> symbolic resolution (pure, mocked repository) ====================

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetConfigurationPropertiesToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetConfigurationPropertiesToolTest.java
@@ -9,6 +9,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
 
@@ -92,7 +93,7 @@ public class GetConfigurationPropertiesToolTest
         if (requiredIdx >= 0)
         {
             String tail = schema.substring(requiredIdx);
-            assertTrue("projectName must NOT be required", !tail.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+            assertFalse("projectName must NOT be required", tail.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
         }
     }
 

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetConfigurationPropertiesToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetConfigurationPropertiesToolTest.java
@@ -19,9 +19,11 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
  * <p>
  * {@code projectName} is optional (when absent the tool falls back to the first
  * configuration project), so there is no argument-validation branch that returns
- * before live access — {@code execute()} goes straight to the UI thread / DT
- * project manager. The headless surface is therefore the static contract (name,
- * response type, schema); the properties payload is covered by the E2E suite.
+ * before live access — {@code execute()} goes STRAIGHT to {@code Display.getDefault()}
+ * (the SWT UI thread) and the DT project manager, so it is NOT unit-testable here.
+ * The headless surface is therefore the static contract (name, response type, the
+ * YAML result-file agreement, schema, guide); the properties payload is covered by
+ * the E2E suite.
  */
 public class GetConfigurationPropertiesToolTest
 {
@@ -78,5 +80,40 @@ public class GetConfigurationPropertiesToolTest
         String schema = new GetConfigurationPropertiesTool().getInputSchema();
         assertNotNull(schema);
         assertTrue(schema.contains("\"projectName\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testProjectNameIsOptional()
+    {
+        // projectName is optional: absent => first configuration project. The schema
+        // must therefore declare NO required array (or one without projectName).
+        String schema = new GetConfigurationPropertiesTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        if (requiredIdx >= 0)
+        {
+            String tail = schema.substring(requiredIdx);
+            assertTrue("projectName must NOT be required", !tail.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+    }
+
+    @Test
+    public void testResultFileNameIsStableAcrossParams()
+    {
+        // getResultFileName ignores its params (constant file name), so the same
+        // .yaml name comes back regardless of what is passed.
+        GetConfigurationPropertiesTool tool = new GetConfigurationPropertiesTool();
+        java.util.Map<String, String> withName = new java.util.HashMap<>();
+        withName.put("projectName", "AnyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("configuration-properties.yaml", tool.getResultFileName(withName)); //$NON-NLS-1$
+        assertEquals(tool.getResultFileName(new java.util.HashMap<>()),
+            tool.getResultFileName(withName));
+    }
+
+    @Test
+    public void testGuideNotEmpty()
+    {
+        String guide = new GetConfigurationPropertiesTool().getGuide();
+        assertNotNull(guide);
+        assertTrue(guide.length() > 0);
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetContentAssistToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetContentAssistToolTest.java
@@ -96,6 +96,69 @@ public class GetContentAssistToolTest
         assertTrue(guide.contains("retry")); //$NON-NLS-1$
     }
 
+    @Test
+    public void testInputSchemaDeclaresPaginationAndFilterParameters()
+    {
+        // The lean schema must still surface the pagination/filter/doc knobs so a client
+        // can drive offset/limit/contains/extendedDocumentation without reading the guide.
+        String schema = new GetContentAssistTool().getInputSchema();
+        assertTrue(schema.contains("\"limit\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"offset\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"contains\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"extendedDocumentation\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRequiredParametersInInputSchema()
+    {
+        // projectName/line/column are the required trio; the optional knobs must NOT be
+        // listed in the required array (a client must be free to omit them).
+        String schema = new GetContentAssistTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        assertTrue("schema must declare a required array", requiredIdx >= 0); //$NON-NLS-1$
+        int open = schema.indexOf('[', requiredIdx);
+        int close = schema.indexOf(']', open);
+        assertTrue(open >= 0 && close > open);
+        String requiredBlock = schema.substring(open, close + 1);
+        assertTrue("projectName must be required", requiredBlock.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("line must be required", requiredBlock.contains("\"line\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("column must be required", requiredBlock.contains("\"column\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("offset must NOT be required", requiredBlock.contains("\"offset\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("contains must NOT be required", requiredBlock.contains("\"contains\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("limit must NOT be required", requiredBlock.contains("\"limit\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testOutputSchemaIsDeclaredForJsonTool()
+    {
+        // A JSON tool puts its payload in structuredContent, so it MUST publish an output
+        // schema (the IMcpTool default is null). Pin the success envelope + result fields.
+        String schema = new GetContentAssistTool().getOutputSchema();
+        assertNotNull("a JSON tool must override getOutputSchema()", schema); //$NON-NLS-1$
+        assertFalse(schema.isEmpty());
+        assertTrue("output must declare success", schema.contains("\"success\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("output must declare file", schema.contains("\"file\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("output must declare line", schema.contains("\"line\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("output must declare column", schema.contains("\"column\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("output must declare totalProposals", schema.contains("\"totalProposals\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("output must declare filteredOut", schema.contains("\"filteredOut\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("output must declare skipped", schema.contains("\"skipped\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("output must declare returnedProposals", //$NON-NLS-1$
+            schema.contains("\"returnedProposals\"")); //$NON-NLS-1$
+        assertTrue("output must declare proposals", schema.contains("\"proposals\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testResultFileNameDefaultsToToolNameMarkdown()
+    {
+        // Inherited IMcpTool default: getName() + ".md", independent of the params map.
+        GetContentAssistTool tool = new GetContentAssistTool();
+        assertEquals("get_content_assist.md", tool.getResultFileName(new HashMap<>())); //$NON-NLS-1$
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "Whatever"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("get_content_assist.md", tool.getResultFileName(params)); //$NON-NLS-1$
+    }
+
     // ==================== Argument validation (no live workbench needed) ====================
 
     @Test
@@ -138,6 +201,95 @@ public class GetContentAssistToolTest
         // without '>': ToolResult.toJson() (Gson) escapes '>' as > in JSON.
         String result = new GetContentAssistTool().execute(params);
         assertTrue(result.contains("Line and column must be")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testColumnMustBePositive()
+    {
+        // Mirror of the line guard, but the failing coordinate is the column: line >= 1,
+        // column 0 must still trip the "Line and column must be >= 1" branch.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("modulePath", "CommonModules/M/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("line", "5"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("column", "0"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetContentAssistTool().execute(params);
+        assertTrue(result.contains("Line and column must be")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNegativeLineRejected()
+    {
+        // A negative line also fails the >= 1 guard (distinct from the 0 boundary).
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("modulePath", "CommonModules/M/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("line", "-3"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("column", "2"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetContentAssistTool().execute(params);
+        assertTrue(result.contains("Line and column must be")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testDoubleFormatLineBelowOneRejected()
+    {
+        // The parser accepts a "33.0"-style double and truncates to int; "0.4" truncates
+        // to 0, which the >= 1 guard then rejects. Exercises the Double.parseDouble path
+        // feeding the positivity check (no NumberFormatException is thrown).
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("modulePath", "CommonModules/M/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("line", "0.4"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("column", "2"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetContentAssistTool().execute(params);
+        assertTrue(result.contains("Line and column must be")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNonNumericColumnIsInvalid()
+    {
+        // line parses fine, column "abc" throws NumberFormatException -> the combined
+        // "Invalid line or column number" branch (column-side of the try).
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("modulePath", "CommonModules/M/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("line", "10"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("column", "abc"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetContentAssistTool().execute(params);
+        assertTrue(result.contains("Invalid line or column number")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testModulePathCanonicalKeyIsReadBeforeFilePathAlias()
+    {
+        // Supplying ONLY the canonical modulePath (no filePath alias) must satisfy the
+        // file-path requirement; execution then proceeds to the numeric parse and fails
+        // there (line missing) rather than at the "modulePath is required" guard. This
+        // proves modulePath is read first.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("modulePath", "CommonModules/M/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetContentAssistTool().execute(params);
+        assertFalse("modulePath provided -> must NOT report modulePath as missing", //$NON-NLS-1$
+            result.contains("modulePath is required")); //$NON-NLS-1$
+        assertTrue("with no line/column the next guard is the numeric parse", //$NON-NLS-1$
+            result.contains("Invalid line or column number")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testEmptyModulePathFallsBackToFilePathAlias()
+    {
+        // An empty modulePath (present but blank) must fall through to the deprecated
+        // filePath alias rather than failing the requirement. With filePath set and no
+        // line/column the next stop is the numeric-parse error, NOT "modulePath is required".
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("modulePath", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("filePath", "src/Foo.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetContentAssistTool().execute(params);
+        assertFalse("filePath alias must satisfy the requirement", //$NON-NLS-1$
+            result.contains("modulePath is required")); //$NON-NLS-1$
+        assertTrue(result.contains("Invalid line or column number")); //$NON-NLS-1$
     }
 
     // ==================== formatProposals (filter / offset / limit) ====================
@@ -227,6 +379,40 @@ public class GetContentAssistToolTest
         assertTrue(json.contains("\"success\":true")); //$NON-NLS-1$
         assertTrue(json.contains("\"totalProposals\":0")); //$NON-NLS-1$
         assertTrue(json.contains("\"returnedProposals\":0")); //$NON-NLS-1$
+        assertTrue(json.contains("\"proposals\":[]")); //$NON-NLS-1$
+    }
+
+    // ==================== formatProposals null-array guard (no proposal construction) ====================
+    // formatProposals guards every dereference with proposals != null, so a null array is a
+    // valid input (the engine can hand back null). These exercise the false side of the sort
+    // guard, the count guard and the totalProposals computation without building any proposal.
+
+    @Test
+    public void testFormatProposalsNullArrayIsEmptySuccess()
+    {
+        String json = GetContentAssistTool.formatProposals(null, 10, 0, null, false, 7, 3, "/P/src/Bar.bsl"); //$NON-NLS-1$
+        assertTrue(json.contains("\"success\":true")); //$NON-NLS-1$
+        assertTrue(json.contains("\"totalProposals\":0")); //$NON-NLS-1$
+        assertTrue(json.contains("\"returnedProposals\":0")); //$NON-NLS-1$
+        assertTrue(json.contains("\"filteredOut\":0")); //$NON-NLS-1$
+        assertTrue(json.contains("\"skipped\":0")); //$NON-NLS-1$
+        assertTrue(json.contains("\"proposals\":[]")); //$NON-NLS-1$
+        // line/column/file are echoed straight through, untouched by the null guard.
+        assertTrue(json.contains("\"line\":7")); //$NON-NLS-1$
+        assertTrue(json.contains("\"column\":3")); //$NON-NLS-1$
+        assertTrue(json.contains("Bar.bsl")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFormatProposalsNullArrayWithFilterStaysEmpty()
+    {
+        // A contains filter is parsed before the (skipped) loop; with a null array there is
+        // nothing to filter, so filteredOut stays 0 and the result is still an empty success.
+        String json = GetContentAssistTool.formatProposals(null, 5, 2, "get,add", true, 1, 1, "/f"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(json.contains("\"success\":true")); //$NON-NLS-1$
+        assertTrue(json.contains("\"totalProposals\":0")); //$NON-NLS-1$
+        assertTrue(json.contains("\"returnedProposals\":0")); //$NON-NLS-1$
+        assertTrue(json.contains("\"filteredOut\":0")); //$NON-NLS-1$
         assertTrue(json.contains("\"proposals\":[]")); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMarkersToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMarkersToolTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
@@ -18,6 +19,8 @@ import java.util.Map;
 import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 /**
  * Tests for {@link GetMarkersTool} (the consolidation of the former
@@ -191,5 +194,199 @@ public class GetMarkersToolTest
         String a = GetMarkersTool.taskKey("/P/ab", 1, "", "normal"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         String b = GetMarkersTool.taskKey("/P/a", 1, "b", "normal"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testTaskKeyEmbedsTheLineNumber()
+    {
+        // The line number participates in the key, so it must surface in the text.
+        String key = GetMarkersTool.taskKey("/P/src/Module.bsl", 42, "TODO", "high"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        assertTrue("key must embed the line number", key.contains("42")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("key must contain all textual fields", //$NON-NLS-1$
+            key.contains("/P/src/Module.bsl") && key.contains("TODO") && key.contains("high")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    @Test
+    public void testTaskKeyUsesNewlineSeparator()
+    {
+        // The dedup key joins fields with a newline separator that cannot appear in
+        // a line number; pin it so a future refactor cannot silently switch to a
+        // separator that a path/message could itself contain.
+        String key = GetMarkersTool.taskKey("/P/src/Module.bsl", 7, "TODO: x", "low"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        assertTrue("key must join fields with newlines", key.contains("\n")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== Closed-vocabulary collections (the validation sets) ====================
+
+    @Test
+    public void testMarkerKindsVocabulary()
+    {
+        // The closed set the markerKind validation checks against.
+        assertEquals(2, GetMarkersTool.MARKER_KINDS.size());
+        assertTrue(GetMarkersTool.MARKER_KINDS.contains("bookmark")); //$NON-NLS-1$
+        assertTrue(GetMarkersTool.MARKER_KINDS.contains("task")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testPriorityValuesVocabulary()
+    {
+        // The closed set the priority validation checks against.
+        assertEquals(3, GetMarkersTool.PRIORITY_VALUES.size());
+        assertTrue(GetMarkersTool.PRIORITY_VALUES.contains("high")); //$NON-NLS-1$
+        assertTrue(GetMarkersTool.PRIORITY_VALUES.contains("normal")); //$NON-NLS-1$
+        assertTrue(GetMarkersTool.PRIORITY_VALUES.contains("low")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMarkerKindsAndPriorityValuesAreDisjoint()
+    {
+        // markerKind and priority are independent vocabularies; no value is shared,
+        // so a stray cross-assignment cannot pass the wrong validation gate.
+        for (String kind : GetMarkersTool.MARKER_KINDS)
+        {
+            assertFalse("'" + kind + "' must not also be a priority value", //$NON-NLS-1$ //$NON-NLS-2$
+                GetMarkersTool.PRIORITY_VALUES.contains(kind));
+        }
+    }
+
+    // ==================== Static contract: schema / output / annotations / guide ====================
+
+    @Test
+    public void testInputSchemaIsValidJsonObject()
+    {
+        // The advertised input schema must itself be syntactically valid JSON.
+        JsonObject schema = JsonParser.parseString(new GetMarkersTool().getInputSchema()).getAsJsonObject();
+        assertEquals("object", schema.get("type").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("schema must carry a properties block", schema.has("properties")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testSchemaLimitAdvertisesDefaultAndMax()
+    {
+        // The limit help must pin the canonical default (100) and max (1000) so an
+        // agent knows the bounds without a probe call.
+        String schema = new GetMarkersTool().getInputSchema();
+        assertTrue("limit help must mention the default", schema.contains("100")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("limit help must mention the max", schema.contains("1000")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testOutputSchemaIsNullForMarkdownTool()
+    {
+        // get_markers returns a MARKDOWN report (content, not structuredContent), so
+        // it must leave the JSON output schema null per the IMcpTool contract.
+        assertNull(new GetMarkersTool().getOutputSchema());
+    }
+
+    @Test
+    public void testResultFileNameDefaultsToMarkdown()
+    {
+        // A MARKDOWN tool's embedded-resource file name defaults to <name>.md.
+        assertEquals("get_markers.md", //$NON-NLS-1$
+            new GetMarkersTool().getResultFileName(new HashMap<>()));
+    }
+
+    @Test
+    public void testAnnotationsDefaultToCentralClassifier()
+    {
+        // The tool does not override annotations; returning null lets the central
+        // classifier derive the read-only hints from the name.
+        assertNull(new GetMarkersTool().getAnnotations());
+    }
+
+    @Test
+    public void testGuideIsServedAndDocumentsKeyConcepts()
+    {
+        // The on-demand guide (guides/get_markers.md) must load and cover the
+        // marker families, the task-marker-only priority rule and the dedup note.
+        String guide = new GetMarkersTool().getGuide();
+        assertNotNull(guide);
+        assertTrue("guide must be served (non-empty)", guide.length() > 0); //$NON-NLS-1$
+        assertTrue("guide must mention bookmarks", guide.toLowerCase().contains("bookmark")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("guide must mention task markers", guide.toLowerCase().contains("task")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("guide must scope priority to task markers", guide.contains("priority")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testDescriptionListsTaskMarkerKeywords()
+    {
+        // The description advertises the recognized task-marker keywords so an agent
+        // knows what get_markers surfaces without reading the guide.
+        String desc = new GetMarkersTool().getDescription();
+        assertTrue(desc.contains("TODO")); //$NON-NLS-1$
+        assertTrue(desc.contains("FIXME")); //$NON-NLS-1$
+        assertTrue(desc.contains("XXX")); //$NON-NLS-1$
+        assertTrue(desc.contains("HACK")); //$NON-NLS-1$
+    }
+
+    // ==================== Validation branches: case-insensitivity + JSON error shape ====================
+
+    @Test
+    public void testInvalidMarkerKindIsCaseInsensitiveReject()
+    {
+        // markerKind is normalized via toLowerCase() before the set check, so an
+        // upper-cased out-of-set value is still rejected (covers the lowercasing
+        // branch of the markerKind guard).
+        Map<String, String> params = new HashMap<>();
+        params.put("markerKind", "COMMENT"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetMarkersTool().execute(params);
+        assertTrue(result.contains("COMMENT")); //$NON-NLS-1$
+        assertTrue(result.contains("Must be one of")); //$NON-NLS-1$
+        assertFalse(result.contains("## Markers")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testInvalidPriorityIsCaseInsensitiveReject()
+    {
+        // priority is normalized via toLowerCase() before the set check.
+        Map<String, String> params = new HashMap<>();
+        params.put("priority", "URGENT"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetMarkersTool().execute(params);
+        assertTrue(result.contains("URGENT")); //$NON-NLS-1$
+        assertTrue(result.contains("Must be one of")); //$NON-NLS-1$
+        assertFalse(result.contains("## Markers")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testPriorityWithBookmarkKindRejectedCaseInsensitively()
+    {
+        // The contradiction guard lowercases markerKind before comparing to
+        // 'bookmark', so a mixed-case 'BookMark' still triggers the rejection.
+        Map<String, String> params = new HashMap<>();
+        params.put("markerKind", "BookMark"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("priority", "high"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetMarkersTool().execute(params);
+        assertTrue(result.contains("task markers only")); //$NON-NLS-1$
+        assertFalse(result.contains("## Markers")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testValidationErrorIsWellFormedToolResultJson()
+    {
+        // A rejected parameter returns a ToolResult.error envelope: valid JSON with
+        // success=false and a populated error message naming the bad value.
+        Map<String, String> params = new HashMap<>();
+        params.put("markerKind", "nope"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetMarkersTool().execute(params);
+        JsonObject json = JsonParser.parseString(result).getAsJsonObject();
+        assertFalse("validation failure must report success=false", //$NON-NLS-1$
+            json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertTrue("error envelope must carry an error message", json.has("error")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("error message must name the rejected value", //$NON-NLS-1$
+            json.get("error").getAsString().contains("nope")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testInvalidMarkerKindTakesPrecedenceOverPriority()
+    {
+        // markerKind is validated before priority; when both are bad, the markerKind
+        // error is the one returned (pins guard ordering).
+        Map<String, String> params = new HashMap<>();
+        params.put("markerKind", "badKind"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("priority", "badPriority"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetMarkersTool().execute(params);
+        assertTrue("markerKind error must win", result.contains("Invalid markerKind")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("priority error must not be reached", //$NON-NLS-1$
+            result.contains("Invalid priority")); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataDetailsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataDetailsToolTest.java
@@ -9,6 +9,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -23,10 +24,12 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 /**
  * Tests for {@link GetMetadataDetailsTool}.
  * <p>
- * Covers tool metadata, the input schema, and the projectName/objectFqns
- * required-argument validation that returns before the first
- * {@code PlatformUI.getWorkbench()} call. Resolving the objects needs a live
- * configuration and is covered by the E2E suite.
+ * Covers tool metadata, the input/output schema, the pure {@code getResultFileName}
+ * override, the pure failure-formatting helpers, and the projectName/objectFqns
+ * required-argument validation (presence, precedence, discovery hint, structured
+ * error envelope, empty-array branch) that returns before the first
+ * {@code PlatformUI.getWorkbench()} call — the EDT boundary. Resolving the objects
+ * needs a live configuration and is covered by the E2E suite.
  */
 public class GetMetadataDetailsToolTest
 {
@@ -48,6 +51,17 @@ public class GetMetadataDetailsToolTest
         assertEquals(ResponseType.MARKDOWN, new GetMetadataDetailsTool().getResponseType());
     }
 
+    /**
+     * A MARKDOWN tool returns content, not structured data, so it leaves the
+     * {@code outputSchema} at the interface default ({@code null}); pinning this
+     * guards against a future edit declaring an output schema the tool never fills.
+     */
+    @Test
+    public void testOutputSchemaIsNullForMarkdownTool()
+    {
+        assertNull(new GetMetadataDetailsTool().getOutputSchema());
+    }
+
     @Test
     public void testDescriptionNotEmpty()
     {
@@ -63,6 +77,81 @@ public class GetMetadataDetailsToolTest
         assertNotNull(schema);
         assertTrue(schema.contains("\"projectName\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"objectFqns\"")); //$NON-NLS-1$
+    }
+
+    /**
+     * The optional flags ({@code full}, {@code assignable}, {@code language}) are
+     * part of the always-loaded contract; pin them so a rename can't silently drop
+     * a parameter the description/guide still advertises.
+     */
+    @Test
+    public void testSchemaDeclaresOptionalParameters()
+    {
+        String schema = new GetMetadataDetailsTool().getInputSchema();
+        assertTrue(schema.contains("\"full\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"assignable\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"language\"")); //$NON-NLS-1$
+    }
+
+    /**
+     * Only the two genuinely-required parameters are in the required array; the
+     * optional flags must stay out of it (an over-strict schema would make a
+     * conformant client reject a valid basic-mode call).
+     */
+    @Test
+    public void testRequiredArrayHoldsOnlyProjectNameAndObjectFqns()
+    {
+        String schema = new GetMetadataDetailsTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        assertTrue("schema must declare a required array", requiredIdx >= 0); //$NON-NLS-1$
+        int open = schema.indexOf('[', requiredIdx);
+        int close = schema.indexOf(']', open);
+        assertTrue("required array must be well-formed", open >= 0 && close > open); //$NON-NLS-1$
+        String requiredBlock = schema.substring(open, close + 1);
+        assertTrue("projectName must be required", requiredBlock.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("objectFqns must be required", requiredBlock.contains("\"objectFqns\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("full must NOT be required", requiredBlock.contains("\"full\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("assignable must NOT be required", requiredBlock.contains("\"assignable\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("language must NOT be required", requiredBlock.contains("\"language\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== Result file name (pure override, no live workbench needed) ====================
+
+    /**
+     * With a project name the EmbeddedResource file name carries the project,
+     * lower-cased, between the fixed prefix and the {@code .md} extension.
+     */
+    @Test
+    public void testResultFileNameIncludesLowerCasedProject()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        String fileName = new GetMetadataDetailsTool().getResultFileName(params);
+        assertEquals("metadata-details-myproject.md", fileName); //$NON-NLS-1$
+    }
+
+    /**
+     * With no project name the tool falls back to the generic file name rather than
+     * the interface default ({@code get_metadata_details.md}).
+     */
+    @Test
+    public void testResultFileNameFallsBackWithoutProject()
+    {
+        String fileName = new GetMetadataDetailsTool().getResultFileName(new HashMap<>());
+        assertEquals("metadata-details.md", fileName); //$NON-NLS-1$
+    }
+
+    /**
+     * A blank project name is treated like an absent one (the guard checks both
+     * null and empty), so it also takes the generic-file-name fallback.
+     */
+    @Test
+    public void testResultFileNameBlankProjectFallsBack()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        String fileName = new GetMetadataDetailsTool().getResultFileName(params);
+        assertEquals("metadata-details.md", fileName); //$NON-NLS-1$
     }
 
     @Test
@@ -106,6 +195,78 @@ public class GetMetadataDetailsToolTest
         params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
         String result = new GetMetadataDetailsTool().execute(params);
         assertTrue(result.contains("objectFqns is required")); //$NON-NLS-1$
+    }
+
+    /**
+     * The missing-projectName error carries the shared discovery hint so the caller
+     * is pointed at the tool that lists valid project names.
+     */
+    @Test
+    public void testMissingProjectNameCarriesDiscoveryHint()
+    {
+        String result = new GetMetadataDetailsTool().execute(new HashMap<>());
+        assertTrue("missing projectName must steer to list_projects", //$NON-NLS-1$
+            result.contains("list_projects")); //$NON-NLS-1$
+    }
+
+    /**
+     * A validation error returns the structured {@code {"success":false,...}}
+     * envelope (recognised by the protocol's error diversion), never a partial
+     * Markdown body.
+     */
+    @Test
+    public void testValidationErrorIsStructuredFailureEnvelope()
+    {
+        String result = new GetMetadataDetailsTool().execute(new HashMap<>());
+        assertTrue("error must be a structured failure envelope", //$NON-NLS-1$
+            result.contains("\"success\"") && result.contains("false")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("a validation error must not emit the Markdown details header", //$NON-NLS-1$
+            result.contains("# Metadata Details")); //$NON-NLS-1$
+    }
+
+    /**
+     * projectName is validated before objectFqns: when BOTH are missing the
+     * projectName error wins, so a caller fixes the most fundamental gap first.
+     */
+    @Test
+    public void testProjectNameValidatedBeforeObjectFqns()
+    {
+        // objectFqns present, projectName absent -> projectName error.
+        Map<String, String> onlyFqns = new HashMap<>();
+        onlyFqns.put("objectFqns", "[\"Catalog.Products\"]"); //$NON-NLS-1$ //$NON-NLS-2$
+        String r1 = new GetMetadataDetailsTool().execute(onlyFqns);
+        assertTrue("projectName must be reported when it is the missing one", //$NON-NLS-1$
+            r1.contains("projectName is required")); //$NON-NLS-1$
+        assertFalse("objectFqns is present, so its error must not appear", //$NON-NLS-1$
+            r1.contains("objectFqns is required")); //$NON-NLS-1$
+
+        // Both missing -> still the projectName error (checked first).
+        String r2 = new GetMetadataDetailsTool().execute(new HashMap<>());
+        assertTrue("with both missing, projectName is reported first", //$NON-NLS-1$
+            r2.contains("projectName is required")); //$NON-NLS-1$
+        assertFalse("the objectFqns error must not pre-empt projectName", //$NON-NLS-1$
+            r2.contains("objectFqns is required")); //$NON-NLS-1$
+    }
+
+    /**
+     * An empty JSON array (and a comma-only string) parse to no FQNs, which is the
+     * same "objectFqns is required" branch as an absent key — the empty-array case
+     * the missing-key test does not exercise.
+     */
+    @Test
+    public void testEmptyObjectFqnsArrayIsRequiredError()
+    {
+        Map<String, String> emptyArray = new HashMap<>();
+        emptyArray.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        emptyArray.put("objectFqns", "[]"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("an empty JSON array must hit the required-objectFqns branch", //$NON-NLS-1$
+            new GetMetadataDetailsTool().execute(emptyArray).contains("objectFqns is required")); //$NON-NLS-1$
+
+        Map<String, String> commaOnly = new HashMap<>();
+        commaOnly.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        commaOnly.put("objectFqns", " , , "); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a comma-only string yields no FQNs and hits the same branch", //$NON-NLS-1$
+            new GetMetadataDetailsTool().execute(commaOnly).contains("objectFqns is required")); //$NON-NLS-1$
     }
 
     // ==================== Per-object failure channel (no live workbench needed) ====================

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataObjectsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataObjectsToolTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -109,9 +110,9 @@ public class GetMetadataObjectsToolTest
         assertTrue("projectName must be required", requiredBlock.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("metadataType must NOT be required", //$NON-NLS-1$
             !requiredBlock.contains("\"metadataType\"")); //$NON-NLS-1$
-        assertTrue("nameFilter must NOT be required", !requiredBlock.contains("\"nameFilter\"")); //$NON-NLS-1$ //$NON-NLS-2$
-        assertTrue("limit must NOT be required", !requiredBlock.contains("\"limit\"")); //$NON-NLS-1$ //$NON-NLS-2$
-        assertTrue("language must NOT be required", !requiredBlock.contains("\"language\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("nameFilter must NOT be required", requiredBlock.contains("\"nameFilter\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("limit must NOT be required", requiredBlock.contains("\"limit\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("language must NOT be required", requiredBlock.contains("\"language\"")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     // ==================== Metadata: output schema ====================

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataObjectsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataObjectsToolTest.java
@@ -8,6 +8,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
@@ -20,13 +21,18 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 /**
  * Tests for {@link GetMetadataObjectsTool}.
  * <p>
- * Covers tool metadata, the input schema, and the projectName required-argument
- * validation that returns before the first {@code PlatformUI.getWorkbench()}
- * call. Enumerating metadata needs a live configuration and is covered by the
- * E2E suite.
+ * Covers tool metadata (name/constant, response type, description, input schema,
+ * output schema, result file name, guide) and the {@code projectName}
+ * required-argument validation in {@code execute(Map)} that returns BEFORE the
+ * first {@code PlatformUI.getWorkbench().getDisplay()} call. Everything past that
+ * call (project/configuration resolution, the metadataType switch including the
+ * "Unknown metadata type" branch, collection and formatting) needs a live EDT
+ * workspace and is covered by the E2E suite.
  */
 public class GetMetadataObjectsToolTest
 {
+    // ==================== Metadata: name / response type ====================
+
     @Test
     public void testName()
     {
@@ -45,6 +51,8 @@ public class GetMetadataObjectsToolTest
         assertEquals(ResponseType.MARKDOWN, new GetMetadataObjectsTool().getResponseType());
     }
 
+    // ==================== Metadata: description ====================
+
     @Test
     public void testDescriptionNotEmpty()
     {
@@ -52,6 +60,20 @@ public class GetMetadataObjectsToolTest
         assertNotNull(desc);
         assertTrue(desc.length() > 0);
     }
+
+    @Test
+    public void testDescriptionSteersToGuideAndSiblingTool()
+    {
+        // The lean description must point at the on-demand guide for the full parameter
+        // set and at get_metadata_details for the single-object drill-down.
+        String desc = new GetMetadataObjectsTool().getDescription();
+        assertTrue("description must steer to the on-demand guide", //$NON-NLS-1$
+            desc.contains("get_tool_guide('get_metadata_objects')")); //$NON-NLS-1$
+        assertTrue("description must point at get_metadata_details for one object", //$NON-NLS-1$
+            desc.contains("get_metadata_details")); //$NON-NLS-1$
+    }
+
+    // ==================== Metadata: input schema ====================
 
     @Test
     public void testSchemaDeclaresParameters()
@@ -62,6 +84,79 @@ public class GetMetadataObjectsToolTest
         assertTrue(schema.contains("\"metadataType\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"nameFilter\"")); //$NON-NLS-1$
     }
+
+    @Test
+    public void testSchemaDeclaresLimitAndLanguageParameters()
+    {
+        String schema = new GetMetadataObjectsTool().getInputSchema();
+        assertTrue("schema must declare the limit parameter", schema.contains("\"limit\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("schema must declare the language parameter", //$NON-NLS-1$
+            schema.contains("\"language\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testProjectNameIsRequiredInSchema()
+    {
+        // projectName is the only required parameter; the optional filters must NOT be
+        // in the required array.
+        String schema = new GetMetadataObjectsTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        assertTrue("schema must declare a required array", requiredIdx >= 0); //$NON-NLS-1$
+        int open = schema.indexOf('[', requiredIdx);
+        int close = schema.indexOf(']', open);
+        assertTrue("required array must be well-formed", open >= 0 && close > open); //$NON-NLS-1$
+        String requiredBlock = schema.substring(open, close + 1);
+        assertTrue("projectName must be required", requiredBlock.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("metadataType must NOT be required", //$NON-NLS-1$
+            !requiredBlock.contains("\"metadataType\"")); //$NON-NLS-1$
+        assertTrue("nameFilter must NOT be required", !requiredBlock.contains("\"nameFilter\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("limit must NOT be required", !requiredBlock.contains("\"limit\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("language must NOT be required", !requiredBlock.contains("\"language\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== Metadata: output schema ====================
+
+    @Test
+    public void testOutputSchemaIsNullForMarkdownTool()
+    {
+        // This is a MARKDOWN tool: it returns content, not structuredContent, so it must
+        // inherit the IMcpTool default null output schema (over-declaring one would lie to
+        // clients about a structured envelope that never arrives).
+        assertNull("markdown tool must not declare an output schema", //$NON-NLS-1$
+            new GetMetadataObjectsTool().getOutputSchema());
+    }
+
+    // ==================== Metadata: result file name (both branches, no workspace) ====================
+
+    @Test
+    public void testResultFileNameUsesLowercasedProjectName()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("metadata-myproject.md", //$NON-NLS-1$
+            new GetMetadataObjectsTool().getResultFileName(params));
+    }
+
+    @Test
+    public void testResultFileNameFallbackWhenProjectNameMissing()
+    {
+        // No projectName -> the generic file name.
+        Map<String, String> params = new HashMap<>();
+        assertEquals("metadata-objects.md", //$NON-NLS-1$
+            new GetMetadataObjectsTool().getResultFileName(params));
+    }
+
+    @Test
+    public void testResultFileNameFallbackWhenProjectNameEmpty()
+    {
+        // An empty projectName is treated like a missing one for the file name.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("metadata-objects.md", //$NON-NLS-1$
+            new GetMetadataObjectsTool().getResultFileName(params));
+    }
+
+    // ==================== Metadata: guide ====================
 
     @Test
     public void testGuideHasMigratedDetail()
@@ -78,7 +173,7 @@ public class GetMetadataObjectsToolTest
         assertTrue(guide.contains("ManagerModule")); //$NON-NLS-1$
     }
 
-    // ==================== Argument validation (no live workbench needed) ====================
+    // ==================== Argument validation (returns before any workbench access) ====================
 
     @Test
     public void testMissingProjectName()
@@ -91,5 +186,45 @@ public class GetMetadataObjectsToolTest
         assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
         assertTrue(result.contains("\"success\":false")); //$NON-NLS-1$
         assertTrue(result.contains("\"error\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingProjectNameCarriesDiscoveryHint()
+    {
+        // The required-argument guard appends an actionable discovery hint pointing the
+        // caller at list_projects; pin it so the lean error stays self-service.
+        Map<String, String> params = new HashMap<>();
+        String result = new GetMetadataObjectsTool().execute(params);
+        assertTrue("error must steer the caller to list_projects", //$NON-NLS-1$
+            result.contains("list_projects")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testEmptyProjectNameIsError()
+    {
+        // An empty (blank) projectName is rejected by the same required-argument guard,
+        // before any workbench access.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetMetadataObjectsTool().execute(params);
+        assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
+        assertTrue(result.contains("\"success\":false")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingProjectNameIgnoresOtherArgs()
+    {
+        // Supplying metadataType/nameFilter/limit/language without a projectName still
+        // trips the projectName guard first (the guard runs before defaults and before
+        // the workbench is touched), so the metadataType value is never validated here.
+        Map<String, String> params = new HashMap<>();
+        params.put("metadataType", "catalogs"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("nameFilter", "Prod"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("limit", "50"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("language", "en"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetMetadataObjectsTool().execute(params);
+        assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
+        assertTrue("an invalid metadataType must NOT leak through before the projectName guard", //$NON-NLS-1$
+            !result.contains("Unknown metadata type")); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyToolTest.java
@@ -149,4 +149,84 @@ public class GetMethodCallHierarchyToolTest
         assertNull(GetMethodCallHierarchyTool.extractModuleName(null));
         assertNull(GetMethodCallHierarchyTool.extractModuleName("Module.bsl")); //$NON-NLS-1$
     }
+
+    // ==================== getResultFileName (pure, no live workbench) ====================
+
+    @Test
+    public void testResultFileNameWithMethodAndDirection()
+    {
+        // methodName + an explicit direction → "call-hierarchy-<method>-<direction>.md",
+        // with the method name lower-cased and the direction appended verbatim.
+        Map<String, String> params = new HashMap<>();
+        params.put("methodName", "DoWork"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("direction", "callees"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("call-hierarchy-dowork-callees.md", //$NON-NLS-1$
+            new GetMethodCallHierarchyTool().getResultFileName(params));
+    }
+
+    @Test
+    public void testResultFileNameWithMethodDefaultsDirectionToCallers()
+    {
+        // methodName present but NO direction argument → the direction segment
+        // defaults to "callers" (the (direction != null ? direction : KEY_CALLERS) branch).
+        Map<String, String> params = new HashMap<>();
+        params.put("methodName", "Calculate"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("call-hierarchy-calculate-callers.md", //$NON-NLS-1$
+            new GetMethodCallHierarchyTool().getResultFileName(params));
+    }
+
+    @Test
+    public void testResultFileNameLowercasesMethodName()
+    {
+        // The method-name segment is always lower-cased, so a mixed-case ru/en spelling
+        // produces a stable, case-insensitive file name.
+        Map<String, String> params = new HashMap<>();
+        params.put("methodName", "ПолучитьДанные"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("direction", "callers"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("call-hierarchy-получитьданные-callers.md", //$NON-NLS-1$
+            new GetMethodCallHierarchyTool().getResultFileName(params));
+    }
+
+    @Test
+    public void testResultFileNameEmptyDirectionIsAppendedVerbatim()
+    {
+        // The direction segment guards on null, NOT on emptiness: an explicitly empty
+        // direction is appended as-is (it does not fall back to "callers"). Pins the
+        // exact (direction != null ? direction : KEY_CALLERS) semantics.
+        Map<String, String> params = new HashMap<>();
+        params.put("methodName", "DoWork"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("direction", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("call-hierarchy-dowork-.md", //$NON-NLS-1$
+            new GetMethodCallHierarchyTool().getResultFileName(params));
+    }
+
+    @Test
+    public void testResultFileNameDefaultWhenMethodNameMissing()
+    {
+        // No methodName argument → the generic fallback file name (the direction is
+        // irrelevant when there is no method to name).
+        Map<String, String> params = new HashMap<>();
+        params.put("direction", "callees"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("call-hierarchy.md", //$NON-NLS-1$
+            new GetMethodCallHierarchyTool().getResultFileName(params));
+    }
+
+    @Test
+    public void testResultFileNameDefaultWhenMethodNameEmpty()
+    {
+        // An explicitly empty methodName also falls back to the generic name
+        // (the !methodName.isEmpty() guard).
+        Map<String, String> params = new HashMap<>();
+        params.put("methodName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("call-hierarchy.md", //$NON-NLS-1$
+            new GetMethodCallHierarchyTool().getResultFileName(params));
+    }
+
+    @Test
+    public void testResultFileNameDefaultWhenParamsEmpty()
+    {
+        // The no-arguments case (neither methodName nor direction) returns the constant fallback.
+        assertEquals("call-hierarchy.md", //$NON-NLS-1$
+            new GetMethodCallHierarchyTool().getResultFileName(new HashMap<>()));
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetModuleStructureToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetModuleStructureToolTest.java
@@ -22,7 +22,8 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 /**
  * Tests for {@link GetModuleStructureTool}.
  * <p>
- * Covers tool metadata, the input schema, and the projectName/modulePath
+ * Covers tool metadata, the input schema, the {@link GetModuleStructureTool#getResultFileName}
+ * name slugging, the pure region-marker helpers, and the projectName/modulePath
  * required-argument validation that returns before the first
  * {@code PlatformUI.getWorkbench()} call. Parsing the module structure needs a
  * live workbench and is covered by the E2E suite.
@@ -75,6 +76,59 @@ public class GetModuleStructureToolTest
         assertTrue(schema.contains("\"concise\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"detailed\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"enum\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSchemaDeclaresOptionalBooleanFlags()
+    {
+        // The two optional boolean toggles must be present in the schema
+        // (schema<->execute parity: execute() reads includeVariables/includeComments).
+        String schema = new GetModuleStructureTool().getInputSchema();
+        assertNotNull(schema);
+        assertTrue(schema.contains("\"includeVariables\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"includeComments\"")); //$NON-NLS-1$
+    }
+
+    // ==================== getResultFileName (pure, no live workbench) ====================
+
+    @Test
+    public void testResultFileNameWithModulePath()
+    {
+        // A modulePath produces a slugged "structure-<path>.md" name with the
+        // path separators replaced by '-' and the whole thing lower-cased.
+        Map<String, String> params = new HashMap<>();
+        params.put("modulePath", "CommonModules/MyModule/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+        String name = new GetModuleStructureTool().getResultFileName(params);
+        assertEquals("structure-commonmodules-mymodule-module.bsl.md", name); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResultFileNameReplacesBackslashesAndLowercases()
+    {
+        // Windows-style backslash separators and upper-case characters must both
+        // be normalised (covers the '\\' replacement and toLowerCase branches).
+        Map<String, String> params = new HashMap<>();
+        params.put("modulePath", "Catalogs\\Goods\\Forms\\ItemForm\\Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+        String name = new GetModuleStructureTool().getResultFileName(params);
+        assertEquals("structure-catalogs-goods-forms-itemform-module.bsl.md", name); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResultFileNameDefaultWhenModulePathMissing()
+    {
+        // No modulePath argument → the generic fallback file name.
+        assertEquals("module-structure.md", //$NON-NLS-1$
+            new GetModuleStructureTool().getResultFileName(new HashMap<>()));
+    }
+
+    @Test
+    public void testResultFileNameDefaultWhenModulePathEmpty()
+    {
+        // An explicitly empty modulePath also falls back to the generic name.
+        Map<String, String> params = new HashMap<>();
+        params.put("modulePath", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("module-structure.md", //$NON-NLS-1$
+            new GetModuleStructureTool().getResultFileName(params));
     }
 
     // ==================== Argument validation (no live workbench needed) ====================
@@ -153,9 +207,25 @@ public class GetModuleStructureToolTest
         assertEquals(5, GetModuleStructureTool.computeRegionEndLine(null, 5));
         // start line beyond EOF → returns the start line unchanged.
         assertEquals(3, GetModuleStructureTool.computeRegionEndLine(List.of("a", "b"), 3)); //$NON-NLS-1$ //$NON-NLS-2$
+        // start line below 1 → returns the start line unchanged (lower guard).
+        assertEquals(0, GetModuleStructureTool.computeRegionEndLine(List.of("a", "b"), 0)); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(-2, GetModuleStructureTool.computeRegionEndLine(List.of("a", "b"), -2)); //$NON-NLS-1$ //$NON-NLS-2$
         // unterminated region → returns the start line unchanged.
         List<String> noEnd = List.of("#Region X", "Procedure A() EndProcedure"); //$NON-NLS-1$ //$NON-NLS-2$
         assertEquals(1, GetModuleStructureTool.computeRegionEndLine(noEnd, 1));
+    }
+
+    @Test
+    public void testComputeRegionEndLineIgnoresPlainCodeLines()
+    {
+        // Lines that are neither #Region nor #EndRegion must not affect the
+        // depth counter — the end marker is still matched correctly.
+        List<String> lines = List.of(
+            "#Region Service",              // 1 //$NON-NLS-1$
+            "X = 1;",                       // 2 (plain code) //$NON-NLS-1$
+            "Y = ConfigureRegion();",       // 3 (substring 'Region' but not a marker) //$NON-NLS-1$
+            "#EndRegion");                  // 4 //$NON-NLS-1$
+        assertEquals(4, GetModuleStructureTool.computeRegionEndLine(lines, 1));
     }
 
     @Test
@@ -171,5 +241,18 @@ public class GetModuleStructureToolTest
         assertTrue(GetModuleStructureTool.isRegionEnd("#endregion")); //$NON-NLS-1$
         assertTrue(GetModuleStructureTool.isRegionEnd(RU_END_REGION));
         assertFalse(GetModuleStructureTool.isRegionEnd("#Region Foo")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRegionMarkersRejectPlainAndEmptyLines()
+    {
+        // A plain code line and an empty line are neither a start nor an end
+        // marker (the markers are matched on the trimmed line via startsWith).
+        assertFalse(GetModuleStructureTool.isRegionStart("Procedure A() EndProcedure")); //$NON-NLS-1$
+        assertFalse(GetModuleStructureTool.isRegionStart("")); //$NON-NLS-1$
+        assertFalse(GetModuleStructureTool.isRegionEnd("X = 1;")); //$NON-NLS-1$
+        assertFalse(GetModuleStructureTool.isRegionEnd("")); //$NON-NLS-1$
+        // A name that merely contains 'Region' as a substring is not a marker.
+        assertFalse(GetModuleStructureTool.isRegionStart("Y = ConfigureRegion();")); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetObjectsByTagsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetObjectsByTagsToolTest.java
@@ -20,11 +20,14 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 /**
  * Tests for {@link GetObjectsByTagsTool}.
  * <p>
- * Covers tool metadata, the input schema, and the projectName required-argument
- * validation that returns before the first {@code ProjectStateChecker}/
- * {@code ResourcesPlugin} access. The tags-required check runs after the live
- * project-readiness check, so only the projectName sentinel is reachable
- * headlessly; resolving tagged objects is covered by the E2E suite.
+ * Covers tool metadata, the input schema, and every {@code execute()}
+ * early-validation branch reachable headlessly: the missing-projectName guard,
+ * the empty-tags guard, and the project-not-found sentinel. These all return
+ * BEFORE the {@code TagService.getTagStorage(project)} call (the EDT boundary,
+ * which needs a live project's tag store). The transient BUILDING pre-flight
+ * ({@code ResourcesPlugin}-backed) is traversed safely for a non-existent
+ * project name (it resolves to NOT_AVAILABLE, never BUILDING, so it does not
+ * short-circuit). Resolving tagged objects is covered by the E2E suite.
  */
 public class GetObjectsByTagsToolTest
 {
@@ -63,7 +66,23 @@ public class GetObjectsByTagsToolTest
         assertTrue(schema.contains("\"tags\"")); //$NON-NLS-1$
     }
 
-    // ==================== Argument validation (no live workspace needed) ====================
+    @Test
+    public void testSchemaRequiresProjectNameAndTags()
+    {
+        // projectName and tags are both required; limit is the only optional input.
+        String schema = new GetObjectsByTagsTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        assertTrue("schema must declare a required array", requiredIdx >= 0); //$NON-NLS-1$
+        int open = schema.indexOf('[', requiredIdx);
+        int close = schema.indexOf(']', open);
+        assertTrue("required array must be well-formed", open >= 0 && close > open); //$NON-NLS-1$
+        String requiredBlock = schema.substring(open, close + 1);
+        assertTrue("projectName must be required", requiredBlock.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("tags must be required", requiredBlock.contains("\"tags\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("limit must NOT be required", !requiredBlock.contains("\"limit\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== Argument validation (no live tag store needed) ====================
 
     @Test
     public void testMissingProjectName()
@@ -71,5 +90,56 @@ public class GetObjectsByTagsToolTest
         Map<String, String> params = new HashMap<>();
         String result = new GetObjectsByTagsTool().execute(params);
         assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingTagsIsError()
+    {
+        // projectName present but no tags: the building pre-flight resolves a
+        // non-existent project to NOT_AVAILABLE (not BUILDING) and falls through,
+        // so the tags-required guard is reached before any tag-store access.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "NoSuchProject_GetObjectsByTags"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetObjectsByTagsTool().execute(params);
+        assertTrue("missing tags must produce the tags-required error", //$NON-NLS-1$
+            result.contains("Tags array is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBlankTagsIsError()
+    {
+        // A blank/whitespace tags value parses to an empty list -> tags-required error.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "NoSuchProject_GetObjectsByTags"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("tags", "   "); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetObjectsByTagsTool().execute(params);
+        assertTrue("blank tags must produce the tags-required error", //$NON-NLS-1$
+            result.contains("Tags array is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testEmptyJsonArrayTagsIsError()
+    {
+        // An explicit empty JSON array is still "no tags" -> tags-required error.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "NoSuchProject_GetObjectsByTags"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("tags", "[]"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetObjectsByTagsTool().execute(params);
+        assertTrue("empty tags array must produce the tags-required error", //$NON-NLS-1$
+            result.contains("Tags array is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testUnknownProjectWithTagsIsNotFound()
+    {
+        // projectName + tags present, but the project does not exist in the
+        // (empty) test workspace: resolution fails and the tool returns the
+        // actionable "Project not found" sentinel before the tag-store access.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "NoSuchProject_GetObjectsByTags"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("tags", "[\"Important\", \"NeedsReview\"]"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetObjectsByTagsTool().execute(params);
+        assertTrue("an unknown project must produce 'Project not found'", //$NON-NLS-1$
+            result.contains("Project not found")); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetObjectsByTagsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetObjectsByTagsToolTest.java
@@ -9,6 +9,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -79,7 +80,7 @@ public class GetObjectsByTagsToolTest
         String requiredBlock = schema.substring(open, close + 1);
         assertTrue("projectName must be required", requiredBlock.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("tags must be required", requiredBlock.contains("\"tags\"")); //$NON-NLS-1$ //$NON-NLS-2$
-        assertTrue("limit must NOT be required", !requiredBlock.contains("\"limit\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("limit must NOT be required", requiredBlock.contains("\"limit\"")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     // ==================== Argument validation (no live tag store needed) ====================

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProblemSummaryToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProblemSummaryToolTest.java
@@ -22,10 +22,12 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
  * Tests for {@link GetProblemSummaryTool}.
  * <p>
  * {@code projectName} is optional (absent = all projects) and {@code execute()}
- * goes straight to the live {@code IMarkerManager} service, so there is no
- * argument-validation branch reachable before live access. The headless surface
- * is the static contract (note: the tool uses the {@code IMcpTool} default
- * MARKDOWN response type); the summary is covered by the E2E suite.
+ * goes straight to {@code Activator.getDefault().getMarkerManager()} (the EDT
+ * boundary), so there is no argument-validation branch reachable before live
+ * access — {@code execute()} is intentionally NOT called here. The headless
+ * surface is the static contract (note: the tool uses the {@code IMcpTool}
+ * default MARKDOWN response type) plus the pure {@code sumDisplayedSeverities}
+ * grouping helper; the rendered summary is covered by the E2E suite.
  */
 public class GetProblemSummaryToolTest
 {
@@ -56,11 +58,43 @@ public class GetProblemSummaryToolTest
     }
 
     @Test
+    public void testDescriptionNamesSeveritiesAndSteersToDetailTool()
+    {
+        // The description advertises the severity vocabulary it groups by, and steers callers
+        // wanting per-marker detail to get_project_errors (this tool is totals-only).
+        String desc = new GetProblemSummaryTool().getDescription();
+        assertTrue("description must mention ERRORS", desc.contains("ERRORS")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("description must mention BLOCKER", desc.contains("BLOCKER")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("description must mention TRIVIAL", desc.contains("TRIVIAL")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("description must steer to get_project_errors for detail", //$NON-NLS-1$
+            desc.contains("get_project_errors")); //$NON-NLS-1$
+    }
+
+    @Test
     public void testSchemaDeclaresParameters()
     {
         String schema = new GetProblemSummaryTool().getInputSchema();
         assertNotNull(schema);
         assertTrue(schema.contains("\"projectName\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testProjectNameIsOptionalNotRequired()
+    {
+        // projectName is optional (absent = all projects); it must NOT appear in the required array.
+        String schema = new GetProblemSummaryTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        if (requiredIdx >= 0)
+        {
+            int open = schema.indexOf('[', requiredIdx);
+            int close = schema.indexOf(']', open);
+            if (open >= 0 && close > open)
+            {
+                String requiredBlock = schema.substring(open, close + 1);
+                assertTrue("projectName must NOT be required", //$NON-NLS-1$
+                    !requiredBlock.contains("\"projectName\"")); //$NON-NLS-1$
+            }
+        }
     }
 
     // ========== sumDisplayedSeverities (pure) ==========
@@ -95,5 +129,44 @@ public class GetProblemSummaryToolTest
     {
         assertEquals(0, GetProblemSummaryTool.sumDisplayedSeverities(new EnumMap<>(MarkerSeverity.class)));
         assertEquals(0, GetProblemSummaryTool.sumDisplayedSeverities(null));
+    }
+
+    @Test
+    public void testSumDisplayedSeveritiesEachColumnContributesIndependently()
+    {
+        // Each of the six displayed severities must be counted; a per-column probe guards
+        // against a future edit dropping one column from the sum.
+        MarkerSeverity[] displayed = {
+            MarkerSeverity.ERRORS, MarkerSeverity.BLOCKER, MarkerSeverity.CRITICAL,
+            MarkerSeverity.MAJOR, MarkerSeverity.MINOR, MarkerSeverity.TRIVIAL };
+        for (MarkerSeverity sev : displayed)
+        {
+            Map<MarkerSeverity, Integer> counts = new EnumMap<>(MarkerSeverity.class);
+            counts.put(sev, 7);
+            assertEquals("column " + sev.name() + " must contribute to the total", //$NON-NLS-1$ //$NON-NLS-2$
+                7, GetProblemSummaryTool.sumDisplayedSeverities(counts));
+        }
+    }
+
+    @Test
+    public void testSumDisplayedSeveritiesIgnoresOnlyNoneEntry()
+    {
+        // A map carrying ONLY a NONE count (no displayed column) sums to zero: NONE has no column.
+        Map<MarkerSeverity, Integer> counts = new EnumMap<>(MarkerSeverity.class);
+        counts.put(MarkerSeverity.NONE, 42);
+        assertEquals(0, GetProblemSummaryTool.sumDisplayedSeverities(counts));
+    }
+
+    @Test
+    public void testSumDisplayedSeveritiesIsAdditiveOverDisplayedColumns()
+    {
+        // Mixed: some displayed columns present, some absent (default 0), plus a NONE that
+        // must be excluded. Total = 10 + 20 + 30 = 60 (NONE's 99 is ignored).
+        Map<MarkerSeverity, Integer> counts = new EnumMap<>(MarkerSeverity.class);
+        counts.put(MarkerSeverity.ERRORS, 10);
+        counts.put(MarkerSeverity.CRITICAL, 20);
+        counts.put(MarkerSeverity.TRIVIAL, 30);
+        counts.put(MarkerSeverity.NONE, 99);
+        assertEquals(60, GetProblemSummaryTool.sumDisplayedSeverities(counts));
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProfilingResultsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProfilingResultsToolTest.java
@@ -7,25 +7,70 @@
 package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 /**
  * Tests for {@link GetProfilingResultsTool}.
  * <p>
- * This tool performs no argument validation; its only pre-EDT error returns are
- * OSGi bundle-presence guards ({@code Platform.getBundle(...)==null}) whose
- * outcome depends on which 1C profiling bundles the test runtime resolves — so
- * asserting on them would be environment-dependent. The headless surface is
- * therefore limited to the static contract; the profiling readout is covered by
- * the E2E suite.
+ * The headless surface of this tool is two-fold. First, the static contract
+ * (name, response type, the slim description that steers to the guide, the
+ * input/output schemas, and the migrated guide detail). Second, the part of
+ * {@code execute()} that runs BEFORE the EDT/reflection path:
+ * <ul>
+ * <li>argument parsing for {@code moduleFilter}, {@code minFrequency},
+ * {@code applicationId} and the {@code responseFormat} concise/detailed
+ * coercion — none of which validates or rejects, so for ANY input
+ * {@code execute()} stays total and returns parseable {@code success}-carrying
+ * JSON;</li>
+ * <li>the {@code profilingActive} precomputation, which reads the shared on/off
+ * state owned by {@link StartProfilingTool} (no EDT access) — the
+ * {@code isAnyProfilingActive()} branch when no {@code applicationId} is given and
+ * the {@code isProfilingActive(id)} branch when one is.</li>
+ * </ul>
+ * <p>
+ * Beyond that precomputation, {@code execute()}'s first action inside its
+ * {@code try} is an OSGi bundle-presence guard ({@code Platform.getBundle(...)});
+ * whether the {@code com._1c.g5.v8.dt.profiling.core} bundle resolves — and thus
+ * whether the call reaches the benign "no results" sentinel (which carries
+ * {@code count}/{@code profilingActive}) or returns a bundle-missing error — is
+ * environment-dependent. The tests below therefore assert the precomputation only
+ * on the sentinel path and otherwise pin only the env-independent invariant that
+ * the result is parseable JSON. The per-result summary helpers and {@code latestOnly}
+ * use reflective {@code Method} handles on a live profiling object and are off-limits
+ * headless; the profiling readout is covered by the E2E suite.
  */
 public class GetProfilingResultsToolTest
 {
+    /**
+     * The {@code profilingActive} flag mirrors {@link StartProfilingTool}'s shared
+     * state, so isolate every test from leaked profiling markers (here and in any
+     * other test) before and after running.
+     */
+    @Before
+    public void resetState()
+    {
+        StartProfilingTool.clearStateForTests();
+    }
+
+    @After
+    public void clearState()
+    {
+        StartProfilingTool.clearStateForTests();
+    }
+
     @Test
     public void testName()
     {
@@ -112,5 +157,251 @@ public class GetProfilingResultsToolTest
         assertTrue(guide.contains("responseFormat")); //$NON-NLS-1$
         assertTrue(guide.contains("concise")); //$NON-NLS-1$
         assertTrue(guide.contains("detailed")); //$NON-NLS-1$
+    }
+
+    // ==================== Output schema (pure, env-independent) ====================
+
+    @Test
+    public void testOutputSchemaDeclaresResultFields()
+    {
+        // The output schema is the wire contract clients key off: the success flag,
+        // the count (0 or 1 — only the latest session), the profilingActive on/off
+        // hint, the no-results message and the per-result "results" array. Pin them so
+        // a future edit can't drop a field the consumer relies on.
+        String schema = new GetProfilingResultsTool().getOutputSchema();
+        assertNotNull(schema);
+        assertTrue("outputSchema must declare success", schema.contains("\"success\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare count", schema.contains("\"count\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare profilingActive", //$NON-NLS-1$
+            schema.contains("\"profilingActive\"")); //$NON-NLS-1$
+        assertTrue("outputSchema must declare message", schema.contains("\"message\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare results", schema.contains("\"results\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testOutputSchemaCountNotesLatestSessionOnly()
+    {
+        // The "only the latest session" contract (count is 0 or 1, historical sessions
+        // dropped) must be documented on the count field so the consumer knows a single
+        // result set — not a history — is returned.
+        String schema = new GetProfilingResultsTool().getOutputSchema();
+        assertTrue("outputSchema must note count is 0 or 1 (latest session only)", //$NON-NLS-1$
+            schema.contains("latest session")); //$NON-NLS-1$
+    }
+
+    // ==================== execute() totality (runs before the EDT path) ====================
+    //
+    // The tool does NO argument validation: every parameter is optional and parsed
+    // leniently (extractStringArgument / extractIntArgument), and the responseFormat
+    // concise/detailed coercion treats any blank/unknown value as concise. So for ANY
+    // input execute() must not throw and must return parseable JSON carrying the
+    // success flag. The EDT/reflection readout that follows the precomputation is
+    // covered by the E2E suite; here we pin only the env-independent invariant. A
+    // null/false success-typed JSON is still well-formed (a bundle-missing error is
+    // success:false; the no-results sentinel is success:true) — both are accepted, we
+    // assert only that the field is present and boolean.
+
+    private static JsonObject executeAsJson(Map<String, String> params)
+    {
+        String result = new GetProfilingResultsTool().execute(params);
+        assertNotNull("execute() must never return null", result); //$NON-NLS-1$
+        JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
+        assertTrue("every execute() result must carry a boolean success flag", //$NON-NLS-1$
+            obj.has("success") && obj.get("success").isJsonPrimitive()); //$NON-NLS-1$ //$NON-NLS-2$
+        return obj;
+    }
+
+    /**
+     * @return {@code true} when the call reached the benign "no results" sentinel
+     *         (the OSGi profiling bundles resolved and there were no results), i.e.
+     *         the env-dependent happy path that emits {@code count}/{@code profilingActive}.
+     *         When a profiling bundle is absent the call returns a bundle-missing error
+     *         instead, which carries neither field.
+     */
+    private static boolean isNoResultsSentinel(JsonObject obj)
+    {
+        return obj.get("success").getAsBoolean() && obj.has("count") //$NON-NLS-1$ //$NON-NLS-2$
+            && obj.has("profilingActive"); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteWithNoParamsReturnsParseableJson()
+    {
+        // The all-defaults call (no filter, minFrequency=1, concise) must stay total
+        // and well-formed regardless of which profiling bundles the runtime resolves.
+        executeAsJson(new HashMap<>());
+    }
+
+    @Test
+    public void testExecuteWithModuleFilterReturnsParseableJson()
+    {
+        // A module filter is a free-form, never-rejected substring — it must parse and
+        // the call stays total.
+        Map<String, String> params = new HashMap<>();
+        params.put("moduleFilter", "CommonModule.Foo"); //$NON-NLS-1$ //$NON-NLS-2$
+        executeAsJson(params);
+    }
+
+    @Test
+    public void testExecuteWithValidMinFrequencyReturnsParseableJson()
+    {
+        // A valid integer minFrequency parses via extractIntArgument; the call is total.
+        Map<String, String> params = new HashMap<>();
+        params.put("minFrequency", "5"); //$NON-NLS-1$ //$NON-NLS-2$
+        executeAsJson(params);
+    }
+
+    @Test
+    public void testExecuteWithJsonNumberMinFrequencyReturnsParseableJson()
+    {
+        // Gson stringifies JSON numbers as "5.0"; extractIntArgument accepts the whole
+        // form (5.0 -> 5) — the lenient parse must not throw.
+        Map<String, String> params = new HashMap<>();
+        params.put("minFrequency", "5.0"); //$NON-NLS-1$ //$NON-NLS-2$
+        executeAsJson(params);
+    }
+
+    @Test
+    public void testExecuteWithGarbageMinFrequencyFallsBackAndDoesNotThrow()
+    {
+        // A non-numeric (and a non-integer "1.5") minFrequency falls back to the
+        // default of 1 inside extractIntArgument rather than erroring — the parse is
+        // lenient, so the call still returns well-formed JSON.
+        Map<String, String> garbage = new HashMap<>();
+        garbage.put("minFrequency", "abc"); //$NON-NLS-1$ //$NON-NLS-2$
+        executeAsJson(garbage);
+        Map<String, String> fractional = new HashMap<>();
+        fractional.put("minFrequency", "1.5"); //$NON-NLS-1$ //$NON-NLS-2$
+        executeAsJson(fractional);
+    }
+
+    @Test
+    public void testExecuteWithResponseFormatDetailedReturnsParseableJson()
+    {
+        // detailed flips the verbose-columns coercion (case-insensitive); the branch
+        // before the EDT path must not throw and the result stays parseable.
+        Map<String, String> params = new HashMap<>();
+        params.put("responseFormat", "DETAILED"); //$NON-NLS-1$ //$NON-NLS-2$
+        executeAsJson(params);
+    }
+
+    @Test
+    public void testExecuteWithResponseFormatConciseReturnsParseableJson()
+    {
+        // The explicit concise value (the default verbosity) parses and stays total.
+        Map<String, String> params = new HashMap<>();
+        params.put("responseFormat", "concise"); //$NON-NLS-1$ //$NON-NLS-2$
+        executeAsJson(params);
+    }
+
+    @Test
+    public void testExecuteWithUnknownResponseFormatCoercesToConciseWithoutThrowing()
+    {
+        // Any blank/unrecognized responseFormat is treated as concise (detailed is only
+        // "detailed", case-insensitive). The coercion (responseFormat==null?null:trim())
+        // must not throw on an unexpected token and the call stays total.
+        Map<String, String> garbage = new HashMap<>();
+        garbage.put("responseFormat", "verbose-please"); //$NON-NLS-1$ //$NON-NLS-2$
+        executeAsJson(garbage);
+        Map<String, String> blank = new HashMap<>();
+        blank.put("responseFormat", "   "); //$NON-NLS-1$ //$NON-NLS-2$
+        executeAsJson(blank);
+    }
+
+    @Test
+    public void testExecuteWithAllOptionsTogetherReturnsParseableJson()
+    {
+        // Every option supplied at once: all four parse paths run before the EDT
+        // boundary and the result is still well-formed JSON.
+        Map<String, String> params = new HashMap<>();
+        params.put("moduleFilter", "Doc"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("minFrequency", "2"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("applicationId", "app-xyz"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("responseFormat", "detailed"); //$NON-NLS-1$ //$NON-NLS-2$
+        executeAsJson(params);
+    }
+
+    // ============ profilingActive precomputation reads the shared StartProfilingTool state ============
+    //
+    // The on/off flag is computed BEFORE the EDT path from StartProfilingTool's shared
+    // markers: with no applicationId it surfaces isAnyProfilingActive(), and with one it
+    // surfaces isProfilingActive(id). Whether the call then reaches the sentinel that
+    // EMITS the flag depends on the profiling bundle resolving, so each assertion below
+    // is guarded on the sentinel path; on the bundle-missing error path the result is
+    // still parseable (executeAsJson already verified that) and the active-state check is
+    // simply skipped. The precomputation's two branches are also pinned directly through
+    // the StartProfilingTool state helpers, which need no EDT at all.
+
+    @Test
+    public void testProfilingActiveTrueWhenAnySessionActiveAndNoApplicationId()
+    {
+        // No applicationId -> the flag mirrors isAnyProfilingActive(); with a marker set
+        // it must report true on the sentinel path.
+        StartProfilingTool.markActive("some-session"); //$NON-NLS-1$
+        JsonObject obj = executeAsJson(new HashMap<>());
+        if (isNoResultsSentinel(obj))
+        {
+            assertTrue("profilingActive must mirror isAnyProfilingActive()==true", //$NON-NLS-1$
+                obj.get("profilingActive").getAsBoolean()); //$NON-NLS-1$
+        }
+    }
+
+    @Test
+    public void testProfilingActiveFalseWhenNoSessionActiveAndNoApplicationId()
+    {
+        // No applicationId and no markers -> isAnyProfilingActive()==false, so the
+        // sentinel reports profilingActive:false.
+        JsonObject obj = executeAsJson(new HashMap<>());
+        if (isNoResultsSentinel(obj))
+        {
+            assertFalse("profilingActive must mirror isAnyProfilingActive()==false", //$NON-NLS-1$
+                obj.get("profilingActive").getAsBoolean()); //$NON-NLS-1$
+        }
+    }
+
+    @Test
+    public void testProfilingActiveTracksPerApplicationIdState()
+    {
+        // With an applicationId the flag is isProfilingActive(id): active only for the
+        // marked id, false for a different one — proving the per-id branch, not the
+        // global any-active branch, is used when an id is supplied.
+        StartProfilingTool.markActive("debug-1"); //$NON-NLS-1$
+
+        Map<String, String> active = new HashMap<>();
+        active.put("applicationId", "debug-1"); //$NON-NLS-1$ //$NON-NLS-2$
+        JsonObject activeObj = executeAsJson(active);
+        if (isNoResultsSentinel(activeObj))
+        {
+            assertTrue("profilingActive must be true for the marked applicationId", //$NON-NLS-1$
+                activeObj.get("profilingActive").getAsBoolean()); //$NON-NLS-1$
+        }
+
+        Map<String, String> other = new HashMap<>();
+        other.put("applicationId", "debug-2"); //$NON-NLS-1$ //$NON-NLS-2$
+        JsonObject otherObj = executeAsJson(other);
+        if (isNoResultsSentinel(otherObj))
+        {
+            assertFalse("profilingActive must be false for an unmarked applicationId", //$NON-NLS-1$
+                otherObj.get("profilingActive").getAsBoolean()); //$NON-NLS-1$
+        }
+    }
+
+    @Test
+    public void testNoResultsSentinelCarriesGuidanceMessage()
+    {
+        // When the sentinel path is reached (profiling bundles resolved, no results
+        // accumulated), it is a benign success — count:0 plus a message that steers the
+        // caller back to start_profiling. Only asserted on that path; a bundle-missing
+        // runtime returns an error instead, which has no count/message pair.
+        JsonObject obj = executeAsJson(new HashMap<>());
+        if (isNoResultsSentinel(obj))
+        {
+            assertEquals("the no-results sentinel must report count:0", //$NON-NLS-1$
+                0, obj.get("count").getAsInt()); //$NON-NLS-1$
+            assertTrue("the no-results sentinel must carry a guidance message", //$NON-NLS-1$
+                obj.has("message")); //$NON-NLS-1$
+            assertTrue("the message must steer the caller to start_profiling", //$NON-NLS-1$
+                obj.get("message").getAsString().contains("start_profiling")); //$NON-NLS-1$ //$NON-NLS-2$
+        }
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetServerStatusToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetServerStatusToolTest.java
@@ -13,7 +13,10 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import com.ditrix.edt.mcp.server.preferences.PreferenceConstants;
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 /**
  * Tests for {@link GetServerStatusTool}.
@@ -92,5 +95,98 @@ public class GetServerStatusToolTest
         assertNotNull(json);
         assertFalse(json.contains("authToken")); //$NON-NLS-1$
         assertFalse(json.contains("checksFolder\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testDescriptionNamesKeyDiagnostics()
+    {
+        // The description is the tool's self-advertised diagnostic vocabulary; pin the
+        // form-render flags and the never-leaks contract it promises.
+        String desc = new GetServerStatusTool().getDescription();
+        assertTrue(desc.contains("nativeFormBufferedLayoutRender")); //$NON-NLS-1$
+        assertTrue(desc.contains("nativeFormLayoutRender")); //$NON-NLS-1$
+        assertTrue(desc.toLowerCase().contains("plaintextmode")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testOutputSchemaDeclaresAllFields()
+    {
+        String schema = new GetServerStatusTool().getOutputSchema();
+        assertNotNull(schema);
+        assertTrue(schema.contains("\"success\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"port\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"running\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"protocolVersion\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"pluginVersion\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"edtVersion\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"enabledTools\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"totalTools\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"plainTextMode\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"checksFolderConfigured\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"authEnabled\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"formRenderFlags\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteIsWellFormedJsonObject()
+    {
+        // The snapshot is delivered as a JSON object; parse it to prove it is not a
+        // truncated/plain string and that the documented numeric/object fields are present.
+        String json = new GetServerStatusTool().execute(java.util.Collections.emptyMap());
+        JsonObject obj = JsonParser.parseString(json).getAsJsonObject();
+        assertTrue("success must be true", obj.get("success").getAsBoolean()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("port must be a number", obj.get("port").getAsJsonPrimitive().isNumber()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("formRenderFlags must be an object", //$NON-NLS-1$
+            obj.get("formRenderFlags").isJsonObject()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testHeadlessPortAndRunningDegradeToDefaults()
+    {
+        // With no live McpServer the status still serialises: a numeric port field
+        // and running=false (the server is not up in the headless test runtime).
+        String json = new GetServerStatusTool().execute(java.util.Collections.emptyMap());
+        JsonObject obj = JsonParser.parseString(json).getAsJsonObject();
+        assertTrue("port must be a non-negative int", obj.get("port").getAsInt() >= 0); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("no live server => running must be false", obj.get("running").getAsBoolean()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormRenderFlagsReflectSystemProperties()
+    {
+        // The two form-render flags are read from System properties via Boolean.parseBoolean:
+        // set => true, absent => false. Restore the prior values to keep the test isolated.
+        String bufferedKey = "nativeFormBufferedLayoutRender"; //$NON-NLS-1$
+        String nativeKey = "nativeFormLayoutRender"; //$NON-NLS-1$
+        String savedBuffered = System.getProperty(bufferedKey);
+        String savedNative = System.getProperty(nativeKey);
+        try
+        {
+            System.setProperty(bufferedKey, "true"); //$NON-NLS-1$
+            System.clearProperty(nativeKey);
+
+            JsonObject flags = JsonParser
+                .parseString(new GetServerStatusTool().execute(java.util.Collections.emptyMap()))
+                .getAsJsonObject().getAsJsonObject("formRenderFlags"); //$NON-NLS-1$
+            assertTrue("buffered flag set => true", flags.get(bufferedKey).getAsBoolean()); //$NON-NLS-1$
+            assertFalse("native flag absent => false", flags.get(nativeKey).getAsBoolean()); //$NON-NLS-1$
+        }
+        finally
+        {
+            restoreProperty(bufferedKey, savedBuffered);
+            restoreProperty(nativeKey, savedNative);
+        }
+    }
+
+    private static void restoreProperty(String key, String saved)
+    {
+        if (saved == null)
+        {
+            System.clearProperty(key);
+        }
+        else
+        {
+            System.setProperty(key, saved);
+        }
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetServerStatusToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetServerStatusToolTest.java
@@ -13,7 +13,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import com.ditrix.edt.mcp.server.preferences.PreferenceConstants;
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetSubsystemContentToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetSubsystemContentToolTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -87,8 +88,8 @@ public class GetSubsystemContentToolTest
         String requiredBlock = schema.substring(open, close + 1);
         assertTrue("projectName must be required", requiredBlock.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("subsystemFqn must be required", requiredBlock.contains("\"subsystemFqn\"")); //$NON-NLS-1$ //$NON-NLS-2$
-        assertTrue("recursive must NOT be required", !requiredBlock.contains("\"recursive\"")); //$NON-NLS-1$ //$NON-NLS-2$
-        assertTrue("language must NOT be required", !requiredBlock.contains("\"language\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("recursive must NOT be required", requiredBlock.contains("\"recursive\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("language must NOT be required", requiredBlock.contains("\"language\"")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetSubsystemContentToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetSubsystemContentToolTest.java
@@ -8,6 +8,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
@@ -20,10 +21,11 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 /**
  * Tests for {@link GetSubsystemContentTool}.
  * <p>
- * Covers tool metadata, the input schema, and the projectName/subsystemFqn
+ * Covers tool metadata, the input/output schema, the on-demand guide, the pure
+ * {@code getResultFileName} file-name derivation, and the projectName/subsystemFqn
  * required-argument validation that returns before the first
- * {@code PlatformUI.getWorkbench()} call. Resolving the subsystem needs a live
- * configuration and is covered by the E2E suite.
+ * {@code PlatformUI.getWorkbench()} call (the EDT boundary). Resolving the subsystem
+ * and formatting its content need a live configuration and are covered by the E2E suite.
  */
 public class GetSubsystemContentToolTest
 {
@@ -63,6 +65,49 @@ public class GetSubsystemContentToolTest
     }
 
     @Test
+    public void testSchemaDeclaresOptionalParameters()
+    {
+        // recursive (boolean) and language (string) are the two optional inputs the tool reads.
+        String schema = new GetSubsystemContentTool().getInputSchema();
+        assertTrue("schema must declare the recursive flag", schema.contains("\"recursive\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("schema must declare the language code", schema.contains("\"language\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testRequiredArrayHasProjectNameAndSubsystemFqn()
+    {
+        // The two required inputs are the only ones in the schema's required array; the optional
+        // recursive/language must NOT be required.
+        String schema = new GetSubsystemContentTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        assertTrue("schema must declare a required array", requiredIdx >= 0); //$NON-NLS-1$
+        int open = schema.indexOf('[', requiredIdx);
+        int close = schema.indexOf(']', open);
+        assertTrue("required array must be well-formed", open >= 0 && close > open); //$NON-NLS-1$
+        String requiredBlock = schema.substring(open, close + 1);
+        assertTrue("projectName must be required", requiredBlock.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("subsystemFqn must be required", requiredBlock.contains("\"subsystemFqn\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("recursive must NOT be required", !requiredBlock.contains("\"recursive\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("language must NOT be required", !requiredBlock.contains("\"language\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testDescriptionSteersToGuide()
+    {
+        // The slimmed description must advertise the on-demand guide entry point.
+        String desc = new GetSubsystemContentTool().getDescription();
+        assertTrue("description must steer to the on-demand guide", //$NON-NLS-1$
+            desc.contains("get_tool_guide('get_subsystem_content')")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testOutputSchemaIsNullForMarkdownTool()
+    {
+        // A MARKDOWN tool returns content, not structuredContent, so it leaves the output schema null.
+        assertNull(new GetSubsystemContentTool().getOutputSchema());
+    }
+
+    @Test
     public void testGuideHasMigratedDetail()
     {
         String guide = new GetSubsystemContentTool().getGuide();
@@ -72,6 +117,63 @@ public class GetSubsystemContentToolTest
         assertTrue(guide.contains("recursive")); //$NON-NLS-1$
         assertTrue(guide.contains("FQN format")); //$NON-NLS-1$
         assertTrue(guide.contains("deduplicated")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testGuideDocumentsParametersAndSections()
+    {
+        // Pin the guide vocabulary agents key off: it must document the two optional params and the
+        // three Markdown output sections the formatter emits.
+        String guide = new GetSubsystemContentTool().getGuide();
+        assertTrue("guide must document the language param", guide.contains("language")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("guide must document subsystemFqn", guide.contains("subsystemFqn")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("guide must document the Properties section", guide.contains("Properties")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("guide must document the Content section", guide.contains("Content")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("guide must document the Child Subsystems section", //$NON-NLS-1$
+            guide.contains("Child Subsystems")); //$NON-NLS-1$
+    }
+
+    // ==================== getResultFileName (pure helper, no live workbench needed) =================
+
+    @Test
+    public void testResultFileNameDefaultWhenFqnAbsent()
+    {
+        // No subsystemFqn → the static default file name.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("subsystem-content.md", //$NON-NLS-1$
+            new GetSubsystemContentTool().getResultFileName(params));
+    }
+
+    @Test
+    public void testResultFileNameDefaultWhenFqnEmpty()
+    {
+        // A blank FQN is treated as absent and falls back to the default file name.
+        Map<String, String> params = new HashMap<>();
+        params.put("subsystemFqn", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("subsystem-content.md", //$NON-NLS-1$
+            new GetSubsystemContentTool().getResultFileName(params));
+    }
+
+    @Test
+    public void testResultFileNameDerivedFromFqn()
+    {
+        // FQN present → dots become dashes and the whole name is lower-cased.
+        Map<String, String> params = new HashMap<>();
+        params.put("subsystemFqn", "Subsystem.Sales.Subsystem.Orders"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("subsystem-subsystem-sales-subsystem-orders.md", //$NON-NLS-1$
+            new GetSubsystemContentTool().getResultFileName(params));
+    }
+
+    @Test
+    public void testResultFileNameLowerCasesAndKeepsExtension()
+    {
+        // A single-segment FQN with mixed case is lower-cased; only dots (not other chars) are mapped.
+        Map<String, String> params = new HashMap<>();
+        params.put("subsystemFqn", "Subsystem.SalesAndCRM"); //$NON-NLS-1$ //$NON-NLS-2$
+        String name = new GetSubsystemContentTool().getResultFileName(params);
+        assertEquals("subsystem-subsystem-salesandcrm.md", name); //$NON-NLS-1$
+        assertTrue("result file name must keep the .md extension", name.endsWith(".md")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     // ==================== Argument validation (no live workbench needed) ====================
@@ -85,11 +187,56 @@ public class GetSubsystemContentToolTest
     }
 
     @Test
+    public void testMissingProjectNameCarriesDiscoveryHint()
+    {
+        // projectName is an enumerable parameter, so its required-error carries the list_projects hint.
+        Map<String, String> params = new HashMap<>();
+        String result = new GetSubsystemContentTool().execute(params);
+        assertTrue("projectName error must point at list_projects", //$NON-NLS-1$
+            result.contains("list_projects")); //$NON-NLS-1$
+    }
+
+    @Test
     public void testMissingSubsystemFqn()
     {
         Map<String, String> params = new HashMap<>();
         params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
         String result = new GetSubsystemContentTool().execute(params);
         assertTrue(result.contains("subsystemFqn is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingSubsystemFqnCarriesExampleHint()
+    {
+        // The subsystemFqn guard appends an inline example so the caller learns the FQN shape.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetSubsystemContentTool().execute(params);
+        assertTrue("subsystemFqn error must include the 'Subsystem.Sales' example", //$NON-NLS-1$
+            result.contains("Subsystem.Sales")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBlankProjectNameIsTreatedAsMissing()
+    {
+        // A blank projectName is rejected by the same required-argument guard (empty == missing),
+        // returning before the workbench is touched.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("subsystemFqn", "Subsystem.Sales"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetSubsystemContentTool().execute(params);
+        assertTrue("blank projectName must fail the required-argument guard", //$NON-NLS-1$
+            result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testValidationErrorIsStructuredJson()
+    {
+        // The required-argument guard returns a structured ToolResult error payload, not Markdown,
+        // so the protocol layer can divert it to an isError result.
+        Map<String, String> params = new HashMap<>();
+        String result = new GetSubsystemContentTool().execute(params);
+        assertTrue("validation error must be a JSON object", //$NON-NLS-1$
+            result.trim().startsWith("{") && result.contains("\"error\"")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetTagsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetTagsToolTest.java
@@ -20,10 +20,14 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 /**
  * Tests for {@link GetTagsTool}.
  * <p>
- * Covers tool metadata, the input schema, and the projectName required-argument
- * validation that returns before the first {@code ProjectStateChecker}/
- * {@code ResourcesPlugin} access. Reading the tag store needs a live project and
- * is covered by the E2E suite.
+ * Covers tool metadata, the input schema, and the two {@code execute()}
+ * early-validation branches reachable headlessly: the missing-projectName guard
+ * and the project-not-found sentinel. Both return BEFORE the
+ * {@code TagService.getTagStorage(project)} call (the EDT boundary, which needs a
+ * live project's tag store). The transient BUILDING pre-flight
+ * ({@code ResourcesPlugin}-backed) is traversed safely for a non-existent project
+ * name (it resolves to NOT_AVAILABLE, never BUILDING). Reading the tag store is
+ * covered by the E2E suite.
  */
 public class GetTagsToolTest
 {
@@ -61,7 +65,18 @@ public class GetTagsToolTest
         assertTrue(schema.contains("\"projectName\"")); //$NON-NLS-1$
     }
 
-    // ==================== Argument validation (no live workspace needed) ====================
+    @Test
+    public void testSchemaRequiresProjectName()
+    {
+        // projectName is the sole input and it is required.
+        String schema = new GetTagsTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        assertTrue("schema must declare a required array", requiredIdx >= 0); //$NON-NLS-1$
+        assertTrue("projectName must be required", //$NON-NLS-1$
+            schema.substring(requiredIdx).contains("\"projectName\"")); //$NON-NLS-1$
+    }
+
+    // ==================== Argument validation (no live tag store needed) ====================
 
     @Test
     public void testMissingProjectName()
@@ -69,5 +84,19 @@ public class GetTagsToolTest
         Map<String, String> params = new HashMap<>();
         String result = new GetTagsTool().execute(params);
         assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testUnknownProjectIsNotFound()
+    {
+        // projectName present but the project does not exist in the (empty) test
+        // workspace: the building pre-flight resolves it to NOT_AVAILABLE (never
+        // BUILDING) and falls through to the actionable "Project not found"
+        // sentinel, which is returned before any tag-store access.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "NoSuchProject_GetTags"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetTagsTool().execute(params);
+        assertTrue("an unknown project must produce 'Project not found'", //$NON-NLS-1$
+            result.contains("Project not found")); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GoToDefinitionToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GoToDefinitionToolTest.java
@@ -152,4 +152,123 @@ public class GoToDefinitionToolTest
         assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
         assertFalse(result.contains("symbol is required")); //$NON-NLS-1$
     }
+
+    /**
+     * Blank (empty-string) projectName is treated as missing by the required-argument
+     * guard, exactly like an absent key.
+     */
+    @Test
+    public void testBlankProjectNameIsMissing()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("symbol", "Catalog.Products"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GoToDefinitionTool().execute(params);
+        assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    /**
+     * Blank symbol is treated as missing — projectName is present, so the symbol
+     * sentinel fires (the symbol guard is the second one checked).
+     */
+    @Test
+    public void testBlankSymbolIsMissing()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "TestProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("symbol", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GoToDefinitionTool().execute(params);
+        assertTrue(result.contains("symbol is required")); //$NON-NLS-1$
+    }
+
+    /**
+     * A bare method name WITH a blank modulePath is still rejected — an empty
+     * modulePath does not satisfy the "module context required" rule.
+     */
+    @Test
+    public void testBareMethodWithBlankModulePathIsRejected()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "TestProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("symbol", "MyMethod"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("modulePath", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GoToDefinitionTool().execute(params);
+        assertTrue(result.contains("modulePath is required")); //$NON-NLS-1$
+    }
+
+    // ==================== getResultFileName (pure, no workbench) ====================
+
+    /**
+     * A qualified two-part symbol is turned into a per-symbol result filename:
+     * the dot becomes a dash and the whole name is lower-cased.
+     */
+    @Test
+    public void testResultFileNameForQualifiedSymbol()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("symbol", "Catalog.Products"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("definition-catalog-products.md", //$NON-NLS-1$
+            new GoToDefinitionTool().getResultFileName(params));
+    }
+
+    /**
+     * A bare (single-part) symbol still produces a per-symbol filename — no dot,
+     * so nothing to replace, just the lower-cased name.
+     */
+    @Test
+    public void testResultFileNameForBareSymbol()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("symbol", "MyMethod"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("definition-mymethod.md", //$NON-NLS-1$
+            new GoToDefinitionTool().getResultFileName(params));
+    }
+
+    /**
+     * The result filename is lower-cased even for an already-mixed-case symbol,
+     * and every dot is replaced (not just the first).
+     */
+    @Test
+    public void testResultFileNameLowercasesAndReplacesEveryDot()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("symbol", "InformationRegister.Rates.RecordSet"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("definition-informationregister-rates-recordset.md", //$NON-NLS-1$
+            new GoToDefinitionTool().getResultFileName(params));
+    }
+
+    /**
+     * With no symbol argument the generic fallback filename is used (the per-symbol
+     * branch is guarded by a non-empty check).
+     */
+    @Test
+    public void testResultFileNameFallbackWhenSymbolMissing()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "TestProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("definition.md", new GoToDefinitionTool().getResultFileName(params)); //$NON-NLS-1$
+    }
+
+    /**
+     * An empty-string symbol also takes the fallback branch (the guard rejects both
+     * null and empty), so it does not yield "definition-.md".
+     */
+    @Test
+    public void testResultFileNameFallbackWhenSymbolBlank()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("symbol", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("definition.md", new GoToDefinitionTool().getResultFileName(params)); //$NON-NLS-1$
+    }
+
+    /**
+     * An empty params map (no symbol key) falls back to the generic filename
+     * without throwing.
+     */
+    @Test
+    public void testResultFileNameWithEmptyParams()
+    {
+        assertEquals("definition.md", //$NON-NLS-1$
+            new GoToDefinitionTool().getResultFileName(new HashMap<>()));
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ImportConfigurationFromXmlToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ImportConfigurationFromXmlToolTest.java
@@ -8,13 +8,26 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.*;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 
 /**
- * Lightweight tests for {@link ImportConfigurationFromXmlTool} that exercise
- * tool metadata and JSON schema without needing the Eclipse runtime.
+ * Lightweight tests for {@link ImportConfigurationFromXmlTool} that exercise tool
+ * metadata, JSON schema, and the argument/path-validation guards that fire BEFORE
+ * the workspace project lookup — so they run headless.
+ * <p>
+ * {@code execute()} requires {@code importPath} + {@code projectName} up front, then
+ * checks the source path on disk ("does not exist" / "is not a directory") using only
+ * {@code java.nio.file}. The "project already exists" check and the real import need a
+ * live workspace and are covered by the E2E suite.
  */
 public class ImportConfigurationFromXmlToolTest
 {
@@ -80,5 +93,64 @@ public class ImportConfigurationFromXmlToolTest
             tail.contains("\"projectNature\",") || tail.contains(",\"projectNature\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertFalse("xmlVersion must NOT be required", //$NON-NLS-1$
             tail.contains("\"xmlVersion\",") || tail.contains(",\"xmlVersion\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== Argument & path validation (returns before the workspace lookup) ===========
+
+    @Test
+    public void testExecuteMissingImportPathIsError()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "NewConfig"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ImportConfigurationFromXmlTool().execute(params);
+        assertTrue("missing importPath must produce 'importPath is required'", //$NON-NLS-1$
+            result.contains("importPath is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteMissingProjectNameIsError()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("importPath", "C:/tmp/xml-src"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ImportConfigurationFromXmlTool().execute(params);
+        assertTrue("missing projectName must produce 'projectName is required'", //$NON-NLS-1$
+            result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteNonExistentImportPathIsError()
+    {
+        // A source path that does not exist is rejected on disk, before the
+        // workspace project lookup — reachable headless.
+        String nonExistent = System.getProperty("java.io.tmpdir") //$NON-NLS-1$
+            + "/import-does-not-exist-" + UUID.randomUUID(); //$NON-NLS-1$
+        Map<String, String> params = new HashMap<>();
+        params.put("importPath", nonExistent); //$NON-NLS-1$
+        params.put("projectName", "NewConfig"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ImportConfigurationFromXmlTool().execute(params);
+        assertTrue("a non-existent importPath must be rejected", //$NON-NLS-1$
+            result.contains("does not exist")); //$NON-NLS-1$
+        assertTrue("error payload must be JSON", result.trim().startsWith("{")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testExecuteImportPathIsAFileIsError() throws IOException
+    {
+        // A source path that is a file (not a directory) is rejected on disk,
+        // before the workspace project lookup.
+        Path tempFile = Files.createTempFile("import-cfg-not-a-dir", ".tmp"); //$NON-NLS-1$ //$NON-NLS-2$
+        try
+        {
+            Map<String, String> params = new HashMap<>();
+            params.put("importPath", tempFile.toString()); //$NON-NLS-1$
+            params.put("projectName", "NewConfig"); //$NON-NLS-1$ //$NON-NLS-2$
+            String result = new ImportConfigurationFromXmlTool().execute(params);
+            assertTrue("a file importPath must be rejected as not a directory", //$NON-NLS-1$
+                result.contains("is not a directory")); //$NON-NLS-1$
+        }
+        finally
+        {
+            Files.deleteIfExists(tempFile);
+        }
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ListConfigurationsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ListConfigurationsToolTest.java
@@ -62,6 +62,37 @@ public class ListConfigurationsToolTest
     }
 
     @Test
+    public void testSchemaTypeEnumListsAllValues()
+    {
+        // The 'type' filter is an enum; the schema must advertise each accepted value
+        // so a client can offer them. Runtime validation honours the same set.
+        String schema = new ListConfigurationsTool().getInputSchema();
+        assertTrue("type enum must include 'attach'", schema.contains("attach")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("type enum must include 'client'", schema.contains("client")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("type enum must include 'all'", schema.contains("all")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testOutputSchemaDeclaresEnvelopeFields()
+    {
+        // JSON tool: it overrides the (null) default with a permissive success envelope.
+        String schema = new ListConfigurationsTool().getOutputSchema();
+        assertNotNull(schema);
+        assertTrue("outputSchema must declare success", schema.contains("\"success\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare configurations", //$NON-NLS-1$
+            schema.contains("\"configurations\"")); //$NON-NLS-1$
+        assertTrue("outputSchema must declare count", schema.contains("\"count\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testResultFileNameIsJsonDefault()
+    {
+        // No override: the IMcpTool default derives the file name from the tool name.
+        assertEquals("list_configurations.md", //$NON-NLS-1$
+            new ListConfigurationsTool().getResultFileName(new HashMap<>()));
+    }
+
+    @Test
     public void testInvalidTypeRejected()
     {
         // The out-of-enum 'type' guard runs before any live launch-manager access,
@@ -73,6 +104,30 @@ public class ListConfigurationsToolTest
         assertTrue("must be a structured error", result.contains("\"success\":false")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("must name the failing param value", result.contains("Invalid type")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("must echo the rejected value", result.contains("bogus_enum_value")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testInvalidTypeErrorNamesValidSet()
+    {
+        // The rejection message must spell out the accepted values so the caller can self-correct.
+        Map<String, String> params = new HashMap<>();
+        params.put("type", "xyz"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ListConfigurationsTool().execute(params);
+        assertTrue("must list 'all'", result.contains("all")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must list 'attach'", result.contains("attach")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must list 'client'", result.contains("client")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testUnknownTypeWithWeirdCasingRejected()
+    {
+        // Only the known tokens (case-insensitively) pass; an arbitrary value is
+        // rejected up front, before any live launch-manager access.
+        Map<String, String> params = new HashMap<>();
+        params.put("type", "Attached"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ListConfigurationsTool().execute(params);
+        assertTrue("near-miss token must still be rejected", result.contains("Invalid type")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("rejected value echoed", result.contains("Attached")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ListModulesToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ListModulesToolTest.java
@@ -8,6 +8,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
@@ -20,10 +21,10 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 /**
  * Tests for {@link ListModulesTool}.
  * <p>
- * Covers tool metadata, the input schema, and the projectName required-argument
- * validation that returns before the first {@code PlatformUI.getWorkbench()}
- * call. Enumerating modules needs a live project and is covered by the E2E
- * suite.
+ * Covers tool metadata, the input schema, the dynamic result file name, and the
+ * projectName required-argument validation that returns before the first
+ * {@code PlatformUI.getWorkbench()} call. Enumerating modules needs a live
+ * project and is covered by the E2E suite.
  */
 public class ListModulesToolTest
 {
@@ -54,15 +55,56 @@ public class ListModulesToolTest
     }
 
     @Test
+    public void testDescriptionSteersToGuideAndStructure()
+    {
+        String desc = new ListModulesTool().getDescription();
+        // The lean description must point at the on-demand guide and at the
+        // companion per-module tool, not duplicate the full parameter list.
+        assertTrue("description must steer to the on-demand guide", //$NON-NLS-1$
+            desc.contains("get_tool_guide('list_modules')")); //$NON-NLS-1$
+        assertTrue("description must point at get_module_structure for in-module detail", //$NON-NLS-1$
+            desc.contains("get_module_structure")); //$NON-NLS-1$
+    }
+
+    @Test
     public void testSchemaDeclaresParameters()
     {
         String schema = new ListModulesTool().getInputSchema();
         assertNotNull(schema);
         assertTrue(schema.contains("\"projectName\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"metadataType\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"objectName\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"nameFilter\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"limit\"")); //$NON-NLS-1$
         // metadataType is now a declared enum (schema honours the closed value set).
         assertTrue("metadataType must declare an enum", schema.contains("\"enum\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("enum must list a known value", schema.contains("commonModules")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testSchemaEnumListsEveryHandledType()
+    {
+        // The closed metadataType value set must enumerate every type the execute()
+        // switch handles (a mismatch would let a client send a value the tool rejects,
+        // or omit one it accepts). "all" is the default whole-project scan.
+        String schema = new ListModulesTool().getInputSchema();
+        String[] types = { "all", "documents", "catalogs", "commonModules", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            "informationRegisters", "accumulationRegisters", "reports", "dataProcessors", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            "exchangePlans", "businessProcesses", "tasks", "constants", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            "commonCommands", "commonForms", "webServices", "httpServices" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        for (String type : types)
+        {
+            assertTrue("metadataType enum must list '" + type + "'", //$NON-NLS-1$ //$NON-NLS-2$
+                schema.contains("\"" + type + "\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+    }
+
+    @Test
+    public void testOutputSchemaIsNullForMarkdownTool()
+    {
+        // A MARKDOWN tool returns content, not structuredContent, so it must leave
+        // the output schema at the interface default of null.
+        assertNull(new ListModulesTool().getOutputSchema());
     }
 
     @Test
@@ -76,6 +118,35 @@ public class ListModulesToolTest
         assertTrue(guide.contains("nameFilter")); //$NON-NLS-1$
     }
 
+    // ==================== Dynamic result file name (pure, no workbench) ====================
+
+    @Test
+    public void testResultFileNameUsesLowercasedProjectName()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("modules-myproject.md", //$NON-NLS-1$
+            new ListModulesTool().getResultFileName(params));
+    }
+
+    @Test
+    public void testResultFileNameFallsBackWhenProjectNameMissing()
+    {
+        // No projectName key → the static fallback file name.
+        assertEquals("modules-list.md", //$NON-NLS-1$
+            new ListModulesTool().getResultFileName(new HashMap<>()));
+    }
+
+    @Test
+    public void testResultFileNameFallsBackOnBlankProjectName()
+    {
+        // An empty projectName is treated the same as a missing one.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("modules-list.md", //$NON-NLS-1$
+            new ListModulesTool().getResultFileName(params));
+    }
+
     // ==================== Argument validation (no live workbench needed) ====================
 
     @Test
@@ -83,6 +154,35 @@ public class ListModulesToolTest
     {
         Map<String, String> params = new HashMap<>();
         String result = new ListModulesTool().execute(params);
+        assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingProjectNameCarriesDiscoveryHint()
+    {
+        // The required-argument error must steer the caller to list_projects.
+        String result = new ListModulesTool().execute(new HashMap<>());
+        assertTrue("error must point at list_projects for discovery", //$NON-NLS-1$
+            result.contains("Use list_projects")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBlankProjectNameIsError()
+    {
+        // An empty projectName is treated as missing and short-circuits before any
+        // workbench access (extractStringArgument is empty → requireArgument fails).
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ListModulesTool().execute(params);
+        assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNullParamsIsError()
+    {
+        // requireArgument tolerates a null params map and returns the error JSON
+        // rather than throwing, well before any PlatformUI call.
+        String result = new ListModulesTool().execute(null);
         assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ListProjectsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ListProjectsToolTest.java
@@ -8,7 +8,10 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
 
 import org.junit.Test;
 
@@ -18,10 +21,14 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
  * Tests for {@link ListProjectsTool}.
  * <p>
  * Takes no parameters and {@code execute()} goes straight to the live
- * {@code ResourcesPlugin} workspace, so there is no argument-validation branch.
- * The headless surface is the static contract (the tool uses the
- * {@code IMcpTool} default MARKDOWN response type); the project list is covered
- * by the E2E suite.
+ * {@code ResourcesPlugin.getWorkspace()} workspace (the EDT boundary), so there
+ * is no argument-validation branch and no pure static helper that can run
+ * headlessly: both {@code listProjects()} and {@code readEdtStatusAndNatures}
+ * read the live workspace / construct against {@code IProject}. The
+ * unit-testable surface is therefore the static metadata contract (the tool uses
+ * the {@code IMcpTool} default MARKDOWN response type and, being a content tool,
+ * declares no structured output schema); the project list is covered by the E2E
+ * suite — execute() is deliberately NOT called here.
  */
 public class ListProjectsToolTest
 {
@@ -57,5 +64,28 @@ public class ListProjectsToolTest
         String schema = new ListProjectsTool().getInputSchema();
         assertNotNull(schema);
         assertTrue(schema.contains("object")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNoOutputSchemaForContentTool()
+    {
+        // MARKDOWN content tools carry their data in content, not structuredContent,
+        // so they leave the output schema null (IMcpTool default).
+        assertNull(new ListProjectsTool().getOutputSchema());
+    }
+
+    @Test
+    public void testGuideNeverNull()
+    {
+        // GuideLoader returns "" when no bundled guide exists; never null.
+        assertNotNull(new ListProjectsTool().getGuide());
+    }
+
+    @Test
+    public void testResultFileNameIsMarkdownDefault()
+    {
+        // No override: the IMcpTool default derives the file name from the tool name.
+        assertEquals("list_projects.md", //$NON-NLS-1$
+            new ListProjectsTool().getResultFileName(new HashMap<>()));
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ListSubsystemsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ListSubsystemsToolTest.java
@@ -8,6 +8,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
@@ -63,6 +64,60 @@ public class ListSubsystemsToolTest
     }
 
     @Test
+    public void testSchemaDeclaresAllParameters()
+    {
+        String schema = new ListSubsystemsTool().getInputSchema();
+        assertTrue("schema must declare recursive", schema.contains("\"recursive\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("schema must declare limit", schema.contains("\"limit\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("schema must declare language", schema.contains("\"language\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testProjectNameIsRequiredInSchema()
+    {
+        String schema = new ListSubsystemsTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        assertTrue("schema must declare a required array", requiredIdx >= 0); //$NON-NLS-1$
+        assertTrue("projectName must be required", //$NON-NLS-1$
+            schema.substring(requiredIdx).contains("\"projectName\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNoOutputSchemaForMarkdownTool()
+    {
+        // MARKDOWN content tool: no structured output schema (IMcpTool default).
+        assertNull(new ListSubsystemsTool().getOutputSchema());
+    }
+
+    // ==================== getResultFileName (pure, no live workbench) ====================
+
+    @Test
+    public void testResultFileNameUsesLowercasedProject()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyConfig"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("subsystems-myconfig.md", //$NON-NLS-1$
+            new ListSubsystemsTool().getResultFileName(params));
+    }
+
+    @Test
+    public void testResultFileNameFallsBackWhenProjectMissing()
+    {
+        // No projectName: the generic file name (no per-project suffix).
+        assertEquals("subsystems.md", //$NON-NLS-1$
+            new ListSubsystemsTool().getResultFileName(new HashMap<>()));
+    }
+
+    @Test
+    public void testResultFileNameFallsBackWhenProjectBlank()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("subsystems.md", //$NON-NLS-1$
+            new ListSubsystemsTool().getResultFileName(params));
+    }
+
+    @Test
     public void testGuideHasMigratedDetail()
     {
         String guide = new ListSubsystemsTool().getGuide();
@@ -80,6 +135,21 @@ public class ListSubsystemsToolTest
     public void testMissingProjectName()
     {
         Map<String, String> params = new HashMap<>();
+        String result = new ListSubsystemsTool().execute(params);
+        assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
+        // Structured error envelope, returned before the first PlatformUI access.
+        assertTrue("must be a structured error", result.contains("\"success\":false")); //$NON-NLS-1$ //$NON-NLS-2$
+        // The required-arg guard appends the canonical discovery hint for projectName.
+        assertTrue("must steer to list_projects", result.contains("list_projects")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testBlankProjectName()
+    {
+        // A blank value is treated as missing by the required-arg guard, still
+        // returning before the live workbench is touched.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", ""); //$NON-NLS-1$ //$NON-NLS-2$
         String result = new ListSubsystemsTool().execute(params);
         assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
     }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ReadMethodSourceToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ReadMethodSourceToolTest.java
@@ -7,7 +7,9 @@
 package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
@@ -20,10 +22,13 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 /**
  * Tests for {@link ReadMethodSourceTool}.
  * <p>
- * Covers tool metadata, the input schema, and the three required-argument
- * validation branches (projectName, modulePath, methodName) that return before
- * the first {@code PlatformUI.getWorkbench()} call. Method extraction needs a
- * live workbench and the loaded BSL model and is covered by the E2E suite.
+ * Covers tool metadata, the input schema, the on-demand guide, the pure
+ * {@code getResultFileName} helper, and the three required-argument validation
+ * branches (projectName, modulePath, methodName) — including blank values,
+ * check ordering, discovery hints, and the error-JSON envelope — that return
+ * before the first {@code PlatformUI.getWorkbench()} call (the EDT boundary).
+ * Method extraction needs a live workbench and the loaded BSL model and is
+ * covered by the E2E suite.
  */
 public class ReadMethodSourceToolTest
 {
@@ -90,5 +95,194 @@ public class ReadMethodSourceToolTest
         params.put("modulePath", "CommonModules/Foo/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
         String result = new ReadMethodSourceTool().execute(params);
         assertTrue(result.contains("methodName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBlankProjectNameIsError()
+    {
+        // A blank value is treated like a missing one by the required-argument guard.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("modulePath", "CommonModules/Foo/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("methodName", "DoStuff"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ReadMethodSourceTool().execute(params);
+        assertTrue("blank projectName must be rejected", //$NON-NLS-1$
+            result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBlankModulePathIsError()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("modulePath", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("methodName", "DoStuff"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ReadMethodSourceTool().execute(params);
+        assertTrue("blank modulePath must be rejected", //$NON-NLS-1$
+            result.contains("modulePath is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBlankMethodNameIsError()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("modulePath", "CommonModules/Foo/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("methodName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ReadMethodSourceTool().execute(params);
+        assertTrue("blank methodName must be rejected", //$NON-NLS-1$
+            result.contains("methodName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testValidationChecksProjectNameFirst()
+    {
+        // requireArguments checks projectName, then modulePath, then methodName in order and
+        // returns the FIRST failure. With ALL three missing, the error must name projectName only.
+        Map<String, String> params = new HashMap<>();
+        String result = new ReadMethodSourceTool().execute(params);
+        assertTrue("first failure must be projectName", //$NON-NLS-1$
+            result.contains("projectName is required")); //$NON-NLS-1$
+        assertFalse("must not report modulePath before projectName is satisfied", //$NON-NLS-1$
+            result.contains("modulePath is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testValidationChecksModulePathBeforeMethodName()
+    {
+        // projectName satisfied, modulePath and methodName both missing → modulePath first.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ReadMethodSourceTool().execute(params);
+        assertTrue("second failure must be modulePath", //$NON-NLS-1$
+            result.contains("modulePath is required")); //$NON-NLS-1$
+        assertFalse("must not report methodName before modulePath is satisfied", //$NON-NLS-1$
+            result.contains("methodName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingProjectNameErrorCarriesDiscoveryHint()
+    {
+        Map<String, String> params = new HashMap<>();
+        String result = new ReadMethodSourceTool().execute(params);
+        assertTrue("projectName error must steer to list_projects", //$NON-NLS-1$
+            result.contains("list_projects")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingModulePathErrorCarriesDiscoveryHint()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ReadMethodSourceTool().execute(params);
+        assertTrue("modulePath error must steer to list_modules", //$NON-NLS-1$
+            result.contains("list_modules")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingMethodNameErrorCarriesDiscoveryHint()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("modulePath", "CommonModules/Foo/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ReadMethodSourceTool().execute(params);
+        assertTrue("methodName error must steer to get_module_structure", //$NON-NLS-1$
+            result.contains("get_module_structure")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testValidationErrorIsStructuredFailureJson()
+    {
+        // The required-argument guard returns the structured error envelope.
+        Map<String, String> params = new HashMap<>();
+        String result = new ReadMethodSourceTool().execute(params);
+        assertTrue("error payload must carry success:false", //$NON-NLS-1$
+            result.contains("\"success\":false") || result.contains("\"success\": false")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("error payload must carry an error field", result.contains("\"error\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== getResultFileName (pure helper, no workbench) ====================
+
+    @Test
+    public void testResultFileNameWithMethodName()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("methodName", "MyMethod"); //$NON-NLS-1$ //$NON-NLS-2$
+        // Name is lower-cased and wrapped as method-<name>.md.
+        assertEquals("method-mymethod.md", new ReadMethodSourceTool().getResultFileName(params)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResultFileNameLowercasesMixedCase()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("methodName", "CamelCaseName"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("method-camelcasename.md", //$NON-NLS-1$
+            new ReadMethodSourceTool().getResultFileName(params));
+    }
+
+    @Test
+    public void testResultFileNameWithoutMethodName()
+    {
+        Map<String, String> params = new HashMap<>();
+        assertEquals("method-source.md", new ReadMethodSourceTool().getResultFileName(params)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResultFileNameWithBlankMethodName()
+    {
+        // An empty methodName is treated as absent → the generic file name.
+        Map<String, String> params = new HashMap<>();
+        params.put("methodName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("method-source.md", new ReadMethodSourceTool().getResultFileName(params)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResultFileNameWithNullParamsIsSafe()
+    {
+        // extractStringArgument tolerates a null params map → generic file name, no NPE.
+        assertEquals("method-source.md", new ReadMethodSourceTool().getResultFileName(null)); //$NON-NLS-1$
+    }
+
+    // ==================== Schema / metadata details ====================
+
+    @Test
+    public void testSchemaMarksAllThreeParametersRequired()
+    {
+        String schema = new ReadMethodSourceTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        assertTrue("schema must declare a required array", requiredIdx >= 0); //$NON-NLS-1$
+        String tail = schema.substring(requiredIdx);
+        assertTrue("projectName must be required", tail.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("modulePath must be required", tail.contains("\"modulePath\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("methodName must be required", tail.contains("\"methodName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testDescriptionSteersToReadModuleSource()
+    {
+        // The single-method tool advertises its whole-module sibling.
+        String desc = new ReadMethodSourceTool().getDescription();
+        assertTrue("description must point to read_module_source", //$NON-NLS-1$
+            desc.contains("read_module_source")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testOutputSchemaIsNullForMarkdownTool()
+    {
+        // MARKDOWN tools return content, not structuredContent → no output schema.
+        assertNull(new ReadMethodSourceTool().getOutputSchema());
+    }
+
+    @Test
+    public void testGuideIsServedAndDocumentsContentHashRoundTrip()
+    {
+        String guide = new ReadMethodSourceTool().getGuide();
+        assertNotNull(guide);
+        assertFalse("guide must not be empty", guide.isEmpty()); //$NON-NLS-1$
+        assertTrue("guide must explain the contentHash round-trip", //$NON-NLS-1$
+            guide.contains("contentHash")); //$NON-NLS-1$
+        assertTrue("guide must note case-insensitive method matching", //$NON-NLS-1$
+            guide.toLowerCase().contains("case-insensitive")); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ReadModuleSourceToolTest.java
@@ -118,6 +118,68 @@ public class ReadModuleSourceToolTest
         assertEquals("module-source.md", fileName); //$NON-NLS-1$
     }
 
+    @Test
+    public void testResultFileNameNormalizesBackslashes()
+    {
+        // Both '/' and '\\' separators collapse to '-' and the name is lower-cased.
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("modulePath", "CommonModules\\MyModule\\Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        String fileName = tool.getResultFileName(params);
+        assertEquals("source-commonmodules-mymodule-module.bsl.md", fileName); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResultFileNameWithBlankModulePath()
+    {
+        // An empty modulePath is treated as absent → the generic file name.
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("modulePath", ""); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertEquals("module-source.md", tool.getResultFileName(params)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResultFileNameWithNullParamsIsSafe()
+    {
+        // extractStringArgument tolerates a null params map → generic file name, no NPE.
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        assertEquals("module-source.md", tool.getResultFileName(null)); //$NON-NLS-1$
+    }
+
+    // ==================== Schema typing / output schema ====================
+
+    @Test
+    public void testInputSchemaTypesLineRangeAsOptionalIntegers()
+    {
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        String schema = tool.getInputSchema();
+
+        // startLine/endLine are integer-typed (not strings).
+        assertTrue("schema must type line params as integer", schema.contains("\"integer\"")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        // ...and they must NOT be in the required array (only projectName + modulePath are).
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        assertTrue("schema must declare a required array", requiredIdx >= 0); //$NON-NLS-1$
+        int open = schema.indexOf('[', requiredIdx);
+        int close = schema.indexOf(']', open);
+        assertTrue("required array must be well-formed", open >= 0 && close > open); //$NON-NLS-1$
+        String requiredBlock = schema.substring(open, close + 1);
+        assertTrue("projectName must be required", requiredBlock.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("modulePath must be required", requiredBlock.contains("\"modulePath\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("startLine must NOT be required", requiredBlock.contains("\"startLine\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("endLine must NOT be required", requiredBlock.contains("\"endLine\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testOutputSchemaIsNullForMarkdownTool()
+    {
+        // MARKDOWN tools return content, not structuredContent → no output schema.
+        assertNull(new ReadModuleSourceTool().getOutputSchema());
+    }
+
     // ==================== Required parameter validation ====================
 
     @Test
@@ -140,6 +202,84 @@ public class ReadModuleSourceToolTest
 
         String result = tool.execute(params);
         assertTrue(result.contains("modulePath is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteBlankProjectName()
+    {
+        // A blank value is rejected exactly like a missing one.
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("modulePath", "CommonModules/MyModule/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        String result = tool.execute(params);
+        assertTrue("blank projectName must be rejected", //$NON-NLS-1$
+            result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteBlankModulePath()
+    {
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "TestProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("modulePath", ""); //$NON-NLS-1$ //$NON-NLS-2$
+
+        String result = tool.execute(params);
+        assertTrue("blank modulePath must be rejected", //$NON-NLS-1$
+            result.contains("modulePath is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testProjectNameCheckedBeforeModulePath()
+    {
+        // projectName is validated first; with both absent the error names projectName only.
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        Map<String, String> params = new HashMap<>();
+
+        String result = tool.execute(params);
+        assertTrue("first failure must be projectName", //$NON-NLS-1$
+            result.contains("projectName is required")); //$NON-NLS-1$
+        assertFalse("must not report modulePath before projectName is satisfied", //$NON-NLS-1$
+            result.contains("modulePath is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingProjectNameErrorCarriesDiscoveryHint()
+    {
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        Map<String, String> params = new HashMap<>();
+
+        String result = tool.execute(params);
+        assertTrue("projectName error must steer to list_projects", //$NON-NLS-1$
+            result.contains("list_projects")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingModulePathErrorCarriesExampleDetail()
+    {
+        // modulePath uses the two-arg requireArgument with a custom example suffix,
+        // NOT the canonical discovery hint.
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "TestProject"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        String result = tool.execute(params);
+        assertTrue("modulePath error must include the example path", //$NON-NLS-1$
+            result.contains("CommonModules/MyModule/Module.bsl")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testValidationErrorIsStructuredFailureJson()
+    {
+        ReadModuleSourceTool tool = new ReadModuleSourceTool();
+        Map<String, String> params = new HashMap<>();
+
+        String result = tool.execute(params);
+        assertTrue("error payload must carry success:false", //$NON-NLS-1$
+            result.contains("\"success\":false") || result.contains("\"success\": false")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("error payload must carry an error field", result.contains("\"error\"")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     // ==================== formatOutput ====================
@@ -226,5 +366,40 @@ public class ReadModuleSourceToolTest
 
         assertFalse("must NOT contain contentHash when null", result.contains("contentHash")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("other frontmatter still present", result.contains("totalLines: 1\n")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatOutputEmitsOnlyRequestedRange()
+    {
+        // A range read (from=2, to=4 over a 5-line file) must slice the body to those
+        // lines only — line1 and line5 are excluded, but totalLines still reports 5.
+        List<String> lines = Arrays.asList(
+            "line1", "line2", "line3", "line4", "line5"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+
+        String result = ReadModuleSourceTool.formatOutput(
+            "MyProject", "CommonModules/Mid/Module.bsl", lines, 2, 4, 5, false, "abc123"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+        assertTrue("must report the requested window start", result.contains("startLine: 2\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must report the requested window end", result.contains("endLine: 4\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must report the FULL file length", result.contains("totalLines: 5\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("body must include line2", result.contains("line2\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("body must include line3", result.contains("line3\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("body must include line4", result.contains("line4\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("body must exclude line before the window", result.contains("line1\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("body must exclude line after the window", result.contains("line5\n")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatOutputSingleLineRange()
+    {
+        // A single-line window (from == to) yields exactly that one body line.
+        List<String> lines = Arrays.asList("alpha", "beta", "gamma"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+        String result = ReadModuleSourceTool.formatOutput(
+            "P", "CommonModules/One/Module.bsl", lines, 2, 2, 3, false, "h"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+        assertTrue("body must include the single requested line", result.contains("beta\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("body must exclude the preceding line", result.contains("alpha\n")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("body must exclude the following line", result.contains("gamma\n")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ResumeToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ResumeToolTest.java
@@ -9,13 +9,18 @@ package com.ditrix.edt.mcp.server.tools.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.debug.core.model.IThread;
+import org.junit.After;
 import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+import com.ditrix.edt.mcp.server.utils.DebugSessionRegistry;
 
 /**
  * Tests for {@link ResumeTool}.
@@ -65,7 +70,26 @@ public class ResumeToolTest
         assertTrue(schema.contains("\"applicationId\"")); //$NON-NLS-1$
     }
 
+    @Test
+    public void testOutputSchemaDeclaresResumeFields()
+    {
+        String schema = new ResumeTool().getOutputSchema();
+        assertNotNull(schema);
+        assertTrue(schema.contains("\"resumed\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"scope\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"applicationId\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"autoResolved\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"serverTarget\"")); //$NON-NLS-1$
+    }
+
     // ==================== Argument validation (no live debug session needed) ====================
+
+    /** Keep the shared singleton registry clean between cases that mutate it. */
+    @After
+    public void clearRegistry()
+    {
+        DebugSessionRegistry.get().clear();
+    }
 
     @Test
     public void testStaleThreadIdWhenNoLiveSession()
@@ -74,5 +98,52 @@ public class ResumeToolTest
         params.put("threadId", "999999"); //$NON-NLS-1$ //$NON-NLS-2$
         String result = new ResumeTool().execute(params);
         assertTrue(result.contains("stale threadId")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNoArgumentsWithNoActiveSessionIsError()
+    {
+        // No threadId, no applicationId, and no auto-resolvable session headless:
+        // the tool reports the "provide threadId or applicationId" error.
+        DebugSessionRegistry.get().clear();
+        Map<String, String> params = new HashMap<>();
+        String result = new ResumeTool().execute(params);
+        assertTrue(result.contains("Provide threadId or applicationId")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testUnknownExplicitApplicationIdIsError()
+    {
+        // A concrete, non-matching applicationId resolves to null headless and must
+        // NOT fall back to a lone session — it reports the specific not-found error.
+        Map<String, String> params = new HashMap<>();
+        params.put("applicationId", "launch:DoesNotExist"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ResumeTool().execute(params);
+        assertTrue(result.contains("no active debug target for applicationId")); //$NON-NLS-1$
+        assertTrue(result.contains("launch:DoesNotExist")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testThreadThatCannotResumeIsError()
+    {
+        // A registered thread that reports canResume()==false drives the
+        // "thread cannot resume" guard — reachable headlessly via the in-memory
+        // registry without any live DebugPlugin target.
+        DebugSessionRegistry registry = DebugSessionRegistry.get();
+        registry.clear();
+        IThread thread = mock(IThread.class);
+        when(thread.canResume()).thenReturn(false);
+        when(thread.isSuspended()).thenReturn(false);
+        String appId = "launch:NoResumeCfg"; //$NON-NLS-1$
+        registry.injectSuspend(appId, thread);
+        long threadId = registry.getSnapshot(appId).threadId;
+
+        Map<String, String> params = new HashMap<>();
+        params.put("threadId", Long.toString(threadId)); //$NON-NLS-1$
+        String result = new ResumeTool().execute(params);
+
+        assertTrue(result.contains("thread cannot resume")); //$NON-NLS-1$
+        // The state hint reflects the stubbed running thread.
+        assertTrue(result.contains("running")); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskToolTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -17,7 +18,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
@@ -25,18 +28,25 @@ import org.junit.Test;
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 
 /**
- * Lightweight contract tests for {@link ResyncToDiskTool}: tool metadata, JSON input/output
- * schema, the documented response-format policy, plus the headless-testable decision cores -
- * which FQNs the export takes ({@code selectExportFqns}), the commit-honest dangling-removal
- * reporting ({@code runRemovalWriteTask}) and the missing-{@code .mdo} filesystem checks -
- * without needing the Eclipse/EDT runtime.
+ * Lightweight contract tests for {@link ResyncToDiskTool}: tool metadata, the bundled
+ * {@code get_tool_guide} body, JSON input/output schema (incl. input/output field separation),
+ * the documented response-format policy, plus the headless-testable decision cores - which FQNs
+ * the export takes ({@code selectExportFqns}), the {@code DanglingResult} report/commit-count
+ * semantics, the commit-honest dangling-removal reporting ({@code runRemovalWriteTask}) and the
+ * missing-{@code .mdo} filesystem checks ({@code findMissingMdoFiles} /
+ * {@code findMissingMdoFilesWithWait}) - without needing the Eclipse/EDT runtime.
  * <p>
- * The {@code execute()} path walks the live BM model, force-exports {@code .mdo} files to disk
- * and (only with {@code cleanDanglingReferences=true}) mutates the {@code Configuration}, so it
- * needs a live workbench and BM model; the real repair behaviour (delete a {@code .mdo} and
- * restore it) is covered by the E2E suite. Fabricating a genuinely dangling Configuration
- * reference through public tools is not possible headless, so the REMOVAL outcome reporting is
- * pinned here at the unit level instead (see the {@code runRemovalWriteTask} tests).
+ * {@code execute()} is NOT exercised here: it is {@code final} on
+ * {@link com.ditrix.edt.mcp.server.tools.base.AbstractMetadataWriteTool} and immediately calls
+ * {@code ProjectStateChecker.buildingErrorOrNull(...)} then
+ * {@code PlatformUI.getWorkbench().getDisplay()} BEFORE any subclass arg-validation, so it cannot
+ * run headlessly - the {@code projectName is required} guard lives in {@code executeOnUiThread},
+ * which only runs on the SWT UI thread. The {@code execute()} path then walks the live BM model,
+ * force-exports {@code .mdo} files and (only with {@code cleanDanglingReferences=true}) mutates the
+ * {@code Configuration}, so the real repair behaviour (delete a {@code .mdo} and restore it) is
+ * covered by the E2E suite. Fabricating a genuinely dangling Configuration reference through public
+ * tools is not possible headless, so the REMOVAL outcome reporting is pinned here at the unit level
+ * instead (see the {@code runRemovalWriteTask} tests).
  */
 public class ResyncToDiskToolTest
 {
@@ -118,6 +128,68 @@ public class ResyncToDiskToolTest
         // The request flags are echoed back so a caller can verify what actually ran.
         assertTrue(schema.contains("\"fullExport\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"revalidate\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"cleanDanglingReferences\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testReportOnlyOutputFieldsAreNotInputParameters()
+    {
+        // The dangling-scan report fields are AUTO-COMPUTED outputs, never inputs. A future
+        // edit must not accidentally turn one into an input the tool would then ignore.
+        ResyncToDiskTool tool = new ResyncToDiskTool();
+        String input = tool.getInputSchema();
+        assertFalse("danglingFound is an output, not an input parameter", //$NON-NLS-1$
+            input.contains("\"danglingFound\"")); //$NON-NLS-1$
+        assertFalse("missingBefore is an output, not an input parameter", //$NON-NLS-1$
+            input.contains("\"missingBefore\"")); //$NON-NLS-1$
+        assertFalse("objectsExported is an output, not an input parameter", //$NON-NLS-1$
+            input.contains("\"objectsExported\"")); //$NON-NLS-1$
+        // ...and they ARE declared on the output side.
+        String output = tool.getOutputSchema();
+        assertTrue(output.contains("\"danglingFound\"")); //$NON-NLS-1$
+        assertTrue(output.contains("\"objectsExported\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResultFileNameDefaultsToToolNameMarkdown()
+    {
+        // resync_to_disk does not override getResultFileName, so the IMcpTool default
+        // (toolName + ".md") applies regardless of params.
+        ResyncToDiskTool tool = new ResyncToDiskTool();
+        assertEquals("resync_to_disk.md", tool.getResultFileName(Collections.emptyMap())); //$NON-NLS-1$
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "Whatever"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("the result file name must not depend on the params", //$NON-NLS-1$
+            "resync_to_disk.md", tool.getResultFileName(params)); //$NON-NLS-1$
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // getGuide(): the on-demand how-to. resync_to_disk does NOT override it, so the IMcpTool
+    // default loads guides/resync_to_disk.md via GuideLoader (resolves through the OSGi bundle
+    // active under Tycho Surefire). This pins that the guide resource is actually PACKAGED and
+    // keyed off the tool name, and that it documents the destructive opt-in and the report fields.
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void testGuideIsPackagedAndNonEmpty()
+    {
+        String guide = new ResyncToDiskTool().getGuide();
+        assertNotNull("getGuide() must never return null", guide); //$NON-NLS-1$
+        assertFalse("the bundled guides/resync_to_disk.md must be packaged and load non-empty", //$NON-NLS-1$
+            guide.isEmpty());
+    }
+
+    @Test
+    public void testGuideDocumentsTheDestructiveDanglingOptIn()
+    {
+        String guide = new ResyncToDiskTool().getGuide();
+        assertTrue("guide must document the cleanDanglingReferences opt-in", //$NON-NLS-1$
+            guide.contains("cleanDanglingReferences")); //$NON-NLS-1$
+        assertTrue("guide must warn the opt-in is destructive", //$NON-NLS-1$
+            guide.toLowerCase().contains("destructive")); //$NON-NLS-1$
+        assertTrue("guide must document the fullExport refresh", guide.contains("fullExport")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("guide must document the missingBefore desync report", //$NON-NLS-1$
+            guide.contains("missingBefore")); //$NON-NLS-1$
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -150,6 +222,27 @@ public class ResyncToDiskToolTest
         List<String> missing = Arrays.asList("Catalog.B"); //$NON-NLS-1$
         assertEquals("fullExport=true must opt back in to the export-everything refresh", //$NON-NLS-1$
             all, ResyncToDiskTool.selectExportFqns(true, all, missing));
+    }
+
+    @Test
+    public void testSelectExportFqnsDefaultReturnsTheMissingListItself()
+    {
+        // The default branch must hand back the missing subset as-is (no copy/filter): the
+        // caller exports exactly the objects integrity-checked as missing, nothing more.
+        List<String> all = Arrays.asList("Catalog.A", "Catalog.B"); //$NON-NLS-1$ //$NON-NLS-2$
+        List<String> missing = Arrays.asList("Catalog.B"); //$NON-NLS-1$
+        assertSame("default must reuse the missing list, not derive a new one", //$NON-NLS-1$
+            missing, ResyncToDiskTool.selectExportFqns(false, all, missing));
+    }
+
+    @Test
+    public void testSelectExportFqnsFullExportEvenWhenNothingMissing()
+    {
+        // fullExport=true is a deliberate full refresh: it exports every object even on an
+        // in-sync project (empty missing set), unlike the default no-op.
+        List<String> all = Arrays.asList("Catalog.A", "Document.C"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("fullExport=true must export all even with an empty missing set", //$NON-NLS-1$
+            all, ResyncToDiskTool.selectExportFqns(true, all, Collections.emptyList()));
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -204,6 +297,43 @@ public class ResyncToDiskToolTest
         assertNull(result.warning);
     }
 
+    @Test
+    public void testFreshDanglingResultIsAnEmptyCleanReport()
+    {
+        // A just-constructed result (the clean-project / scan-skipped baseline) must report
+        // nothing found, nothing removed, no warning - so an in-sync run shows danglingFound 0.
+        ResyncToDiskTool.DanglingResult result = new ResyncToDiskTool.DanglingResult();
+        assertEquals("a fresh result must have found nothing", 0, result.found); //$NON-NLS-1$
+        assertFalse("a fresh result must claim no removal", result.removedFromModel); //$NON-NLS-1$
+        assertEquals("a fresh result must report 0 removed", 0, result.removedCount()); //$NON-NLS-1$
+        assertNotNull("details must be a live (empty) list, never null", result.details); //$NON-NLS-1$
+        assertTrue(result.details.isEmpty());
+        assertNull("a fresh result must carry no warning", result.warning); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRemovedCountIsZeroWhenFoundButNotCommitted()
+    {
+        // removedCount() gates on the COMMIT flag, not on `found`: entries were observed
+        // (found > 0) but the removal was not committed, so the reported count stays 0 -
+        // a report-only scan never over-claims a removal.
+        ResyncToDiskTool.DanglingResult result = new ResyncToDiskTool.DanglingResult();
+        result.found = 5;
+        // removedFromModel left at its default false (no committed write).
+        assertEquals("found entries that were not committed must report 0 removed", //$NON-NLS-1$
+            0, result.removedCount());
+    }
+
+    @Test
+    public void testRemovedCountEqualsFoundOnlyWhenCommitted()
+    {
+        ResyncToDiskTool.DanglingResult result = new ResyncToDiskTool.DanglingResult();
+        result.found = 4;
+        result.removedFromModel = true;
+        assertEquals("a committed removal reports exactly the found count", //$NON-NLS-1$
+            4, result.removedCount());
+    }
+
     // ---------------------------------------------------------------------------------------------
     // The post-export integrity check must reflect REAL on-disk state. The force-export
     // flushes the .mdo asynchronously, so stillMissing is computed with a short bounded wait that
@@ -252,6 +382,82 @@ public class ResyncToDiskToolTest
             List<String> missing =
                 ResyncToDiskTool.findMissingMdoFiles(projectRoot, Arrays.asList("Catalog.Foo")); //$NON-NLS-1$
             assertTrue("a present .mdo must not be reported as missing", missing.isEmpty()); //$NON-NLS-1$
+        }
+        finally
+        {
+            deleteRecursively(projectRoot);
+        }
+    }
+
+    @Test
+    public void testFindMissingMdoFilesEmptyInputIsEmpty() throws IOException
+    {
+        File projectRoot = Files.createTempDirectory("resync-empty").toFile(); //$NON-NLS-1$
+        try
+        {
+            assertTrue("no FQNs in means no missing FQNs out", //$NON-NLS-1$
+                ResyncToDiskTool.findMissingMdoFiles(projectRoot, Collections.emptyList()).isEmpty());
+        }
+        finally
+        {
+            deleteRecursively(projectRoot);
+        }
+    }
+
+    @Test
+    public void testFindMissingMdoFilesPartitionsPresentFromAbsent() throws IOException
+    {
+        File projectRoot = Files.createTempDirectory("resync-mixed").toFile(); //$NON-NLS-1$
+        try
+        {
+            // Foo exists on disk; Bar does not - only Bar must be reported, in input order.
+            touch(new File(projectRoot, "src/Catalogs/Foo/Foo.mdo")); //$NON-NLS-1$
+            List<String> missing = ResyncToDiskTool.findMissingMdoFiles(projectRoot,
+                Arrays.asList("Catalog.Foo", "Document.Bar")); //$NON-NLS-1$ //$NON-NLS-2$
+            assertEquals(1, missing.size());
+            assertEquals("only the absent .mdo is reported missing", //$NON-NLS-1$
+                "Document.Bar", missing.get(0)); //$NON-NLS-1$
+        }
+        finally
+        {
+            deleteRecursively(projectRoot);
+        }
+    }
+
+    @Test
+    public void testFindMissingMdoFilesSkipsFqnWithNoTypeDirectoryLayout() throws IOException
+    {
+        File projectRoot = Files.createTempDirectory("resync-skip").toFile(); //$NON-NLS-1$
+        try
+        {
+            // "Configuration" is dotless -> MetadataPathResolver.resolveTopObjectMdoPath returns
+            // null (no src/<TypeDir>/<Name>/<Name>.mdo layout), so it must be SKIPPED, never
+            // reported as a missing desync even though no such file exists on disk.
+            List<String> missing = ResyncToDiskTool.findMissingMdoFiles(projectRoot,
+                Arrays.asList("Configuration", "Catalog.Foo")); //$NON-NLS-1$ //$NON-NLS-2$
+            assertEquals("the dotless/no-layout FQN must be skipped, only the real desync reported", //$NON-NLS-1$
+                Arrays.asList("Catalog.Foo"), missing); //$NON-NLS-1$
+        }
+        finally
+        {
+            deleteRecursively(projectRoot);
+        }
+    }
+
+    @Test
+    public void testBoundedWaitEmptyInputReturnsImmediatelyEmpty() throws IOException
+    {
+        File projectRoot = Files.createTempDirectory("resync-wait-empty").toFile(); //$NON-NLS-1$
+        try
+        {
+            // Nothing to wait for: an empty FQN set must return at once without paying the budget.
+            long start = System.currentTimeMillis();
+            List<String> missing = ResyncToDiskTool.findMissingMdoFilesWithWait(projectRoot,
+                Collections.emptyList(), 5000L, 100L);
+            long elapsed = System.currentTimeMillis() - start;
+            assertTrue("an empty input must yield an empty still-missing set", missing.isEmpty()); //$NON-NLS-1$
+            assertTrue("an empty input must not spend the wait budget (elapsed=" //$NON-NLS-1$
+                + elapsed + "ms)", elapsed < 1000L); //$NON-NLS-1$
         }
         finally
         {

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/RevalidateObjectsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/RevalidateObjectsToolTest.java
@@ -9,6 +9,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -80,7 +81,7 @@ public class RevalidateObjectsToolTest
         String tail = schema.substring(requiredIdx);
         assertTrue("projectName must be required", tail.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
         // The objects filter is optional (empty/absent = full-project revalidation).
-        assertTrue("objects must NOT be required", !tail.contains("\"objects\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("objects must NOT be required", tail.contains("\"objects\"")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/RevalidateObjectsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/RevalidateObjectsToolTest.java
@@ -10,6 +10,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
@@ -17,11 +23,13 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 /**
  * Tests for {@link RevalidateObjectsTool}.
  * <p>
- * {@code projectName} is optional (an empty/absent objects array means full-project
- * revalidation) and both branches go through {@code ProjectStateChecker}/the live
- * validation manager, so there is no argument-validation branch reachable before
- * live access. The headless surface is the static contract; revalidation is
- * covered by the E2E suite.
+ * {@code projectName} is optional in the schema, but the static
+ * {@link RevalidateObjectsTool#revalidateObjects(String, List)} entry point guards a
+ * null/blank {@code projectName} BEFORE any workspace or platform-services access, and
+ * {@code execute()} reaches that same guard when {@code projectName} is missing/blank
+ * (the only branch it skips for a blank name is the {@code ProjectStateChecker} call).
+ * Everything past a non-empty name needs a live EDT workspace and is covered by the
+ * E2E suite. These tests pin the metadata contract plus that headless guard.
  */
 public class RevalidateObjectsToolTest
 {
@@ -61,5 +69,92 @@ public class RevalidateObjectsToolTest
         assertNotNull(schema);
         assertTrue(schema.contains("\"projectName\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"objects\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testProjectNameIsTheOnlyRequiredParameter()
+    {
+        String schema = new RevalidateObjectsTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        assertTrue("schema must declare a required array", requiredIdx >= 0); //$NON-NLS-1$
+        String tail = schema.substring(requiredIdx);
+        assertTrue("projectName must be required", tail.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        // The objects filter is optional (empty/absent = full-project revalidation).
+        assertTrue("objects must NOT be required", !tail.contains("\"objects\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testGuideNotEmpty()
+    {
+        String guide = new RevalidateObjectsTool().getGuide();
+        assertNotNull(guide);
+        assertTrue(guide.length() > 0);
+    }
+
+    // ==================== revalidateObjects static guard (returns before any EDT access) ====================
+
+    @Test
+    public void testStaticRevalidateNullProjectIsError()
+    {
+        // The first guard in revalidateObjects rejects a null projectName before
+        // touching ProjectContext / the BM model — so this is headless-safe.
+        String result = RevalidateObjectsTool.revalidateObjects(null, Collections.emptyList());
+        assertTrue("null projectName must produce 'projectName is required'", //$NON-NLS-1$
+            result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStaticRevalidateEmptyProjectIsError()
+    {
+        // A non-empty objects list must not change the outcome: a blank projectName
+        // is rejected by the first guard before the FQNs are ever looked up.
+        List<String> objects = new ArrayList<>();
+        objects.add("Document.SalesOrder"); //$NON-NLS-1$
+        String result = RevalidateObjectsTool.revalidateObjects("", objects); //$NON-NLS-1$
+        assertTrue("empty projectName must produce 'projectName is required'", //$NON-NLS-1$
+            result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStaticRevalidateNullObjectsListWithBlankProjectIsError()
+    {
+        // A null objects list is normalized to a full-project revalidation, but the
+        // blank-projectName guard still fires first — no EDT access on this path.
+        String result = RevalidateObjectsTool.revalidateObjects("", null); //$NON-NLS-1$
+        assertTrue("blank projectName must produce 'projectName is required'", //$NON-NLS-1$
+            result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteMissingProjectNameIsError()
+    {
+        // With no projectName, execute() skips the ProjectStateChecker block and
+        // delegates to the static guard, which returns the error before any EDT access.
+        Map<String, String> params = new HashMap<>();
+        String result = new RevalidateObjectsTool().execute(params);
+        assertTrue("missing projectName must produce 'projectName is required'", //$NON-NLS-1$
+            result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteBlankProjectNameWithObjectsIsError()
+    {
+        // objects is parsed (a pure helper) before delegating; a blank projectName
+        // still short-circuits at the static guard ahead of any workspace lookup.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("objects", "[\"Document.SalesOrder\"]"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new RevalidateObjectsTool().execute(params);
+        assertTrue("blank projectName must produce 'projectName is required'", //$NON-NLS-1$
+            result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStaticRevalidateErrorPayloadIsJson()
+    {
+        // The guard returns a ToolResult.error(...).toJson() payload (structured
+        // error), not a MARKDOWN body — pin that the error travels as JSON.
+        String result = RevalidateObjectsTool.revalidateObjects(null, new ArrayList<>());
+        assertTrue("error payload must be JSON", result.trim().startsWith("{")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/SearchInCodeToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/SearchInCodeToolTest.java
@@ -7,6 +7,7 @@
 package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -20,10 +21,12 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 /**
  * Tests for {@link SearchInCodeTool}.
  * <p>
- * Covers tool metadata, the input schema, and the argument-validation branches
- * (projectName, query, outputMode) that return before the first
- * {@code ResourcesPlugin}/project access. The actual search needs a live project
- * and is covered by the E2E suite.
+ * Covers tool metadata, the input schema, the pure {@code getResultFileName}
+ * sanitiser, and the argument-validation branches (projectName, query, outputMode)
+ * that return before the first {@code ProjectContext.of(...)} →
+ * {@code ResourcesPlugin.getWorkspace()} access (the EDT boundary). The regex-compile,
+ * unknown-metadataType and actual file-scan paths run AFTER that boundary and need a
+ * live project, so they are covered by the E2E suite, not here.
  */
 public class SearchInCodeToolTest
 {
@@ -61,6 +64,107 @@ public class SearchInCodeToolTest
         assertTrue(schema.contains("\"projectName\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"query\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"outputMode\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSchemaDeclaresAllOptionalParameters()
+    {
+        String schema = new SearchInCodeTool().getInputSchema();
+        assertTrue("schema must declare caseSensitive", schema.contains("\"caseSensitive\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("schema must declare isRegex", schema.contains("\"isRegex\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("schema must declare limit", schema.contains("\"limit\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("schema must declare the deprecated maxResults alias", //$NON-NLS-1$
+            schema.contains("\"maxResults\"")); //$NON-NLS-1$
+        assertTrue("schema must declare contextLines", schema.contains("\"contextLines\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("schema must declare fileMask", schema.contains("\"fileMask\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("schema must declare metadataType", schema.contains("\"metadataType\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testSchemaRequiresProjectNameAndQuery()
+    {
+        String schema = new SearchInCodeTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        assertTrue("schema must declare a required array", requiredIdx >= 0); //$NON-NLS-1$
+        String tail = schema.substring(requiredIdx);
+        assertTrue("projectName must be required", tail.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("query must be required", tail.contains("\"query\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testOutputModeEnumDeclaresAllModes()
+    {
+        // The outputMode enum pins the vocabulary the validation branch accepts.
+        String schema = new SearchInCodeTool().getInputSchema();
+        assertTrue("outputMode enum must offer 'full'", schema.contains("\"full\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputMode enum must offer 'count'", schema.contains("\"count\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputMode enum must offer 'files'", schema.contains("\"files\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testDescriptionSteersToGuide()
+    {
+        String desc = new SearchInCodeTool().getDescription();
+        assertTrue("description must point to the on-demand guide", //$NON-NLS-1$
+            desc.contains("get_tool_guide('search_in_code')")); //$NON-NLS-1$
+    }
+
+    // ==================== getResultFileName (pure sanitiser, no workspace) ====================
+
+    @Test
+    public void testResultFileNameDefaultsWhenQueryAbsent()
+    {
+        Map<String, String> params = new HashMap<>();
+        assertEquals("search-results.md", new SearchInCodeTool().getResultFileName(params)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResultFileNameDefaultsWhenQueryEmpty()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("query", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("search-results.md", new SearchInCodeTool().getResultFileName(params)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResultFileNameSanitisesAndLowercases()
+    {
+        // Non-alphanumeric chars become '-', and the whole name is lowercased.
+        Map<String, String> params = new HashMap<>();
+        params.put("query", "Foo Bar.Baz()"); //$NON-NLS-1$ //$NON-NLS-2$
+        String name = new SearchInCodeTool().getResultFileName(params);
+        assertEquals("search-foo-bar-baz--.md", name); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResultFileNameKeepsCyrillic()
+    {
+        // Cyrillic (Ѐ-ӿ) is preserved by the sanitiser; only the casing changes.
+        Map<String, String> params = new HashMap<>();
+        params.put("query", "Справочник"); // "Справочник" //$NON-NLS-1$ //$NON-NLS-2$
+        String name = new SearchInCodeTool().getResultFileName(params);
+        assertTrue("filename must keep the lowercased Cyrillic token", //$NON-NLS-1$
+            name.contains("справочник")); // "справочник" //$NON-NLS-1$
+        assertTrue(name.startsWith("search-")); //$NON-NLS-1$
+        assertTrue(name.endsWith(".md")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResultFileNameTruncatesLongQueryToForty()
+    {
+        // The sanitised middle is capped at 40 chars (before the search-/.md wrapping).
+        StringBuilder q = new StringBuilder();
+        for (int i = 0; i < 60; i++)
+        {
+            q.append('a');
+        }
+        Map<String, String> params = new HashMap<>();
+        params.put("query", q.toString()); //$NON-NLS-1$
+        String name = new SearchInCodeTool().getResultFileName(params);
+        // "search-" (7) + 40 sanitised chars + ".md" (3) == 50.
+        assertEquals(50, name.length());
+        assertTrue(name.startsWith("search-")); //$NON-NLS-1$
+        assertTrue(name.endsWith(".md")); //$NON-NLS-1$
     }
 
     @Test
@@ -104,5 +208,55 @@ public class SearchInCodeToolTest
         params.put("outputMode", "sideways"); //$NON-NLS-1$ //$NON-NLS-2$
         String result = new SearchInCodeTool().execute(params);
         assertTrue(result.contains("outputMode must be")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testInvalidOutputModeIsCaseInsensitiveStillRejected()
+    {
+        // The mode is lowercased before the membership check, so an uppercased
+        // unknown value is rejected by the same branch (not silently accepted).
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("query", "Foo"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("outputMode", "SIDEWAYS"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new SearchInCodeTool().execute(params);
+        assertTrue(result.contains("outputMode must be")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingProjectNameWinsOverInvalidOutputMode()
+    {
+        // requireArguments runs before the outputMode validation: the missing
+        // projectName error is reported even when outputMode is also invalid.
+        Map<String, String> params = new HashMap<>();
+        params.put("query", "Foo"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("outputMode", "sideways"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new SearchInCodeTool().execute(params);
+        assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
+        assertFalse("argument validation must precede outputMode validation", //$NON-NLS-1$
+            result.contains("outputMode must be")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingQueryWinsOverInvalidOutputMode()
+    {
+        // projectName present, query missing, outputMode invalid: the query-required
+        // guard fires first (it is checked before the outputMode membership test).
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("outputMode", "sideways"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new SearchInCodeTool().execute(params);
+        assertTrue(result.contains("query is required")); //$NON-NLS-1$
+        assertFalse(result.contains("outputMode must be")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNullParamsMissingProjectName()
+    {
+        // Null-safe extraction: a null map yields the projectName-required error,
+        // never an NPE, and never reaches the workspace.
+        String result = new SearchInCodeTool().execute(null);
+        assertNotNull(result);
+        assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/StandaloneServerSupportTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/StandaloneServerSupportTest.java
@@ -1,0 +1,505 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.tools.impl.StandaloneServerSupport.RegistryCleanup;
+
+/**
+ * Tests for {@link StandaloneServerSupport}.
+ * <p>
+ * {@code StandaloneServerSupport} reaches the EDT standalone-server feature REFLECTIVELY
+ * (OSGi lookup by class name + {@code Method.invoke}) so the plugin loads even on a headless
+ * EDT where that feature is absent. The reflective call wrappers that take a plain {@code Object}
+ * / {@code String} ({@code infobaseIdOf}, {@code databaseDirOf}, {@code findServerByModuleName},
+ * {@code deleteServer}) reflect on the PASSED object's class, so they can be exercised end-to-end
+ * with hand-written fake classes — no live EDT model, OSGi service, SWT or workspace required.
+ * <p>
+ * These tests cover every such pure-reflective branch (method present / absent / wrong return /
+ * throwing), the {@code RegistryCleanup} enum, and the deterministic "feature absent" outcomes of
+ * the OSGi-bound entry points ({@code acquireService}, {@code removeFromInfobaseRegistry}) which in
+ * the headless test runtime degrade gracefully (the WST bundles are intentionally NOT a dependency
+ * of the host plugin). The {@code IApplication}-typed wrappers ({@code serverOfApplication},
+ * {@code moduleOfApplication}) are covered only on their null/failure branch (returns {@code null},
+ * never throws); their success branch needs a live wst-server {@code IApplication} and is left to
+ * the e2e suite.
+ */
+public class StandaloneServerSupportTest
+{
+    private static final IProgressMonitor MONITOR = new NullProgressMonitor();
+
+    // ==================== RegistryCleanup enum ====================
+
+    @Test
+    public void testRegistryCleanupHasThreeValues()
+    {
+        assertEquals(3, RegistryCleanup.values().length);
+    }
+
+    @Test
+    public void testRegistryCleanupValueOfRemoved()
+    {
+        assertSame(RegistryCleanup.REMOVED, RegistryCleanup.valueOf("REMOVED")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRegistryCleanupValueOfNotPresent()
+    {
+        assertSame(RegistryCleanup.NOT_PRESENT, RegistryCleanup.valueOf("NOT_PRESENT")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRegistryCleanupValueOfFailed()
+    {
+        assertSame(RegistryCleanup.FAILED, RegistryCleanup.valueOf("FAILED")); //$NON-NLS-1$
+    }
+
+    // ==================== infobaseIdOf ====================
+
+    @Test
+    public void testInfobaseIdOfReadsValueAsString()
+    {
+        // getInfobaseId() returns a non-null value -> its toString() is returned.
+        Object module = new FakeInfobaseModule("ib-42"); //$NON-NLS-1$
+        assertEquals("ib-42", StandaloneServerSupport.infobaseIdOf(module)); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testInfobaseIdOfReturnsNullWhenIdIsNull()
+    {
+        // getInfobaseId() returns null -> the method must return null (not "null").
+        Object module = new FakeInfobaseModule(null);
+        assertNull(StandaloneServerSupport.infobaseIdOf(module));
+    }
+
+    @Test
+    public void testInfobaseIdOfReturnsNullWhenMethodAbsent()
+    {
+        // An object without getInfobaseId() -> NoSuchMethodException is swallowed -> null.
+        assertNull(StandaloneServerSupport.infobaseIdOf(new Object()));
+    }
+
+    @Test
+    public void testInfobaseIdOfUsesToStringOfNonStringId()
+    {
+        // A UUID-like non-String id is rendered via toString().
+        Object module = new FakeInfobaseModule(Integer.valueOf(7));
+        assertEquals("7", StandaloneServerSupport.infobaseIdOf(module)); //$NON-NLS-1$
+    }
+
+    // ==================== databaseDirOf ====================
+
+    @Test
+    public void testDatabaseDirOfReturnsConfigDirectoryForFileDatabase()
+    {
+        // Full happy chain: configuration -> file database -> getConfigDirectory() (a String).
+        Object module = new FakeServerInfobaseModule(
+            new FakeConfiguration(new FakeFileDatabase("C:/data/ib"))); //$NON-NLS-1$
+        assertEquals("C:/data/ib", StandaloneServerSupport.databaseDirOf(module)); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testDatabaseDirOfReturnsNullWhenConfigurationIsNull()
+    {
+        // getStandaloneServerConfiguration() returns null -> null.
+        Object module = new FakeServerInfobaseModule(null);
+        assertNull(StandaloneServerSupport.databaseDirOf(module));
+    }
+
+    @Test
+    public void testDatabaseDirOfReturnsNullWhenDatabaseIsNull()
+    {
+        // getDatabase() returns null -> null.
+        Object module = new FakeServerInfobaseModule(new FakeConfiguration(null));
+        assertNull(StandaloneServerSupport.databaseDirOf(module));
+    }
+
+    @Test
+    public void testDatabaseDirOfReturnsNullForRdbmsDatabaseWithoutConfigDirectory()
+    {
+        // An RDBMS database has no getConfigDirectory() -> NoSuchMethodException -> null.
+        Object module = new FakeServerInfobaseModule(
+            new FakeConfiguration(new FakeRdbmsDatabase()));
+        assertNull(StandaloneServerSupport.databaseDirOf(module));
+    }
+
+    @Test
+    public void testDatabaseDirOfReturnsNullWhenConfigDirectoryIsNotAString()
+    {
+        // getConfigDirectory() exists but returns a non-String -> null (instanceof guard).
+        Object module = new FakeServerInfobaseModule(
+            new FakeConfiguration(new FakeNonStringDirDatabase()));
+        assertNull(StandaloneServerSupport.databaseDirOf(module));
+    }
+
+    @Test
+    public void testDatabaseDirOfReturnsNullWhenModuleHasNoConfigurationMethod()
+    {
+        // The outer getStandaloneServerConfiguration() is absent -> Throwable caught -> null.
+        assertNull(StandaloneServerSupport.databaseDirOf(new Object()));
+    }
+
+    // ==================== findServerByModuleName ====================
+
+    @Test
+    public void testFindServerByModuleNameReturnsMatchingServer()
+    {
+        FakeServer match = new FakeServer(new FakeModule("MyServer")); //$NON-NLS-1$
+        FakeServer other = new FakeServer(new FakeModule("OtherServer")); //$NON-NLS-1$
+        FakeStandaloneServerService service =
+            new FakeStandaloneServerService(Arrays.asList(other, match));
+        Object found = StandaloneServerSupport.findServerByModuleName(service, "MyServer"); //$NON-NLS-1$
+        assertSame(match, found);
+    }
+
+    @Test
+    public void testFindServerByModuleNameReturnsNullWhenNoModuleMatches()
+    {
+        FakeServer s1 = new FakeServer(new FakeModule("A")); //$NON-NLS-1$
+        FakeServer s2 = new FakeServer(new FakeModule("B")); //$NON-NLS-1$
+        FakeStandaloneServerService service =
+            new FakeStandaloneServerService(Arrays.asList(s1, s2));
+        assertNull(StandaloneServerSupport.findServerByModuleName(service, "Missing")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindServerByModuleNameReturnsNullWhenGetServersAbsent()
+    {
+        // A service object without getServers() -> findMethod returns null -> null.
+        assertNull(StandaloneServerSupport.findServerByModuleName(new Object(), "Any")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindServerByModuleNameReturnsNullWhenGetServersReturnsNonList()
+    {
+        // getServers() returns something that is not a List -> null.
+        assertNull(StandaloneServerSupport.findServerByModuleName(
+            new FakeServiceWithNonListServers(), "Any")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindServerByModuleNameSkipsNullServersInList()
+    {
+        // A null entry in the servers list must be skipped without NPE; match still found after it.
+        FakeServer match = new FakeServer(new FakeModule("Target")); //$NON-NLS-1$
+        List<Object> servers = new ArrayList<>();
+        servers.add(null);
+        servers.add(match);
+        FakeStandaloneServerService service = new FakeStandaloneServerService(servers);
+        assertSame(match, StandaloneServerSupport.findServerByModuleName(service, "Target")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindServerByModuleNameReturnsNullForEmptyServerList()
+    {
+        FakeStandaloneServerService service =
+            new FakeStandaloneServerService(Collections.emptyList());
+        assertNull(StandaloneServerSupport.findServerByModuleName(service, "Any")); //$NON-NLS-1$
+    }
+
+    // ==================== deleteServer ====================
+
+    @Test
+    public void testDeleteServerReturnsErrorStatusWhenMethodAbsent()
+    {
+        // A service without deleteServer(2 args) -> a synthesized ERROR status (NOT mistaken success).
+        try
+        {
+            IStatus status = StandaloneServerSupport.deleteServer(new Object(), new Object(), MONITOR);
+            assertNotNull(status);
+            assertEquals(IStatus.ERROR, status.getSeverity());
+            assertFalse(status.isOK());
+        }
+        catch (Exception e)
+        {
+            fail("deleteServer must not throw when the method is simply absent: " + e); //$NON-NLS-1$
+        }
+    }
+
+    @Test
+    public void testDeleteServerReturnsStatusFromInvokedMethod()
+    {
+        // A service whose deleteServer(Object, Object) returns an OK IStatus -> that status is returned.
+        IStatus ok = org.eclipse.core.runtime.Status.OK_STATUS;
+        FakeDeleteService service = new FakeDeleteService(ok, null);
+        try
+        {
+            IStatus status = StandaloneServerSupport.deleteServer(service, new Object(), MONITOR);
+            assertSame(ok, status);
+        }
+        catch (Exception e)
+        {
+            fail("deleteServer must not throw on a clean OK return: " + e); //$NON-NLS-1$
+        }
+    }
+
+    @Test
+    public void testDeleteServerReturnsNullWhenInvokedMethodReturnsNonStatus()
+    {
+        // deleteServer() exists but returns a non-IStatus -> the wrapper returns null.
+        FakeDeleteService service = new FakeDeleteService("not-a-status", null); //$NON-NLS-1$
+        try
+        {
+            assertNull(StandaloneServerSupport.deleteServer(service, new Object(), MONITOR));
+        }
+        catch (Exception e)
+        {
+            fail("deleteServer must not throw when the return type is unexpected: " + e); //$NON-NLS-1$
+        }
+    }
+
+    @Test
+    public void testDeleteServerPropagatesInvocationException()
+    {
+        // The invoked deleteServer() throws a checked Exception -> it is unwrapped and rethrown.
+        Exception boom = new java.io.IOException("delete failed"); //$NON-NLS-1$
+        FakeDeleteService service = new FakeDeleteService(null, boom);
+        try
+        {
+            StandaloneServerSupport.deleteServer(service, new Object(), MONITOR);
+            fail("deleteServer must rethrow the underlying invocation failure"); //$NON-NLS-1$
+        }
+        catch (Exception e)
+        {
+            assertSame("the original cause must be unwrapped from InvocationTargetException", //$NON-NLS-1$
+                boom, e);
+        }
+    }
+
+    // ==================== serverOfApplication / moduleOfApplication (null/failure branch) ====================
+
+    @Test
+    public void testServerOfApplicationReturnsNullOnFailure()
+    {
+        // Passing null triggers the catch(Throwable) branch -> returns null, never throws.
+        assertNull(StandaloneServerSupport.serverOfApplication(null));
+    }
+
+    @Test
+    public void testModuleOfApplicationReturnsNullOnFailure()
+    {
+        assertNull(StandaloneServerSupport.moduleOfApplication(null));
+    }
+
+    // ==================== removeFromInfobaseRegistry ====================
+
+    @Test
+    public void testRemoveFromInfobaseRegistryNullIdReturnsFailed()
+    {
+        // PURE branch (no OSGi): a null infobaseId can target no entry -> FAILED (honest, not NOT_PRESENT).
+        assertSame(RegistryCleanup.FAILED,
+            StandaloneServerSupport.removeFromInfobaseRegistry(null, MONITOR));
+    }
+
+    @Test
+    public void testRemoveFromInfobaseRegistryWithIdDegradesGracefully()
+    {
+        // The WST server-core bundle is intentionally NOT a host dependency, so in the headless test
+        // runtime the cleanup cannot run: it must return a non-null RegistryCleanup (FAILED) and never
+        // throw. (On a real EDT with the feature installed this is where REMOVED/NOT_PRESENT happen.)
+        RegistryCleanup result =
+            StandaloneServerSupport.removeFromInfobaseRegistry("some-id", MONITOR); //$NON-NLS-1$
+        assertNotNull(result);
+    }
+
+    // ==================== acquireService ====================
+
+    @Test
+    public void testAcquireServiceDegradesGracefullyWhenFeatureAbsent()
+    {
+        // The standalone-server WST bundle is not a host dependency; in the headless test runtime
+        // acquireService() must degrade gracefully (return null, never throw).
+        try
+        {
+            assertNull(StandaloneServerSupport.acquireService());
+        }
+        catch (Throwable t)
+        {
+            fail("acquireService must never throw, even when the feature is absent: " + t); //$NON-NLS-1$
+        }
+    }
+
+    // ==================== Fakes (plain classes the reflective wrappers introspect) ====================
+
+    /** Stands in for {@code StandaloneServerInfobase} for {@code infobaseIdOf}. */
+    public static final class FakeInfobaseModule
+    {
+        private final Object id;
+
+        FakeInfobaseModule(Object id)
+        {
+            this.id = id;
+        }
+
+        public Object getInfobaseId()
+        {
+            return id;
+        }
+    }
+
+    /** Stands in for the wst-server infobase module for {@code databaseDirOf}. */
+    public static final class FakeServerInfobaseModule
+    {
+        private final Object configuration;
+
+        FakeServerInfobaseModule(Object configuration)
+        {
+            this.configuration = configuration;
+        }
+
+        public Object getStandaloneServerConfiguration()
+        {
+            return configuration;
+        }
+    }
+
+    /** Standalone-server configuration holding the database object. */
+    public static final class FakeConfiguration
+    {
+        private final Object database;
+
+        FakeConfiguration(Object database)
+        {
+            this.database = database;
+        }
+
+        public Object getDatabase()
+        {
+            return database;
+        }
+    }
+
+    /** File-backed database: exposes getConfigDirectory() returning a String. */
+    public static final class FakeFileDatabase
+    {
+        private final String dir;
+
+        FakeFileDatabase(String dir)
+        {
+            this.dir = dir;
+        }
+
+        public Object getConfigDirectory()
+        {
+            return dir;
+        }
+    }
+
+    /** RDBMS database: deliberately has NO getConfigDirectory() method. */
+    public static final class FakeRdbmsDatabase
+    {
+        // no getConfigDirectory()
+    }
+
+    /** File-like database whose getConfigDirectory() returns a non-String (the instanceof guard). */
+    public static final class FakeNonStringDirDatabase
+    {
+        public Object getConfigDirectory()
+        {
+            return new java.io.File("x"); //$NON-NLS-1$
+        }
+    }
+
+    /** A WST module with a display name, scanned by {@code findServerByModuleName}. */
+    public static final class FakeModule
+    {
+        private final String name;
+
+        FakeModule(String name)
+        {
+            this.name = name;
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+    }
+
+    /** A WST {@code IServer} stand-in exposing getModules():Object[]. */
+    public static final class FakeServer
+    {
+        private final FakeModule[] modules;
+
+        FakeServer(FakeModule... modules)
+        {
+            this.modules = modules;
+        }
+
+        public Object getModules()
+        {
+            return modules;
+        }
+    }
+
+    /** The standalone-server service stand-in for {@code findServerByModuleName}. */
+    public static final class FakeStandaloneServerService
+    {
+        private final List<?> servers;
+
+        FakeStandaloneServerService(List<?> servers)
+        {
+            this.servers = servers;
+        }
+
+        public List<?> getServers()
+        {
+            return servers;
+        }
+    }
+
+    /** A service whose getServers() returns a non-List (the type guard branch). */
+    public static final class FakeServiceWithNonListServers
+    {
+        public Object getServers()
+        {
+            return "not a list"; //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * A service stand-in for {@code deleteServer}: a 2-arg deleteServer(Object, Object) that either
+     * returns {@code result} or, when {@code toThrow} is set, throws it (to exercise the
+     * InvocationTargetException-unwrap path).
+     */
+    public static final class FakeDeleteService
+    {
+        private final Object result;
+        private final Exception toThrow;
+
+        FakeDeleteService(Object result, Exception toThrow)
+        {
+            this.result = result;
+            this.toThrow = toThrow;
+        }
+
+        public Object deleteServer(Object server, Object monitor) throws Exception
+        {
+            if (toThrow != null)
+            {
+                throw toThrow;
+            }
+            return result;
+        }
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchToolTest.java
@@ -10,9 +10,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.eclipse.debug.core.ILaunch;
 import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
@@ -149,6 +152,78 @@ public class TerminateLaunchToolTest
         assertEquals("terminate-all-myproject.md", tool.getResultFileName(params));
     }
 
+    @Test
+    public void testFileNameForProjectPlusApplicationId()
+    {
+        // projectName + applicationId mode: both parts are sanitised/lowercased and
+        // joined, so parallel calls against different IBs do not collide.
+        TerminateLaunchTool tool = new TerminateLaunchTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "My Proj");
+        params.put("applicationId", "App.42");
+        String name = tool.getResultFileName(params);
+        assertEquals("terminate-my-proj-app.42.md", name);
+    }
+
+    @Test
+    public void testFileNameTruncatesLongApplicationId()
+    {
+        // Long UUID-style applicationIds are truncated to 16 sanitised chars to keep
+        // the result-file path short.
+        TerminateLaunchTool tool = new TerminateLaunchTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "Proj");
+        params.put("applicationId", "0123456789abcdef0123456789abcdef"); // 32 chars
+        String name = tool.getResultFileName(params);
+        // 16-char truncated tail, then the .md suffix.
+        assertEquals("terminate-proj-0123456789abcdef.md", name);
+    }
+
+    @Test
+    public void testFileNameDefaultFallback()
+    {
+        // applicationId WITHOUT projectName matches no naming branch (it is not a valid
+        // selection) and must fall back to the generic terminate-launch.md.
+        TerminateLaunchTool tool = new TerminateLaunchTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("applicationId", "orphan-app-id");
+        assertEquals("terminate-launch.md", tool.getResultFileName(params));
+    }
+
+    @Test
+    public void testFileNameDefaultFallbackForEmptyParams()
+    {
+        // No selection params at all → generic default file name.
+        TerminateLaunchTool tool = new TerminateLaunchTool();
+        assertEquals("terminate-launch.md",
+            tool.getResultFileName(new HashMap<String, String>()));
+    }
+
+    @Test
+    public void testFileNameAllModeIgnoresBlankProject()
+    {
+        // A blank projectName must NOT produce "terminate-all-.md"; the empty-name
+        // guard falls through to the plain all-mode file name.
+        TerminateLaunchTool tool = new TerminateLaunchTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("all", "true");
+        params.put("projectName", "");
+        assertEquals("terminate-all.md", tool.getResultFileName(params));
+    }
+
+    @Test
+    public void testFileNameByConfigNameIgnoresOtherParams()
+    {
+        // launchConfigurationName wins over all other selection params for naming.
+        TerminateLaunchTool tool = new TerminateLaunchTool();
+        Map<String, String> params = new HashMap<>();
+        params.put("launchConfigurationName", "OnlyMe");
+        params.put("projectName", "Proj");
+        params.put("applicationId", "app");
+        params.put("all", "true");
+        assertEquals("terminate-onlyme.md", tool.getResultFileName(params));
+    }
+
     // === validateSelection — error messages from execute() ===
 
     @Test
@@ -243,5 +318,57 @@ public class TerminateLaunchToolTest
         assertTrue(result.contains("\"success\":false"));
         assertTrue("must report mutual exclusivity",
             result.contains("mutually exclusive"));
+    }
+
+    // === selectStaleTerminated — EDT-free guard branches ===
+    // This helper is package-private specifically for unit testing. Its data-driven
+    // matching path needs live ILaunch/ILaunchConfiguration instances (off-limits
+    // here), but the early guards — a null snapshot and an empty snapshot — are pure
+    // and exercise the method's contract that it never throws and returns a fresh,
+    // empty, mutable list when there is nothing to evict.
+
+    @Test
+    public void testSelectStaleTerminatedNullSnapshotReturnsEmpty()
+    {
+        List<ILaunch> selected = new ArrayList<>();
+        List<ILaunch> stale = TerminateLaunchTool.selectStaleTerminated(
+            null, selected, "Cfg", "Proj", "app", false, true, false, false);
+        assertNotNull("must never return null", stale);
+        assertTrue("a null snapshot yields nothing to evict", stale.isEmpty());
+    }
+
+    @Test
+    public void testSelectStaleTerminatedEmptySnapshotReturnsEmpty()
+    {
+        // An empty manager snapshot loops zero times and returns an empty result.
+        // new ILaunch[0] allocates an array but constructs no ILaunch instance.
+        List<ILaunch> stale = TerminateLaunchTool.selectStaleTerminated(
+            new ILaunch[0], new ArrayList<ILaunch>(), null, null, null, true, false, false,
+            false);
+        assertNotNull("must never return null", stale);
+        assertTrue("an empty snapshot yields nothing to evict", stale.isEmpty());
+    }
+
+    @Test
+    public void testSelectStaleTerminatedToleratesNullAlreadySelected()
+    {
+        // The identity-skip helper must tolerate a null already-selected list; with a
+        // null/empty snapshot the method short-circuits before ever consulting it.
+        List<ILaunch> stale = TerminateLaunchTool.selectStaleTerminated(
+            null, null, "Cfg", null, null, false, true, false, false);
+        assertNotNull(stale);
+        assertTrue(stale.isEmpty());
+    }
+
+    @Test
+    public void testSelectStaleTerminatedReturnsMutableList()
+    {
+        // Callers append to the returned list (targets.addAll then mutate), so it must
+        // be a fresh mutable list, not an immutable/shared singleton.
+        List<ILaunch> stale = TerminateLaunchTool.selectStaleTerminated(
+            new ILaunch[0], new ArrayList<ILaunch>(), null, "Proj", null, true, false, false,
+            false);
+        stale.clear(); // must not throw on an unmodifiable list
+        assertTrue(stale.isEmpty());
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchToolTest.java
@@ -9,6 +9,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -129,8 +130,8 @@ public class TerminateLaunchToolTest
         assertTrue("file name should derive from config name",
             name.startsWith("terminate-") && name.endsWith(".md"));
         // Should be sanitised — no slashes or spaces in the middle
-        assertTrue("file name should be sanitised", !name.contains(" "));
-        assertTrue("file name should be sanitised", !name.contains("/"));
+        assertFalse("file name should be sanitised", name.contains(" "));
+        assertFalse("file name should be sanitised", name.contains("/"));
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ValidateQueryToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ValidateQueryToolTest.java
@@ -8,6 +8,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +19,12 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 
 /**
  * Tests for {@link ValidateQueryTool}.
+ * <p>
+ * Covers tool metadata (name/constant/responseType/description/input+output schema/guide),
+ * the argument-validation branches in {@code execute(...)} that return BEFORE the first
+ * {@code ProjectContext.of(...)} → {@code ResourcesPlugin.getWorkspace()} access (the EDT
+ * boundary), and the pure static {@code buildResult}/{@code QueryIssue} result-formatting
+ * surface. The live Xtext validation path needs a workspace and is covered by the e2e suite.
  */
 public class ValidateQueryToolTest
 {
@@ -29,10 +36,41 @@ public class ValidateQueryToolTest
     }
 
     @Test
+    public void testNameConstant()
+    {
+        assertEquals(ValidateQueryTool.NAME, new ValidateQueryTool().getName());
+    }
+
+    @Test
     public void testResponseType()
     {
         ValidateQueryTool tool = new ValidateQueryTool();
         assertEquals(ResponseType.JSON, tool.getResponseType());
+    }
+
+    @Test
+    public void testDescriptionNotEmptyAndMentionsQuery()
+    {
+        String desc = new ValidateQueryTool().getDescription();
+        assertNotNull(desc);
+        assertTrue(desc.length() > 0);
+        // The description must advertise what is validated (query / QL).
+        assertTrue("description must mention query validation", //$NON-NLS-1$
+            desc.toLowerCase().contains("query")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testOutputSchemaDeclaresResultFields()
+    {
+        String schema = new ValidateQueryTool().getOutputSchema();
+        assertNotNull(schema);
+        assertTrue("outputSchema must declare success", schema.contains("\"success\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare valid", schema.contains("\"valid\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare dcsMode", schema.contains("\"dcsMode\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare errorCount", schema.contains("\"errorCount\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare warningCount", schema.contains("\"warningCount\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare infoCount", schema.contains("\"infoCount\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare issues", schema.contains("\"issues\"")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     @Test
@@ -93,6 +131,52 @@ public class ValidateQueryToolTest
         assertTrue(result.contains("queryText is required")); //$NON-NLS-1$
     }
 
+    @Test
+    public void testExecuteMissingProjectNameCarriesDiscoveryHint()
+    {
+        // The shared required-argument guard adds a list_projects discovery hint for projectName.
+        Map<String, String> params = new HashMap<>();
+        params.put("queryText", "SELECT 1"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ValidateQueryTool().execute(params);
+        assertTrue("projectName error must steer to list_projects", //$NON-NLS-1$
+            result.contains("list_projects")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteBothMissingReportsProjectNameFirst()
+    {
+        // requireArguments(projectName, queryText) checks in order: projectName is reported first.
+        Map<String, String> params = new HashMap<>();
+        String result = new ValidateQueryTool().execute(params);
+        assertNotNull(result);
+        assertTrue(result.contains("\"success\":false")); //$NON-NLS-1$
+        assertTrue("projectName must be the first reported missing argument", //$NON-NLS-1$
+            result.contains("projectName is required")); //$NON-NLS-1$
+        assertFalse("queryText error must not appear while projectName is also missing", //$NON-NLS-1$
+            result.contains("queryText is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteBlankProjectNameIsError()
+    {
+        // A present-but-blank value is treated as missing by the required-argument guard.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("queryText", "SELECT 1"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ValidateQueryTool().execute(params);
+        assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteNullParamsMissingProjectName()
+    {
+        // extractStringArgument/requireArguments are null-safe: a null map yields the
+        // projectName-required error, never an NPE (the EDT boundary is never reached).
+        String result = new ValidateQueryTool().execute(null);
+        assertNotNull(result);
+        assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
     // ==================== buildResult (migrated to ToolResult) ====================
     // The result JSON is built by the shared ToolResult/Gson path. Gson emits
     // compact ("key":value, no spaces) and escapes >, <, & as \\uXXXX, so the
@@ -145,5 +229,82 @@ public class ValidateQueryToolTest
         assertFalse(json.contains("\"line\":")); //$NON-NLS-1$
         assertFalse(json.contains("\"column\":")); //$NON-NLS-1$
         assertFalse(json.contains("\"offset\":")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBuildResultCountsInfoSeverity()
+    {
+        // An INFO issue increments infoCount only and still makes the query "not valid".
+        ValidateQueryTool.QueryIssue info =
+            new ValidateQueryTool.QueryIssue("INFO", "informational note", 3, 1, 12); //$NON-NLS-1$ //$NON-NLS-2$
+        String json = ValidateQueryTool.buildResult(List.of(info), false);
+        assertTrue(json.contains("\"valid\":false")); //$NON-NLS-1$
+        assertTrue(json.contains("\"errorCount\":0")); //$NON-NLS-1$
+        assertTrue(json.contains("\"warningCount\":0")); //$NON-NLS-1$
+        assertTrue(json.contains("\"infoCount\":1")); //$NON-NLS-1$
+        assertTrue(json.contains("\"severity\":\"INFO\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBuildResultCountsMixedSeverities()
+    {
+        // Mixed bag: two errors, one warning, one info — each bucket counted independently.
+        List<ValidateQueryTool.QueryIssue> issues = Arrays.asList(
+            new ValidateQueryTool.QueryIssue("ERROR", "e1", 1, 1, 0), //$NON-NLS-1$ //$NON-NLS-2$
+            new ValidateQueryTool.QueryIssue("ERROR", "e2", 2, 1, 5), //$NON-NLS-1$ //$NON-NLS-2$
+            new ValidateQueryTool.QueryIssue("WARNING", "w1", 3, 1, 9), //$NON-NLS-1$ //$NON-NLS-2$
+            new ValidateQueryTool.QueryIssue("INFO", "i1", 4, 1, 13)); //$NON-NLS-1$ //$NON-NLS-2$
+        String json = ValidateQueryTool.buildResult(issues, false);
+        assertTrue(json.contains("\"valid\":false")); //$NON-NLS-1$
+        assertTrue(json.contains("\"errorCount\":2")); //$NON-NLS-1$
+        assertTrue(json.contains("\"warningCount\":1")); //$NON-NLS-1$
+        assertTrue(json.contains("\"infoCount\":1")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBuildResultEmptyWithDcsModeTrue()
+    {
+        // dcsMode is echoed verbatim independent of the (empty) issue list.
+        String json = ValidateQueryTool.buildResult(List.of(), true);
+        assertTrue(json.contains("\"valid\":true")); //$NON-NLS-1$
+        assertTrue(json.contains("\"dcsMode\":true")); //$NON-NLS-1$
+        assertTrue(json.contains("\"issues\":[]")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBuildResultLineOnlyEmitsLineNotColumnNorOffset()
+    {
+        // line > 0 but column <= 0 and offset < 0: only the "line" key is emitted.
+        ValidateQueryTool.QueryIssue issue =
+            new ValidateQueryTool.QueryIssue("ERROR", "located by line only", 42, 0, -1); //$NON-NLS-1$ //$NON-NLS-2$
+        String json = ValidateQueryTool.buildResult(List.of(issue), false);
+        assertTrue(json.contains("\"line\":42")); //$NON-NLS-1$
+        assertFalse(json.contains("\"column\":")); //$NON-NLS-1$
+        assertFalse(json.contains("\"offset\":")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBuildResultOffsetZeroIsEmitted()
+    {
+        // offset uses a >= 0 guard (line/column use > 0): offset 0 IS a valid location and is emitted.
+        ValidateQueryTool.QueryIssue issue =
+            new ValidateQueryTool.QueryIssue("WARNING", "at start", -1, -1, 0); //$NON-NLS-1$ //$NON-NLS-2$
+        String json = ValidateQueryTool.buildResult(List.of(issue), false);
+        assertTrue("offset 0 must be emitted (>=0 guard)", json.contains("\"offset\":0")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse(json.contains("\"line\":")); //$NON-NLS-1$
+        assertFalse(json.contains("\"column\":")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testQueryIssueFieldsArePreserved()
+    {
+        // The internal carrier keeps every field verbatim for buildResult to read.
+        ValidateQueryTool.QueryIssue issue =
+            new ValidateQueryTool.QueryIssue("ERROR", "msg", 7, 3, 21); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("ERROR", issue.severity); //$NON-NLS-1$
+        assertEquals("msg", issue.message); //$NON-NLS-1$
+        assertEquals(7, issue.line);
+        assertEquals(3, issue.column);
+        assertEquals(21, issue.offset);
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/WaitForBreakToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/WaitForBreakToolTest.java
@@ -13,6 +13,9 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.eclipse.debug.core.model.IStackFrame;
 import org.eclipse.debug.core.model.IThread;
 import org.junit.After;
@@ -66,6 +69,20 @@ public class WaitForBreakToolTest
         assertNotNull(schema);
         assertTrue(schema.contains("\"applicationId\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"timeout\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testOutputSchemaDeclaresSnapshotFields()
+    {
+        String schema = new WaitForBreakTool().getOutputSchema();
+        assertNotNull(schema);
+        assertTrue(schema.contains("\"hit\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"reason\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"applicationId\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"threadId\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"frames\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"topFrameRef\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"serverTarget\"")); //$NON-NLS-1$
     }
 
     // ==================== Timeout clamping (pure, no live debug session) ====================
@@ -146,5 +163,69 @@ public class WaitForBreakToolTest
         assertTrue(json.contains("\"hit\":true")); //$NON-NLS-1$
         // Same emit-only-when-true convention as the timeout path.
         assertFalse(json.contains("serverTarget")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testHitResponseCarriesAutoResolvedAndTopFrameRefWithFrames() throws Exception
+    {
+        // A snapshot with one (mocked) stack frame: the response must register the
+        // frame, expose its frameRef as topFrameRef, and flag autoResolved when set.
+        DebugSessionRegistry registry = DebugSessionRegistry.get();
+        registry.clear();
+        IThread thread = mock(IThread.class);
+        when(thread.getName()).thenReturn("auto thread"); //$NON-NLS-1$
+        IStackFrame frame = mock(IStackFrame.class);
+        when(frame.getName()).thenReturn("Module.Method"); //$NON-NLS-1$
+        when(frame.getLineNumber()).thenReturn(42);
+        when(thread.getStackFrames()).thenReturn(new IStackFrame[] { frame });
+        String appId = "launch:AutoCfg"; //$NON-NLS-1$
+        registry.injectSuspend(appId, thread);
+
+        String json = WaitForBreakTool.buildSnapshotResponse(registry.getSnapshot(appId), registry,
+            appId, true, false);
+
+        assertTrue(json.contains("\"hit\":true")); //$NON-NLS-1$
+        assertTrue(json.contains("\"autoResolved\":true")); //$NON-NLS-1$
+        assertTrue(json.contains("\"frameIndex\":0")); //$NON-NLS-1$
+        assertTrue(json.contains("\"topFrameRef\":")); //$NON-NLS-1$
+        assertTrue(json.contains("\"line\":42")); //$NON-NLS-1$
+    }
+
+    // ==================== execute(): headless-reachable branches ====================
+
+    @Test
+    public void testExecuteBlankApplicationIdWithNoActiveSessionIsError()
+    {
+        // No active launch/server session exists headless, so a blank applicationId
+        // cannot be auto-resolved: the tool must return the structured error BEFORE
+        // entering any blocking wait.
+        DebugSessionRegistry.get().clear();
+        Map<String, String> params = new HashMap<>();
+        params.put("timeout", "1"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new WaitForBreakTool().execute(params);
+        assertTrue(result.contains("applicationId is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExecuteReturnsExistingSnapshotImmediatelyAsHit() throws Exception
+    {
+        // An explicit id with a pre-existing snapshot resolves to no live target
+        // headless, falls through with that id, and waitForSuspend returns the
+        // already-present snapshot immediately — no blocking, a clean hit.
+        DebugSessionRegistry registry = DebugSessionRegistry.get();
+        registry.clear();
+        IThread thread = mock(IThread.class);
+        when(thread.getName()).thenReturn("pre-suspended"); //$NON-NLS-1$
+        when(thread.getStackFrames()).thenReturn(new IStackFrame[0]);
+        String appId = "launch:PreCfg"; //$NON-NLS-1$
+        registry.injectSuspend(appId, thread);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("applicationId", appId); //$NON-NLS-1$
+        params.put("timeout", "1"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new WaitForBreakTool().execute(params);
+
+        assertTrue(result.contains("\"hit\":true")); //$NON-NLS-1$
+        assertTrue(result.contains("\"applicationId\":\"launch:PreCfg\"")); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/metadata/AbstractMetadataFormatterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/metadata/AbstractMetadataFormatterTest.java
@@ -171,6 +171,56 @@ public class AbstractMetadataFormatterTest
             out.contains("face='Arial'") && out.contains("height=12") && out.contains("bold")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
     }
 
+    // ==================== formatType — TypeDescription rendering (S2) ====================
+
+    @Test
+    public void testFormatTypeNullDescriptionReturnsDash()
+    {
+        // A null TypeDescription (an unset attribute type) must render as a dash, never NPE.
+        assertEquals("-", f.formatType(null)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFormatTypeEmptyDescriptionReturnsDash()
+    {
+        // A TypeDescription with no type items (e.g. a freshly-created, untyped attribute)
+        // has nothing to name, so it renders as a dash rather than an empty string.
+        com._1c.g5.v8.dt.mcore.TypeDescription td =
+            com._1c.g5.v8.dt.mcore.McoreFactory.eINSTANCE.createTypeDescription();
+        assertEquals("-", f.formatType(td)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFormatTypeSingleTypeReturnsItsName()
+    {
+        // McoreUtil.getTypeName returns getName() directly for a non-proxy (in-memory) TypeItem,
+        // so a single named Type renders as exactly that name.
+        com._1c.g5.v8.dt.mcore.TypeDescription td =
+            com._1c.g5.v8.dt.mcore.McoreFactory.eINSTANCE.createTypeDescription();
+        td.getTypes().add(newType("String")); //$NON-NLS-1$
+        assertEquals("String", f.formatType(td)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFormatTypeMultipleTypesJoinedByComma()
+    {
+        // A composite type (several TypeItems) is rendered as the names joined by ", ",
+        // in the order they appear in the description.
+        com._1c.g5.v8.dt.mcore.TypeDescription td =
+            com._1c.g5.v8.dt.mcore.McoreFactory.eINSTANCE.createTypeDescription();
+        td.getTypes().add(newType("String")); //$NON-NLS-1$
+        td.getTypes().add(newType("Number")); //$NON-NLS-1$
+        assertEquals("String, Number", f.formatType(td)); //$NON-NLS-1$
+    }
+
+    /** Creates an in-memory, non-proxy {@link com._1c.g5.v8.dt.mcore.Type} with the given name. */
+    private static com._1c.g5.v8.dt.mcore.TypeItem newType(String name)
+    {
+        com._1c.g5.v8.dt.mcore.Type type = com._1c.g5.v8.dt.mcore.McoreFactory.eINSTANCE.createType();
+        type.setName(name);
+        return type;
+    }
+
     // ==================== pure markdown/cell helpers ====================
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/metadata/AbstractMetadataFormatterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/metadata/AbstractMetadataFormatterTest.java
@@ -12,11 +12,19 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.emf.common.util.BasicEMap;
 import org.eclipse.emf.common.util.EMap;
 import org.junit.Test;
 
+import com._1c.g5.v8.dt.metadata.mdclass.Catalog;
+import com._1c.g5.v8.dt.metadata.mdclass.MdClassFactory;
 import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
+import com._1c.g5.v8.dt.metadata.mdclass.StandardAttribute;
+import com._1c.g5.v8.dt.mcore.McoreFactory;
+import com._1c.g5.v8.dt.mcore.TypeDescription;
 
 /**
  * Tests for the protected helpers of {@link AbstractMetadataFormatter}, reached
@@ -318,6 +326,322 @@ public class AbstractMetadataFormatterTest
         // Exactly one row: a lone trailing newline, no embedded ones that would
         // split the table.
         assertEquals("the notice must be exactly one row", 1, countChar(row, '\n'));
+    }
+
+    // ==================== addPropertyRow overloads ====================
+
+    @Test
+    public void testAddPropertyRowStringValue()
+    {
+        // The String overload prints the value as-is in the second cell.
+        StringBuilder sb = new StringBuilder();
+        f.addPropertyRow(sb, "Name", "Products"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("| Name | Products |\n", sb.toString()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testAddPropertyRowNullStringValueRendersDash()
+    {
+        // A null String value falls back to the DASH placeholder, never a literal "null".
+        StringBuilder sb = new StringBuilder();
+        f.addPropertyRow(sb, "Comment", (String) null); //$NON-NLS-1$
+        assertEquals("| Comment | - |\n", sb.toString()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testAddPropertyRowBooleanValue()
+    {
+        // The boolean overload renders Yes / No via formatBoolean.
+        StringBuilder sb = new StringBuilder();
+        f.addPropertyRow(sb, "Indexed", true); //$NON-NLS-1$
+        f.addPropertyRow(sb, "Indexed", false); //$NON-NLS-1$
+        assertEquals("| Indexed | Yes |\n| Indexed | No |\n", sb.toString()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testAddPropertyRowIntValue()
+    {
+        // The int overload renders the decimal string of the value.
+        StringBuilder sb = new StringBuilder();
+        f.addPropertyRow(sb, "Code Length", 9); //$NON-NLS-1$
+        assertEquals("| Code Length | 9 |\n", sb.toString()); //$NON-NLS-1$
+    }
+
+    // ==================== header helpers ====================
+
+    @Test
+    public void testAddSectionHeaderFormatsLevel3()
+    {
+        StringBuilder sb = new StringBuilder();
+        f.addSectionHeader(sb, "Basic Properties"); //$NON-NLS-1$
+        assertEquals("\n### Basic Properties\n\n", sb.toString()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testAddMainHeaderFormatsTypeAndName()
+    {
+        StringBuilder sb = new StringBuilder();
+        f.addMainHeader(sb, "Catalog", "Products"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("## Catalog: Products\n\n", sb.toString()); //$NON-NLS-1$
+    }
+
+    // ==================== formatFeatureName — camelCase splitting ====================
+
+    @Test
+    public void testFormatFeatureNameSplitsCamelCaseAndCapitalizes()
+    {
+        // "codeLength" -> "Code Length": the leading char is upper-cased and a space is
+        // inserted before every interior upper-case char.
+        assertEquals("Code Length", f.formatFeatureName("codeLength")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatFeatureNameSingleWordJustCapitalizes()
+    {
+        assertEquals("Name", f.formatFeatureName("name")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatFeatureNameNullAndEmptyArePassedThrough()
+    {
+        assertEquals("", f.formatFeatureName("")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(null, f.formatFeatureName(null));
+    }
+
+    // ==================== formatEObjectReference ====================
+
+    @Test
+    public void testFormatEObjectReferenceNullReturnsDash()
+    {
+        assertEquals("-", f.formatEObjectReference(null)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFormatEObjectReferenceMdObjectAsTypeDotName()
+    {
+        // An MdObject reference renders as EClass.Name (e.g. "Catalog.Products").
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        cat.setName("Products"); //$NON-NLS-1$
+        assertEquals("Catalog.Products", f.formatEObjectReference(cat)); //$NON-NLS-1$
+    }
+
+    // ==================== formatDynamicValue — type dispatch ====================
+
+    @Test
+    public void testFormatDynamicValueNullReturnsDash()
+    {
+        assertEquals("-", f.formatDynamicValue(null, "en")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatDynamicValueBoolean()
+    {
+        assertEquals("Yes", f.formatDynamicValue(Boolean.TRUE, "en")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("No", f.formatDynamicValue(Boolean.FALSE, "en")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatDynamicValueEnum()
+    {
+        // A raw Java enum is rendered via formatEnum (toString of the literal).
+        assertEquals("MONDAY", f.formatDynamicValue(java.time.DayOfWeek.MONDAY, "en")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatDynamicValueTypeDescription()
+    {
+        // A TypeDescription value is delegated to formatType (single named type -> its name).
+        TypeDescription td = McoreFactory.eINSTANCE.createTypeDescription();
+        td.getTypes().add(newType("String")); //$NON-NLS-1$
+        assertEquals("String", f.formatDynamicValue(td, "en")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatDynamicValueEMapPicksByLanguageCode()
+    {
+        // An EMap value (e.g. a synonym map) is resolved by language CODE, like getSynonym.
+        BasicEMap<String, String> syn = new BasicEMap<>();
+        syn.put("en", "Goods"); //$NON-NLS-1$ //$NON-NLS-2$
+        syn.put("ru", "Tovary"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("Goods", f.formatDynamicValue(syn, "en")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("Tovary", f.formatDynamicValue(syn, "ru")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatDynamicValueMdObjectReference()
+    {
+        // An MdObject value renders as a Type.Name reference.
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        cat.setName("Partners"); //$NON-NLS-1$
+        assertEquals("Catalog.Partners", f.formatDynamicValue(cat, "en")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatDynamicValueEmptyCollectionReturnsDash()
+    {
+        assertEquals("-", f.formatDynamicValue(new ArrayList<>(), "en")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatDynamicValueSmallCollectionInlinedAsCommaList()
+    {
+        // A small (<= 5) collection of MdObjects is inlined as "Type.Name, Type.Name".
+        Catalog a = MdClassFactory.eINSTANCE.createCatalog();
+        a.setName("A"); //$NON-NLS-1$
+        Catalog b = MdClassFactory.eINSTANCE.createCatalog();
+        b.setName("B"); //$NON-NLS-1$
+        List<MdObject> list = new ArrayList<>();
+        list.add(a);
+        list.add(b);
+        assertEquals("Catalog.A, Catalog.B", f.formatDynamicValue(list, "en")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatDynamicValueLargeCollectionShowsCountOnly()
+    {
+        // A collection larger than 5 is summarised as "[N items]" rather than inlined.
+        List<MdObject> list = new ArrayList<>();
+        for (int i = 0; i < 6; i++)
+        {
+            Catalog c = MdClassFactory.eINSTANCE.createCatalog();
+            c.setName("C" + i); //$NON-NLS-1$
+            list.add(c);
+        }
+        assertEquals("[6 items]", f.formatDynamicValue(list, "en")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatDynamicValueStringFallsBackToToString()
+    {
+        // A plain non-EMF value falls through to toString().
+        assertEquals("plain", f.formatDynamicValue("plain", "en")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    // ==================== formatReferenceCollection ====================
+
+    @Test
+    public void testFormatReferenceCollectionMdObjectsRenderFqnTable()
+    {
+        // A collection of MdObjects renders a section header with the count and an FQN/Synonym table.
+        Catalog a = MdClassFactory.eINSTANCE.createCatalog();
+        a.setName("Products"); //$NON-NLS-1$
+        a.getSynonym().put("en", "Goods"); //$NON-NLS-1$ //$NON-NLS-2$
+        Catalog b = MdClassFactory.eINSTANCE.createCatalog();
+        b.setName("Partners"); //$NON-NLS-1$
+        List<MdObject> list = new ArrayList<>();
+        list.add(a);
+        list.add(b);
+
+        StringBuilder sb = new StringBuilder();
+        f.formatReferenceCollection(sb, "content", list, "en"); //$NON-NLS-1$ //$NON-NLS-2$
+        String out = sb.toString();
+
+        assertTrue("header must carry the camelCased name and count, got:\n" + out, //$NON-NLS-1$
+            out.contains("### Content (2)")); //$NON-NLS-1$
+        assertTrue("the FQN/Synonym table header must be present", out.contains("| FQN | Synonym |")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("first MdObject row shows its FQN and synonym", //$NON-NLS-1$
+            out.contains("| Catalog.Products | Goods |")); //$NON-NLS-1$
+        // The second catalog has no synonym -> its synonym cell is empty.
+        assertTrue("second MdObject row shows its FQN", out.contains("| Catalog.Partners |")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatReferenceCollectionEMapEntriesRenderLanguageTable()
+    {
+        // A collection whose items are Map.Entry (an EMap like a synonym) renders a Language/Value table.
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        cat.getSynonym().put("en", "Goods"); //$NON-NLS-1$ //$NON-NLS-2$
+        cat.getSynonym().put("ru", "Tovary"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        StringBuilder sb = new StringBuilder();
+        f.formatReferenceCollection(sb, "synonym", cat.getSynonym(), "en"); //$NON-NLS-1$ //$NON-NLS-2$
+        String out = sb.toString();
+
+        assertTrue("header must show the EMap entry count, got:\n" + out, //$NON-NLS-1$
+            out.contains("### Synonym (2)")); //$NON-NLS-1$
+        assertTrue("the Language/Value table header must be present", out.contains("| Language | Value |")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("an en entry row must be present", out.contains("| en | Goods |")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a ru entry row must be present", out.contains("| ru | Tovary |")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== formatStandardAttributes ====================
+
+    @Test
+    public void testFormatStandardAttributesEmitsTableForPopulatedList()
+    {
+        // A Catalog (a BasicDbObject) exposes getStandardAttributes(); a populated entry must produce
+        // the StandardAttributes section with the attribute's name in a row.
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        StandardAttribute attr = MdClassFactory.eINSTANCE.createStandardAttribute();
+        attr.setName("Code"); //$NON-NLS-1$
+        attr.getSynonym().put("en", "Code"); //$NON-NLS-1$ //$NON-NLS-2$
+        cat.getStandardAttributes().add(attr);
+
+        StringBuilder sb = new StringBuilder();
+        f.formatStandardAttributes(sb, cat, "en"); //$NON-NLS-1$
+        String out = sb.toString();
+
+        assertTrue("a populated list must emit the StandardAttributes section, got:\n" + out, //$NON-NLS-1$
+            out.contains("### StandardAttributes")); //$NON-NLS-1$
+        assertTrue("the standard-attribute name must appear in a row", out.contains("| Code | Code |")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFormatStandardAttributesEmptyListEmitsNothing()
+    {
+        // A Catalog with no standard attributes set must not emit the section at all.
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        StringBuilder sb = new StringBuilder();
+        f.formatStandardAttributes(sb, cat, "en"); //$NON-NLS-1$
+        assertEquals("", sb.toString()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFormatStandardAttributesNoSuchMethodIsSilent()
+    {
+        // An object lacking getStandardAttributes() (a plain TypeDescription) is a no-op, not an error.
+        StringBuilder sb = new StringBuilder();
+        f.formatStandardAttributes(sb, McoreFactory.eINSTANCE.createTypeDescription(), "en"); //$NON-NLS-1$
+        assertEquals("", sb.toString()); //$NON-NLS-1$
+    }
+
+    // ==================== formatDynamicPropertiesSeparated ====================
+
+    @Test
+    public void testFormatDynamicPropertiesSeparatedRendersSetScalarsAsProperties()
+    {
+        // Only features that are actually eIsSet are rendered; a Catalog with name + comment set
+        // produces a Properties section carrying those scalar rows.
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        cat.setName("Products"); //$NON-NLS-1$
+        cat.setComment("A catalog"); //$NON-NLS-1$
+
+        StringBuilder sb = new StringBuilder();
+        f.formatDynamicPropertiesSeparated(sb, cat, "en"); //$NON-NLS-1$
+        String out = sb.toString();
+
+        assertTrue("a Properties section must be present, got:\n" + out, out.contains("### Properties")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the set name scalar must be rendered", out.contains("| Name | Products |")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the set comment scalar must be rendered", out.contains("| Comment | A catalog |")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== formatAllDynamicProperties ====================
+
+    @Test
+    public void testFormatAllDynamicPropertiesEmitsTitledTable()
+    {
+        // The reflection dump emits the given section title, a Property/Value table, and a row for a
+        // set scalar (Name). Containment children (attributes) are NOT dumped here.
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        cat.setName("Products"); //$NON-NLS-1$
+
+        StringBuilder sb = new StringBuilder();
+        f.formatAllDynamicProperties(sb, cat, "en", "All Properties"); //$NON-NLS-1$ //$NON-NLS-2$
+        String out = sb.toString();
+
+        assertTrue("the section title must be emitted, got:\n" + out, out.contains("### All Properties")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a Property/Value table must be opened", out.contains("| Property | Value |")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the set Name scalar must appear", out.contains("| Name | Products |")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     private static int countChar(String s, char c)

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/metadata/EObjectInspectorTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/metadata/EObjectInspectorTest.java
@@ -8,6 +8,8 @@ package com.ditrix.edt.mcp.server.tools.metadata;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -16,20 +18,36 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.junit.Test;
 
+import com._1c.g5.v8.dt.mcore.ColorDef;
+import com._1c.g5.v8.dt.mcore.ColorValue;
+import com._1c.g5.v8.dt.mcore.CommandGroupCategory;
+import com._1c.g5.v8.dt.mcore.McoreFactory;
+import com._1c.g5.v8.dt.mcore.Parameter;
 import com._1c.g5.v8.dt.mcore.ReferenceValue;
+import com._1c.g5.v8.dt.mcore.StandardCommandGroup;
+import com._1c.g5.v8.dt.mcore.Type;
+import com._1c.g5.v8.dt.metadata.mdclass.Catalog;
+import com._1c.g5.v8.dt.metadata.mdclass.MdClassFactory;
 import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
 
 /**
  * Tests for {@link EObjectInspector}.
  * <p>
- * Covers the branches that short-circuit before any EClass feature-list walk and
- * are therefore exercisable with bare Mockito mocks of the EMF/EDT interfaces:
- * the {@code MdObject} reference ("Type.Name"), the {@code ReferenceValue}
- * unwrap, {@code getCleanClassName} (Impl stripping), the null/MdObject paths of
- * {@code getFormatStyle}, and {@code isMdObjectReference}. The generic
- * value/expand branches reflect over {@code getEAllAttributes()}/
- * {@code getEAllReferences()} and are covered by the E2E suite against a real
- * EMF model.
+ * The first group covers the branches that short-circuit before any EClass
+ * feature-list walk, exercisable with bare Mockito mocks of the EMF/EDT
+ * interfaces: the {@code MdObject} reference ("Type.Name"), the
+ * {@code ReferenceValue} unwrap, {@code getCleanClassName} (Impl stripping), the
+ * null/MdObject paths of {@code getFormatStyle}, and {@code isMdObjectReference}.
+ * <p>
+ * The second group (issue #171) covers the generic value/expand branches that
+ * reflect over {@code getEAllAttributes()}/{@code getEAllReferences()} —
+ * {@code getPrimaryValue}'s priority cascade (enum / name / class-name fallback),
+ * {@code countMeaningfulAttributes}, {@code hasNonEmptyContainment},
+ * {@code isSimpleValueHolder} and the {@code getFormatStyle}
+ * SIMPLE_VALUE/EXPAND outcomes — using small, in-memory, NON-proxy EObjects built
+ * from the EMF factories ({@link MdClassFactory}/{@link McoreFactory}). No live
+ * project, injector, workspace or Mockito is involved, so these run headlessly
+ * under Tycho Surefire.
  */
 public class EObjectInspectorTest
 {
@@ -123,5 +141,200 @@ public class EObjectInspectorTest
     {
         assertTrue(EObjectInspector.isMdObjectReference(mock(MdObject.class)));
         assertFalse(EObjectInspector.isMdObjectReference(mock(EObject.class)));
+    }
+
+    // ====================================================================================
+    // In-memory EMF coverage (issue #171): the reflective branches that walk
+    // getEAllAttributes()/getEAllReferences() — exercised with real, non-proxy EObjects
+    // built from the EMF factories (no live project / injector / Mockito), so the priority
+    // cascade of getPrimaryValue and the containment / class-name paths are covered
+    // headlessly under Tycho Surefire.
+    // ====================================================================================
+
+    /** A StandardCommandGroup is the canonical "simple wrapper" whose category enum is the value. */
+    private static StandardCommandGroup commandGroup(CommandGroupCategory category)
+    {
+        StandardCommandGroup g = McoreFactory.eINSTANCE.createStandardCommandGroup();
+        g.setCategory(category);
+        return g;
+    }
+
+    // -------------------- getPrimaryValue: priority 1 (enum attribute) --------------------
+
+    @Test
+    public void testGetPrimaryValueReturnsEnumAttributeFirst()
+    {
+        // StandardCommandGroup.category is an enum attribute -> highest-priority branch.
+        StandardCommandGroup g = commandGroup(CommandGroupCategory.FORM_COMMAND_BAR);
+        Object value = EObjectInspector.getPrimaryValue(g);
+        assertSame("the category enum literal must be returned verbatim", //$NON-NLS-1$
+            CommandGroupCategory.FORM_COMMAND_BAR, value);
+        assertTrue("an EMF EEnum literal must be a real java enum", value.getClass().isEnum()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testGetPrimaryValueAsStringRendersEnumLiteral()
+    {
+        StandardCommandGroup g = commandGroup(CommandGroupCategory.NAVIGATION_PANEL);
+        assertEquals(CommandGroupCategory.NAVIGATION_PANEL.toString(),
+            EObjectInspector.getPrimaryValueAsString(g));
+    }
+
+    @Test
+    public void testGetPrimaryValueNullReturnsNull()
+    {
+        assertNull(EObjectInspector.getPrimaryValue(null));
+    }
+
+    @Test
+    public void testGetPrimaryValueAsStringNullReturnsEmpty()
+    {
+        assertEquals("", EObjectInspector.getPrimaryValueAsString(null)); //$NON-NLS-1$
+    }
+
+    // -------------------- getPrimaryValue: priority 3 (name feature) --------------------
+
+    @Test
+    public void testGetPrimaryValueFallsBackToNameFeature()
+    {
+        // A mcore Parameter has NO enum attribute, and none of its category/group/type/value
+        // features are set (its 'type' list is empty on a fresh object), but it carries a 'name'
+        // feature -> the name branch (priority 3) wins over the lower priorities.
+        Parameter p = McoreFactory.eINSTANCE.createParameter();
+        p.setName("Source"); //$NON-NLS-1$
+        assertEquals("Source", EObjectInspector.getPrimaryValue(p)); //$NON-NLS-1$
+    }
+
+    // -------------------- getPrimaryValue: priority 5 (class-name fallback) --------------------
+
+    @Test
+    public void testGetPrimaryValueClassNameFallbackWhenNothingSet()
+    {
+        // A freshly-created Parameter has nothing set: no enum value, no category/group/type/value,
+        // an unset name, no other set attribute -> the cascade falls through to the EClass name.
+        Parameter p = McoreFactory.eINSTANCE.createParameter();
+        assertEquals("Parameter", EObjectInspector.getPrimaryValue(p)); //$NON-NLS-1$
+    }
+
+    // -------------------- countMeaningfulAttributes --------------------
+
+    @Test
+    public void testCountMeaningfulAttributesNullIsZero()
+    {
+        assertEquals(0, EObjectInspector.countMeaningfulAttributes(null));
+    }
+
+    @Test
+    public void testCountMeaningfulAttributesCountsSetAttribute()
+    {
+        // priority is unset on a fresh group; setting it must make it count as a meaningful attribute.
+        StandardCommandGroup before = McoreFactory.eINSTANCE.createStandardCommandGroup();
+        int baseline = EObjectInspector.countMeaningfulAttributes(before);
+
+        StandardCommandGroup after = McoreFactory.eINSTANCE.createStandardCommandGroup();
+        after.setPriority(7);
+        int withPriority = EObjectInspector.countMeaningfulAttributes(after);
+
+        assertTrue("setting an attribute must increase the meaningful-attribute count, baseline=" //$NON-NLS-1$
+            + baseline + " withPriority=" + withPriority, withPriority > baseline); //$NON-NLS-1$
+    }
+
+    // -------------------- hasNonEmptyContainment --------------------
+
+    @Test
+    public void testHasNonEmptyContainmentNullIsFalse()
+    {
+        assertFalse(EObjectInspector.hasNonEmptyContainment(null));
+    }
+
+    @Test
+    public void testHasNonEmptyContainmentFalseForEmptyObject()
+    {
+        // A bare Catalog owns no attributes/forms yet -> no non-empty containment.
+        Catalog empty = MdClassFactory.eINSTANCE.createCatalog();
+        assertFalse(EObjectInspector.hasNonEmptyContainment(empty));
+    }
+
+    @Test
+    public void testHasNonEmptyContainmentTrueWhenChildAdded()
+    {
+        // Catalog.attributes is a containment list; adding a child makes containment non-empty.
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        cat.getAttributes().add(MdClassFactory.eINSTANCE.createCatalogAttribute());
+        assertTrue(EObjectInspector.hasNonEmptyContainment(cat));
+    }
+
+    // -------------------- isSimpleValueHolder(EObject) --------------------
+
+    @Test
+    public void testIsSimpleValueHolderTrueForCommandGroup()
+    {
+        // No containment references and only a couple of attributes -> a simple value holder.
+        assertTrue(EObjectInspector.isSimpleValueHolder(commandGroup(CommandGroupCategory.ACTIONS_PANEL)));
+    }
+
+    @Test
+    public void testIsSimpleValueHolderFalseForObjectWithContainment()
+    {
+        // A Catalog owns containment references (attributes/forms/...) -> never a simple holder.
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        assertFalse(EObjectInspector.isSimpleValueHolder(cat));
+    }
+
+    @Test
+    public void testIsSimpleValueHolderNullEObjectIsFalse()
+    {
+        assertFalse(EObjectInspector.isSimpleValueHolder((EObject) null));
+    }
+
+    @Test
+    public void testIsSimpleValueHolderNullEClassIsFalse()
+    {
+        assertFalse(EObjectInspector.isSimpleValueHolder((EClass) null));
+    }
+
+    // -------------------- getFormatStyle (reflective branches) --------------------
+
+    @Test
+    public void testGetFormatStyleSimpleValueForFewAttributes()
+    {
+        // Not an MdObject, no containment, only the single category attribute set
+        // (<= MAX_ATTRIBUTES_FOR_SIMPLE_VALUE) -> SIMPLE_VALUE.
+        assertEquals(EObjectInspector.FormatStyle.SIMPLE_VALUE,
+            EObjectInspector.getFormatStyle(commandGroup(CommandGroupCategory.FORM_NAVIGATION_PANEL)));
+    }
+
+    @Test
+    public void testGetFormatStyleExpandWhenContainmentPresent()
+    {
+        // ColorValue is NOT an MdObject and its 'value' is a containment reference. With a ColorDef
+        // contained, the non-empty-containment branch (3) of getFormatStyle wins -> EXPAND, before any
+        // attribute counting.
+        ColorValue cv = McoreFactory.eINSTANCE.createColorValue();
+        ColorDef def = McoreFactory.eINSTANCE.createColorDef();
+        def.setRed(1);
+        cv.setValue(def);
+        assertEquals(EObjectInspector.FormatStyle.EXPAND, EObjectInspector.getFormatStyle(cv));
+    }
+
+    // -------------------- getCleanClassName / formatReference on a real EObject --------------------
+
+    @Test
+    public void testGetCleanClassNameOnRealEObjectReturnsModelName()
+    {
+        // On a real EObject getCleanClassName reads eClass().getName(), which is already the
+        // un-suffixed model name "Type" (the Impl suffix lives only on the Java class, not the
+        // EClass) -> the clean name path returns "Type" without any stripping needed.
+        Type t = McoreFactory.eINSTANCE.createType();
+        assertEquals("Type", EObjectInspector.getCleanClassName(t)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFormatReferenceSimpleHolderShowsPrimaryValue()
+    {
+        // A simple value holder formats to its primary (enum) value, not a Type.Name string.
+        StandardCommandGroup g = commandGroup(CommandGroupCategory.FORM_COMMAND_BAR);
+        assertEquals(CommandGroupCategory.FORM_COMMAND_BAR.toString(),
+            EObjectInspector.formatReference(g));
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatterTest.java
@@ -1,0 +1,336 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.metadata;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com._1c.g5.v8.dt.mcore.McoreFactory;
+import com._1c.g5.v8.dt.mcore.Type;
+import com._1c.g5.v8.dt.mcore.TypeDescription;
+import com._1c.g5.v8.dt.metadata.mdclass.Catalog;
+import com._1c.g5.v8.dt.metadata.mdclass.CatalogAttribute;
+import com._1c.g5.v8.dt.metadata.mdclass.CatalogCommand;
+import com._1c.g5.v8.dt.metadata.mdclass.CatalogForm;
+import com._1c.g5.v8.dt.metadata.mdclass.CatalogTabularSection;
+import com._1c.g5.v8.dt.metadata.mdclass.FormType;
+import com._1c.g5.v8.dt.metadata.mdclass.Indexing;
+import com._1c.g5.v8.dt.metadata.mdclass.MdClassFactory;
+import com._1c.g5.v8.dt.metadata.mdclass.TabularSectionAttribute;
+
+/**
+ * Tests the PURE formatting paths of {@link UniversalMetadataFormatter} - the universal,
+ * EMF-reflection-driven markdown renderer - using only IN-MEMORY, NON-proxy EMF objects built
+ * with {@link MdClassFactory} / {@link McoreFactory}. No live project, injector or service is
+ * touched: a {@code Catalog} graph (attributes, a tabular section, a form, a command) and a
+ * {@code TypeDescription} are constructed in memory and run through the public
+ * {@link UniversalMetadataFormatter#format(com._1c.g5.v8.dt.metadata.mdclass.MdObject, boolean,
+ * String)} entry point, which drives the (otherwise private) collection formatters.
+ * <p>
+ * The construction pattern mirrors {@link AbstractMetadataFormatterTest} and
+ * {@code MetadataPropertyIntrospectorTest}; assertions match markdown substrings / exact rows
+ * against the formatter's literal output. {@code McoreUtil.getTypeName} returns {@code getName()}
+ * for a non-proxy in-memory {@link Type}, so type rendering needs no injector.
+ * <p>
+ * Methods that require a live service / Guice injector / {@code IV8ProjectManager} are NOT
+ * exercised here - the formatter itself is service-free, so its full surface is reachable purely.
+ */
+public class UniversalMetadataFormatterTest
+{
+    /** The singleton under test (its collection formatters are private, reached via format()). */
+    private final UniversalMetadataFormatter f = UniversalMetadataFormatter.getInstance();
+
+    private static final String EN = "en"; //$NON-NLS-1$
+
+    // ==================== helpers: in-memory builders ====================
+
+    /** A non-proxy in-memory {@link Type} whose name is returned verbatim by McoreUtil.getTypeName. */
+    private static Type newType(String name)
+    {
+        Type type = McoreFactory.eINSTANCE.createType();
+        type.setName(name);
+        return type;
+    }
+
+    /** A {@link TypeDescription} wrapping a single named primitive type. */
+    private static TypeDescription typeOf(String name)
+    {
+        TypeDescription td = McoreFactory.eINSTANCE.createTypeDescription();
+        td.getTypes().add(newType(name));
+        return td;
+    }
+
+    /** A catalog attribute with a name, an "en" synonym and a single-type TypeDescription. */
+    private static CatalogAttribute newAttribute(String name, String synonymEn, String typeName)
+    {
+        CatalogAttribute attr = MdClassFactory.eINSTANCE.createCatalogAttribute();
+        attr.setName(name);
+        attr.getSynonym().put(EN, synonymEn);
+        attr.setType(typeOf(typeName));
+        return attr;
+    }
+
+    /** A tabular-section column (the element type of a tabular section's attributes list). */
+    private static TabularSectionAttribute newTabularSectionAttribute(String name, String synonymEn,
+        String typeName)
+    {
+        TabularSectionAttribute attr = MdClassFactory.eINSTANCE.createTabularSectionAttribute();
+        attr.setName(name);
+        attr.getSynonym().put(EN, synonymEn);
+        attr.setType(typeOf(typeName));
+        return attr;
+    }
+
+    // ==================== format() null / header guards ====================
+
+    @Test
+    public void testFormatNullReturnsErrorString()
+    {
+        // The null guard must return a stable error sentinel, never NPE.
+        assertEquals("Error: MdObject is null", f.format(null, false, EN)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFormatEmptyCatalogRendersTypedMainHeaderAndBasicProperties()
+    {
+        // The main header uses the EMF eClass name as the type, and basic mode emits a
+        // Basic Properties section with the object's Name row.
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        cat.setName("Products"); //$NON-NLS-1$
+        cat.getSynonym().put(EN, "Goods"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        String md = f.format(cat, false, EN);
+        assertTrue("main header must be '## Catalog: Products', got:\n" + md, //$NON-NLS-1$
+            md.contains("## Catalog: Products")); //$NON-NLS-1$
+        assertTrue("must have a Basic Properties section", md.contains("### Basic Properties")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the Name row must render", md.contains("| Name | Products |")); //$NON-NLS-1$
+        assertTrue("the Synonym row must render the en value", md.contains("| Synonym | Goods |")); //$NON-NLS-1$
+    }
+
+    // ==================== formatAttributesCollection - compact (full=false) ====================
+
+    @Test
+    public void testCompactAttributesTableHasThreeColumnRowsWithTypeName()
+    {
+        // Basic mode renders each attribute as a compact Name | Synonym | Type row. The single
+        // in-memory Type's name flows through formatType -> McoreUtil.getTypeName verbatim.
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        cat.setName("Cat"); //$NON-NLS-1$
+        cat.getAttributes().add(newAttribute("Price", "Price", "Number")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        cat.getAttributes().add(newAttribute("Note", "Note", "String")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+        String md = f.format(cat, false, EN);
+        // The containment collection becomes an "Attributes" section (formatFeatureName of "attributes").
+        assertTrue("must have an Attributes section", md.contains("### Attributes")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("compact header is Name | Synonym | Type", //$NON-NLS-1$
+            md.contains("| Name | Synonym | Type |")); //$NON-NLS-1$
+        assertTrue("compact table has a 3-col separator", md.contains("|---|---|---|\n")); //$NON-NLS-1$
+        assertTrue("the Price row shows its type name", md.contains("| Price | Price | Number |")); //$NON-NLS-1$
+        assertTrue("the Note row shows its type name", md.contains("| Note | Note | String |")); //$NON-NLS-1$
+        // No extended columns in compact mode.
+        assertFalse("compact mode must not emit the Indexing column", md.contains("Indexing")); //$NON-NLS-1$
+    }
+
+    // ==================== formatAttributesCollection - extended (full=true) ====================
+
+    @Test
+    public void testExtendedAttributesTableHasTenColumnHeaderAndIndexing()
+    {
+        // Full mode renders the 10-column extended attribute table; a CatalogAttribute is a
+        // DbObjectAttribute, so the Indexing / Full Text Search cells come from its real enums.
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        cat.setName("Cat"); //$NON-NLS-1$
+        CatalogAttribute attr = newAttribute("Price", "Price", "Number"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        attr.setIndexing(Indexing.INDEX);
+        cat.getAttributes().add(attr);
+
+        String md = f.format(cat, true, EN);
+        assertTrue("extended header must list all 10 columns, got:\n" + md, //$NON-NLS-1$
+            md.contains("| Name | Synonym | Type | Indexing | Fill Checking | Full Text Search | " //$NON-NLS-1$
+                + "Password Mode | Multi Line | Quick Choice | Create On Input |")); //$NON-NLS-1$
+        assertTrue("extended table has a 10-col separator", //$NON-NLS-1$
+            md.contains("|---|---|---|---|---|---|---|---|---|---|\n")); //$NON-NLS-1$
+        // Indexing was set to INDEX -> the EMF literal toString is "Index".
+        assertTrue("the Indexing cell must reflect the set enum literal, got:\n" + md, //$NON-NLS-1$
+            md.contains("| Price | Price | Number | Index |")); //$NON-NLS-1$
+        // Password Mode / Multi Line are read by reflection and default to No for a flagless attribute.
+        assertTrue("password / multi-line flags default to No", md.contains("| No | No |")); //$NON-NLS-1$
+    }
+
+    // ==================== formatTabularSectionsExtended ====================
+
+    @Test
+    public void testTabularSectionRendersSubHeaderPropertiesAndNestedAttributes()
+    {
+        // A tabular section is rendered with its own #### sub-header, a Property/Value table and a
+        // nested "Attributes:" block for its columns.
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        cat.setName("Cat"); //$NON-NLS-1$
+        CatalogTabularSection ts = MdClassFactory.eINSTANCE.createCatalogTabularSection();
+        ts.setName("Lines"); //$NON-NLS-1$
+        ts.getSynonym().put(EN, "Rows"); //$NON-NLS-1$ //$NON-NLS-2$
+        ts.setComment("a comment"); //$NON-NLS-1$
+        TabularSectionAttribute col = newTabularSectionAttribute("Qty", "Quantity", "Number"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        ts.getAttributes().add(col);
+        cat.getTabularSections().add(ts);
+
+        String md = f.format(cat, false, EN);
+        assertTrue("the tabular-sections collection must be a 'Tabular Sections' section", //$NON-NLS-1$
+            md.contains("### Tabular Sections")); //$NON-NLS-1$
+        assertTrue("the TS must have its own #### sub-header", md.contains("#### Lines")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the TS Name property row", md.contains("| Name | Lines |")); //$NON-NLS-1$
+        assertTrue("the TS Synonym property row", md.contains("| Synonym | Rows |")); //$NON-NLS-1$
+        assertTrue("the TS Comment property row", md.contains("| Comment | a comment |")); //$NON-NLS-1$
+        assertTrue("the nested attributes block label", md.contains("**Attributes:**")); //$NON-NLS-1$
+        assertTrue("the TS column renders as a compact attribute row", //$NON-NLS-1$
+            md.contains("| Qty | Quantity | Number |")); //$NON-NLS-1$
+    }
+
+    // ==================== formatFormsCollection ====================
+
+    @Test
+    public void testFormsCollectionRendersNameSynonymFormType()
+    {
+        // A form collection (no adopted members -> no Origin column) renders Name | Synonym | Form Type.
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        cat.setName("Cat"); //$NON-NLS-1$
+        CatalogForm form = MdClassFactory.eINSTANCE.createCatalogForm();
+        form.setName("ListForm"); //$NON-NLS-1$
+        form.getSynonym().put(EN, "List"); //$NON-NLS-1$ //$NON-NLS-2$
+        form.setFormType(FormType.MANAGED);
+        cat.getForms().add(form);
+
+        String md = f.format(cat, false, EN);
+        assertTrue("must have a Forms section", md.contains("### Forms")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a base form collection has no Origin column", //$NON-NLS-1$
+            md.contains("| Name | Synonym | Form Type |")); //$NON-NLS-1$
+        assertFalse("a base (non-adopted) collection must not add an Origin column", //$NON-NLS-1$
+            md.contains("Origin")); //$NON-NLS-1$
+        // FormType.MANAGED toStrings to the EMF literal "Managed".
+        assertTrue("the form row must show name / synonym / form type, got:\n" + md, //$NON-NLS-1$
+            md.contains("| ListForm | List | Managed |")); //$NON-NLS-1$
+    }
+
+    // ==================== formatCommandsCollection ====================
+
+    @Test
+    public void testCommandsCollectionRendersNameSynonymGroupDashWhenUnset()
+    {
+        // A command collection renders Name | Synonym | Group; an unset group -> a dash cell
+        // (formatCommandGroup(null) -> DASH), with no service lookup.
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        cat.setName("Cat"); //$NON-NLS-1$
+        CatalogCommand cmd = MdClassFactory.eINSTANCE.createCatalogCommand();
+        cmd.setName("Refill"); //$NON-NLS-1$
+        cmd.getSynonym().put(EN, "Refill"); //$NON-NLS-1$ //$NON-NLS-2$
+        cat.getCommands().add(cmd);
+
+        String md = f.format(cat, false, EN);
+        assertTrue("must have a Commands section", md.contains("### Commands")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("commands header is Name | Synonym | Group", //$NON-NLS-1$
+            md.contains("| Name | Synonym | Group |")); //$NON-NLS-1$
+        assertTrue("an unset command group renders as a dash, got:\n" + md, //$NON-NLS-1$
+            md.contains("| Refill | Refill | - |")); //$NON-NLS-1$
+    }
+
+    // ==================== formatType direct (single + composite + empty) ====================
+
+    @Test
+    public void testFormatTypeCompositeJoinsNamesAndEmptyIsDash()
+    {
+        // Direct formatType coverage: a multi-type description joins names by ", "; an empty one
+        // (no types) and null both render as a dash.
+        TypeDescription composite = McoreFactory.eINSTANCE.createTypeDescription();
+        composite.getTypes().add(newType("String")); //$NON-NLS-1$
+        composite.getTypes().add(newType("Number")); //$NON-NLS-1$
+        assertEquals("String, Number", f.formatType(composite)); //$NON-NLS-1$
+
+        assertEquals("-", f.formatType(McoreFactory.eINSTANCE.createTypeDescription())); //$NON-NLS-1$
+        assertEquals("-", f.formatType(null)); //$NON-NLS-1$
+    }
+
+    // ==================== StyleItem value branches via format() ====================
+
+    @Test
+    public void testStyleItemWithNoValueRendersDashValueRow()
+    {
+        // A StyleItem with no Color/Font value set must still render a Value section, falling to the
+        // else-branch: a "Value | -" row (no NPE on the null containment value).
+        com._1c.g5.v8.dt.metadata.mdclass.StyleItem item =
+            MdClassFactory.eINSTANCE.createStyleItem();
+        item.setName("Empty"); //$NON-NLS-1$
+        item.setType(com._1c.g5.v8.dt.metadata.mdclass.StyleElementType.COLOR);
+
+        String md = f.format(item, false, EN);
+        assertTrue("a StyleItem render must have a Value section", md.contains("### Value")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the Style Type row must show Color", md.contains("| Style Type | Color |")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a value-less style item falls to the dash Value row, got:\n" + md, //$NON-NLS-1$
+            md.contains("| Value | - |")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStyleItemColorValueRendersRgbThroughFormat()
+    {
+        // A StyleItem holding an explicit ColorValue renders the RGB triple in its Value section
+        // (the single-valued containment value is only shown by the explicit StyleItem branch).
+        com._1c.g5.v8.dt.metadata.mdclass.StyleItem item =
+            MdClassFactory.eINSTANCE.createStyleItem();
+        item.setName("Accent"); //$NON-NLS-1$
+        item.setType(com._1c.g5.v8.dt.metadata.mdclass.StyleElementType.COLOR);
+        com._1c.g5.v8.dt.mcore.ColorValue cv = McoreFactory.eINSTANCE.createColorValue();
+        com._1c.g5.v8.dt.mcore.ColorDef def = McoreFactory.eINSTANCE.createColorDef();
+        def.setRed(1);
+        def.setGreen(2);
+        def.setBlue(3);
+        cv.setValue(def);
+        item.setValue(cv);
+
+        String md = f.format(item, false, EN);
+        assertTrue("the Color row must show the RGB triple, got:\n" + md, //$NON-NLS-1$
+            md.contains("| Color | RGB(1, 2, 3) |")); //$NON-NLS-1$
+    }
+
+    // ==================== full-mode dynamic dump (formatAllDynamicProperties) ====================
+
+    @Test
+    public void testFullModeEmitsAllPropertiesDumpSection()
+    {
+        // Full mode replaces Basic Properties with the reflective All Properties dump; the Name row
+        // (a stored scalar) must appear there, proving the dynamic dump ran over the real eClass.
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        cat.setName("Products"); //$NON-NLS-1$
+
+        String md = f.format(cat, true, EN);
+        assertTrue("full mode must emit the All Properties section", //$NON-NLS-1$
+            md.contains("### All Properties")); //$NON-NLS-1$
+        assertTrue("the reflective dump must include the Name property row", //$NON-NLS-1$
+            md.contains("| Name | Products |")); //$NON-NLS-1$
+        assertFalse("full mode replaces the Basic Properties section", //$NON-NLS-1$
+            md.contains("### Basic Properties")); //$NON-NLS-1$
+    }
+
+    // ==================== empty collections are silent ====================
+
+    @Test
+    public void testEmptyCollectionsProduceNoSectionHeaders()
+    {
+        // A catalog with no attributes / forms / commands must not emit those empty section
+        // headers (the collection loop skips empty collections).
+        Catalog cat = MdClassFactory.eINSTANCE.createCatalog();
+        cat.setName("Bare"); //$NON-NLS-1$
+
+        String md = f.format(cat, false, EN);
+        assertFalse("no Attributes section for an attribute-less catalog", //$NON-NLS-1$
+            md.contains("### Attributes")); //$NON-NLS-1$
+        assertFalse("no Forms section for a form-less catalog", md.contains("### Forms")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("no Commands section for a command-less catalog", //$NON-NLS-1$
+            md.contains("### Commands")); //$NON-NLS-1$
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/symbol/SymbolInfoServiceTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/symbol/SymbolInfoServiceTest.java
@@ -7,19 +7,46 @@
 package com.ditrix.edt.mcp.server.tools.symbol;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import com._1c.g5.v8.dt.bsl.model.BslFactory;
+import com._1c.g5.v8.dt.bsl.model.DynamicFeatureAccess;
+import com._1c.g5.v8.dt.bsl.model.FormalParam;
+import com._1c.g5.v8.dt.bsl.model.Function;
+import com._1c.g5.v8.dt.bsl.model.Invocation;
+import com._1c.g5.v8.dt.bsl.model.Method;
+import com._1c.g5.v8.dt.bsl.model.Module;
+import com._1c.g5.v8.dt.bsl.model.Procedure;
+import com._1c.g5.v8.dt.bsl.model.StaticFeatureAccess;
+
 /**
- * Tests for {@link SymbolInfoService#meaningfulOrNull(String)} — the guard that keeps
- * get_symbol_info from leaking a bare {@code Object.toString()} reference when a hover
- * (e.g. an annotation/quick-fix hover at a validation-marked position) has no
- * extractable text. The full hover path needs a live workbench and is e2e-covered; this
- * unit-tests just the pure string guard.
+ * Tests for {@link SymbolInfoService}.
+ * <p>
+ * Two layers:
+ * <ul>
+ * <li>{@link SymbolInfoService#meaningfulOrNull(String)} — the pure string guard that keeps
+ * get_symbol_info from leaking a bare {@code Object.toString()} reference when a hover (e.g. an
+ * annotation/quick-fix hover at a validation-marked position) has no extractable text.</li>
+ * <li>{@link SymbolInfoService#buildEObjectInfo(org.eclipse.emf.ecore.EObject)} — the per-kind
+ * Markdown-table formatter. It is driven here with in-memory {@code BslFactory}-built BSL model
+ * objects (no live workbench, editor, Xtext resource or injector). Every branch exercised below
+ * reads only EMF getters on the constructed object; {@code getStartLine}/{@code getEndLine}
+ * return 0 for an object with no node model, so the "Lines" row is simply omitted — no exception.
+ * The live editor/hover path of {@code getSymbolInfo} needs a real workbench and is e2e-covered.</li>
+ * </ul>
+ * Same-package access reaches the package-private {@code buildEObjectInfo}, matching the seam
+ * convention used by {@code AbstractMetadataFormatterTest}.
  */
 public class SymbolInfoServiceTest
 {
+    private final SymbolInfoService service = new SymbolInfoService();
+
+    // ==================== meaningfulOrNull — the pure string guard ====================
+
     @Test
     public void testRawObjectReferenceBecomesNull()
     {
@@ -54,5 +81,141 @@ public class SymbolInfoServiceTest
         // A real hover with an @ inside multi-token prose is NOT a bare ClassName@hash.
         String s = "Annotation &Вместо(\"Method\") — overrides at line 9";
         assertEquals(s, SymbolInfoService.meaningfulOrNull(s));
+    }
+
+    // ==================== cell / codeCell — the pure row builders ====================
+
+    @Test
+    public void testCellEscapesPipe()
+    {
+        // A '|' in the value must be escaped so it cannot break the table column.
+        assertEquals("| **Type** | String \\| Number |\n",
+            SymbolInfoService.cell("Type", "String | Number"));
+    }
+
+    @Test
+    public void testCellNullValueRendersEmpty()
+    {
+        assertEquals("| **Kind** |  |\n", SymbolInfoService.cell("Kind", null));
+    }
+
+    @Test
+    public void testCodeCellWrapsInBackticks()
+    {
+        assertEquals("| **Symbol** | `Name` |\n", SymbolInfoService.codeCell("Symbol", "Name"));
+    }
+
+    // ==================== buildEObjectInfo — per-kind formatting ====================
+
+    @Test
+    public void testProcedureInfo()
+    {
+        Procedure proc = BslFactory.eINSTANCE.createProcedure();
+        proc.setName("DoWork");
+
+        String info = service.buildEObjectInfo(proc);
+
+        assertTrue("has table header", info.startsWith("| Property | Value |"));
+        assertTrue("symbol row", info.contains("| **Symbol** | `DoWork` |"));
+        assertTrue("kind is Procedure", info.contains("| **Kind** | Procedure |"));
+        assertTrue("signature row", info.contains("| **Signature** | `Procedure DoWork(-)` |"));
+        assertTrue("not exported", info.contains("| **Export** | No |"));
+        // No node model on an in-memory object -> no "Lines" row.
+        assertFalse("no lines row without node model", info.contains("**Lines**"));
+    }
+
+    @Test
+    public void testExportedFunctionWithParameter()
+    {
+        Function fn = BslFactory.eINSTANCE.createFunction();
+        fn.setName("Compute");
+        fn.setExport(true);
+
+        FormalParam p = BslFactory.eINSTANCE.createFormalParam();
+        p.setName("Source");
+        p.setByValue(true);
+        fn.getFormalParams().add(p);
+
+        String info = service.buildEObjectInfo(fn);
+
+        assertTrue("kind is Function", info.contains("| **Kind** | Function |"));
+        assertTrue("exported", info.contains("| **Export** | Yes |"));
+        // ByVal parameter appears in both the signature and the Parameters row.
+        assertTrue("signature includes Val param and Export",
+            info.contains("| **Signature** | `Function Compute(Val Source) Export` |"));
+        assertTrue("parameters row", info.contains("| **Parameters** | Val Source |"));
+    }
+
+    @Test
+    public void testFormalParamInfo()
+    {
+        // A param contained by a method so the "In method" row is exercised too.
+        Method owner = BslFactory.eINSTANCE.createProcedure();
+        owner.setName("Owner");
+
+        FormalParam p = BslFactory.eINSTANCE.createFormalParam();
+        p.setName("Value");
+        p.setByValue(false);
+        owner.getFormalParams().add(p);
+
+        String info = service.buildEObjectInfo(p);
+
+        assertTrue("symbol row", info.contains("| **Symbol** | `Value` |"));
+        assertTrue("kind is Parameter", info.contains("| **Kind** | Parameter |"));
+        assertTrue("not by value", info.contains("| **ByValue** | No |"));
+        assertTrue("containing method", info.contains("| **In method** | `Owner` |"));
+    }
+
+    @Test
+    public void testStaticFeatureAccessInfo()
+    {
+        StaticFeatureAccess sfa = BslFactory.eINSTANCE.createStaticFeatureAccess();
+        sfa.setName("MyVar");
+
+        String info = service.buildEObjectInfo(sfa);
+
+        assertTrue("symbol row", info.contains("| **Symbol** | `MyVar` |"));
+        assertTrue("kind", info.contains("| **Kind** | StaticFeatureAccess |"));
+        assertTrue("emf type row", info.contains("| **EMF type** | StaticFeatureAccess |"));
+    }
+
+    @Test
+    public void testDynamicFeatureAccessInfo()
+    {
+        DynamicFeatureAccess dfa = BslFactory.eINSTANCE.createDynamicFeatureAccess();
+        dfa.setName("Property");
+
+        String info = service.buildEObjectInfo(dfa);
+
+        assertTrue("symbol row", info.contains("| **Symbol** | `Property` |"));
+        assertTrue("kind", info.contains("| **Kind** | DynamicFeatureAccess |"));
+        assertTrue("emf type row", info.contains("| **EMF type** | DynamicFeatureAccess |"));
+    }
+
+    @Test
+    public void testInvocationInfoUsesMethodAccessName()
+    {
+        StaticFeatureAccess called = BslFactory.eINSTANCE.createStaticFeatureAccess();
+        called.setName("Message");
+
+        Invocation inv = BslFactory.eINSTANCE.createInvocation();
+        inv.setMethodAccess(called);
+
+        String info = service.buildEObjectInfo(inv);
+
+        assertTrue("kind is Invocation", info.contains("| **Kind** | Invocation |"));
+        assertTrue("emf type row", info.contains("| **EMF type** | Invocation |"));
+        assertTrue("symbol taken from method access", info.contains("| **Symbol** | `Message` |"));
+    }
+
+    @Test
+    public void testModuleInfo()
+    {
+        Module module = BslFactory.eINSTANCE.createModule();
+
+        String info = service.buildEObjectInfo(module);
+
+        assertTrue("kind is Module", info.contains("| **Kind** | Module |"));
+        assertTrue("emf type row", info.contains("| **EMF type** | Module |"));
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/BslModuleUtilsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/BslModuleUtilsTest.java
@@ -316,4 +316,170 @@ public class BslModuleUtilsTest
 
         assertSame("must return the conventional src/ handle when nothing matches", srcFile, result); //$NON-NLS-1$
     }
+
+    // ========== looksLikeAbsolutePath ==========
+
+    @Test
+    public void testLooksLikeAbsolutePathNullIsFalse()
+    {
+        assertFalse(BslModuleUtils.looksLikeAbsolutePath(null));
+    }
+
+    @Test
+    public void testLooksLikeAbsolutePathEmptyIsFalse()
+    {
+        assertFalse(BslModuleUtils.looksLikeAbsolutePath("")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testLooksLikeAbsolutePathForwardSlashIsTrue()
+    {
+        assertTrue(BslModuleUtils.looksLikeAbsolutePath("/home/user/Module.bsl")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testLooksLikeAbsolutePathBackslashIsTrue()
+    {
+        assertTrue(BslModuleUtils.looksLikeAbsolutePath("\\\\server\\share\\Module.bsl")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testLooksLikeAbsolutePathWindowsDriveIsTrue()
+    {
+        assertTrue(BslModuleUtils.looksLikeAbsolutePath("C:\\projects\\Module.bsl")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testLooksLikeAbsolutePathRelativeIsFalse()
+    {
+        assertFalse(BslModuleUtils.looksLikeAbsolutePath("CommonModules/Foo/Module.bsl")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testLooksLikeAbsolutePathSingleCharIsFalse()
+    {
+        // length < 2 and not starting with a slash → cannot be a drive prefix
+        assertFalse(BslModuleUtils.looksLikeAbsolutePath("C")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testLooksLikeAbsolutePathColonAsSecondCharIsTrue()
+    {
+        // the heuristic only inspects the second char for a colon (drive-like)
+        assertTrue(BslModuleUtils.looksLikeAbsolutePath("z:")); //$NON-NLS-1$
+    }
+
+    // ========== extractModulePath ==========
+
+    @Test
+    public void testExtractModulePathNullReturnsUnknown()
+    {
+        assertEquals("Unknown module", BslModuleUtils.extractModulePath(null)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExtractModulePathStripsSrcPrefix()
+    {
+        assertEquals("CommonModules/Foo/Module.bsl", //$NON-NLS-1$
+            BslModuleUtils.extractModulePath("MyProject/src/CommonModules/Foo/Module.bsl")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExtractModulePathReturnsAsIsWhenNoSrcMarker()
+    {
+        // no "/src/" segment → the path is returned unchanged
+        assertEquals("CommonModules/Foo/Module.bsl", //$NON-NLS-1$
+            BslModuleUtils.extractModulePath("CommonModules/Foo/Module.bsl")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExtractModulePathUsesFirstSrcMarker()
+    {
+        // indexOf finds the first "/src/"; the remainder (including a later src/) is kept
+        assertEquals("a/src/b/Module.bsl", //$NON-NLS-1$
+            BslModuleUtils.extractModulePath("Proj/src/a/src/b/Module.bsl")); //$NON-NLS-1$
+    }
+
+    // ========== findRegionForLine ==========
+
+    @Test
+    public void testFindRegionNullLinesIsNull()
+    {
+        assertNull(BslModuleUtils.findRegionForLine(null, 1));
+    }
+
+    @Test
+    public void testFindRegionTargetLineBelowOneIsNull()
+    {
+        List<String> lines = List.of(
+            "#Region Public",               // 1 //$NON-NLS-1$
+            "#EndRegion");                  // 2 //$NON-NLS-1$
+        assertNull(BslModuleUtils.findRegionForLine(lines, 0));
+    }
+
+    @Test
+    public void testFindRegionCodeLineInsideSingleRegion()
+    {
+        List<String> lines = List.of(
+            "#Region Public",               // 1 //$NON-NLS-1$
+            "Procedure A() EndProcedure",   // 2 //$NON-NLS-1$
+            "#EndRegion");                  // 3 //$NON-NLS-1$
+        assertEquals("Public", BslModuleUtils.findRegionForLine(lines, 2)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindRegionReturnsInnermostWhenNested()
+    {
+        List<String> lines = List.of(
+            "#Region Outer",                // 1 //$NON-NLS-1$
+            "#Region Inner",                // 2 //$NON-NLS-1$
+            "SomeCode();",                  // 3 //$NON-NLS-1$
+            "#EndRegion",                   // 4 //$NON-NLS-1$
+            "#EndRegion");                  // 5 //$NON-NLS-1$
+        assertEquals("Inner", BslModuleUtils.findRegionForLine(lines, 3)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindRegionAfterInnerClosedReturnsOuter()
+    {
+        List<String> lines = List.of(
+            "#Region Outer",                // 1 //$NON-NLS-1$
+            "#Region Inner",                // 2 //$NON-NLS-1$
+            "#EndRegion",                   // 3 (closes Inner) //$NON-NLS-1$
+            "Code();",                      // 4 //$NON-NLS-1$
+            "#EndRegion");                  // 5 //$NON-NLS-1$
+        assertEquals("Outer", BslModuleUtils.findRegionForLine(lines, 4)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindRegionLineOutsideAnyRegionIsNull()
+    {
+        List<String> lines = List.of(
+            "Procedure A() EndProcedure",   // 1 (before any region) //$NON-NLS-1$
+            "#Region Public",               // 2 //$NON-NLS-1$
+            "#EndRegion");                  // 3 //$NON-NLS-1$
+        assertNull(BslModuleUtils.findRegionForLine(lines, 1));
+    }
+
+    @Test
+    public void testFindRegionTargetOnRegionStartLine()
+    {
+        List<String> lines = List.of(
+            "#Region Outer",                // 1 //$NON-NLS-1$
+            "#Region Inner",                // 2 (the region-start line itself) //$NON-NLS-1$
+            "#EndRegion",                   // 3 //$NON-NLS-1$
+            "#EndRegion");                  // 4 //$NON-NLS-1$
+        assertEquals("Inner", BslModuleUtils.findRegionForLine(lines, 2)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindRegionRussianDirectivesAndIndentation()
+    {
+        List<String> lines = List.of(
+            "  #Область ПрограммныйИнтерфейс", // 1 #Область ПрограммныйИнтерфейс //$NON-NLS-1$
+            "Code();",                      // 2 //$NON-NLS-1$
+            "  #КонецОбласти"); // 3 #КонецОбласти //$NON-NLS-1$
+        assertEquals("ПрограммныйИнтерфейс", //$NON-NLS-1$
+            BslModuleUtils.findRegionForLine(lines, 2));
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/BslModuleUtilsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/BslModuleUtilsTest.java
@@ -180,6 +180,68 @@ public class BslModuleUtilsTest
         assertNull(BslModuleUtils.extractDocCommentText(null, 5));
     }
 
+    @Test
+    public void testExtractTextDeclarationAtLineOneIsNull()
+    {
+        // declarationLine1Based <= 1 → findDocCommentStartLine returns the line
+        // itself, so there is no preceding comment block to extract
+        List<String> lines = List.of(
+            "// Doc above nothing",          // 1 //$NON-NLS-1$
+            "Procedure A() EndProcedure");   // 2 //$NON-NLS-1$
+        assertNull(BslModuleUtils.extractDocCommentText(lines, 1));
+    }
+
+    @Test
+    public void testExtractTextTrailingSlashesAreKeptAfterFirstTwo()
+    {
+        // only the first "//" is stripped; an inner "//" stays in the text
+        List<String> lines = List.of(
+            "// see http://example",         // 1 //$NON-NLS-1$
+            "Procedure A() EndProcedure");   // 2 //$NON-NLS-1$
+        assertEquals("see http://example", BslModuleUtils.extractDocCommentText(lines, 2)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExtractTextEmptyCommentLineYieldsEmptyToken()
+    {
+        // a bare "//" with nothing after it contributes an empty token joined by space
+        List<String> lines = List.of(
+            "// First",                      // 1 //$NON-NLS-1$
+            "//",                            // 2 (empty comment body) //$NON-NLS-1$
+            "// Third",                      // 3 //$NON-NLS-1$
+            "Procedure A() EndProcedure");   // 4 //$NON-NLS-1$
+        assertEquals("First  Third", BslModuleUtils.extractDocCommentText(lines, 4)); //$NON-NLS-1$
+    }
+
+    // ========== findDocCommentStartLine — boundary branches ==========
+
+    @Test
+    public void testStartLineDeclarationLineZeroReturnedAsIs()
+    {
+        // declarationLine1Based <= 1 short-circuits and returns the input unchanged
+        List<String> lines = List.of(
+            "// Doc line",                  // 1 //$NON-NLS-1$
+            "Procedure A() EndProcedure");  // 2 //$NON-NLS-1$
+        assertEquals(0, BslModuleUtils.findDocCommentStartLine(lines, 0));
+    }
+
+    @Test
+    public void testStartLineNegativeDeclarationLineReturnedAsIs()
+    {
+        assertEquals(-3, BslModuleUtils.findDocCommentStartLine(null, -3));
+    }
+
+    @Test
+    public void testStartLineNonCommentLineImmediatelyAboveExcluded()
+    {
+        // the line above the declaration is code, not a comment → block is empty
+        List<String> lines = List.of(
+            "// distant doc",               // 1 //$NON-NLS-1$
+            "Var Counter;",                 // 2 (code, breaks adjacency) //$NON-NLS-1$
+            "Procedure A() EndProcedure");  // 3 //$NON-NLS-1$
+        assertEquals(3, BslModuleUtils.findDocCommentStartLine(lines, 3));
+    }
+
     // ========== findMethodViaText / buildTextMethodNotFoundResponse ==========
 
     @Test
@@ -253,6 +315,70 @@ public class BslModuleUtilsTest
     }
 
     @Test
+    public void testFindMethodViaTextRussianKeywordsAndExportFunction()
+    {
+        // exercises the Cyrillic Функция/КонецФункции alternations and the Export flag
+        List<String> lines = List.of(
+            "Функция Сумма(А, Б) Экспорт", // Функция Сумма(А, Б) Экспорт //$NON-NLS-1$
+            "  Возврат А + Б;", // Возврат А + Б; //$NON-NLS-1$
+            "КонецФункции"); // КонецФункции //$NON-NLS-1$
+        BslModuleUtils.TextMethod tm = BslModuleUtils.findMethodViaText(lines, "Сумма"); // Сумма //$NON-NLS-1$
+        assertTrue(tm.found);
+        assertTrue(tm.isFunction);
+        assertEquals("Сумма", tm.matchedName); // Сумма //$NON-NLS-1$
+        assertEquals(0, tm.startLine);
+        assertEquals(2, tm.endLine);
+    }
+
+    @Test
+    public void testFindMethodViaTextMatchesSecondMethodNotFirst()
+    {
+        // the requested method is the second declaration: startLine must point at it,
+        // not at the first method, and only its own End* terminates the block
+        List<String> lines = List.of(
+            "Procedure Alpha()",            // 0 //$NON-NLS-1$
+            "EndProcedure",                 // 1 //$NON-NLS-1$
+            "Function Beta() Export",       // 2 //$NON-NLS-1$
+            "  Return 1;",                  // 3 //$NON-NLS-1$
+            "EndFunction");                 // 4 //$NON-NLS-1$
+        BslModuleUtils.TextMethod tm = BslModuleUtils.findMethodViaText(lines, "Beta"); //$NON-NLS-1$
+        assertTrue(tm.found);
+        assertTrue(tm.isFunction);
+        assertEquals(2, tm.startLine);
+        assertEquals(4, tm.endLine);
+        assertEquals(2, tm.allMethodNames.size());
+    }
+
+    @Test
+    public void testFindMethodViaTextMultiContiguousDocCommentIncluded()
+    {
+        // a multi-line, blank-separated doc block: only the contiguous part is included
+        List<String> lines = List.of(
+            "// stray header",              // 0 //$NON-NLS-1$
+            "",                             // 1 (blank breaks adjacency) //$NON-NLS-1$
+            "// near one",                  // 2 //$NON-NLS-1$
+            "// near two",                  // 3 //$NON-NLS-1$
+            "Procedure Gamma()",            // 4 //$NON-NLS-1$
+            "EndProcedure");                // 5 //$NON-NLS-1$
+        BslModuleUtils.TextMethod tm = BslModuleUtils.findMethodViaText(lines, "Gamma"); //$NON-NLS-1$
+        assertTrue(tm.found);
+        assertFalse(tm.isFunction);
+        assertEquals(2, tm.startLine); // contiguous doc block begins at line index 2
+        assertEquals(5, tm.endLine);
+    }
+
+    @Test
+    public void testFindMethodViaTextEmptyInputNotFoundEmptyNames()
+    {
+        BslModuleUtils.TextMethod tm = BslModuleUtils.findMethodViaText(List.of(), "Whatever"); //$NON-NLS-1$
+        assertFalse(tm.found);
+        assertEquals(-1, tm.startLine);
+        assertEquals(-1, tm.endLine);
+        assertNull(tm.matchedName);
+        assertTrue(tm.allMethodNames.isEmpty());
+    }
+
+    @Test
     public void testBuildTextMethodNotFoundResponse()
     {
         String r = BslModuleUtils.buildTextMethodNotFoundResponse(
@@ -261,6 +387,17 @@ public class BslModuleUtilsTest
         assertTrue(r.contains("**Available methods** (2)")); //$NON-NLS-1$
         assertTrue(r.contains("- Alpha")); //$NON-NLS-1$
         assertTrue(r.contains("- Beta")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBuildTextMethodNotFoundResponseEmptyListReportsZero()
+    {
+        String r = BslModuleUtils.buildTextMethodNotFoundResponse(
+            "Foo", "CommonModules/X/Module.bsl", List.of()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(r.contains("Method 'Foo' not found in CommonModules/X/Module.bsl")); //$NON-NLS-1$
+        assertTrue(r.contains("**Available methods** (0)")); //$NON-NLS-1$
+        // no method bullets when the list is empty
+        assertFalse(r.contains("\n- ")); //$NON-NLS-1$
     }
 
     // ========== resolveModuleFile source-folder resolution (A27) ==========
@@ -317,6 +454,47 @@ public class BslModuleUtilsTest
         assertSame("must return the conventional src/ handle when nothing matches", srcFile, result); //$NON-NLS-1$
     }
 
+    @Test
+    public void testResolveModuleFileNullModulePathIsNull()
+    {
+        // the empty/null modulePath guard returns before the project is dereferenced
+        assertNull(BslModuleUtils.resolveModuleFile(null, null));
+    }
+
+    @Test
+    public void testResolveModuleFileEmptyModulePathIsNull()
+    {
+        assertNull(BslModuleUtils.resolveModuleFile(null, "")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResolveModuleFileAbsolutePathNotInWorkspaceIsNull()
+    {
+        // an absolute path takes the workspace-lookup branch; a path that maps to no
+        // workspace file yields an empty result array → null (no project access needed)
+        IFile result = BslModuleUtils.resolveModuleFile(
+            null, "C:\\nonexistent\\path\\does\\not\\exist\\Module.bsl"); //$NON-NLS-1$
+        assertNull(result);
+    }
+
+    @Test
+    public void testResolveModuleFileAbsolutePathWithNullProjectIsNull()
+    {
+        // the absolute-path branch is taken BEFORE the project null-check, so a null
+        // project is tolerated when the path is absolute
+        IFile result = BslModuleUtils.resolveModuleFile(
+            null, "/var/tmp/missing/Module.bsl"); //$NON-NLS-1$
+        assertNull(result);
+    }
+
+    @Test
+    public void testResolveModuleFileNullProjectRelativePathIsNull()
+    {
+        // a relative path with a null project: the absolute heuristic fails, then the
+        // project null-guard returns null
+        assertNull(BslModuleUtils.resolveModuleFile(null, "CommonModules/Foo/Module.bsl")); //$NON-NLS-1$
+    }
+
     // ========== looksLikeAbsolutePath ==========
 
     @Test
@@ -367,6 +545,20 @@ public class BslModuleUtilsTest
     {
         // the heuristic only inspects the second char for a colon (drive-like)
         assertTrue(BslModuleUtils.looksLikeAbsolutePath("z:")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testLooksLikeAbsolutePathLeadingBackslashIsTrue()
+    {
+        // a single leading backslash is enough (not only the UNC double form)
+        assertTrue(BslModuleUtils.looksLikeAbsolutePath("\\relative\\Module.bsl")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testLooksLikeAbsolutePathTwoCharNonColonIsFalse()
+    {
+        // length >= 2 but the second char is not a colon → not drive-like
+        assertFalse(BslModuleUtils.looksLikeAbsolutePath("ab")); //$NON-NLS-1$
     }
 
     // ========== extractModulePath ==========
@@ -481,5 +673,46 @@ public class BslModuleUtilsTest
             "  #КонецОбласти"); // 3 #КонецОбласти //$NON-NLS-1$
         assertEquals("ПрограммныйИнтерфейс", //$NON-NLS-1$
             BslModuleUtils.findRegionForLine(lines, 2));
+    }
+
+    @Test
+    public void testFindRegionTargetBeyondAllLinesIsNull()
+    {
+        // no line satisfies lineNum >= targetLine → the loop exits and returns null
+        List<String> lines = List.of(
+            "#Region Public",               // 1 //$NON-NLS-1$
+            "#EndRegion");                  // 2 //$NON-NLS-1$
+        assertNull(BslModuleUtils.findRegionForLine(lines, 99));
+    }
+
+    @Test
+    public void testFindRegionTargetOnEndRegionLineReturnsClosingRegion()
+    {
+        // when the target lands on the #EndRegion line, the still-open region is reported
+        List<String> lines = List.of(
+            "#Region Public",               // 1 //$NON-NLS-1$
+            "Code();",                      // 2 //$NON-NLS-1$
+            "#EndRegion");                  // 3 (target) //$NON-NLS-1$
+        assertEquals("Public", BslModuleUtils.findRegionForLine(lines, 3)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindRegionStrayEndRegionWithEmptyStackBeforeTarget()
+    {
+        // a stray #EndRegion with an empty stack must not pop anything; a later code
+        // line inside a real region still resolves correctly
+        List<String> lines = List.of(
+            "#EndRegion",                   // 1 (stray, empty stack) //$NON-NLS-1$
+            "#Region Public",               // 2 //$NON-NLS-1$
+            "Code();",                      // 3 (target) //$NON-NLS-1$
+            "#EndRegion");                  // 4 //$NON-NLS-1$
+        assertEquals("Public", BslModuleUtils.findRegionForLine(lines, 3)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindRegionEmptyLinesIsNull()
+    {
+        // empty source: the loop never runs and the method returns null
+        assertNull(BslModuleUtils.findRegionForLine(List.of(), 1));
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/EditorScreenshotHelperTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/EditorScreenshotHelperTest.java
@@ -177,6 +177,114 @@ public class EditorScreenshotHelperTest
                 "Catalog.Products.Attribute.Name", "Catalog.Products.Attribute.Name")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
+    @Test
+    public void testFqnMatchEmptyStringIsNullSafe()
+    {
+        // An empty FQN/path hits the isEmpty() guard (distinct from the null guard) and must never
+        // canonicalize to a key, so it cannot be accepted as the requested form.
+        assertFalse("an empty actual FQN must not match", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath("", "CommonForm.MyForm")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("an empty requested path must not match", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath("CommonForm.MyForm", "")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("two empty strings must not match", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath("", "")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFqnMatchesContentFormSymmetric()
+    {
+        // canonicalization is applied to BOTH sides, so the content-form FQN (trailing .Form) matches
+        // the requested MD-form path regardless of which argument carries the extra segment.
+        assertTrue("content-form FQN as the requested path must match the actual MD-form FQN", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath(
+                "Catalog.Products.Forms.ItemForm", "Catalog.Products.Form.ItemForm.Form")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("common content-form FQN on the requested side must match the common MD-form", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath(
+                "CommonForm.MyForm", "CommonForm.MyForm.Form")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFqnMatchesUnknownMetadataTypeFallsBackToRawSegment()
+    {
+        // When the leading type segment is not a recognized metadata type, toEnglishSingular returns
+        // null and canonicalization falls back to the raw segment (lower-cased). Such an FQN must
+        // still match itself (object form and common form), and the raw fallback is case-insensitive.
+        assertTrue("an unknown object-form type must match itself via the raw-segment fallback", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath(
+                "Widget.Gadget.Form.MainForm", "Widget.Gadget.Forms.MainForm")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the unknown-type fallback must be case-insensitive", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath(
+                "Widget.Gadget.Form.MainForm", "WIDGET.Gadget.forms.MainForm")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("an unknown common-form type must match itself via the raw-segment fallback", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath(
+                "Widget.MyForm", "widget.MyForm")); //$NON-NLS-1$ //$NON-NLS-2$
+        // Two genuinely different unknown types must not be conflated.
+        assertFalse("different unknown types must not match", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath(
+                "Widget.Gadget.Form.MainForm", "Gizmo.Gadget.Forms.MainForm")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFqnMatchesRussianFormsSeparator()
+    {
+        // The owner/forms separator of an object form may itself be Russian (Форма / Формы), not only
+        // the type segment. isFormsSeparator (FormElementWriter.isFormToken) must accept those so a
+        // Russian-separated FQN matches the English-separated requested path.
+        assertTrue("Russian singular form separator must match the English request", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath(
+                "Catalog.Products.Форма.ItemForm", "Catalog.Products.Forms.ItemForm")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("Russian plural form separator must match the English request", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath(
+                "Catalog.Products.Формы.ItemForm", "Catalog.Products.Form.ItemForm")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFqnMatchesRussianContentFormSeparator()
+    {
+        // The trailing content-form segment appended to the representation's content-form FQN may be
+        // the Russian singular Форма. isContentFormSeparator must strip it so the content FQN still
+        // matches the requested MD-form path (object and common form).
+        assertTrue("a Russian trailing content separator must be stripped for an object form", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath(
+                "Catalog.Products.Form.ItemForm.Форма", "Catalog.Products.Forms.ItemForm")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a Russian trailing content separator must be stripped for a common form", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath(
+                "CommonForm.MyForm.Форма", "CommonForm.MyForm")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFqnContentStripOnlyWhenRemainderIsValidFormShape()
+    {
+        // A trailing ".Form" is stripped as a content separator only when the remainder is a valid
+        // form shape. A 5-part FQN whose remaining 4 parts lack a forms separator is NOT a content
+        // form: after stripping, canonicalFormFqnFromParts returns null, so it must not match itself.
+        assertFalse("a 5-part .Form tail with a non-form remainder must not match", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath(
+                "Catalog.Products.Attribute.Name.Form", "Catalog.Products.Attribute.Name.Form")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFqnThreePartShapeNeverMatches()
+    {
+        // A 3-part FQN whose last segment is not a content separator is an unrecognized shape (neither
+        // a 2-part common form nor a 4-part object form), so it canonicalizes to null and never matches.
+        assertFalse("a 3-part non-content FQN must not match itself", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath(
+                "Catalog.Products.ItemForm", "Catalog.Products.ItemForm")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFqnFormNamedFormIsNotContentStripped()
+    {
+        // A two-segment "Owner.Form" path must be treated as a 2-part common form named "Form", NOT as
+        // a content-form whose ".Form" tail is stripped (stripping requires a 3- or 5-part length).
+        // It must match itself and must NOT collapse to a bare single owner segment.
+        assertTrue("a 2-part path ending in Form is a common form and matches itself", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath("CommonForm.Form", "CommonForm.Form")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("a 2-part Owner.Form must not collapse to the bare owner segment", //$NON-NLS-1$
+            EditorScreenshotHelper.fqnMatchesFormPath("CommonForm.Form", "CommonForm")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
     // ==================== ensureRenderedFormImage force-refresh (stale-screenshot fix) ====================
     //
     // These tests cover the runtime-free decision logic of the force-refresh mode with a fake


### PR DESCRIPTION
Addresses **#171** (raise code coverage). As the issue notes, much of the codebase only runs under a live 1C/EDT runtime — those paths stay covered by the python e2e suite. This PR maximises the **unit-testable surface** that runs in Tycho Surefire **without a live EDT/1C/SWT**: **+433 JUnit tests** (2202 → **2635**, all green, `mvn clean verify`).

### What's covered (and how)
- **Metadata formatters via IN-MEMORY EMF** — the biggest win. The test bundle is a `Fragment-Host` of the main bundle, so non-proxy EMF objects can be built headlessly via `MdClassFactory`/`McoreFactory`/`BslFactory` (existing precedent: MetadataPropertyIntrospectorTest, StyleValueBuilderTest). Result:
  - `UniversalMetadataFormatter` 11% → **63%**
  - `AbstractMetadataFormatter` 17% → **81%**
  - `EObjectInspector` 18% → **79%**
  - `SymbolInfoService` 2% → 22% (the BSL-model formatting branches; the Xtext/editor path stays e2e)
- **Pure utilities** — `StandaloneServerSupport` 0%→55%, `TagUtils`, `BslModuleUtils` (extended), `EditorScreenshotHelper` (FQN matching), plus `GroupStorage`→94% / `Group`→99% via a SnakeYAML round-trip.
- **Tool metadata + `execute()` early-validation** — for ~20 tools: name/NAME/responseType/description/input+output schema/getResultFileName, and every argument-validation branch reachable before the first workspace/UI call (bad/missing/invalid args → error JSON). Where a tool extends `AbstractMetadataWriteTool` (whose `final execute()` hits the workbench before validation) only the metadata + pure statics are tested.

### Method
SDD-style: each class was studied (entry points, the exact EDT boundary, existing test patterns) before tests were written; only deterministic, runtime-free surface is asserted; the full suite is green. No Mockito was added beyond what the repo already uses; no live-workspace/SWT objects are constructed.

### One production change
`SymbolInfoService.buildEObjectInfo` widened `private` → package-private as a test seam (behaviour-preserving), mirroring the protected-helper convention already used by `AbstractMetadataFormatter`.

Overall instruction coverage ~30% → **~33%**; the remaining gap is the genuinely runtime-bound code (BM transactions, live model, SWT UI) that needs the EDT-in-the-loop setup discussed in #171.