### PR TITLE
Suppress the false-positive SonarCloud clusters with // NOSONAR + reason (#164)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/Activator.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/Activator.java
@@ -64,7 +64,7 @@ public class Activator extends AbstractUIPlugin
     public void start(BundleContext context) throws Exception
     {
         super.start(context);
-        plugin = this;
+        plugin = this; // NOSONAR Eclipse singleton/Activator init pattern; method cannot be static
         mcpServer = new McpServer();
 
         // In Tycho headless test runtime, avoid eager workspace/UI/platform initialization.
@@ -105,7 +105,7 @@ public class Activator extends AbstractUIPlugin
         orchestrator.stop(isHeadless());
 
         logInfo("EDT MCP Server plugin stopped"); //$NON-NLS-1$
-        plugin = null;
+        plugin = null; // NOSONAR Eclipse singleton/Activator init pattern; method cannot be static
         super.stop(context);
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/EdtServices.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/EdtServices.java
@@ -222,7 +222,7 @@ public class EdtServices
     public void dispose()
     {
         // Close service trackers (each closeTracker() closes when non-null and returns null,
-        // exactly reproducing the former "if (t != null) { t.close(); t = null; }" per-field block).
+        // exactly reproducing the former "if (t != null) { t.close(); t = null; }" per-field block). // NOSONAR explanatory comment, not commented-out code
         v8ProjectManagerTracker = closeTracker(v8ProjectManagerTracker);
         dtProjectManagerTracker = closeTracker(dtProjectManagerTracker);
         configurationProviderTracker = closeTracker(configurationProviderTracker);
@@ -586,7 +586,7 @@ public class EdtServices
         IModelObjectFactory factory = formModelObjectFactoryTracker.getService();
         if (factory == null)
         {
-            // The form bundle is lazily activated and registers its services in start();
+            // The form bundle is lazily activated and registers its services in start(); // NOSONAR explanatory comment, not commented-out code
             // trip the activation, then re-read the tracker.
             Bundle formBundle = Platform.getBundle(FORM_BUNDLE_ID);
             if (formBundle == null)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/UpdateChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/UpdateChecker.java
@@ -242,7 +242,7 @@ public final class UpdateChecker
         if (responseCode != HttpURLConnection.HTTP_OK)
         {
             Activator.logInfo("EDT MCP Server update check: GitHub API returned HTTP " + responseCode); //$NON-NLS-1$
-            return null;
+            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
         }
 
         StringBuilder sb = new StringBuilder();
@@ -283,7 +283,7 @@ public final class UpdateChecker
                 return new String[] { tagName, body, htmlUrl };
             }
         }
-        return null;
+        return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/NewGroupHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/NewGroupHandler.java
@@ -228,7 +228,7 @@ public class NewGroupHandler extends AbstractHandler {
      * Returns the model object name (e.g. "CommonModule", "Catalog"), or
      * {@code null} when the method is absent or does not return a String.
      */
-    private String invokeGetModelObjectName(Object adapter) throws Exception {
+    private String invokeGetModelObjectName(Object adapter) throws Exception { // NOSONAR propagates checked exceptions across the reflective boundary by design
         try {
             Method getModelObjectNameMethod = adapter.getClass().getMethod("getModelObjectName");
             Object result = getModelObjectNameMethod.invoke(adapter);
@@ -247,7 +247,7 @@ public class NewGroupHandler extends AbstractHandler {
      * reflective {@code getParent(Object)} method is absent this is treated as a
      * top-level collection (returns {@code false}).
      */
-    private boolean isNestedCollection(Object adapter) throws Exception {
+    private boolean isNestedCollection(Object adapter) throws Exception { // NOSONAR propagates checked exceptions across the reflective boundary by design
         try {
             Method getParentMethod = adapter.getClass().getMethod("getParent", Object.class);
             Object parent = getParentMethod.invoke(adapter, adapter);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupNavigatorAdapter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupNavigatorAdapter.java
@@ -84,7 +84,7 @@ public class GroupNavigatorAdapter extends WorkbenchAdapter implements IAdaptabl
                 Bundle bundle = Activator.getDefault().getBundle();
                 URL url = bundle.getEntry("icons/group.png");
                 if (url != null) {
-                    folderIcon = ImageDescriptor.createFromURL(url);
+                    folderIcon = ImageDescriptor.createFromURL(url); // NOSONAR Eclipse singleton/Activator init pattern; method cannot be static
                 }
             } catch (Exception e) {
                 Activator.logError("Failed to load folder icon", e);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/JsonUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/JsonUtils.java
@@ -253,13 +253,13 @@ public final class JsonUtils
     {
         if (params == null || argumentName == null)
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
         }
         
         String value = params.get(argumentName);
         if (value == null || value.isEmpty())
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
         }
         
         value = value.trim();
@@ -317,7 +317,7 @@ public final class JsonUtils
         {
             // Fall through to comma-separated parsing
         }
-        return null;
+        return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/jsonrpc/JsonRpcRequest.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/jsonrpc/JsonRpcRequest.java
@@ -79,14 +79,14 @@ public class JsonRpcRequest
     {
         if (params == null)
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
         }
         Object args = params.get("arguments"); //$NON-NLS-1$
         if (args instanceof Map)
         {
             return (Map<String, Object>) args;
         }
-        return null;
+        return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
     }
     
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/Messages.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/Messages.java
@@ -16,19 +16,19 @@ public class Messages extends NLS {
     private static final String BUNDLE_NAME = "com.ditrix.edt.mcp.server.tags.ui.messages"; //$NON-NLS-1$
     
     // FilterByTagDialog
-    public static String FilterByTagDialog_Title;
-    public static String FilterByTagDialog_Description;
-    public static String FilterByTagDialog_SetButton;
-    public static String FilterByTagDialog_TurnOffButton;
-    public static String FilterByTagDialog_SelectAll;
-    public static String FilterByTagDialog_DeselectAll;
-    public static String FilterByTagDialog_SearchPlaceholder;
-    public static String FilterByTagDialog_EditTag;
-    public static String FilterByTagDialog_ShowUntaggedOnly;
-    public static String FilterByTagDialog_ShowUntaggedOnlyTooltip;
+    public static String FilterByTagDialog_Title; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
+    public static String FilterByTagDialog_Description; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
+    public static String FilterByTagDialog_SetButton; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
+    public static String FilterByTagDialog_TurnOffButton; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
+    public static String FilterByTagDialog_SelectAll; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
+    public static String FilterByTagDialog_DeselectAll; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
+    public static String FilterByTagDialog_SearchPlaceholder; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
+    public static String FilterByTagDialog_EditTag; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
+    public static String FilterByTagDialog_ShowUntaggedOnly; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
+    public static String FilterByTagDialog_ShowUntaggedOnlyTooltip; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
     
     // FilterByTagManager
-    public static String FilterByTagManager_FilterName;
+    public static String FilterByTagManager_FilterName; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
     
     static {
         NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagSearchFilter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagSearchFilter.java
@@ -490,19 +490,19 @@ public class TagSearchFilter extends ViewerFilter {
             // First get the parent EObject
             EObject parent = resolveNestedFolderParent(element);
             if (parent == null) {
-                return null; // Not a nested folder
+                return null; // Not a nested folder // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
             }
 
             // Get the parent's FQN
             String parentFqn = TagUtils.extractFqn(parent);
             if (parentFqn == null) {
-                return null;
+                return null; // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
             }
 
             // Get the model object name (Attribute, EnumValue, TabularSection, etc.)
             String modelObjectName = resolveModelObjectName(element);
             if (modelObjectName == null) {
-                return null;
+                return null; // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
             }
 
             Set<String> projectFqns = getCurrentMatchingFqns();
@@ -516,7 +516,7 @@ public class TagSearchFilter extends ViewerFilter {
 
         } catch (Exception e) {
             Activator.logError("Error checking nested folder", e);
-            return null;
+            return null; // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
         }
     }
 
@@ -527,7 +527,7 @@ public class TagSearchFilter extends ViewerFilter {
      * {@link NoSuchMethodException} reflection failures propagate to the caller (preserving
      * the original outer try/catch behaviour).
      */
-    private static EObject resolveNestedFolderParent(Object element) throws Exception {
+    private static EObject resolveNestedFolderParent(Object element) throws Exception { // NOSONAR propagates checked exceptions across the reflective boundary by design
         // Try getModel() or getModel(false)
         for (String methodName : new String[]{"getModel"}) {
             try {
@@ -559,7 +559,7 @@ public class TagSearchFilter extends ViewerFilter {
      * accessor is absent or yields null. Side-effect free; non-{@link NoSuchMethodException}
      * reflection failures propagate to the caller (preserving the original outer try/catch).
      */
-    private static String resolveModelObjectName(Object element) throws Exception {
+    private static String resolveModelObjectName(Object element) throws Exception { // NOSONAR propagates checked exceptions across the reflective boundary by design
         try {
             var method = element.getClass().getMethod("getModelObjectName");
             Object result = method.invoke(element);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/base/AbstractMetadataWriteTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/base/AbstractMetadataWriteTool.java
@@ -85,7 +85,7 @@ public abstract class AbstractMetadataWriteTool implements IMcpTool
      * @return the JSON result string
      * @throws Exception on unexpected failure
      */
-    protected abstract String executeOnUiThread(Map<String, String> params) throws Exception;
+    protected abstract String executeOnUiThread(Map<String, String> params) throws Exception; // NOSONAR propagates checked exceptions across the reflective boundary by design
 
     /**
      * Holds the resolved project and configuration, or a ready-to-return JSON

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/doc/PlatformDocumentationService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/doc/PlatformDocumentationService.java
@@ -213,7 +213,7 @@ public class PlatformDocumentationService
                 availableTypes.add(lastSegment != null ? lastSegment : fullName);
             }
 
-            // Check if this is the type we're looking for (case-insensitive, check both full and last segment)
+            // Check if this is the type we're looking for (case-insensitive, check both full and last segment) // NOSONAR explanatory comment, not commented-out code
             if (fullName.equalsIgnoreCase(typeName) ||
                 (lastSegment != null && lastSegment.equalsIgnoreCase(typeName)))
             {
@@ -980,7 +980,7 @@ public class PlatformDocumentationService
                 availableMethods.add(methodName);
             }
 
-            // Check if this is the function we're looking for (case-insensitive)
+            // Check if this is the function we're looking for (case-insensitive) // NOSONAR explanatory comment, not commented-out code
             if (methodName.equalsIgnoreCase(functionName))
             {
                 Method resolvedMethod = resolveDescriptionAsMethod(desc, resourceSet);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/form/FormLayoutSnapshotService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/form/FormLayoutSnapshotService.java
@@ -305,7 +305,7 @@ public class FormLayoutSnapshotService
         Map<String, Object> bounds = getBounds(presentation, layoutProjection, viewProjection);
         if (!fullMode && !hasPositiveBounds(bounds))
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
         }
 
         Map<String, Object> item = new LinkedHashMap<>();
@@ -370,7 +370,7 @@ public class FormLayoutSnapshotService
             return boundsMap(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
         }
 
-        return null;
+        return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
     }
 
     private String getBoundsSource(Object presentation, Object layoutProjection, Object viewProjection)
@@ -407,7 +407,7 @@ public class FormLayoutSnapshotService
     {
         if (layout == null)
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
         }
 
         Object left = invokeNoArg(layout, "getLeft"); //$NON-NLS-1$
@@ -420,7 +420,7 @@ public class FormLayoutSnapshotService
                 ((Number)width).intValue(), ((Number)height).intValue());
         }
 
-        return null;
+        return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
     }
 
     private Map<String, Object> boundsMap(int left, int top, int width, int height)
@@ -781,7 +781,7 @@ public class FormLayoutSnapshotService
     {
         if (!(value instanceof EObject))
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
         }
 
         EObject object = (EObject)value;
@@ -869,7 +869,7 @@ public class FormLayoutSnapshotService
             {
                 method = target.getClass().getMethod(methodName, Object.class);
             }
-            method.setAccessible(true);
+            method.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
             return method.invoke(target, argument);
         }
         catch (Exception e)
@@ -895,7 +895,7 @@ public class FormLayoutSnapshotService
             return boundsMap(0, 0, controlImageData.width, controlImageData.height);
         }
 
-        return null;
+        return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
     }
 
     private int countElementsWithBounds(List<Map<String, Object>> elements)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
@@ -917,7 +917,7 @@ public class CreateInfobaseTool implements IMcpTool
             Object opt = m.invoke(service, versionMask, null);
             return (opt instanceof Optional) && ((Optional<?>)opt).isPresent();
         }
-        catch (Throwable t)
+        catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
         {
             Activator.logError("create_infobase: standalone-server runtime probe failed", t); //$NON-NLS-1$
             return false;
@@ -931,7 +931,7 @@ public class CreateInfobaseTool implements IMcpTool
      */
     private static Object ssCreateServerWithInfobase(Object service, String versionMask,
             String projectName, InfobaseReference ib, int clusterPort, String clusterRegistryDirectory,
-            String publicationPath, IProgressMonitor monitor) throws Exception
+            String publicationPath, IProgressMonitor monitor) throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
     {
         Method m = service.getClass().getMethod("createServerWithInfobase", //$NON-NLS-1$
             String.class, String.class, InfobaseReference.class, int.class, String.class, String.class,
@@ -1013,7 +1013,7 @@ public class CreateInfobaseTool implements IMcpTool
 
     /** Reflectively invokes the first public method of {@code target} matching name + arg count. */
     private static Object ssInvoke(Object target, String name, int argCount, Object... args)
-        throws Exception
+        throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
     {
         Method m = ssMethod(target.getClass(), name, argCount);
         if (m == null)
@@ -1083,7 +1083,7 @@ public class CreateInfobaseTool implements IMcpTool
             Object name = m.invoke(standaloneServerInfobase);
             return (name instanceof String) ? (String)name : null;
         }
-        catch (Throwable t)
+        catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
         {
             Activator.logError("create_infobase: could not read standalone-server infobase name", t); //$NON-NLS-1$
             return null;
@@ -1274,7 +1274,7 @@ public class CreateInfobaseTool implements IMcpTool
             .put(KEY_INFOBASE_NAME, infobaseName)
             .put(KEY_APPLICATIONS, appsArray);
 
-        // Report the ACTUAL auto-allocated port only when we could resolve it from the web URL;
+        // Report the ACTUAL auto-allocated port only when we could resolve it from the web URL; // NOSONAR explanatory comment, not commented-out code
         // never echo the requested/hint port (EDT ignores it for a FILE-backed standalone server).
         if (actualPort > 0)
         {
@@ -1458,7 +1458,7 @@ public class CreateInfobaseTool implements IMcpTool
     {
         try
         {
-            // PlatformServicesCore is an INTERNAL class of the platform-services.core bundle;
+            // PlatformServicesCore is an INTERNAL class of the platform-services.core bundle; // NOSONAR explanatory comment, not commented-out code
             // it is not exported, so Class.forName via OUR bundle classloader cannot see it.
             // Load it through the OWNING bundle's classloader instead (the same pattern
             // EdtServices uses for the form bundle's internal service class).
@@ -1472,7 +1472,7 @@ public class CreateInfobaseTool implements IMcpTool
             // Touching a class trips the bundle's lazy activation so getDefault() is populated.
             Class<?> coreClass = psCoreBundle.loadClass(PLATFORM_SERVICES_CORE_CLASS);
             java.lang.reflect.Method getDefault = coreClass.getDeclaredMethod("getDefault"); //$NON-NLS-1$
-            getDefault.setAccessible(true);
+            getDefault.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
             Object coreInstance = getDefault.invoke(null);
             if (coreInstance == null)
             {
@@ -1487,7 +1487,7 @@ public class CreateInfobaseTool implements IMcpTool
             }
             java.lang.reflect.Method getInjector =
                 coreClass.getDeclaredMethod("getInjector"); //$NON-NLS-1$
-            getInjector.setAccessible(true);
+            getInjector.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
             Object injector = getInjector.invoke(coreInstance);
             if (injector == null)
             {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ExportConfigurationToXmlTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ExportConfigurationToXmlTool.java
@@ -100,7 +100,7 @@ public class ExportConfigurationToXmlTool implements IMcpTool
             Files.createDirectories(outputPath);
 
             // Defense-in-depth: export can write to ANY absolute path. With the
-            // server bound to loopback + optional token this is trusted-caller-only;
+            // server bound to loopback + optional token this is trusted-caller-only; // NOSONAR explanatory comment, not commented-out code
             // still flag writes outside the workspace so an injected/erroneous call
             // is visible. Non-breaking: warn, do not reject (local export to an
             // external dir is a legitimate action).

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetContentAssistTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetContentAssistTool.java
@@ -661,7 +661,7 @@ public class GetContentAssistTool implements IMcpTool
     {
         if (containsFilter == null || containsFilter.isEmpty())
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
         }
         String[] filterParts = containsFilter.toLowerCase().split(","); //$NON-NLS-1$
         for (int i = 0; i < filterParts.length; i++)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMarkersTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMarkersTool.java
@@ -160,7 +160,7 @@ public class GetMarkersTool implements IMcpTool
         try
         {
             List<MarkerRow> rows = new ArrayList<>();
-            // Dedup set shared across the two task marker types: a BSL TODO/FIXME
+            // Dedup set shared across the two task marker types: a BSL TODO/FIXME // NOSONAR tracking FIXME, intentionally retained; tracking TODO, intentionally retained
             // surfaces under both the base task marker and the Xtext task marker
             // subtype and must be counted once.
             Set<String> seenTasks = new HashSet<>();
@@ -456,7 +456,7 @@ public class GetMarkersTool implements IMcpTool
         }
     }
 
-    /** Extracts the task type (TODO, FIXME, XXX, HACK) from the marker message. */
+    /** Extracts the task type (TODO, FIXME, XXX, HACK) from the marker message. */ // NOSONAR tracking FIXME, intentionally retained; tracking TODO, intentionally retained
     private static String getTaskType(String message)
     {
         if (message == null || message.isEmpty())

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetModuleStructureTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetModuleStructureTool.java
@@ -489,7 +489,7 @@ public class GetModuleStructureTool implements IMcpTool
         {
             Activator.logWarning("Failed to load source lines: " + e.getMessage()); //$NON-NLS-1$
         }
-        return null;
+        return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
     }
     private List<MethodInfo> collectMethods(Module module, List<RegionInfo> regions,
         boolean includeComments, List<String> sourceLines)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProfilingResultsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProfilingResultsTool.java
@@ -278,7 +278,7 @@ public class GetProfilingResultsTool implements IMcpTool
      * session dates are present. Caller has already verified {@code results} is non-empty.
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private static List<?> latestOnly(List<?> results, Method getDateOfSession) throws Exception
+    private static List<?> latestOnly(List<?> results, Method getDateOfSession) throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
     {
         Object latest = null;
         Comparable latestDate = null;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -102,7 +102,7 @@ public class GetProjectErrorsTool implements IMcpTool
         String severity = JsonUtils.extractStringArgument(params, "severity"); //$NON-NLS-1$
         String checkId = JsonUtils.extractStringArgument(params, "checkId"); //$NON-NLS-1$
 
-        // Output verbosity: concise (default) trims the secondary 'Has docs' column;
+        // Output verbosity: concise (default) trims the secondary 'Has docs' column; // NOSONAR explanatory comment, not commented-out code
         // detailed renders the full historical table. Any absent/blank/unrecognized value
         // falls back to concise (the lean default), never an error.
         String responseFormat = JsonUtils.extractStringArgument(params, "responseFormat"); //$NON-NLS-1$
@@ -212,7 +212,7 @@ public class GetProjectErrorsTool implements IMcpTool
             // Markers whose presentation could not be resolved even inside a transaction.
             // They are NOT dropped, but they are surfaced differently depending on context,
             // so we track the two cases separately to keep the warning text honest:
-            //  - unresolvedShown: reported in the table with a "<unresolved: ...>" placeholder;
+            //  - unresolvedShown: reported in the table with a "<unresolved: ...>" placeholder; // NOSONAR explanatory comment, not commented-out code
             //  - unresolvedFilteredOut: excluded from the result because an explicit objects
             //    filter is active and the location could not be resolved to test membership.
             final int[] unresolvedShown = {0};

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -1328,7 +1328,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
     {
         if (value == null)
         {
-            return null;
+            return null; // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
         }
         String v = value.trim().toLowerCase();
         if ("true".equals(v) || "1".equals(v) || "yes".equals(v)) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
@@ -1339,7 +1339,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         {
             return Boolean.FALSE;
         }
-        return null;
+        return null; // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
     }
 
     private static Integer parseInteger(String value)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskTool.java
@@ -228,7 +228,7 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
         // Configuration.mdo, so the destructive step must be an explicit opt-in, never
         // a side effect of a diagnostic run.
         boolean cleanDangling = JsonUtils.extractBooleanArgument(params, KEY_CLEAN_DANGLING_REFERENCES, false);
-        // Default FALSE: only the objects whose .mdo is actually missing are exported;
+        // Default FALSE: only the objects whose .mdo is actually missing are exported; // NOSONAR explanatory comment, not commented-out code
         // true re-exports everything (a full disk refresh, slow on the UI thread).
         boolean fullExport = JsonUtils.extractBooleanArgument(params, KEY_FULL_EXPORT, false);
 
@@ -528,7 +528,7 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
 
         // Detection (and, when remove=true, mutation) run inside one BM write task so
         // the same transaction that observes the proxies also removes them atomically.
-        // The task body only reports whether it removed anything IN the transaction;
+        // The task body only reports whether it removed anything IN the transaction; // NOSONAR explanatory comment, not commented-out code
         // the removedFromModel claim is made by runRemovalWriteTask AFTER
         // BmTransactions.write returned, i.e. only once the transaction actually
         // committed - a failed commit must not be reported as "Removed N".

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
@@ -342,7 +342,7 @@ public class RunYaxunitTestsTool implements IMcpTool
             }
 
             // No active launch. Deliver a previously reported Pending result EXACTLY ONCE: a re-call
-            // fetching the result of a run that finished after a Pending response gets the report;
+            // fetching the result of a run that finished after a Pending response gets the report; // NOSONAR explanatory comment, not commented-out code
             // any later call with the same key falls through to a fresh run. There is NO time-based
             // cache, so a genuine re-run always re-executes the tests.
             String pendingResult = tryDeliverPendingResult(runKey, reportDir, projectName, applicationId);
@@ -1011,7 +1011,7 @@ public class RunYaxunitTestsTool implements IMcpTool
                             jobEntry.error = result.getError();
                         }
                     }
-                    catch (Throwable e)
+                    catch (Throwable e) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
                     {
                         // Throwable, not Exception: an Error escaping the prep must still
                         // surface as a prep failure — otherwise the retry call would see
@@ -1536,7 +1536,7 @@ public class RunYaxunitTestsTool implements IMcpTool
         {
             return;
         }
-        // try-with-resources releases the file-system handle held by Files.walk's stream;
+        // try-with-resources releases the file-system handle held by Files.walk's stream; // NOSONAR explanatory comment, not commented-out code
         // on Windows, leaving it open can prevent subsequent deletions of the same path.
         try (java.util.stream.Stream<Path> stream = Files.walk(tempDir))
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SearchInCodeTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SearchInCodeTool.java
@@ -148,7 +148,7 @@ public class SearchInCodeTool implements IMcpTool
             .getParameterValue(NAME, KEY_MAX_RESULTS, DEFAULT_MAX_RESULTS);
         int configuredContextLines = ToolParameterSettings.getInstance()
             .getParameterValue(NAME, KEY_CONTEXT_LINES, DEFAULT_CONTEXT_LINES);
-        // Canonical param is "limit" (consistent with other paginated tools);
+        // Canonical param is "limit" (consistent with other paginated tools); // NOSONAR explanatory comment, not commented-out code
         // "maxResults" is kept as a deprecated alias (precedence: limit, then maxResults).
         int maxResultsAlias = JsonUtils.extractIntArgument(params, KEY_MAX_RESULTS, configuredMaxResults);
         int maxResults = JsonUtils.extractIntArgument(params, "limit", maxResultsAlias); //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/StandaloneServerSupport.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/StandaloneServerSupport.java
@@ -233,7 +233,7 @@ final class StandaloneServerSupport
                 .invoke(standaloneServerInfobaseModule);
             return id != null ? id.toString() : null;
         }
-        catch (Throwable t)
+        catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
         {
             Activator.logError("delete_infobase: could not read standalone-server infobaseId", t); //$NON-NLS-1$
             return null;
@@ -282,7 +282,7 @@ final class StandaloneServerSupport
             }
             return (dir instanceof String) ? (String)dir : null;
         }
-        catch (Throwable t)
+        catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
         {
             Activator.logError("delete_infobase: could not read standalone-server database directory", t); //$NON-NLS-1$
             return null;
@@ -329,7 +329,7 @@ final class StandaloneServerSupport
                 }
             }
         }
-        catch (Throwable t)
+        catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
         {
             Activator.logError("delete_infobase: server-by-name scan failed", t); //$NON-NLS-1$
         }
@@ -400,9 +400,9 @@ final class StandaloneServerSupport
             {
                 return RegistryCleanup.FAILED;
             }
-            modulesF.setAccessible(true);
-            mapperF.setAccessible(true);
-            locF.setAccessible(true);
+            modulesF.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            mapperF.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            locF.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
 
             @SuppressWarnings("unchecked")
             Map<Object, Object> modules = (Map<Object, Object>)modulesF.get(delegate);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
@@ -212,7 +212,7 @@ public class WriteModuleSourceTool implements IMcpTool
             // expectedHash from its last read, reject if the module changed since —
             // a cheap lost-update check that complements searchReplace's oldSource
             // match and replace's expectedSource. Read the canonical text the same way
-            // those guards do (readFileText, \n-normalized) so the hashes always agree;
+            // those guards do (readFileText, \n-normalized) so the hashes always agree; // NOSONAR explanatory comment, not commented-out code
             // skipped entirely when no expectedHash is given.
             String currentTextForHash = (expectedHash != null && !expectedHash.isEmpty() && fileExists)
                 ? BslModuleUtils.readFileText(file).replace("\r\n", "\n") //$NON-NLS-1$ //$NON-NLS-2$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
@@ -176,7 +176,7 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
     {
         if (!(feature instanceof EReference))
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
         }
 
         EReference ref = (EReference) feature;
@@ -184,24 +184,24 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
         // Only process containment many-valued references
         if (!ref.isContainment() || !ref.isMany())
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
         }
 
         // Skip derived, transient, volatile
         if (ref.isDerived() || ref.isTransient() || ref.isVolatile())
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
         }
 
         if (!mdObject.eIsSet(ref))
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
         }
 
         Object value = mdObject.eGet(ref);
         if (!(value instanceof Collection))
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
         }
 
         return (Collection<?>) value;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
@@ -1248,7 +1248,7 @@ public class MetadataRenameService
             try
             {
                 java.lang.reflect.Field field = type.getDeclaredField(fieldName);
-                field.setAccessible(true);
+                field.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
                 return field.get(target);
             }
             catch (Exception e)
@@ -1260,12 +1260,12 @@ public class MetadataRenameService
     }
 
     private static Object invokeMethod(Object target, String methodName, Class<?>[] parameterTypes, Object... args)
-        throws Exception
+        throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
     {
         java.lang.reflect.Method method = findMethod(target.getClass(), methodName, parameterTypes);
         if (!method.canAccess(target))
         {
-            method.setAccessible(true);
+            method.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
         }
         return method.invoke(target, args);
     }
@@ -1352,7 +1352,7 @@ public class MetadataRenameService
         }
     }
 
-    private static Object getBslInjector() throws Exception
+    private static Object getBslInjector() throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
     {
         Class<?> activatorClass = getClassOrThrow("com._1c.g5.v8.dt.bsl.ui.internal.BslActivator"); //$NON-NLS-1$
         Object activator = activatorClass.getMethod(GET_INSTANCE).invoke(null);
@@ -1360,7 +1360,7 @@ public class MetadataRenameService
             "com._1c.g5.v8.dt.bsl.Bsl"); //$NON-NLS-1$
     }
 
-    private static Object getSearchCoreInjector() throws Exception
+    private static Object getSearchCoreInjector() throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
     {
         Class<?> pluginClass = getClassOrThrow("com._1c.g5.v8.dt.internal.search.core.SearchCorePlugin"); //$NON-NLS-1$
         Object plugin = pluginClass.getMethod("getDefault").invoke(null); //$NON-NLS-1$
@@ -1375,7 +1375,7 @@ public class MetadataRenameService
             getClassOrThrow("org.eclipse.emf.common.util.URI"), //$NON-NLS-1$
             getClassOrThrow("org.eclipse.emf.ecore.EClass"), //$NON-NLS-1$
             getClassOrThrow("com._1c.g5.v8.bm.core.IBmObject")); //$NON-NLS-1$
-        constructor.setAccessible(true);
+        constructor.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
         return constructor.newInstance(EcoreUtil.getURI(targetObject), targetObject.eClass(), targetObject);
     }
 
@@ -1419,7 +1419,7 @@ public class MetadataRenameService
             java.lang.reflect.Method method = findMethod(target.getClass(), methodName, new Class<?>[0]);
             if (!method.canAccess(target))
             {
-                method.setAccessible(true);
+                method.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
             }
             return method.invoke(target);
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/symbol/SymbolInfoService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/symbol/SymbolInfoService.java
@@ -359,7 +359,7 @@ public class SymbolInfoService
                     "getTextHover", int.class, int.class); //$NON-NLS-1$
             if (getTextHoverMethod != null)
             {
-                getTextHoverMethod.setAccessible(true);
+                getTextHoverMethod.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
                 Object result = getTextHoverMethod.invoke(sourceViewer, offset, 0);
                 if (result instanceof ITextHover)
                 {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/transport/InterruptibleToolExecutor.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/transport/InterruptibleToolExecutor.java
@@ -45,7 +45,7 @@ public class InterruptibleToolExecutor
      * @return the response, or {@code null} if the response was already sent (interrupted)
      * @throws Exception if tool execution failed (propagated to the caller for error mapping)
      */
-    public String execute(HttpExchange exchange, String requestBody) throws Exception
+    public String execute(HttpExchange exchange, String requestBody) throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
     {
         // Extract request ID and tool name for ActiveToolCall via the shared parser.
         JsonRpcRequest request = protocolHandler.parse(requestBody);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/ui/NavigatorToolbarCustomizer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/ui/NavigatorToolbarCustomizer.java
@@ -267,6 +267,6 @@ public class NavigatorToolbarCustomizer {
 
         partListener = null;
         initialized = false;
-        instance = null;
+        instance = null; // NOSONAR Eclipse singleton/Activator init pattern; method cannot be static
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BreakpointUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BreakpointUtils.java
@@ -101,7 +101,7 @@ public final class BreakpointUtils
         }
         // Single shared module resolver (BslModuleUtils.resolveModuleFile) handles
         // BOTH an absolute filesystem path and a src/-relative path. For the
-        // absolute case the project is not needed (resolution is by location);
+        // absolute case the project is not needed (resolution is by location); // NOSONAR explanatory comment, not commented-out code
         // for the src/-relative case resolve the project and pass it through.
         IProject project = null;
         if (!BslModuleUtils.looksLikeAbsolutePath(module))

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
@@ -423,7 +423,7 @@ public final class BslModuleUtils
         }
 
         List<String> lines = new ArrayList<>();
-        // Wrap in BufferedInputStream to support mark/reset for BOM detection;
+        // Wrap in BufferedInputStream to support mark/reset for BOM detection; // NOSONAR explanatory comment, not commented-out code
         // rawIs is closed by try-with-resources since BufferedInputStream wraps it
         try (InputStream input = new BufferedInputStream(rawIs))
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DebugServerTargetSupport.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DebugServerTargetSupport.java
@@ -215,7 +215,7 @@ public final class DebugServerTargetSupport
         try
         {
             Method listMethod = manager.getClass().getMethod("listDebugTargets"); //$NON-NLS-1$
-            listMethod.setAccessible(true);
+            listMethod.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
             Object targets = listMethod.invoke(manager);
             if (!(targets instanceof Iterable<?>))
             {
@@ -979,11 +979,11 @@ public final class DebugServerTargetSupport
         try
         {
             Method m = target.getClass().getMethod(getter);
-            m.setAccessible(true);
+            m.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
             Object v = m.invoke(target);
             return v != null ? v.toString() : null;
         }
-        catch (Throwable e)
+        catch (Throwable e) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
         {
             return null;
         }
@@ -1011,7 +1011,7 @@ public final class DebugServerTargetSupport
         try
         {
             Method m = target.getClass().getMethod("getApplication"); //$NON-NLS-1$
-            m.setAccessible(true);
+            m.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
             Object app = m.invoke(target);
             if (app instanceof java.util.Optional<?>)
             {
@@ -1019,7 +1019,7 @@ public final class DebugServerTargetSupport
             }
             return app;
         }
-        catch (Throwable e)
+        catch (Throwable e) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
         {
             return null;
         }
@@ -1036,7 +1036,7 @@ public final class DebugServerTargetSupport
         try
         {
             Method m = application.getClass().getMethod("getProject"); //$NON-NLS-1$
-            m.setAccessible(true);
+            m.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
             Object project = m.invoke(application);
             if (project == null)
             {
@@ -1044,7 +1044,7 @@ public final class DebugServerTargetSupport
             }
             return reflectString(project, "getName"); //$NON-NLS-1$
         }
-        catch (Throwable e)
+        catch (Throwable e) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
         {
             return null;
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/EditorScreenshotHelper.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/EditorScreenshotHelper.java
@@ -167,8 +167,8 @@ public final class EditorScreenshotHelper
         try
         {
             Field bufferedField = serviceClass.getDeclaredField(bufferedFlagField);
-            bufferedField.setAccessible(true);
-            bufferedField.setBoolean(null, true);
+            bufferedField.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            bufferedField.setBoolean(null, true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
         }
         catch (Exception e)
         {
@@ -452,7 +452,7 @@ public final class EditorScreenshotHelper
         {
             return null;
         }
-        findPageMethod.setAccessible(true);
+        findPageMethod.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
         return findPageMethod.invoke(editorPart, FORM_MAIN_PAGE_ID);
     }
 
@@ -487,7 +487,7 @@ public final class EditorScreenshotHelper
     /**
      * Gets the active form editor page via the static FormEditor API.
      */
-    public static Object getActiveFormEditorPage() throws Exception
+    public static Object getActiveFormEditorPage() throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
     {
         Class<?> editorClass = Class.forName(FORM_EDITOR_CLASS);
         Method method = editorClass.getMethod("getActiveFormEditorPage"); //$NON-NLS-1$
@@ -558,7 +558,7 @@ public final class EditorScreenshotHelper
             {
                 return null;
             }
-            method.setAccessible(true);
+            method.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
             Object fqn = method.invoke(model);
             return fqn != null ? fqn.toString() : null;
         }
@@ -955,7 +955,7 @@ public final class EditorScreenshotHelper
         }
         if (syncPathReachable)
         {
-            // The synchronous hooks are present but did not produce a (fresh) image within the budget;
+            // The synchronous hooks are present but did not produce a (fresh) image within the budget; // NOSONAR explanatory comment, not commented-out code
             // one last check (the render task may have settled while pumping events).
             return hasFreshImage(representation, baseline, requireNewInstance);
         }
@@ -1023,8 +1023,8 @@ public final class EditorScreenshotHelper
                 try
                 {
                     Field field = type.getDeclaredField(FORM_IMAGE_DATA_FIELD);
-                    field.setAccessible(true);
-                    field.set(representation, null);
+                    field.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+                    field.set(representation, null); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
                     return true;
                 }
                 catch (NoSuchFieldException e)
@@ -1121,7 +1121,7 @@ public final class EditorScreenshotHelper
 
             // Synchronous sibling of getMappingRootAsync: compute the CommandInterfaceMapping root on
             // THIS thread instead of the background thread whose syncExec callback gets dropped.
-            getMappingRoot.setAccessible(true);
+            getMappingRoot.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
             Object cmiMapping = getMappingRoot.invoke(controller, cmiMappingClass);
             if (cmiMapping == null)
             {
@@ -1135,7 +1135,7 @@ public final class EditorScreenshotHelper
 
             // Invoke the private rebuildInternal(Form, CommandInterfaceMapping, NativeRenderEvent,
             // boolean) directly: this is the synchronous body the async handler would have run.
-            rebuildInternal.setAccessible(true);
+            rebuildInternal.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
             // updateOnly=false → force a full layout/render pass for this form.
             rebuildInternal.invoke(representation, form, cmiMapping, event, Boolean.FALSE);
 
@@ -1259,7 +1259,7 @@ public final class EditorScreenshotHelper
         try
         {
             Method method = representation.getClass().getDeclaredMethod(FORM_IMAGE_METHOD);
-            method.setAccessible(true);
+            method.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
             ImageData data = (ImageData)method.invoke(representation);
             if (data != null && data.width > 0 && data.height > 0)
             {
@@ -1414,7 +1414,7 @@ public final class EditorScreenshotHelper
         try
         {
             Method rebuildMethod = representation.getClass().getDeclaredMethod(REBUILD_METHOD, boolean.class);
-            rebuildMethod.setAccessible(true);
+            rebuildMethod.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
             rebuildMethod.invoke(representation, true);
 
             Display display = Display.getCurrent();
@@ -1545,7 +1545,7 @@ public final class EditorScreenshotHelper
                 ReflectionUtils.findMethod(editorPart.getClass(), "setActivePage", String.class); //$NON-NLS-1$
             if (setActivePageMethod != null)
             {
-                setActivePageMethod.setAccessible(true);
+                setActivePageMethod.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
                 setActivePageMethod.invoke(editorPart, FORM_MAIN_PAGE_ID);
             }
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -471,7 +471,7 @@ public final class FormElementWriter
     // Every form-editing tool repeats the same ~40-line pipeline: resolve the MD-form from a form
     // path, null-check the BM services, capture the bmId, re-fetch the MD-form inside a BM
     // transaction, hop to the editable content form, run the work, then force-export the content
-    // form's own FQN (it serializes to Form.form). The scaffold below owns that pipeline ONCE;
+    // form's own FQN (it serializes to Form.form). The scaffold below owns that pipeline ONCE; // NOSONAR explanatory comment, not commented-out code
     // tools supply only the per-call work and their user-visible "form not found" message. Every
     // scaffold-level failure that carries an actionable message is thrown as a
     // FormValidationException with the READY error JSON, so callers surface it verbatim
@@ -1583,7 +1583,7 @@ public final class FormElementWriter
         // own factory does before the value type is known.
         setEnumFeature(item, FEATURE_TYPE, "InputField"); //$NON-NLS-1$
         setExtInfoClassifier(formModel, item, "InputFieldExtInfo"); //$NON-NLS-1$
-        // The designer's new-field defaults (FormObjectFactory.newFormField / newInputFieldExtInfo);
+        // The designer's new-field defaults (FormObjectFactory.newFormField / newInputFieldExtInfo); // NOSONAR explanatory comment, not commented-out code
         // the booleans default to false in the model, so without them a created field renders with
         // no table header/footer, no wrap and a read-only text box. 'Auto'-valued enums are the
         // model defaults (literal 0) and stay unset, like the XMI omits them.
@@ -2025,7 +2025,7 @@ public final class FormElementWriter
             }
         }
         // Duplicate guard. Base path keeps the original "one handler per event" rule. Extension path lets
-        // the extension handler COEXIST with the base handler and with other-call-type extension handlers;
+        // the extension handler COEXIST with the base handler and with other-call-type extension handlers; // NOSONAR explanatory comment, not commented-out code
         // only a same-(event, callType) EventHandlerExtension is a real duplicate.
         EStructuralFeature evFeat = handlerEventFeature(handlersFeat);
         for (EObject existing : referenceList(container, KEY_HANDLERS))

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/GuideLoader.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/GuideLoader.java
@@ -133,7 +133,7 @@ public final class GuideLoader
                 sb.append(buf, 0, n);
             }
         }
-        // Trim trailing whitespace/newlines so the rendered "## Guide\n<body>" is tidy;
+        // Trim trailing whitespace/newlines so the rendered "## Guide\n<body>" is tidy; // NOSONAR explanatory comment, not commented-out code
         // keep leading content intact.
         int end = sb.length();
         while (end > 0 && Character.isWhitespace(sb.charAt(end - 1)))

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/JUnitXmlParser.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/JUnitXmlParser.java
@@ -70,7 +70,7 @@ public final class JUnitXmlParser
             int attrSkipped = getIntAttr(suite, "skipped", 0); //$NON-NLS-1$
 
             // Scan the suite's testcases: record each failure/error/skipped into 'results'
-            // and return the fallback node counts {caseCount, failures, errors, skipped}
+            // and return the fallback node counts {caseCount, failures, errors, skipped} // NOSONAR explanatory comment, not commented-out code
             // for producers that omit or misreport the testsuite attributes.
             int[] nodeCounts = countSuiteCases(suite, results);
 
@@ -148,7 +148,7 @@ public final class JUnitXmlParser
         return new int[] {caseNodes.getLength(), nodeFailures, nodeErrors, nodeSkipped};
     }
 
-    private static DocumentBuilder newSecureBuilder() throws Exception
+    private static DocumentBuilder newSecureBuilder() throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
     {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         // Harden XML parsing against XXE/SSRF and entity-expansion attacks.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
@@ -1013,7 +1013,7 @@ public final class LaunchLifecycleUtils
         catch (RuntimeException e)
         {
             // Discovery is best-effort: a failure here must not abort the launch.
-            // The workspace-wide build join already drained the extension build;
+            // The workspace-wide build join already drained the extension build; // NOSONAR explanatory comment, not commented-out code
             // we just skip the per-extension derived-data wait.
             Activator.logError("Error collecting extension projects for " //$NON-NLS-1$
                 + launchProject.getName(), e);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataTypeBuilder.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataTypeBuilder.java
@@ -158,7 +158,7 @@ public final class MetadataTypeBuilder
             {
                 // The generic getRefType(MdObject) dispatcher does NOT route Enum (it has a separate
                 // overload) and THROWS AssertionError for kinds with no ref type (registers, reports,
-                // ...). AssertionError is an Error, so it would escape the tool's catch(Exception) -
+                // ...). AssertionError is an Error, so it would escape the tool's catch(Exception) - // NOSONAR explanatory comment, not commented-out code
                 // route Enum explicitly and convert the AssertionError into a clean error Result.
                 refType = (target instanceof com._1c.g5.v8.dt.metadata.mdclass.Enum)
                     ? MdTypeUtil.getRefType((com._1c.g5.v8.dt.metadata.mdclass.Enum)target)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ReflectionUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ReflectionUtils.java
@@ -27,7 +27,7 @@ public final class ReflectionUtils
      * @return the invocation result
      * @throws Exception if invocation fails
      */
-    public static Object invokeMethod(Object target, String methodName) throws Exception
+    public static Object invokeMethod(Object target, String methodName) throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
     {
         Method method = target.getClass().getMethod(methodName);
         return method.invoke(target);
@@ -41,7 +41,7 @@ public final class ReflectionUtils
      * @return the field value, or {@code null} if not found
      * @throws Exception if access fails
      */
-    public static Object getFieldValue(Object target, String fieldName) throws Exception
+    public static Object getFieldValue(Object target, String fieldName) throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
     {
         Class<?> type = target.getClass();
         while (type != null)
@@ -49,7 +49,7 @@ public final class ReflectionUtils
             try
             {
                 Field field = type.getDeclaredField(fieldName);
-                field.setAccessible(true);
+                field.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
                 return field.get(target);
             }
             catch (NoSuchFieldException ex)
@@ -100,11 +100,11 @@ public final class ReflectionUtils
         {
             Class<?> unsafeClass = Class.forName("sun.misc.Unsafe"); //$NON-NLS-1$
             Field theUnsafeField = unsafeClass.getDeclaredField("theUnsafe"); //$NON-NLS-1$
-            theUnsafeField.setAccessible(true);
+            theUnsafeField.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
             Object unsafe = theUnsafeField.get(null);
 
             Field targetField = targetClass.getDeclaredField(fieldName);
-            targetField.setAccessible(true);
+            targetField.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
 
             Method staticFieldBase = unsafeClass.getMethod("staticFieldBase", Field.class); //$NON-NLS-1$
             Method staticFieldOffset = unsafeClass.getMethod("staticFieldOffset", Field.class); //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/StyleValueBuilder.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/StyleValueBuilder.java
@@ -348,12 +348,12 @@ public final class StyleValueBuilder
     {
         if (obj == null || !obj.has(name))
         {
-            return null;
+            return null; // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
         }
         JsonElement el = obj.get(name);
         if (el == null || !el.isJsonPrimitive())
         {
-            return null;
+            return null; // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
         }
         JsonPrimitive p = el.getAsJsonPrimitive();
         if (p.isBoolean())
@@ -369,7 +369,7 @@ public final class StyleValueBuilder
         {
             return Boolean.FALSE;
         }
-        return null;
+        return null; // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
     }
 
     private static String summarizeFont(String faceName, Integer height, boolean bold, boolean italic,

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/SubsystemUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/SubsystemUtils.java
@@ -97,17 +97,17 @@ public final class SubsystemUtils
     {
         if (fqn == null)
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
         }
         String trimmed = fqn.trim();
         if (trimmed.isEmpty())
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
         }
         String[] parts = trimmed.split("\\."); //$NON-NLS-1$
         if (parts.length < 2 || (parts.length % 2) != 0)
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
         }
 
         String[] names = new String[parts.length / 2];
@@ -115,12 +115,12 @@ public final class SubsystemUtils
         {
             if (!isSubsystemTypeToken(parts[i]))
             {
-                return null;
+                return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
             }
             String name = parts[i + 1] != null ? parts[i + 1].trim() : ""; //$NON-NLS-1$
             if (name.isEmpty())
             {
-                return null;
+                return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
             }
             names[i / 2] = name;
         }


### PR DESCRIPTION
Implements your decision in #164 — **`// NOSONAR` in code with a reason description** (instead of Won't Fix in the SonarCloud UI). Adds a trailing `// NOSONAR <reason>` to each of the **130** intentional findings whose 'fix' would break behaviour/i18n or is impossible. Trailing line comments are compile-safe — `mvn clean verify` green (2202 tests). 42 files.\n\n**Suppressed (count) — reason:**\n| Rule | N | Reason |\n|---|---|---|\n| S3011 `setAccessible` | 29 | reflection is required (EDT internals, no Require-Bundle) |\n| S1168 `return null` | 25 | null is a deliberate omit/sentinel signal, not an empty collection |\n| S125 | 25 | explanatory comments, not commented-out code |\n| S112 `throws` | 16 | propagates checked exceptions across the reflective boundary |\n| S1444 + S3008 | 11 fields | Eclipse NLS `Messages` fields — set by `NLS.initializeMessages`, keyed to `.properties` |\n| S2447 | 9 | intentional tri-state Boolean (`null != false`) |\n| S1181 | 9 | deliberate catch-all at a reflective/best-effort boundary |\n| S2696 | 4 | Eclipse singleton/Activator init pattern; method cannot be static |\n| S1135 / S1134 | 2 | tracking TODO/FIXME |\n\n**Could not suppress inline (4):** TODO/FIXME mentions **inside javadoc blocks** (`ProjectContext.java` ×2, `GetMarkersTool.java` ×2) — a `// NOSONAR` line comment doesn't apply inside `/** */`. Suggest marking those few **Won't Fix** in the SonarCloud UI, or I can rephrase the javadoc if you prefer.\n\nThe genuine bugs (9) and safe smells (S3776 + others) were already handled in #166-173, #176, #179-181.