### PR TITLE
Drive remaining S3776 methods under threshold + bundle S107 params into holders (pass 2)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/AddToGroupHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/AddToGroupHandler.java
@@ -136,25 +136,40 @@ public class AddToGroupHandler extends AbstractHandler {
         String objectType = null; // e.g., "Catalog", "CommonModule"
 
         for (Object element : structuredSelection.toList()) {
-            if (element instanceof EObject eObject) {
-                String fqn = TagUtils.extractFqn(eObject);
-                if (fqn != null) {
-                    String[] parts = fqn.split("\\.");
-                    if (parts.length == 2) {
-                        // Top-level object
-                        selectedObjects.add(eObject);
-                        if (project == null) {
-                            project = TagUtils.extractProject(eObject);
-                        }
-                        if (objectType == null) {
-                            objectType = parts[0]; // e.g., "Catalog"
-                        }
-                    }
-                }
+            String type = topLevelTypeOf(element);
+            if (type == null) {
+                continue;
+            }
+            // Top-level object
+            EObject eObject = (EObject) element;
+            selectedObjects.add(eObject);
+            if (project == null) {
+                project = TagUtils.extractProject(eObject);
+            }
+            if (objectType == null) {
+                objectType = type; // e.g., "Catalog"
             }
         }
 
         return new Selected(selectedObjects, project, objectType);
+    }
+
+    /**
+     * Returns the top-level metadata type token (the {@code Type} part of a {@code Type.Name}
+     * FQN, e.g. {@code "Catalog"}) for a selection element, or {@code null} when the element is
+     * not an {@link EObject}, carries no FQN, or its FQN is not a two-part top-level name. Pure,
+     * no side effects.
+     */
+    private static String topLevelTypeOf(Object element) {
+        if (!(element instanceof EObject eObject)) {
+            return null;
+        }
+        String fqn = TagUtils.extractFqn(eObject);
+        if (fqn == null) {
+            return null;
+        }
+        String[] parts = fqn.split("\\.");
+        return parts.length == 2 ? parts[0] : null;
     }
 
     /** Read-only query: the groups whose path matches the given object type. */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/RemoveFromGroupHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/RemoveFromGroupHandler.java
@@ -125,21 +125,37 @@ public class RemoveFromGroupHandler extends AbstractHandler {
             IGroupService service, List<ObjectInGroup> objectsToRemove) {
         IProject project = null;
         for (Object element : structuredSelection.toList()) {
-            if (element instanceof EObject eObject) {
-                IProject objProject = TagUtils.extractProject(eObject);
-                String fqn = TagUtils.extractFqn(eObject);
-                if (objProject != null && fqn != null) {
-                    Group group = service.findGroupForObject(objProject, fqn);
-                    if (group != null) {
-                        objectsToRemove.add(new ObjectInGroup(objProject, fqn));
-                        if (project == null) {
-                            project = objProject;
-                        }
-                    }
-                }
+            ObjectInGroup inGroup = resolveObjectInGroup(element, service);
+            if (inGroup == null) {
+                continue;
+            }
+            objectsToRemove.add(inGroup);
+            if (project == null) {
+                project = inGroup.project();
             }
         }
         return project;
+    }
+
+    /**
+     * Resolves a single selection element to an {@link ObjectInGroup} when it is an {@link EObject}
+     * that has both a project and FQN and is currently a member of some group; otherwise returns
+     * {@code null}. Read-only group lookup — does not modify any group.
+     */
+    private static ObjectInGroup resolveObjectInGroup(Object element, IGroupService service) {
+        if (!(element instanceof EObject eObject)) {
+            return null;
+        }
+        IProject objProject = TagUtils.extractProject(eObject);
+        String fqn = TagUtils.extractFqn(eObject);
+        if (objProject == null || fqn == null) {
+            return null;
+        }
+        Group group = service.findGroupForObject(objProject, fqn);
+        if (group == null) {
+            return null;
+        }
+        return new ObjectInGroup(objProject, fqn);
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/CollectionAdapterUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/CollectionAdapterUtils.java
@@ -92,43 +92,107 @@ public final class CollectionAdapterUtils {
         if (adapter == null) {
             return null;
         }
-        
-        Class<?> clazz = adapter.getClass();
-        
+
+        // A successful MethodHandle invocation is authoritative even when it
+        // returns null - only a missing handle or a failed invocation falls
+        // through to the IWorkbenchAdapter fallback.
+        HandleResult handleResult = invokeGetModelObjectName(adapter, adapter.getClass());
+        if (handleResult.invoked) {
+            return handleResult.value;
+        }
+
+        return getModelObjectNameFallback(adapter);
+    }
+
+    /**
+     * Outcome of attempting the getModelObjectName MethodHandle invocation.
+     * {@link #invoked} is true only when a handle existed and ran without throwing,
+     * in which case {@link #value} (possibly null) is authoritative; otherwise the
+     * caller must apply the fallback.
+     */
+    private static final class HandleResult {
+        final boolean invoked;
+        final String value;
+
+        private HandleResult(boolean invoked, String value) {
+            this.invoked = invoked;
+            this.value = value;
+        }
+
+        static HandleResult fallThrough() {
+            return new HandleResult(false, null);
+        }
+
+        static HandleResult of(String value) {
+            return new HandleResult(true, value);
+        }
+    }
+
+    /**
+     * Resolves the model object name via the cached/looked-up getModelObjectName
+     * MethodHandle. Returns a {@link HandleResult} whose {@code invoked} flag is
+     * false when there is no such method or the invocation throws, so the caller
+     * can apply the IWorkbenchAdapter fallback; otherwise the (possibly null)
+     * invocation result is authoritative.
+     *
+     * @param adapter the adapter to invoke the method on
+     * @param clazz the adapter's runtime class (cache key)
+     * @return the invocation outcome
+     */
+    private static HandleResult invokeGetModelObjectName(Object adapter, Class<?> clazz) {
+        MethodHandle mh = resolveModelObjectNameHandle(clazz);
+        if (mh == null) {
+            return HandleResult.fallThrough();
+        }
+        try {
+            return HandleResult.of((String) mh.invoke(adapter));
+        } catch (Throwable e) {
+            // Fall through to fallback
+            return HandleResult.fallThrough();
+        }
+    }
+
+    /**
+     * Returns the getModelObjectName MethodHandle for the given class, using the
+     * cache. Negative results (no such method) are cached as null keys; positive
+     * results are stored. ConcurrentHashMap forbids null values, so classes without
+     * the method are simply re-looked-up rather than negatively cached.
+     *
+     * @param clazz the adapter class
+     * @return the MethodHandle, or null if the class has no such method
+     */
+    private static MethodHandle resolveModelObjectNameHandle(Class<?> clazz) {
         // Check if we've already cached this class (including negative results)
         if (MODEL_OBJECT_NAME_CACHE.containsKey(clazz)) {
-            MethodHandle cached = MODEL_OBJECT_NAME_CACHE.get(clazz);
-            if (cached != null) {
-                try {
-                    return (String) cached.invoke(adapter);
-                } catch (Throwable e) {
-                    // Fall through to fallback
-                }
-            }
-            // cached is null - means we tried before and there's no method
-        } else {
-            // Cache miss - try to find and cache the method
-            MethodHandle mh = findGetModelObjectNameMethod(clazz);
-            if (mh != null) {
-                MODEL_OBJECT_NAME_CACHE.put(clazz, mh);
-                try {
-                    return (String) mh.invoke(adapter);
-                } catch (Throwable e) {
-                    // Fall through to fallback
-                }
-            }
-            // Don't cache null - ConcurrentHashMap doesn't allow null values
-            // We'll just repeat the lookup for classes without the method
+            // A non-null value is a usable handle; null means we tried before and
+            // there's no method.
+            return MODEL_OBJECT_NAME_CACHE.get(clazz);
         }
-        
-        // Fallback: try IWorkbenchAdapter label
+        // Cache miss - try to find and cache the method
+        MethodHandle mh = findGetModelObjectNameMethod(clazz);
+        if (mh != null) {
+            MODEL_OBJECT_NAME_CACHE.put(clazz, mh);
+        }
+        // Don't cache null - ConcurrentHashMap doesn't allow null values
+        // We'll just repeat the lookup for classes without the method
+        return mh;
+    }
+
+    /**
+     * Fallback model-object-name resolution via the IWorkbenchAdapter label
+     * (spaces stripped), used when the getModelObjectName MethodHandle is
+     * unavailable or fails.
+     *
+     * @param adapter the adapter
+     * @return the label-derived name, or null
+     */
+    private static String getModelObjectNameFallback(Object adapter) {
         if (adapter instanceof IWorkbenchAdapter workbenchAdapter) {
             String label = workbenchAdapter.getLabel(adapter);
             if (label != null) {
                 return label.replace(" ", "");
             }
         }
-        
         return null;
     }
     

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupSelectionHelper.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupSelectionHelper.java
@@ -189,29 +189,46 @@ public class GroupSelectionHelper implements ISelectionChangedListener {
 
         for (Iterator<?> it = lastNonEmptySelection.iterator(); it.hasNext();) {
             Object element = it.next();
-
-            if (element instanceof EObject eObject) {
-                IProject project = TagUtils.extractProject(eObject);
-                String fqn = TagUtils.extractFqn(eObject);
-
-                if (project != null && fqn != null) {
-                    Group group = groupService.findGroupForObject(project, fqn);
-
-                    if (group != null) {
-                        // Find the GroupNavigatorAdapter for this group
-                        GroupNavigatorAdapter groupAdapter = findOrCreateGroupAdapter(project, group);
-
-                        if (groupAdapter != null) {
-                            // Create TreePath: groupAdapter -> element
-                            TreePath path = new TreePath(new Object[] { groupAdapter, element });
-                            treePaths.add(path);
-                        }
-                    }
-                }
+            TreePath path = groupedTreePathFor(element, groupService);
+            if (path != null) {
+                treePaths.add(path);
             }
         }
 
         return treePaths;
+    }
+
+    /**
+     * Builds the {@link TreePath} {@code groupAdapter -> element} for a single selection
+     * element when it is an {@link EObject} that resolves to a project + fqn, is in a group,
+     * and whose {@link GroupNavigatorAdapter} can be located; otherwise returns {@code null}.
+     * Mirrors the per-element body of {@link #collectGroupedTreePaths} (including the
+     * tree-expansion side effects of {@link #findOrCreateGroupAdapter}).
+     *
+     * @param element the selection element to route
+     * @param groupService the (non-{@code null}) group service used to resolve groups
+     * @return the routed tree path, or {@code null} when the element cannot be routed
+     */
+    private TreePath groupedTreePathFor(Object element, IGroupService groupService) {
+        if (!(element instanceof EObject eObject)) {
+            return null;
+        }
+        IProject project = TagUtils.extractProject(eObject);
+        String fqn = TagUtils.extractFqn(eObject);
+        if (project == null || fqn == null) {
+            return null;
+        }
+        Group group = groupService.findGroupForObject(project, fqn);
+        if (group == null) {
+            return null;
+        }
+        // Find the GroupNavigatorAdapter for this group
+        GroupNavigatorAdapter groupAdapter = findOrCreateGroupAdapter(project, group);
+        if (groupAdapter == null) {
+            return null;
+        }
+        // Create TreePath: groupAdapter -> element
+        return new TreePath(new Object[] { groupAdapter, element });
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/McpProtocolHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/McpProtocolHandler.java
@@ -262,8 +262,43 @@ public class McpProtocolHandler
             server.setCurrentToolName(tool.getName());
         }
         
-        // Execute tool, timing the call so each tools/call gets exactly one
-        // completion log line (success or failure) carrying name + duration + outcome.
+        // Execute the tool (timed + logged + status-bar cleared in one place).
+        String result = executeToolTimed(tool, params, server);
+
+        // Check if user sent a signal during execution
+        UserSignal signal = null;
+        if (server != null)
+        {
+            signal = server.consumeUserSignal();
+        }
+        
+        // Check if plain text mode is enabled (Cursor compatibility).
+        // Activator.getDefault() can be null during a shutdown race; in that
+        // case fall back to the safe default (structured content, not plain text).
+        boolean plainTextMode = Activator.getDefault() != null
+            && Activator.getDefault().getPreferenceStore()
+                .getBoolean(PreferenceConstants.PREF_PLAIN_TEXT_MODE);
+
+        // Return response based on tool's declared response type
+        return buildToolCallResponse(tool, result, signal, plainTextMode, requestId, params);
+    }
+
+    /**
+     * Executes {@code tool} while timing the call, clearing the status-bar tool name in a
+     * {@code finally}, and emitting exactly one completion log line (plus, on failure, the
+     * extracted error message at WARNING). Extracted verbatim from {@link #handleToolCall} so
+     * the tool-result hot path stays a thin orchestrator. A thrown exception escaping
+     * {@code execute} is propagated to the caller unchanged AFTER the {@code finally} has run
+     * — same behaviour as the original inline try/finally.
+     *
+     * @param tool the resolved tool to run
+     * @param params the extracted tool params
+     * @param server the MCP server (may be {@code null} during a shutdown race)
+     * @return the raw tool result payload (may be {@code null} only if {@code execute} returned
+     *         {@code null})
+     */
+    private String executeToolTimed(IMcpTool tool, Map<String, String> params, McpServer server)
+    {
         String result = null;
         long startNanos = System.nanoTime();
         boolean threw = true;
@@ -271,6 +306,7 @@ public class McpProtocolHandler
         {
             result = tool.execute(params);
             threw = false;
+            return result;
         }
         finally
         {
@@ -295,23 +331,6 @@ public class McpProtocolHandler
             }
             logToolCallCompletion(tool.getName(), elapsedMs, isError);
         }
-        
-        // Check if user sent a signal during execution
-        UserSignal signal = null;
-        if (server != null)
-        {
-            signal = server.consumeUserSignal();
-        }
-        
-        // Check if plain text mode is enabled (Cursor compatibility).
-        // Activator.getDefault() can be null during a shutdown race; in that
-        // case fall back to the safe default (structured content, not plain text).
-        boolean plainTextMode = Activator.getDefault() != null
-            && Activator.getDefault().getPreferenceStore()
-                .getBoolean(PreferenceConstants.PREF_PLAIN_TEXT_MODE);
-
-        // Return response based on tool's declared response type
-        return buildToolCallResponse(tool, result, signal, plainTextMode, requestId, params);
     }
 
     /**
@@ -338,67 +357,122 @@ public class McpProtocolHandler
             case JSON:
                 return buildJsonToolResponse(tool, result, signal, plainTextMode, requestId);
             case MARKDOWN:
-                // A ToolResult.error JSON payload is delivered as a structured JSON
-                // error (isError:true) instead of a markdown resource, so failures
-                // are machine-detectable regardless of the declared response type.
-                if (isJsonErrorPayload(result))
-                {
-                    return buildToolCallJsonResponse(result, requestId, tool.getName());
-                }
-                // Append user signal as markdown
-                if (signal != null)
-                {
-                    result = result + "\n\n---\n**USER SIGNAL:** " + signal.getMessage();
-                }
-                // In plain text mode, return markdown as plain text instead of embedded resource
-                if (plainTextMode)
-                {
-                    return buildToolCallTextResponse(result, requestId);
-                }
-                String fileName = tool.getResultFileName(params);
-                return buildToolCallResourceResponse(result, MIME_TEXT_MARKDOWN, fileName, requestId);
+                return buildMarkdownToolResponse(tool, result, signal, plainTextMode, requestId,
+                    params);
             case YAML:
-                // Same delivery as MARKDOWN (error diversion, signal append, plain
-                // text fallback) but the embedded resource advertises a YAML
-                // mimeType so it agrees with the .yaml resource URI and the body.
-                if (isJsonErrorPayload(result))
-                {
-                    return buildToolCallJsonResponse(result, requestId, tool.getName());
-                }
-                if (signal != null)
-                {
-                    result = result + "\n\n---\n# USER SIGNAL: " + signal.getMessage();
-                }
-                if (plainTextMode)
-                {
-                    return buildToolCallTextResponse(result, requestId);
-                }
-                String yamlFileName = tool.getResultFileName(params);
-                return buildToolCallResourceResponse(result, "text/yaml", yamlFileName, requestId); //$NON-NLS-1$
+                return buildYamlToolResponse(tool, result, signal, plainTextMode, requestId, params);
             case IMAGE:
-                // Images always returned as embedded resource (ignore plain text mode)
-                // For images, user signals are ignored
-                if (isJsonErrorPayload(result))
-                {
-                    return buildToolCallJsonResponse(result, requestId, tool.getName());
-                }
-                String imageFileName = tool.getResultFileName(params);
-                return buildToolCallResourceBlobResponse(result, "image/png", imageFileName, requestId); //$NON-NLS-1$
+                return buildImageToolResponse(tool, result, requestId, params);
             case TEXT:
             default:
-                // See MARKDOWN: a ToolResult.error JSON payload is delivered as a
-                // structured JSON error regardless of the declared response type.
-                if (isJsonErrorPayload(result))
-                {
-                    return buildToolCallJsonResponse(result, requestId, tool.getName());
-                }
-                // Append user signal as text
-                if (signal != null)
-                {
-                    result = result + "\n\n---\nUSER SIGNAL: " + signal.getMessage();
-                }
-                return buildToolCallTextResponse(result, requestId);
+                return buildTextToolResponse(tool, result, signal, requestId);
         }
+    }
+
+    /**
+     * Delivers a {@code ResponseType.MARKDOWN} tools/call result, holding the MARKDOWN-case
+     * logic extracted verbatim from {@link #buildToolCallResponse}: a {@code ToolResult.error}
+     * JSON payload is diverted to a structured JSON error (machine-detectable regardless of
+     * the declared response type); otherwise a user signal is appended as markdown, plain-text
+     * mode delivers the body as text, and the default is an embedded {@code text/markdown}
+     * resource. Returns the same response in the same case as the original inline branch.
+     */
+    private String buildMarkdownToolResponse(IMcpTool tool, String result, UserSignal signal,
+        boolean plainTextMode, Object requestId, Map<String, String> params)
+    {
+        // A ToolResult.error JSON payload is delivered as a structured JSON
+        // error (isError:true) instead of a markdown resource, so failures
+        // are machine-detectable regardless of the declared response type.
+        if (isJsonErrorPayload(result))
+        {
+            return buildToolCallJsonResponse(result, requestId, tool.getName());
+        }
+        // Append user signal as markdown
+        if (signal != null)
+        {
+            result = result + "\n\n---\n**USER SIGNAL:** " + signal.getMessage();
+        }
+        // In plain text mode, return markdown as plain text instead of embedded resource
+        if (plainTextMode)
+        {
+            return buildToolCallTextResponse(result, requestId);
+        }
+        String fileName = tool.getResultFileName(params);
+        return buildToolCallResourceResponse(result, MIME_TEXT_MARKDOWN, fileName, requestId);
+    }
+
+    /**
+     * Delivers a {@code ResponseType.YAML} tools/call result, holding the YAML-case logic
+     * extracted verbatim from {@link #buildToolCallResponse}: same delivery as
+     * {@link #buildMarkdownToolResponse} (error diversion, signal append, plain-text
+     * fallback) but the signal banner uses the YAML comment form and the embedded resource
+     * advertises a {@code text/yaml} mimeType so it agrees with the {@code .yaml} resource
+     * URI and body. Returns the same response in the same case as the original inline branch.
+     */
+    private String buildYamlToolResponse(IMcpTool tool, String result, UserSignal signal,
+        boolean plainTextMode, Object requestId, Map<String, String> params)
+    {
+        // Same delivery as MARKDOWN (error diversion, signal append, plain
+        // text fallback) but the embedded resource advertises a YAML
+        // mimeType so it agrees with the .yaml resource URI and the body.
+        if (isJsonErrorPayload(result))
+        {
+            return buildToolCallJsonResponse(result, requestId, tool.getName());
+        }
+        if (signal != null)
+        {
+            result = result + "\n\n---\n# USER SIGNAL: " + signal.getMessage();
+        }
+        if (plainTextMode)
+        {
+            return buildToolCallTextResponse(result, requestId);
+        }
+        String yamlFileName = tool.getResultFileName(params);
+        return buildToolCallResourceResponse(result, "text/yaml", yamlFileName, requestId); //$NON-NLS-1$
+    }
+
+    /**
+     * Delivers a {@code ResponseType.IMAGE} tools/call result, holding the IMAGE-case logic
+     * extracted verbatim from {@link #buildToolCallResponse}: an error payload is diverted to
+     * a structured JSON error; otherwise the (base64) image is returned as an embedded
+     * {@code image/png} resource blob — plain-text mode and user signals are ignored for
+     * images. Returns the same response in the same case as the original inline branch.
+     */
+    private String buildImageToolResponse(IMcpTool tool, String result, Object requestId,
+        Map<String, String> params)
+    {
+        // Images always returned as embedded resource (ignore plain text mode)
+        // For images, user signals are ignored
+        if (isJsonErrorPayload(result))
+        {
+            return buildToolCallJsonResponse(result, requestId, tool.getName());
+        }
+        String imageFileName = tool.getResultFileName(params);
+        return buildToolCallResourceBlobResponse(result, "image/png", imageFileName, requestId); //$NON-NLS-1$
+    }
+
+    /**
+     * Delivers a {@code ResponseType.TEXT} (and default) tools/call result, holding the
+     * TEXT-case logic extracted verbatim from {@link #buildToolCallResponse}: an error payload
+     * is diverted to a structured JSON error; otherwise a user signal is appended as plain
+     * text and the body is delivered as a text result. Returns the same response in the same
+     * case as the original inline branch.
+     */
+    private String buildTextToolResponse(IMcpTool tool, String result, UserSignal signal,
+        Object requestId)
+    {
+        // See MARKDOWN: a ToolResult.error JSON payload is delivered as a
+        // structured JSON error regardless of the declared response type.
+        if (isJsonErrorPayload(result))
+        {
+            return buildToolCallJsonResponse(result, requestId, tool.getName());
+        }
+        // Append user signal as text
+        if (signal != null)
+        {
+            result = result + "\n\n---\nUSER SIGNAL: " + signal.getMessage();
+        }
+        return buildToolCallTextResponse(result, requestId);
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CleanProjectTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CleanProjectTool.java
@@ -178,46 +178,74 @@ public class CleanProjectTool implements IMcpTool
 
         if (projectName != null && !projectName.isEmpty())
         {
-            // Clean specific project
-            ProjectContext ctx = ProjectContext.of(projectName);
-            if (!ctx.exists())
-            {
-                collection.error = ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson();
-                return collection;
-            }
-
-            if (!ctx.isOpen())
-            {
-                collection.error = ToolResult.error("Project is closed: " + projectName).toJson(); //$NON-NLS-1$
-                return collection;
-            }
-
-            IProject project = ctx.project();
-
-            IDtProject dtProject = dtProjectManager != null ?
-                dtProjectManager.getDtProject(project) : null;
-
-            collection.projectsToClean.add(new ProjectCleanInfo(project, dtProject));
-            collection.projectNamesList.add(projectName);
+            collectNamedProject(projectName, dtProjectManager, collection);
         }
         else
         {
-            // Clean all EDT projects
-            if (dtProjectManager != null)
-            {
-                for (IDtProject dtProject : dtProjectManager.getDtProjects())
-                {
-                    IProject project = dtProject.getWorkspaceProject();
-                    if (project != null && project.isOpen())
-                    {
-                        collection.projectsToClean.add(new ProjectCleanInfo(project, dtProject));
-                        collection.projectNamesList.add(project.getName());
-                    }
-                }
-            }
+            collectAllEdtProjects(dtProjectManager, collection);
         }
 
         return collection;
+    }
+
+    /**
+     * Resolves a single named project into {@code collection}: validates that it exists and is open,
+     * then records it with its DT project (or {@code null} when the manager is unavailable). On a
+     * missing/closed project it sets {@code collection.error} to the same JSON payload as the original
+     * inline block and leaves the work lists empty.
+     *
+     * @param projectName       the requested project name (non-empty)
+     * @param dtProjectManager  the DT project manager (may be {@code null})
+     * @param collection        the accumulator to populate (mutated)
+     */
+    private static void collectNamedProject(String projectName, IDtProjectManager dtProjectManager,
+        CleanCollection collection)
+    {
+        ProjectContext ctx = ProjectContext.of(projectName);
+        if (!ctx.exists())
+        {
+            collection.error = ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson();
+            return;
+        }
+
+        if (!ctx.isOpen())
+        {
+            collection.error = ToolResult.error("Project is closed: " + projectName).toJson(); //$NON-NLS-1$
+            return;
+        }
+
+        IProject project = ctx.project();
+
+        IDtProject dtProject = dtProjectManager != null ?
+            dtProjectManager.getDtProject(project) : null;
+
+        collection.projectsToClean.add(new ProjectCleanInfo(project, dtProject));
+        collection.projectNamesList.add(projectName);
+    }
+
+    /**
+     * Collects every open EDT project into {@code collection} (the "clean all" path). No-op when the
+     * DT project manager is unavailable; otherwise each DT project whose workspace project exists and
+     * is open is recorded. Behaviour-identical to the original inline {@code else} block.
+     *
+     * @param dtProjectManager  the DT project manager (may be {@code null})
+     * @param collection        the accumulator to populate (mutated)
+     */
+    private static void collectAllEdtProjects(IDtProjectManager dtProjectManager, CleanCollection collection)
+    {
+        if (dtProjectManager == null)
+        {
+            return;
+        }
+        for (IDtProject dtProject : dtProjectManager.getDtProjects())
+        {
+            IProject project = dtProject.getWorkspaceProject();
+            if (project != null && project.isOpen())
+            {
+                collection.projectsToClean.add(new ProjectCleanInfo(project, dtProject));
+                collection.projectNamesList.add(project.getName());
+            }
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
@@ -340,124 +340,195 @@ public class CreateInfobaseTool implements IMcpTool
         }
 
         // --- 4. Prepare the directory ---
-        if (register)
+        String prepareError = prepareInfobaseDirectory(infobaseDir, register);
+        if (prepareError != null)
         {
-            // mode=register: the infobase must already exist on disk; do NOT create it.
-            String registerError = validateRegisterPath(infobaseDir);
-            if (registerError != null)
-            {
-                return registerError;
-            }
-        }
-        else
-        {
-            // mode=create: create the target directory if it does not exist yet.
-            try
-            {
-                Files.createDirectories(infobaseDir);
-            }
-            catch (Exception e)
-            {
-                return ToolResult.error("Cannot create infobase directory '" + infobaseDir //$NON-NLS-1$
-                    + "': " + e.getMessage()).toJson(); //$NON-NLS-1$
-            }
+            return prepareError;
         }
 
         // --- 5. Build the FILE infobase reference ---
         InfobaseReference ibRef = buildInfobaseReference(infobaseDir, infobaseName);
 
         // --- 6. Create the database (create) or register the existing one (register) ---
-        if (register)
+        String databaseError = register
+            ? registerExistingInfobase(ibManager, ibRef, infobaseDir)
+            : createNewInfobase(ibRef, platform, infobaseName, infobaseDir);
+        if (databaseError != null)
         {
-            // mode=register: add the existing infobase to EDT directly. No 1cv8 launch, no
-            // platform runtime needed — this is a fast, synchronous EMF registration.
-            try
-            {
-                ibManager.add(ibRef, null);
-            }
-            catch (Exception e)
-            {
-                Activator.logError("create_infobase: register failed for " + infobaseDir, e); //$NON-NLS-1$
-                return ToolResult.error("Could not register the infobase at '" + infobaseDir //$NON-NLS-1$
-                    + "': " + e.getMessage() //$NON-NLS-1$
-                    + ". Ensure it is a valid file infobase that is not already registered.").toJson(); //$NON-NLS-1$
-            }
-            Activator.logInfo("create_infobase: registered existing infobase at " + infobaseDir); //$NON-NLS-1$
-        }
-        else
-        {
-            // mode=create: a brand-new database via the platform creation operation. This shells
-            // out to 1cv8, so probe for a registered platform runtime first (fail fast, no hang)
-            // and run perform() in a bounded background Job (never on the UI thread).
-            IInfobaseCreationOperation creationOp = resolveCreationOperation();
-            if (creationOp == null)
-            {
-                return ToolResult.error("No 1C platform runtime is registered in EDT - cannot " //$NON-NLS-1$
-                    + "create a new infobase. Register a 1C:Enterprise platform installation in EDT " //$NON-NLS-1$
-                    + "(Window -> Preferences -> 1C:Enterprise -> Installed Installations) and retry, " //$NON-NLS-1$
-                    + "or use mode='register' for an existing infobase.").toJson(); //$NON-NLS-1$
-            }
-
-            final IInfobaseCreationOperation.Descriptor descriptor =
-                buildCreationDescriptor(ibRef, platform);
-
-            final IInfobaseCreationOperation finalOp = creationOp;
-            final AtomicReference<Exception> jobError = new AtomicReference<>();
-            final String jobInfobaseName = infobaseName;
-
-            Job createJob = new Job("Create infobase: " + jobInfobaseName) //$NON-NLS-1$
-            {
-                @Override
-                protected org.eclipse.core.runtime.IStatus run(
-                        org.eclipse.core.runtime.IProgressMonitor monitor)
-                {
-                    try
-                    {
-                        finalOp.perform(descriptor, monitor);
-                    }
-                    catch (Exception e)
-                    {
-                        jobError.set(e);
-                    }
-                    return org.eclipse.core.runtime.Status.OK_STATUS;
-                }
-            };
-            createJob.setUser(false);
-            createJob.setSystem(true);
-            createJob.schedule();
-
-            try
-            {
-                boolean finished = createJob.join(
-                    TimeUnit.SECONDS.toMillis(CREATE_TIMEOUT_SECONDS), null);
-                if (!finished)
-                {
-                    createJob.cancel();
-                    return ToolResult.error("Infobase creation timed out after " //$NON-NLS-1$
-                        + CREATE_TIMEOUT_SECONDS + " seconds. The 1cv8 process may still be running. " //$NON-NLS-1$
-                        + "Check the EDT log and the target directory '" + infobaseDir //$NON-NLS-1$
-                        + "' for partial results.").toJson(); //$NON-NLS-1$
-                }
-            }
-            catch (InterruptedException e)
-            {
-                Thread.currentThread().interrupt();
-                return ToolResult.error("Infobase creation was interrupted.").toJson(); //$NON-NLS-1$
-            }
-
-            if (jobError.get() != null)
-            {
-                Exception ex = jobError.get();
-                Activator.logError("create_infobase: creation failed for " + infobaseDir, ex); //$NON-NLS-1$
-                return ToolResult.error("Infobase creation failed: " + ex.getMessage() //$NON-NLS-1$
-                    + ". Verify that a compatible 1C platform is installed and that the " //$NON-NLS-1$
-                    + "target directory '" + infobaseDir + "' is accessible.").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
-            }
-
-            Activator.logInfo("create_infobase: infobase created at " + infobaseDir); //$NON-NLS-1$
+            return databaseError;
         }
 
         // --- 7. Associate with the project ---
+        String associateError = associateInfobase(assocManager, project, ibRef, infobaseDir, projectName);
+        if (associateError != null)
+        {
+            return associateError;
+        }
+
+        // --- 8. Optionally set as default ---
+        String setDefaultNote = setDefault ? applySetDefault(appManager, project, ibRef) : null;
+
+        // --- 9. Read back and return ---
+        ResultContext rc = new ResultContext(projectName, infobaseDir, infobaseName, appManager, project);
+        return buildSuccessResult(rc, ibRef, setDefaultNote, register);
+    }
+
+    /**
+     * Prepares the infobase directory for the create/register step (step 4). For mode='register' this
+     * is the read-only {@link #validateRegisterPath(Path)} check; for mode='create' it creates the
+     * target directory ({@code Files.createDirectories}) at the SAME sequence point as before. Returns a
+     * ready error tool-result JSON on the SAME early-return cases the inline code produced, else
+     * {@code null}.
+     */
+    private static String prepareInfobaseDirectory(Path infobaseDir, boolean register)
+    {
+        if (register)
+        {
+            // mode=register: the infobase must already exist on disk; do NOT create it.
+            return validateRegisterPath(infobaseDir);
+        }
+        // mode=create: create the target directory if it does not exist yet.
+        try
+        {
+            Files.createDirectories(infobaseDir);
+        }
+        catch (Exception e)
+        {
+            return ToolResult.error("Cannot create infobase directory '" + infobaseDir //$NON-NLS-1$
+                + "': " + e.getMessage()).toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Registers an EXISTING infobase with EDT (mode='register', step 6): adds the reference to EDT
+     * directly via {@code IInfobaseManager.add} — a fast, synchronous EMF registration, no 1cv8 launch.
+     * The {@code add} side effect stays inline here at the SAME sequence point. Returns a ready error
+     * tool-result JSON on the SAME failure case the inline code produced, else {@code null}.
+     */
+    private static String registerExistingInfobase(IInfobaseManager ibManager, InfobaseReference ibRef,
+            Path infobaseDir)
+    {
+        try
+        {
+            ibManager.add(ibRef, null);
+        }
+        catch (Exception e)
+        {
+            Activator.logError("create_infobase: register failed for " + infobaseDir, e); //$NON-NLS-1$
+            return ToolResult.error("Could not register the infobase at '" + infobaseDir //$NON-NLS-1$
+                + "': " + e.getMessage() //$NON-NLS-1$
+                + ". Ensure it is a valid file infobase that is not already registered.").toJson(); //$NON-NLS-1$
+        }
+        Activator.logInfo("create_infobase: registered existing infobase at " + infobaseDir); //$NON-NLS-1$
+        return null;
+    }
+
+    /**
+     * Creates a brand-new database via the platform creation operation (mode='create', step 6). Probes
+     * for a registered platform runtime first (fail fast, no hang), then runs {@code perform()} in a
+     * bounded background Job (never on the UI thread) — the {@code perform} side effect and the Job
+     * schedule stay inline here at the SAME sequence point. Returns a ready error tool-result JSON on
+     * the SAME early-return cases (no runtime / timeout / interrupted / job error) the inline code
+     * produced, else {@code null}.
+     */
+    private static String createNewInfobase(InfobaseReference ibRef, String platform,
+            String infobaseName, Path infobaseDir)
+    {
+        IInfobaseCreationOperation creationOp = resolveCreationOperation();
+        if (creationOp == null)
+        {
+            return ToolResult.error("No 1C platform runtime is registered in EDT - cannot " //$NON-NLS-1$
+                + "create a new infobase. Register a 1C:Enterprise platform installation in EDT " //$NON-NLS-1$
+                + "(Window -> Preferences -> 1C:Enterprise -> Installed Installations) and retry, " //$NON-NLS-1$
+                + "or use mode='register' for an existing infobase.").toJson(); //$NON-NLS-1$
+        }
+
+        final IInfobaseCreationOperation.Descriptor descriptor =
+            buildCreationDescriptor(ibRef, platform);
+
+        final IInfobaseCreationOperation finalOp = creationOp;
+        final AtomicReference<Exception> jobError = new AtomicReference<>();
+        final String jobInfobaseName = infobaseName;
+
+        Job createJob = new Job("Create infobase: " + jobInfobaseName) //$NON-NLS-1$
+        {
+            @Override
+            protected org.eclipse.core.runtime.IStatus run(
+                    org.eclipse.core.runtime.IProgressMonitor monitor)
+            {
+                try
+                {
+                    finalOp.perform(descriptor, monitor);
+                }
+                catch (Exception e)
+                {
+                    jobError.set(e);
+                }
+                return org.eclipse.core.runtime.Status.OK_STATUS;
+            }
+        };
+        createJob.setUser(false);
+        createJob.setSystem(true);
+        createJob.schedule();
+
+        String waitError = awaitCreateJob(createJob, infobaseDir);
+        if (waitError != null)
+        {
+            return waitError;
+        }
+
+        if (jobError.get() != null)
+        {
+            Exception ex = jobError.get();
+            Activator.logError("create_infobase: creation failed for " + infobaseDir, ex); //$NON-NLS-1$
+            return ToolResult.error("Infobase creation failed: " + ex.getMessage() //$NON-NLS-1$
+                + ". Verify that a compatible 1C platform is installed and that the " //$NON-NLS-1$
+                + "target directory '" + infobaseDir + "' is accessible.").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+
+        Activator.logInfo("create_infobase: infobase created at " + infobaseDir); //$NON-NLS-1$
+        return null;
+    }
+
+    /**
+     * Joins the create Job with the bounded {@link #CREATE_TIMEOUT_SECONDS} timeout and maps the
+     * outcome to the SAME error tool-result JSON the inline code produced: a timeout message (Job
+     * cancelled) when it did not finish, or an interrupted message (interrupt flag restored) when the
+     * join threw. Returns {@code null} when the Job finished within the budget. The {@code InterruptedException}
+     * from {@code join} is handled inline here (not propagated) exactly as before.
+     */
+    private static String awaitCreateJob(Job createJob, Path infobaseDir)
+    {
+        try
+        {
+            boolean finished = createJob.join(
+                TimeUnit.SECONDS.toMillis(CREATE_TIMEOUT_SECONDS), null);
+            if (!finished)
+            {
+                createJob.cancel();
+                return ToolResult.error("Infobase creation timed out after " //$NON-NLS-1$
+                    + CREATE_TIMEOUT_SECONDS + " seconds. The 1cv8 process may still be running. " //$NON-NLS-1$
+                    + "Check the EDT log and the target directory '" + infobaseDir //$NON-NLS-1$
+                    + "' for partial results.").toJson(); //$NON-NLS-1$
+            }
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            return ToolResult.error("Infobase creation was interrupted.").toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Associates the infobase with the project (step 7): the {@code associate} side effect stays inline
+     * here at the SAME sequence point. Returns a ready error tool-result JSON on the SAME failure case
+     * the inline code produced, else {@code null}.
+     */
+    private static String associateInfobase(IInfobaseAssociationManager assocManager, IProject project,
+            InfobaseReference ibRef, Path infobaseDir, String projectName)
+    {
         try
         {
             assocManager.associate(project, ibRef, InfobaseAssociationSettings.notSynchronized());
@@ -470,38 +541,37 @@ public class CreateInfobaseTool implements IMcpTool
                 + "': " + e.getMessage() //$NON-NLS-1$
                 + ". Use delete_infobase to clean up if needed.").toJson(); //$NON-NLS-1$
         }
-
         Activator.logInfo("create_infobase: associated with project " + projectName); //$NON-NLS-1$
+        return null;
+    }
 
-        // --- 8. Optionally set as default ---
-        String setDefaultNote = null;
-        if (setDefault)
+    /**
+     * Optionally sets the new infobase as the project's default application (step 8): the
+     * {@code setDefaultApplication} side effect stays inline here at the SAME sequence point. Non-fatal —
+     * returns the SAME nullable {@code setDefaultNote} the inline code produced ({@code null} when the
+     * default was set or the failure was swallowed; a note when the new app was not found yet).
+     */
+    private static String applySetDefault(IApplicationManager appManager, IProject project,
+            InfobaseReference ibRef)
+    {
+        try
         {
-            try
+            IApplication newApp = findNewApplication(appManager, project, ibRef);
+            if (newApp == null)
             {
-                IApplication newApp = findNewApplication(appManager, project, ibRef);
-                if (newApp == null)
-                {
-                    setDefaultNote = "; the new infobase was created but could not be set as " //$NON-NLS-1$
-                        + "default yet - set it manually or retry"; //$NON-NLS-1$
-                    Activator.logError("create_infobase: setDefault skipped — new app not found yet", //$NON-NLS-1$
-                        null);
-                }
-                else
-                {
-                    appManager.setDefaultApplication(project, newApp);
-                }
+                Activator.logError("create_infobase: setDefault skipped — new app not found yet", //$NON-NLS-1$
+                    null);
+                return "; the new infobase was created but could not be set as " //$NON-NLS-1$
+                    + "default yet - set it manually or retry"; //$NON-NLS-1$
             }
-            catch (Exception e)
-            {
-                // Non-fatal: the infobase was created and associated; only the default-setting failed.
-                Activator.logError("create_infobase: setDefault failed", e); //$NON-NLS-1$
-            }
+            appManager.setDefaultApplication(project, newApp);
         }
-
-        // --- 9. Read back and return ---
-        return buildSuccessResult(projectName, infobaseDir, infobaseName,
-            appManager, project, ibRef, setDefaultNote, register);
+        catch (Exception e)
+        {
+            // Non-fatal: the infobase was created and associated; only the default-setting failed.
+            Activator.logError("create_infobase: setDefault failed", e); //$NON-NLS-1$
+        }
+        return null;
     }
 
     /**
@@ -679,34 +749,15 @@ public class CreateInfobaseTool implements IMcpTool
     private String createStandaloneServer(String projectName, Path infobaseDir,
             String infobaseName, String platform, boolean setDefault)
     {
-        // --- 1. Resolve project ---
-        ProjectContext ctx = ProjectContext.of(projectName);
-        if (!ctx.exists())
+        // --- 1-2. Resolve project + services ---
+        StandaloneContext sctx = resolveStandaloneContext(projectName);
+        if (sctx.error != null)
         {
-            return ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson();
+            return sctx.error;
         }
-        if (!ctx.isOpen())
-        {
-            return ToolResult.error("Project is closed: " + projectName //$NON-NLS-1$
-                + ". Open the project in EDT first.").toJson(); //$NON-NLS-1$
-        }
-        IProject project = ctx.project();
-
-        // --- 2. Acquire services ---
-        IApplicationManager appManager = Activator.getDefault().getApplicationManager();
-        if (appManager == null)
-        {
-            return ToolResult.error("IApplicationManager service is not available").toJson(); //$NON-NLS-1$
-        }
-
-        Object serverService = acquireStandaloneServerService();
-        if (serverService == null)
-        {
-            return ToolResult.error("Standalone-server service is not available; the EDT " //$NON-NLS-1$
-                + "standalone-server feature is missing. Install a 1C platform >= 8.3.23 with the " //$NON-NLS-1$
-                + "standalone server and ensure the EDT standalone-server plugins are present.") //$NON-NLS-1$
-                .toJson();
-        }
+        IProject project = sctx.project;
+        IApplicationManager appManager = sctx.appManager;
+        Object serverService = sctx.serverService;
 
         // --- 3. Fail-fast runtime probe (BEFORE the Job, so "no runtime" fails instantly) ---
         final String versionMask = orEmpty(platform);
@@ -738,7 +789,8 @@ public class CreateInfobaseTool implements IMcpTool
 
         // --- 7. Run the one-shot create in a bounded background Job (ibcmd shell-out) ---
         final Object finalService = serverService;
-        final InfobaseReference finalIbRef = ibRef;
+        final ServerCreateArgs createArgs = new ServerCreateArgs(versionMask, projectName, ibRef,
+            clusterPort, clusterRegistryDirectory, publicationPath);
         final String jobInfobaseName = infobaseName;
         final AtomicReference<Object> jobResult = new AtomicReference<>();
         final AtomicReference<Exception> jobError = new AtomicReference<>();
@@ -751,8 +803,7 @@ public class CreateInfobaseTool implements IMcpTool
             {
                 try
                 {
-                    Object pair = ssCreateServerWithInfobase(finalService, versionMask, projectName,
-                        finalIbRef, clusterPort, clusterRegistryDirectory, publicationPath, monitor);
+                    Object pair = ssCreateServerWithInfobase(finalService, createArgs, monitor);
                     // createServerWithInfobase registers the server with the module's create flag = false,
                     // so the served file infobase (1Cv8.1CD) is never physically written — the server then
                     // fails to start ("Информационная база не обнаружена"). Materialize it now (same step
@@ -775,23 +826,10 @@ public class CreateInfobaseTool implements IMcpTool
         createJob.setSystem(true);
         createJob.schedule();
 
-        try
+        String waitError = awaitStandaloneJob(createJob, infobaseDir);
+        if (waitError != null)
         {
-            boolean finished = createJob.join(
-                TimeUnit.SECONDS.toMillis(CREATE_TIMEOUT_SECONDS), null);
-            if (!finished)
-            {
-                createJob.cancel();
-                return ToolResult.error("Standalone-server creation timed out after " //$NON-NLS-1$
-                    + CREATE_TIMEOUT_SECONDS + " seconds. The ibcmd process may still be running. " //$NON-NLS-1$
-                    + "Check the EDT log and the directory '" + infobaseDir //$NON-NLS-1$
-                    + "' for partial results.").toJson(); //$NON-NLS-1$
-            }
-        }
-        catch (InterruptedException e)
-        {
-            Thread.currentThread().interrupt();
-            return ToolResult.error("Standalone-server creation was interrupted.").toJson(); //$NON-NLS-1$
+            return waitError;
         }
 
         if (jobError.get() != null)
@@ -831,8 +869,114 @@ public class CreateInfobaseTool implements IMcpTool
         int actualPort = urlToPort(url);
 
         // --- 9. Read back applications and return ---
-        return buildStandaloneServerResult(projectName, infobaseDir, effectiveName, actualPort,
-            webUrl, setDefault, appManager, project);
+        ResultContext rc = new ResultContext(projectName, infobaseDir, effectiveName, appManager, project);
+        return buildStandaloneServerResult(rc, actualPort, webUrl, setDefault);
+    }
+
+    /**
+     * Resolves the configuration project, the {@link IApplicationManager} and the (reflective)
+     * standalone-server service for {@link #createStandaloneServer} (steps 1-2; read-only). Returns a
+     * {@link StandaloneContext} whose {@code error} field carries the tool-result JSON for the SAME
+     * early-return cases the inline code produced (project missing / closed; {@code IApplicationManager}
+     * unavailable; standalone-server service unavailable); otherwise {@code error} is {@code null} and
+     * the {@code project}/{@code appManager}/{@code serverService} fields are populated.
+     */
+    private static StandaloneContext resolveStandaloneContext(String projectName)
+    {
+        ProjectContext ctx = ProjectContext.of(projectName);
+        if (!ctx.exists())
+        {
+            return StandaloneContext.error(
+                ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson());
+        }
+        if (!ctx.isOpen())
+        {
+            return StandaloneContext.error(ToolResult.error("Project is closed: " + projectName //$NON-NLS-1$
+                + ". Open the project in EDT first.").toJson()); //$NON-NLS-1$
+        }
+
+        IApplicationManager appManager = Activator.getDefault().getApplicationManager();
+        if (appManager == null)
+        {
+            return StandaloneContext.error(
+                ToolResult.error("IApplicationManager service is not available").toJson()); //$NON-NLS-1$
+        }
+
+        Object serverService = acquireStandaloneServerService();
+        if (serverService == null)
+        {
+            return StandaloneContext.error(ToolResult.error("Standalone-server service is not available; the EDT " //$NON-NLS-1$
+                + "standalone-server feature is missing. Install a 1C platform >= 8.3.23 with the " //$NON-NLS-1$
+                + "standalone server and ensure the EDT standalone-server plugins are present.") //$NON-NLS-1$
+                .toJson());
+        }
+
+        return StandaloneContext.of(ctx.project(), appManager, serverService);
+    }
+
+    /**
+     * Joins the standalone-server create Job with the bounded {@link #CREATE_TIMEOUT_SECONDS} timeout
+     * and maps the outcome to the SAME error tool-result JSON the inline code produced: a timeout
+     * message (Job cancelled) when it did not finish, or an interrupted message (interrupt flag
+     * restored) when the join threw. Returns {@code null} when the Job finished within the budget. The
+     * {@code InterruptedException} from {@code join} is handled inline here (not propagated) exactly as
+     * before.
+     */
+    private static String awaitStandaloneJob(Job createJob, Path infobaseDir)
+    {
+        try
+        {
+            boolean finished = createJob.join(
+                TimeUnit.SECONDS.toMillis(CREATE_TIMEOUT_SECONDS), null);
+            if (!finished)
+            {
+                createJob.cancel();
+                return ToolResult.error("Standalone-server creation timed out after " //$NON-NLS-1$
+                    + CREATE_TIMEOUT_SECONDS + " seconds. The ibcmd process may still be running. " //$NON-NLS-1$
+                    + "Check the EDT log and the directory '" + infobaseDir //$NON-NLS-1$
+                    + "' for partial results.").toJson(); //$NON-NLS-1$
+            }
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            return ToolResult.error("Standalone-server creation was interrupted.").toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Holder for the project + {@link IApplicationManager} + standalone-server service resolved by
+     * {@link #resolveStandaloneContext(String)}. When {@code error} is non-null it carries a ready
+     * tool-result JSON and the other fields are unset; otherwise {@code error} is {@code null} and the
+     * fields are populated.
+     */
+    private static final class StandaloneContext
+    {
+        final String error;
+        final IProject project;
+        final IApplicationManager appManager;
+        final Object serverService;
+
+        private StandaloneContext(String error, IProject project, IApplicationManager appManager,
+                Object serverService)
+        {
+            this.error = error;
+            this.project = project;
+            this.appManager = appManager;
+            this.serverService = serverService;
+        }
+
+        static StandaloneContext error(String error)
+        {
+            return new StandaloneContext(error, null, null, null);
+        }
+
+        static StandaloneContext of(IProject project, IApplicationManager appManager,
+                Object serverService)
+        {
+            return new StandaloneContext(null, project, appManager, serverService);
+        }
     }
 
     /**
@@ -929,17 +1073,16 @@ public class CreateInfobaseTool implements IMcpTool
      * {@code Pair<IServer, StandaloneServerInfobase>} as an {@code Object} (cast to {@code Pair} by the
      * caller). Unwraps and rethrows the real failure cause so the caller reports an honest error.
      */
-    private static Object ssCreateServerWithInfobase(Object service, String versionMask,
-            String projectName, InfobaseReference ib, int clusterPort, String clusterRegistryDirectory,
-            String publicationPath, IProgressMonitor monitor) throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
+    private static Object ssCreateServerWithInfobase(Object service, ServerCreateArgs args,
+            IProgressMonitor monitor) throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
     {
         Method m = service.getClass().getMethod("createServerWithInfobase", //$NON-NLS-1$
             String.class, String.class, InfobaseReference.class, int.class, String.class, String.class,
             IProgressMonitor.class);
         try
         {
-            return m.invoke(service, versionMask, projectName, ib, clusterPort, clusterRegistryDirectory,
-                publicationPath, monitor);
+            return m.invoke(service, args.versionMask, args.projectName, args.ib, args.clusterPort,
+                args.clusterRegistryDirectory, args.publicationPath, monitor);
         }
         catch (java.lang.reflect.InvocationTargetException ite)
         {
@@ -949,6 +1092,33 @@ public class CreateInfobaseTool implements IMcpTool
                 throw (Exception)cause;
             }
             throw new IllegalStateException(cause != null ? cause : ite);
+        }
+    }
+
+    /**
+     * Immutable parameter-object bundling the six positional arguments forwarded to the reflective
+     * {@code IStandaloneServerService.createServerWithInfobase(...)} call (everything except the service
+     * receiver and the progress monitor). Keeps {@link #ssCreateServerWithInfobase} under the
+     * parameter-count threshold without changing the reflective invocation.
+     */
+    private static final class ServerCreateArgs
+    {
+        final String versionMask;
+        final String projectName;
+        final InfobaseReference ib;
+        final int clusterPort;
+        final String clusterRegistryDirectory;
+        final String publicationPath;
+
+        ServerCreateArgs(String versionMask, String projectName, InfobaseReference ib, int clusterPort,
+                String clusterRegistryDirectory, String publicationPath)
+        {
+            this.versionMask = versionMask;
+            this.projectName = projectName;
+            this.ib = ib;
+            this.clusterPort = clusterPort;
+            this.clusterRegistryDirectory = clusterRegistryDirectory;
+            this.publicationPath = publicationPath;
         }
     }
 
@@ -1228,12 +1398,12 @@ public class CreateInfobaseTool implements IMcpTool
      * builds the success JSON for the standalone-server path. Uses the same short bounded re-poll as
      * the file path to absorb the provision-delegate listener race.
      */
-    private static String buildStandaloneServerResult(String projectName, Path infobaseDir,
-            String infobaseName, int actualPort, String webUrl, boolean setDefault,
-            IApplicationManager appManager, IProject project)
+    private static String buildStandaloneServerResult(ResultContext rc, int actualPort, String webUrl,
+            boolean setDefault)
     {
         // Read back the applications (bounded re-poll) and locate the just-created wst-server.
-        ServerReadBack readBack = pollForNewServerApplication(appManager, project, infobaseName);
+        ServerReadBack readBack =
+            pollForNewServerApplication(rc.appManager, rc.project, rc.infobaseName);
         JsonArray appsArray = readBack.appsArray;
         String newAppId = readBack.newAppId;
         IApplication newApp = readBack.newApp;
@@ -1248,7 +1418,7 @@ public class CreateInfobaseTool implements IMcpTool
             {
                 try
                 {
-                    appManager.setDefaultApplication(project, newApp);
+                    rc.appManager.setDefaultApplication(rc.project, newApp);
                 }
                 catch (Exception e)
                 {
@@ -1269,9 +1439,9 @@ public class CreateInfobaseTool implements IMcpTool
         ToolResult result = ToolResult.success()
             .put(McpKeys.ACTION, "created") //$NON-NLS-1$
             .put(KEY_APPLICATION_KIND, KIND_STANDALONE_SERVER)
-            .put(McpKeys.PROJECT, projectName)
-            .put(KEY_INFOBASE_FILE, infobaseDir.toAbsolutePath().toString())
-            .put(KEY_INFOBASE_NAME, infobaseName)
+            .put(McpKeys.PROJECT, rc.projectName)
+            .put(KEY_INFOBASE_FILE, rc.infobaseDir.toAbsolutePath().toString())
+            .put(KEY_INFOBASE_NAME, rc.infobaseName)
             .put(KEY_APPLICATIONS, appsArray);
 
         // Report the ACTUAL auto-allocated port only when we could resolve it from the web URL; // NOSONAR explanatory comment, not commented-out code
@@ -1289,8 +1459,8 @@ public class CreateInfobaseTool implements IMcpTool
             result.put(McpKeys.APPLICATION_ID, newAppId);
         }
 
-        result.put(McpKeys.MESSAGE, buildStandaloneServerMessage(projectName, infobaseDir,
-            infobaseName, actualPort, webUrl, setDefaultNote));
+        result.put(McpKeys.MESSAGE, buildStandaloneServerMessage(rc.projectName, rc.infobaseDir,
+            rc.infobaseName, actualPort, webUrl, setDefaultNote));
 
         return result.toJson();
     }
@@ -1307,61 +1477,74 @@ public class CreateInfobaseTool implements IMcpTool
             IProject project, String infobaseName)
     {
         JsonArray appsArray = new JsonArray();
-        String newAppId = null;
-        IApplication newApp = null;
+        IApplication[] newAppHolder = new IApplication[1];
 
         for (int poll = 0; poll < READ_BACK_MAX_POLLS; poll++)
         {
             appsArray = new JsonArray();
-            newAppId = null;
-            newApp = null;
+            newAppHolder[0] = null;
 
-            try
+            if (!readBackServerApplications(appManager, project, infobaseName, appsArray, newAppHolder))
             {
-                List<IApplication> applications = appManager.getApplications(project);
-                if (applications != null)
+                break; // Read failed (logged) — stop re-polling.
+            }
+
+            if (newAppHolder[0] != null)
+            {
+                break; // Found the new server — no need to re-poll.
+            }
+
+            if (poll < READ_BACK_MAX_POLLS - 1 && !sleepBetweenPolls())
+            {
+                break; // Interrupted — stop re-polling.
+            }
+        }
+
+        IApplication newApp = newAppHolder[0];
+        String newAppId = newApp != null ? newApp.getId() : null;
+        return new ServerReadBack(appsArray, newAppId, newApp);
+    }
+
+    /**
+     * Reads the project's applications once, populating {@code appsArray} with one JSON object per
+     * application (same shape as {@code get_applications}) and storing the JUST-created standalone
+     * server — a {@code wst-server} application whose name matches {@code infobaseName} (NOT merely the
+     * first wst-server, which could be a pre-existing one) — in {@code newAppHolder[0]} (left
+     * {@code null} when not yet visible). Read-only.
+     *
+     * @return {@code true} if the read completed (whether or not the new server was found),
+     *         {@code false} if reading the applications failed (already logged) so the caller stops
+     *         re-polling
+     */
+    private static boolean readBackServerApplications(IApplicationManager appManager, IProject project,
+            String infobaseName, JsonArray appsArray, IApplication[] newAppHolder)
+    {
+        try
+        {
+            List<IApplication> applications = appManager.getApplications(project);
+            if (applications != null)
+            {
+                for (IApplication app : applications)
                 {
-                    for (IApplication app : applications)
+                    appsArray.add(toApplicationJson(appManager, app));
+                    // Identify the JUST-created standalone server by its name (a wst-server app whose
+                    // name matches the new infobase) — NOT merely the first wst-server app, which could
+                    // be a pre-existing standalone server already bound to this project.
+                    String typeId = app.getType() != null ? app.getType().getId() : null;
+                    if (newAppHolder[0] == null && StandaloneServerSupport.WST_SERVER_APP_TYPE.equals(typeId)
+                        && infobaseName.equals(app.getName()))
                     {
-                        appsArray.add(toApplicationJson(appManager, app));
-                        // Identify the JUST-created standalone server by its name (a wst-server app whose
-                        // name matches the new infobase) — NOT merely the first wst-server app, which could
-                        // be a pre-existing standalone server already bound to this project.
-                        String typeId = app.getType() != null ? app.getType().getId() : null;
-                        if (newAppId == null && StandaloneServerSupport.WST_SERVER_APP_TYPE.equals(typeId)
-                            && infobaseName.equals(app.getName()))
-                        {
-                            newAppId = app.getId();
-                            newApp = app;
-                        }
+                        newAppHolder[0] = app;
                     }
                 }
             }
-            catch (ApplicationException e)
-            {
-                Activator.logError("create_infobase: error reading back applications", e); //$NON-NLS-1$
-                break;
-            }
-
-            if (newAppId != null)
-            {
-                break;
-            }
-
-            if (poll < READ_BACK_MAX_POLLS - 1)
-            {
-                try
-                {
-                    Thread.sleep(READ_BACK_POLL_DELAY_MS);
-                }
-                catch (InterruptedException ie)
-                {
-                    Thread.currentThread().interrupt();
-                    break;
-                }
-            }
+            return true;
         }
-        return new ServerReadBack(appsArray, newAppId, newApp);
+        catch (ApplicationException e)
+        {
+            Activator.logError("create_infobase: error reading back applications", e); //$NON-NLS-1$
+            return false;
+        }
     }
 
     /**
@@ -1416,6 +1599,32 @@ public class CreateInfobaseTool implements IMcpTool
             this.appsArray = appsArray;
             this.newAppId = newAppId;
             this.newApp = newApp;
+        }
+    }
+
+    /**
+     * Immutable parameter-object bundling the identity + read-back inputs shared by the success-result
+     * builders ({@link #buildSuccessResult} and {@link #buildStandaloneServerResult}): the project
+     * name/handle, the infobase directory and display name, and the {@link IApplicationManager} used
+     * for the application read-back. Keeps those builders under the parameter-count threshold without
+     * changing what they compute.
+     */
+    private static final class ResultContext
+    {
+        final String projectName;
+        final Path infobaseDir;
+        final String infobaseName;
+        final IApplicationManager appManager;
+        final IProject project;
+
+        ResultContext(String projectName, Path infobaseDir, String infobaseName,
+                IApplicationManager appManager, IProject project)
+        {
+            this.projectName = projectName;
+            this.infobaseDir = infobaseDir;
+            this.infobaseName = infobaseName;
+            this.appManager = appManager;
+            this.project = project;
         }
     }
 
@@ -1538,9 +1747,8 @@ public class CreateInfobaseTool implements IMcpTool
      * @param setDefaultNote optional note appended to the message when setDefault could not be
      *        completed (null = no note)
      */
-    private static String buildSuccessResult(String projectName, Path infobaseDir,
-            String infobaseName, IApplicationManager appManager,
-            IProject project, InfobaseReference ibRef, String setDefaultNote, boolean register)
+    private static String buildSuccessResult(ResultContext rc, InfobaseReference ibRef,
+            String setDefaultNote, boolean register)
     {
         JsonArray appsArray = new JsonArray();
         String newAppId = null;
@@ -1553,7 +1761,7 @@ public class CreateInfobaseTool implements IMcpTool
             newAppId = null;
             String[] newAppIdHolder = new String[1];
 
-            if (!readBackApplications(appManager, project, ibRef, appsArray, newAppIdHolder))
+            if (!readBackApplications(rc.appManager, rc.project, ibRef, appsArray, newAppIdHolder))
             {
                 break; // Read failed (logged) — stop re-polling.
             }
@@ -1573,9 +1781,9 @@ public class CreateInfobaseTool implements IMcpTool
         String verb = register ? "registered" : "created"; //$NON-NLS-1$ //$NON-NLS-2$
         ToolResult result = ToolResult.success()
             .put(McpKeys.ACTION, verb)
-            .put(McpKeys.PROJECT, projectName)
-            .put(KEY_INFOBASE_FILE, infobaseDir.toAbsolutePath().toString())
-            .put(KEY_INFOBASE_NAME, infobaseName)
+            .put(McpKeys.PROJECT, rc.projectName)
+            .put(KEY_INFOBASE_FILE, rc.infobaseDir.toAbsolutePath().toString())
+            .put(KEY_INFOBASE_NAME, rc.infobaseName)
             .put(KEY_APPLICATIONS, appsArray);
 
         if (newAppId != null)
@@ -1583,9 +1791,9 @@ public class CreateInfobaseTool implements IMcpTool
             result.put(McpKeys.APPLICATION_ID, newAppId);
         }
 
-        String message = "Infobase '" + infobaseName //$NON-NLS-1$
-            + "' " + verb + " at '" + infobaseDir.toAbsolutePath() //$NON-NLS-1$ //$NON-NLS-2$
-            + "' and bound to project '" + projectName //$NON-NLS-1$
+        String message = "Infobase '" + rc.infobaseName //$NON-NLS-1$
+            + "' " + verb + " at '" + rc.infobaseDir.toAbsolutePath() //$NON-NLS-1$ //$NON-NLS-2$
+            + "' and bound to project '" + rc.projectName //$NON-NLS-1$
             + "'. Use update_database to push the configuration into the infobase." //$NON-NLS-1$
             + (setDefaultNote != null ? setDefaultNote : ""); //$NON-NLS-1$
         result.put(McpKeys.MESSAGE, message);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateLaunchConfigTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateLaunchConfigTool.java
@@ -184,27 +184,22 @@ public class CreateLaunchConfigTool implements IMcpTool
         String applicationIdParam = JsonUtils.extractStringArgument(params, McpKeys.APPLICATION_ID);
 
         // ── 2. Resolve client type ─────────────────────────────────────────────
-        String clientType = (clientTypeParam == null || clientTypeParam.isEmpty()) ? "thin" : clientTypeParam.toLowerCase(java.util.Locale.ROOT); //$NON-NLS-1$
-        String componentTypeId = componentTypeIdFor(clientType);
-        if (componentTypeId == null)
+        ClientTypeResolution clientTypeResolution = resolveClientType(clientTypeParam);
+        if (clientTypeResolution.error != null)
         {
-            return ToolResult.error("Invalid clientType: '" + clientType //$NON-NLS-1$
-                + "'. Must be one of: thin, thick, web.").toJson(); //$NON-NLS-1$
+            return clientTypeResolution.error;
         }
-        String clientLabel = clientLabelFor(clientType);
+        String clientType = clientTypeResolution.clientType;
+        String componentTypeId = clientTypeResolution.componentTypeId;
+        String clientLabel = clientTypeResolution.clientLabel;
 
         // ── 3. Resolve project ─────────────────────────────────────────────────
-        ProjectContext ctx = ProjectContext.of(projectName);
-        if (!ctx.exists())
+        ProjectResolution projectResolution = resolveOpenProject(projectName);
+        if (projectResolution.error != null)
         {
-            return ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson();
+            return projectResolution.error;
         }
-        if (!ctx.isOpen())
-        {
-            return ToolResult.error("Project is closed: " + projectName //$NON-NLS-1$
-                + ". Open the project first.").toJson(); //$NON-NLS-1$
-        }
-        IProject project = ctx.project();
+        IProject project = projectResolution.project;
 
         // ── 4. Reject non-configuration projects ───────────────────────────────
         String natureErr = checkConfigurationNature(project, projectName);
@@ -222,40 +217,21 @@ public class CreateLaunchConfigTool implements IMcpTool
         String effectiveApplicationId = appIdResolution.applicationId;
 
         // ── 6. Acquire launch manager and type ────────────────────────────────
-        ILaunchManager lm = LaunchConfigUtils.getLaunchManager();
-        if (lm == null)
+        LaunchTypeResolution launchTypeResolution = resolveLaunchType();
+        if (launchTypeResolution.error != null)
         {
-            return ToolResult.error("Eclipse launch manager is not available. " //$NON-NLS-1$
-                + "The debug plugin may not have started yet — retry in a moment.").toJson(); //$NON-NLS-1$
+            return launchTypeResolution.error;
         }
-        ILaunchConfigurationType type = lm.getLaunchConfigurationType(LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID);
-        if (type == null)
-        {
-            return ToolResult.error("Launch configuration type '" //$NON-NLS-1$
-                + LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID + "' is not registered. " //$NON-NLS-1$
-                + "Verify that the EDT launching.core plugin is installed.").toJson(); //$NON-NLS-1$
-        }
+        ILaunchManager lm = launchTypeResolution.launchManager;
+        ILaunchConfigurationType type = launchTypeResolution.type;
 
         // ── 7. Resolve effective name ──────────────────────────────────────────
-        String effectiveName;
-        if (nameParam != null && !nameParam.isEmpty())
+        NameResolution nameResolution = resolveEffectiveName(lm, nameParam, projectName, clientLabel);
+        if (nameResolution.error != null)
         {
-            // Caller provided an explicit name — reject duplicates.
-            ILaunchConfiguration existing = LaunchConfigUtils.findLaunchConfigByName(lm, nameParam);
-            if (existing != null)
-            {
-                return ToolResult.error("A launch configuration named '" + nameParam //$NON-NLS-1$
-                    + "' already exists. Use list_configurations to see existing configs, " //$NON-NLS-1$
-                    + "or omit 'name' to auto-generate a unique name.").toJson(); //$NON-NLS-1$
-            }
-            effectiveName = nameParam;
+            return nameResolution.error;
         }
-        else
-        {
-            // Generate a unique name mirroring the EDT shortcut convention.
-            String baseName = projectName + " " + clientLabel; //$NON-NLS-1$
-            effectiveName = lm.generateLaunchConfigurationName(baseName);
-        }
+        String effectiveName = nameResolution.name;
 
         // ── 8. Create and save the working copy ───────────────────────────────
         try
@@ -268,33 +244,7 @@ public class CreateLaunchConfigTool implements IMcpTool
             // null container -> workspace-local config persisted in workspace .metadata.
             ILaunchConfigurationWorkingCopy wc = type.newInstance(null, effectiveName);
 
-            // Identity / binding (required by RuntimeClientLaunchDelegate.getProject + ATTR_APPLICATION_ID
-            // must be real so getApplicationIdFor takes branch A, not the synthetic 'launch:' fallback).
-            wc.setAttribute(LaunchConfigUtils.ATTR_PROJECT_NAME, projectName);
-            wc.setAttribute(LaunchConfigUtils.ATTR_APPLICATION_ID, effectiveApplicationId);
-
-            // Process factory (marks the process as an EDT runtime process in the Debug view).
-            wc.setAttribute(ATTR_PROCESS_FACTORY_ID, VALUE_PROCESS_FACTORY);
-
-            // Client kind (pin the specific kind exactly as the shortcut does).
-            wc.setAttribute(ATTR_CLIENT_AUTO_SELECT, false);
-            wc.setAttribute(ATTR_CLIENT_TYPE, componentTypeId);
-
-            // Runtime + debug-server defaults (from AbstractLaunchShortcut.setDefaults bytecode).
-            wc.setAttribute(ATTR_RUNTIME_INSTALL_AUTO, true);
-            wc.setAttribute(ATTR_USE_LOCAL_DEBUG_SERVER, "AUTO"); //$NON-NLS-1$
-
-            // UX defaults from AbstractRuntimeClientLaunchShortcut.setDefaults (wizard parity).
-            wc.setAttribute(ATTR_LAUNCH_USER_USE_INFOBASE_ACCESS, true);
-            wc.setAttribute(ATTR_CALL_DELAY, 145);
-            wc.setAttribute(ATTR_DATA_SENDING_DELAY, 45);
-            wc.setAttribute(ATTR_DATA_RECEIVING_DELAY, 15);
-            wc.setAttribute(ATTR_DO_NOT_DISPLAY_WARNINGS, true);
-            wc.setAttribute(ATTR_SHOW_PERFORMANCE, true);
-            wc.setAttribute(ATTR_SHOW_ALL_FUNCTIONS, true);
-
-            // Link the config to the project resource (cosmetic; shown in Eclipse Run Configurations UI).
-            wc.setMappedResources(new org.eclipse.core.resources.IResource[]{ project });
+            populateWorkingCopy(wc, project, projectName, effectiveApplicationId, componentTypeId);
 
             ILaunchConfiguration saved = wc.doSave();
 
@@ -322,6 +272,28 @@ public class CreateLaunchConfigTool implements IMcpTool
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    /**
+     * Resolves the client-type selector (read-only): defaults a blank value to {@code "thin"} and
+     * lower-cases it, then maps it to its component-type id and human-readable label. Rejects an
+     * unrecognised token with the same JSON error the original inline block produced. Returns a
+     * {@link ClientTypeResolution} carrying either an error or the {@code clientType}/{@code componentTypeId}
+     * /{@code clientLabel} triple.
+     *
+     * @param clientTypeParam the raw client-type argument (may be {@code null}/empty)
+     * @return the resolved client-type triple, or an error to return as-is
+     */
+    private static ClientTypeResolution resolveClientType(String clientTypeParam)
+    {
+        String clientType = (clientTypeParam == null || clientTypeParam.isEmpty()) ? "thin" : clientTypeParam.toLowerCase(java.util.Locale.ROOT); //$NON-NLS-1$
+        String componentTypeId = componentTypeIdFor(clientType);
+        if (componentTypeId == null)
+        {
+            return ClientTypeResolution.error(ToolResult.error("Invalid clientType: '" + clientType //$NON-NLS-1$
+                + "'. Must be one of: thin, thick, web.").toJson()); //$NON-NLS-1$
+        }
+        return ClientTypeResolution.of(clientType, componentTypeId, clientLabelFor(clientType));
+    }
 
     /**
      * Maps the user-facing client type token to the component-type id stored in
@@ -358,6 +330,54 @@ public class CreateLaunchConfigTool implements IMcpTool
         }
     }
 
+    /**
+     * Resolves the target project and verifies it is open (read-only). Returns a {@link ProjectResolution}
+     * carrying either the open {@link IProject} or the same "not found" / "closed" JSON error the original
+     * inline block produced.
+     *
+     * @param projectName the requested project name
+     * @return the open project, or an error to return as-is
+     */
+    private static ProjectResolution resolveOpenProject(String projectName)
+    {
+        ProjectContext ctx = ProjectContext.of(projectName);
+        if (!ctx.exists())
+        {
+            return ProjectResolution.error(ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson());
+        }
+        if (!ctx.isOpen())
+        {
+            return ProjectResolution.error(ToolResult.error("Project is closed: " + projectName //$NON-NLS-1$
+                + ". Open the project first.").toJson()); //$NON-NLS-1$
+        }
+        return ProjectResolution.project(ctx.project());
+    }
+
+    /**
+     * Acquires the Eclipse launch manager and the EDT runtime-client launch configuration type
+     * (read-only). Returns a {@link LaunchTypeResolution} carrying both, or the same
+     * "manager unavailable" / "type not registered" JSON error the original inline block produced.
+     *
+     * @return the launch manager and config type, or an error to return as-is
+     */
+    private static LaunchTypeResolution resolveLaunchType()
+    {
+        ILaunchManager lm = LaunchConfigUtils.getLaunchManager();
+        if (lm == null)
+        {
+            return LaunchTypeResolution.error(ToolResult.error("Eclipse launch manager is not available. " //$NON-NLS-1$
+                + "The debug plugin may not have started yet — retry in a moment.").toJson()); //$NON-NLS-1$
+        }
+        ILaunchConfigurationType type = lm.getLaunchConfigurationType(LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID);
+        if (type == null)
+        {
+            return LaunchTypeResolution.error(ToolResult.error("Launch configuration type '" //$NON-NLS-1$
+                + LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID + "' is not registered. " //$NON-NLS-1$
+                + "Verify that the EDT launching.core plugin is installed.").toJson()); //$NON-NLS-1$
+        }
+        return LaunchTypeResolution.of(lm, type);
+    }
+
     /** Formats the "application not found" error with an actionable message. */
     private static String buildAppNotFoundError(String projectName, String applicationId)
     {
@@ -365,6 +385,193 @@ public class CreateLaunchConfigTool implements IMcpTool
             + "' was not found for project '" + projectName //$NON-NLS-1$
             + "'. Use get_applications(projectName='" + projectName //$NON-NLS-1$
             + "') to see the valid application IDs for this project.").toJson(); //$NON-NLS-1$
+    }
+
+    /**
+     * Resolves the launch configuration's effective name (read-only — creates nothing). When the caller
+     * supplied an explicit non-empty {@code nameParam} it is used as-is, but a duplicate is rejected with
+     * the same error as the original inline block; otherwise a unique name is generated from
+     * {@code "<project> <clientLabel>"} via the launch manager. Returns a {@link NameResolution} carrying
+     * either an error JSON string or the resolved name.
+     *
+     * @param lm          the launch manager (used for duplicate lookup / name generation)
+     * @param nameParam   the caller-supplied name (may be {@code null}/empty)
+     * @param projectName the target project name (used to build the default base name)
+     * @param clientLabel the human-readable client-kind label (default-name suffix)
+     * @return the resolved name, or an error to return as-is
+     */
+    private static NameResolution resolveEffectiveName(ILaunchManager lm, String nameParam,
+        String projectName, String clientLabel)
+    {
+        if (nameParam != null && !nameParam.isEmpty())
+        {
+            // Caller provided an explicit name — reject duplicates.
+            ILaunchConfiguration existing = LaunchConfigUtils.findLaunchConfigByName(lm, nameParam);
+            if (existing != null)
+            {
+                return NameResolution.error(ToolResult.error("A launch configuration named '" + nameParam //$NON-NLS-1$
+                    + "' already exists. Use list_configurations to see existing configs, " //$NON-NLS-1$
+                    + "or omit 'name' to auto-generate a unique name.").toJson()); //$NON-NLS-1$
+            }
+            return NameResolution.name(nameParam);
+        }
+        // Generate a unique name mirroring the EDT shortcut convention.
+        String baseName = projectName + " " + clientLabel; //$NON-NLS-1$
+        return NameResolution.name(lm.generateLaunchConfigurationName(baseName));
+    }
+
+    /**
+     * Sets every launch attribute on the in-memory working copy exactly as the former inline block did
+     * (identity/binding, process factory, client kind, runtime/debug-server defaults, the wizard-parity
+     * UX defaults and the mapped project resource). This is in-memory configuration only — the working
+     * copy is persisted by the {@code wc.doSave()} call that stays inline in {@code execute}.
+     *
+     * @param wc                     the working copy to populate (mutated in memory; not saved here)
+     * @param project                the project resource to map the config to
+     * @param projectName            the project name attribute value
+     * @param effectiveApplicationId the resolved application (infobase) id attribute value
+     * @param componentTypeId        the pinned client component-type id attribute value
+     */
+    private static void populateWorkingCopy(ILaunchConfigurationWorkingCopy wc, IProject project,
+        String projectName, String effectiveApplicationId, String componentTypeId)
+    {
+        // Identity / binding (required by RuntimeClientLaunchDelegate.getProject + ATTR_APPLICATION_ID
+        // must be real so getApplicationIdFor takes branch A, not the synthetic 'launch:' fallback).
+        wc.setAttribute(LaunchConfigUtils.ATTR_PROJECT_NAME, projectName);
+        wc.setAttribute(LaunchConfigUtils.ATTR_APPLICATION_ID, effectiveApplicationId);
+
+        // Process factory (marks the process as an EDT runtime process in the Debug view).
+        wc.setAttribute(ATTR_PROCESS_FACTORY_ID, VALUE_PROCESS_FACTORY);
+
+        // Client kind (pin the specific kind exactly as the shortcut does).
+        wc.setAttribute(ATTR_CLIENT_AUTO_SELECT, false);
+        wc.setAttribute(ATTR_CLIENT_TYPE, componentTypeId);
+
+        // Runtime + debug-server defaults (from AbstractLaunchShortcut.setDefaults bytecode).
+        wc.setAttribute(ATTR_RUNTIME_INSTALL_AUTO, true);
+        wc.setAttribute(ATTR_USE_LOCAL_DEBUG_SERVER, "AUTO"); //$NON-NLS-1$
+
+        // UX defaults from AbstractRuntimeClientLaunchShortcut.setDefaults (wizard parity).
+        wc.setAttribute(ATTR_LAUNCH_USER_USE_INFOBASE_ACCESS, true);
+        wc.setAttribute(ATTR_CALL_DELAY, 145);
+        wc.setAttribute(ATTR_DATA_SENDING_DELAY, 45);
+        wc.setAttribute(ATTR_DATA_RECEIVING_DELAY, 15);
+        wc.setAttribute(ATTR_DO_NOT_DISPLAY_WARNINGS, true);
+        wc.setAttribute(ATTR_SHOW_PERFORMANCE, true);
+        wc.setAttribute(ATTR_SHOW_ALL_FUNCTIONS, true);
+
+        // Link the config to the project resource (cosmetic; shown in Eclipse Run Configurations UI).
+        wc.setMappedResources(new org.eclipse.core.resources.IResource[]{ project });
+    }
+
+    /**
+     * Outcome of {@link #resolveEffectiveName}: exactly one of {@link #error} (a JSON error string to
+     * return) or {@link #name} (the resolved configuration name) is non-null.
+     */
+    private static final class NameResolution
+    {
+        private final String error;
+        private final String name;
+
+        private NameResolution(String error, String name)
+        {
+            this.error = error;
+            this.name = name;
+        }
+
+        static NameResolution error(String error)
+        {
+            return new NameResolution(error, null);
+        }
+
+        static NameResolution name(String name)
+        {
+            return new NameResolution(null, name);
+        }
+    }
+
+    /**
+     * Outcome of {@link #resolveOpenProject}: exactly one of {@link #error} (a JSON error string to
+     * return) or {@link #project} (the resolved open project) is non-null.
+     */
+    private static final class ProjectResolution
+    {
+        private final String error;
+        private final IProject project;
+
+        private ProjectResolution(String error, IProject project)
+        {
+            this.error = error;
+            this.project = project;
+        }
+
+        static ProjectResolution error(String error)
+        {
+            return new ProjectResolution(error, null);
+        }
+
+        static ProjectResolution project(IProject project)
+        {
+            return new ProjectResolution(null, project);
+        }
+    }
+
+    /**
+     * Outcome of {@link #resolveLaunchType}: either {@link #error} (a JSON error string to return) is
+     * non-null, or both {@link #launchManager} and {@link #type} are non-null.
+     */
+    private static final class LaunchTypeResolution
+    {
+        private final String error;
+        private final ILaunchManager launchManager;
+        private final ILaunchConfigurationType type;
+
+        private LaunchTypeResolution(String error, ILaunchManager launchManager, ILaunchConfigurationType type)
+        {
+            this.error = error;
+            this.launchManager = launchManager;
+            this.type = type;
+        }
+
+        static LaunchTypeResolution error(String error)
+        {
+            return new LaunchTypeResolution(error, null, null);
+        }
+
+        static LaunchTypeResolution of(ILaunchManager launchManager, ILaunchConfigurationType type)
+        {
+            return new LaunchTypeResolution(null, launchManager, type);
+        }
+    }
+
+    /**
+     * Outcome of {@link #resolveClientType}: either {@link #error} (a JSON error string to return) is
+     * non-null, or the {@link #clientType} / {@link #componentTypeId} / {@link #clientLabel} triple is set.
+     */
+    private static final class ClientTypeResolution
+    {
+        private final String error;
+        private final String clientType;
+        private final String componentTypeId;
+        private final String clientLabel;
+
+        private ClientTypeResolution(String error, String clientType, String componentTypeId, String clientLabel)
+        {
+            this.error = error;
+            this.clientType = clientType;
+            this.componentTypeId = componentTypeId;
+            this.clientLabel = clientLabel;
+        }
+
+        static ClientTypeResolution error(String error)
+        {
+            return new ClientTypeResolution(error, null, null, null);
+        }
+
+        static ClientTypeResolution of(String clientType, String componentTypeId, String clientLabel)
+        {
+            return new ClientTypeResolution(null, clientType, componentTypeId, clientLabel);
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
@@ -18,6 +18,7 @@ import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 
 import com._1c.g5.v8.bm.core.IBmObject;
+import com._1c.g5.v8.bm.core.IBmTransaction;
 import com._1c.g5.v8.bm.integration.IBmModel;
 import com._1c.g5.v8.dt.core.model.IModelObjectFactory;
 import com._1c.g5.v8.dt.core.naming.ITopObjectFqnGenerator;
@@ -343,8 +344,8 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
 
         if (target.topLevel)
         {
-            return createTopLevel(project, config, projectName, target, normFqn, props, synonymLanguage,
-                typeSpecific, normReport);
+            return createTopLevel(new TopLevelRequest(project, config, projectName, target, normFqn,
+                props, synonymLanguage, typeSpecific, normReport));
         }
         return createMember(project, projectName, target, normFqn, props, synonymLanguage, normReport);
     }
@@ -384,53 +385,71 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
 
     // ---- top-level creation (mirrors the former create_metadata_object) -------------------------
 
-    private String createTopLevel(IProject project, Configuration config, String projectName,
-        CreateTarget target, String normFqn, Props props, String synonymLanguage,
-        TypeSpecific typeSpecific, MdNameNormalizer.Report normReport)
+    /**
+     * Immutable inputs for a top-level object create, grouping the request so
+     * {@link #createTopLevel(TopLevelRequest)} takes one holder instead of a long argument list.
+     */
+    private static final class TopLevelRequest
+    {
+        final IProject project;
+        final Configuration config;
+        final String projectName;
+        final CreateTarget target;
+        final String normFqn;
+        final Props props;
+        final String synonymLanguage;
+        final TypeSpecific typeSpecific;
+        final MdNameNormalizer.Report normReport;
+
+        TopLevelRequest(IProject project, Configuration config, String projectName,
+            CreateTarget target, String normFqn, Props props, String synonymLanguage,
+            TypeSpecific typeSpecific, MdNameNormalizer.Report normReport)
+        {
+            this.project = project;
+            this.config = config;
+            this.projectName = projectName;
+            this.target = target;
+            this.normFqn = normFqn;
+            this.props = props;
+            this.synonymLanguage = synonymLanguage;
+            this.typeSpecific = typeSpecific;
+            this.normReport = normReport;
+        }
+    }
+
+    private String createTopLevel(TopLevelRequest req)
     {
         // Any configuration top-level type resolved by MetadataTypeUtils is attempted: the EDT
         // model-object factory produces the EDT "New"-wizard default content. A type the factory
         // cannot instantiate fails gracefully below (clean error, no crash) rather than via a
         // hand-maintained allow-list.
-        EStructuralFeature collection = config.eClass().getEStructuralFeature(target.configFeatureName);
-        if (collection == null || !(collection.getEType() instanceof EClass))
+        EClass eClass = resolveCollectionElementType(req.config, req.target.configFeatureName);
+        if (eClass == null)
         {
             return ToolResult.error("Could not resolve configuration collection '" //$NON-NLS-1$
-                + target.configFeatureName + "'").toJson(); //$NON-NLS-1$
+                + req.target.configFeatureName + "'").toJson(); //$NON-NLS-1$
         }
-        final EClass eClass = (EClass)collection.getEType();
 
-        IV8ProjectManager v8ProjectManager = Activator.getDefault().getV8ProjectManager();
-        IModelObjectFactory factory = Activator.getDefault().getModelObjectFactory();
-        IBmModelManager bmModelManager = Activator.getDefault().getBmModelManager();
-        if (v8ProjectManager == null || factory == null || bmModelManager == null)
+        BmContext bm = resolveBmContext(req.project, req.projectName);
+        if (bm.hasError())
         {
-            return ToolResult.error(ERR_SERVICES_UNAVAILABLE).toJson();
+            return bm.error;
         }
-        IV8Project v8Project = v8ProjectManager.getProject(project);
-        if (v8Project == null)
-        {
-            return ToolResult.error(ERR_NO_V8_PROJECT + projectName).toJson();
-        }
-        final Version version = v8Project.getVersion();
-        IBmModel bmModel = bmModelManager.getModel(project);
-        if (bmModel == null)
-        {
-            return ToolResult.error(ERR_NO_BM_MODEL + projectName).toJson();
-        }
-        if (!(config instanceof IBmObject))
+        if (!(req.config instanceof IBmObject))
         {
             return ToolResult.error("Configuration is not a BM object").toJson(); //$NON-NLS-1$
         }
-        final long configBmId = ((IBmObject)config).bmGetId();
-        final String configFqn = ((IBmObject)config).bmGetFqn();
-        final String name = target.childName;
-        final String configFeatureName = target.configFeatureName;
+        final long configBmId = ((IBmObject)req.config).bmGetId();
+        final String configFqn = ((IBmObject)req.config).bmGetFqn();
+        final String name = req.target.childName;
+        final String configFeatureName = req.target.configFeatureName;
+        final IModelObjectFactory factory = bm.factory;
+        final Version version = bm.version;
 
         final EClass createdKind;
         try
         {
-            createdKind = BmTransactions.<EClass>write(bmModel, "CreateMetadataObject", (tx, pm) -> //$NON-NLS-1$
+            createdKind = BmTransactions.<EClass>write(bm.bmModel, "CreateMetadataObject", (tx, pm) -> //$NON-NLS-1$
             {
                 Configuration cfg = (Configuration)tx.getObjectById(configBmId);
                 if (cfg == null)
@@ -444,10 +463,10 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
                         + "' object"); //$NON-NLS-1$
                 }
                 newObject.setName(name);
-                applyScalarProps(newObject, props, synonymLanguage);
+                applyScalarProps(newObject, req.props, req.synonymLanguage);
                 // Type-specific defaults applied on top of the factory's default content.
-                typeSpecific.applyTo(newObject);
-                tx.attachTopObject((IBmObject)newObject, normFqn);
+                req.typeSpecific.applyTo(newObject);
+                tx.attachTopObject((IBmObject)newObject, req.normFqn);
                 addToCollection(cfg, configFeatureName, newObject);
                 factory.fillDefaultReferences(newObject);
                 return newObject.eClass();
@@ -459,15 +478,39 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
             return ToolResult.error("Failed to create object: " + unwrapCauseMessage(e)).toJson(); //$NON-NLS-1$
         }
 
+        boolean persisted =
+            BmTransactions.forceExportToDisk(req.project, dirtyFqns(req.normFqn, configFqn));
+        return success(new SuccessInfo(req.normFqn, createdKind, name, persisted, req.props,
+            req.synonymLanguage, req.typeSpecific, req.normReport));
+    }
+
+    /**
+     * Resolves the EClass of the configuration containment collection named {@code featureName},
+     * or {@code null} when the feature is absent or not an EClass-typed collection. Side-effect-free.
+     */
+    private static EClass resolveCollectionElementType(Configuration config, String featureName)
+    {
+        EStructuralFeature collection = config.eClass().getEStructuralFeature(featureName);
+        if (collection == null || !(collection.getEType() instanceof EClass))
+        {
+            return null;
+        }
+        return (EClass)collection.getEType();
+    }
+
+    /**
+     * Builds the force-export dirty list for a top-object create: the new object's FQN plus the
+     * configuration FQN (which registers the object) when present. Side-effect-free.
+     */
+    private static List<String> dirtyFqns(String normFqn, String configFqn)
+    {
         java.util.List<String> dirty = new java.util.ArrayList<>();
         dirty.add(normFqn);
         if (configFqn != null && !configFqn.isEmpty())
         {
             dirty.add(configFqn);
         }
-        boolean persisted = BmTransactions.forceExportToDisk(project, dirty);
-        return success(normFqn, createdKind, name, persisted, props, synonymLanguage, typeSpecific,
-            normReport);
+        return dirty;
     }
 
     // ---- member creation (mirrors the former add_metadata_attribute, generalized) ---------------
@@ -483,24 +526,11 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         {
             return ToolResult.error("Top object is not a BM object").toJson(); //$NON-NLS-1$
         }
-        IBmModelManager bmModelManager = Activator.getDefault().getBmModelManager();
-        IModelObjectFactory factory = Activator.getDefault().getModelObjectFactory();
-        IV8ProjectManager v8ProjectManager = Activator.getDefault().getV8ProjectManager();
-        if (bmModelManager == null || factory == null || v8ProjectManager == null)
+        BmContext bm = resolveBmContext(project, projectName);
+        if (bm.hasError())
         {
-            return ToolResult.error(ERR_SERVICES_UNAVAILABLE).toJson();
+            return bm.error;
         }
-        IBmModel bmModel = bmModelManager.getModel(project);
-        if (bmModel == null)
-        {
-            return ToolResult.error(ERR_NO_BM_MODEL + projectName).toJson();
-        }
-        IV8Project v8Project = v8ProjectManager.getProject(project);
-        if (v8Project == null)
-        {
-            return ToolResult.error(ERR_NO_V8_PROJECT + projectName).toJson();
-        }
-        final Version version = v8Project.getVersion();
 
         final long topBmId = ((IBmObject)target.topObject).bmGetId();
         final String[] parts = normFqn.split("\\."); //$NON-NLS-1$
@@ -513,58 +543,19 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         final boolean factoryInitialized = isFactoryInitializedChild(elementType);
         // The top object that owns the member's .mdo file (members live inside the top object's file).
         final String topFqn = topFqn(normFqn);
+        final IModelObjectFactory factory = bm.factory;
+        final Version version = bm.version;
 
         final EClass createdKind;
         try
         {
-            createdKind = BmTransactions.<EClass>write(bmModel, "CreateMetadataMember", (tx, pm) -> //$NON-NLS-1$
+            createdKind = BmTransactions.<EClass>write(bm.bmModel, "CreateMetadataMember", (tx, pm) -> //$NON-NLS-1$
             {
-                EObject top = (EObject)tx.getObjectById(topBmId);
-                if (top == null)
-                {
-                    throw new RuntimeException("Owner object not found in transaction"); //$NON-NLS-1$
-                }
-                EObject owner = MetadataNodeResolver.resolveOwnerInTx(top, parts);
-                if (owner == null)
-                {
-                    throw new RuntimeException("Could not re-navigate to the owner inside the transaction"); //$NON-NLS-1$
-                }
-                if (childByName(owner, feature, name) != null)
-                {
-                    throw new RuntimeException("Member already exists: " + name); //$NON-NLS-1$
-                }
-                MdObject child;
-                if (factoryInitialized)
-                {
-                    // The parent-aware factory wires the type's default content (produced types,
-                    // form/template type); fall back to a bare create only if the factory declines.
-                    child = (MdObject)factory.create(elementType, owner, version);
-                    if (child == null)
-                    {
-                        child = (MdObject)EcoreUtil.create(elementType);
-                    }
-                    child.setName(name);
-                    if (child.getUuid() == null)
-                    {
-                        child.setUuid(UUID.randomUUID());
-                    }
-                    // The factory does not default a template's type; set the platform default.
-                    if (child instanceof BasicTemplate && ((BasicTemplate)child).getTemplateType() == null)
-                    {
-                        ((BasicTemplate)child).setTemplateType(TemplateType.SPREADSHEET_DOCUMENT);
-                    }
-                    applyScalarProps(child, props, synonymLanguage);
-                    addToFeature(owner, feature, child);
-                    factory.fillDefaultReferences(child);
-                }
-                else
-                {
-                    child = (MdObject)EcoreUtil.create(elementType);
-                    child.setName(name);
-                    child.setUuid(UUID.randomUUID());
-                    applyScalarProps(child, props, synonymLanguage);
-                    addToFeature(owner, feature, child);
-                }
+                EObject owner = resolveMemberOwnerInTx(tx, topBmId, parts, feature, name);
+                MemberChildSpec spec =
+                    new MemberChildSpec(factory, elementType, owner, version, name, props,
+                        synonymLanguage, feature);
+                MdObject child = createMemberChild(spec, factoryInitialized);
                 return child.eClass();
             });
         }
@@ -575,7 +566,124 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         }
 
         boolean persisted = BmTransactions.forceExportToDisk(project, topFqn);
-        return success(normFqn, createdKind, name, persisted, props, synonymLanguage, null, normReport);
+        return success(new SuccessInfo(normFqn, createdKind, name, persisted, props, synonymLanguage,
+            null, normReport));
+    }
+
+    /**
+     * Re-fetches the member's TOP object by {@code topBmId} inside the transaction and re-navigates
+     * to the leaf's owner BY NAME (per the FQN {@code parts}), then asserts the new member does not
+     * already exist on {@code feature}. Returns the resolved owner. Runs inside the write
+     * transaction; performs no mutation.
+     *
+     * @throws RuntimeException if the top object or owner cannot be re-resolved, or the member exists
+     */
+    private static EObject resolveMemberOwnerInTx(IBmTransaction tx, long topBmId, String[] parts,
+        EStructuralFeature feature, String name)
+    {
+        EObject top = (EObject)tx.getObjectById(topBmId);
+        if (top == null)
+        {
+            throw new RuntimeException("Owner object not found in transaction"); //$NON-NLS-1$
+        }
+        EObject owner = MetadataNodeResolver.resolveOwnerInTx(top, parts);
+        if (owner == null)
+        {
+            throw new RuntimeException("Could not re-navigate to the owner inside the transaction"); //$NON-NLS-1$
+        }
+        if (childByName(owner, feature, name) != null)
+        {
+            throw new RuntimeException("Member already exists: " + name); //$NON-NLS-1$
+        }
+        return owner;
+    }
+
+    /**
+     * Immutable inputs for building one member child inside the write transaction, grouping the
+     * arguments so the child-creation helpers stay within the parameter limit.
+     */
+    private static final class MemberChildSpec
+    {
+        final IModelObjectFactory factory;
+        final EClass elementType;
+        final EObject owner;
+        final Version version;
+        final String name;
+        final Props props;
+        final String synonymLanguage;
+        final EStructuralFeature feature;
+
+        MemberChildSpec(IModelObjectFactory factory, EClass elementType, EObject owner,
+            Version version, String name, Props props, String synonymLanguage,
+            EStructuralFeature feature)
+        {
+            this.factory = factory;
+            this.elementType = elementType;
+            this.owner = owner;
+            this.version = version;
+            this.name = name;
+            this.props = props;
+            this.synonymLanguage = synonymLanguage;
+            this.feature = feature;
+        }
+    }
+
+    /**
+     * Creates and attaches one member child to its (tx-fetched) owner, dispatching to the
+     * factory-initialized or the plain construction path. Performs the irreversible BM mutation; runs
+     * inside the write transaction at the same point the inline code did.
+     *
+     * @return the created child
+     */
+    private static MdObject createMemberChild(MemberChildSpec spec, boolean factoryInitialized)
+    {
+        return factoryInitialized ? createFactoryInitializedChild(spec) : createPlainChild(spec);
+    }
+
+    /**
+     * Factory-initialized member path (Form / Template / Recalculation): the parent-aware factory
+     * wires the type's default content; a bare create is the fallback when the factory declines.
+     * Performs the BM mutation inside the write transaction.
+     *
+     * @return the created and attached child
+     */
+    private static MdObject createFactoryInitializedChild(MemberChildSpec spec)
+    {
+        MdObject child = (MdObject)spec.factory.create(spec.elementType, spec.owner, spec.version);
+        if (child == null)
+        {
+            child = (MdObject)EcoreUtil.create(spec.elementType);
+        }
+        child.setName(spec.name);
+        if (child.getUuid() == null)
+        {
+            child.setUuid(UUID.randomUUID());
+        }
+        // The factory does not default a template's type; set the platform default.
+        if (child instanceof BasicTemplate && ((BasicTemplate)child).getTemplateType() == null)
+        {
+            ((BasicTemplate)child).setTemplateType(TemplateType.SPREADSHEET_DOCUMENT);
+        }
+        applyScalarProps(child, spec.props, spec.synonymLanguage);
+        addToFeature(spec.owner, spec.feature, child);
+        spec.factory.fillDefaultReferences(child);
+        return child;
+    }
+
+    /**
+     * Plain member path (Attribute, Command, ...): a bare {@code EcoreUtil.create}, named, given a
+     * UUID and attached. Performs the BM mutation inside the write transaction.
+     *
+     * @return the created and attached child
+     */
+    private static MdObject createPlainChild(MemberChildSpec spec)
+    {
+        MdObject child = (MdObject)EcoreUtil.create(spec.elementType);
+        child.setName(spec.name);
+        child.setUuid(UUID.randomUUID());
+        applyScalarProps(child, spec.props, spec.synonymLanguage);
+        addToFeature(spec.owner, spec.feature, child);
+        return child;
     }
 
     // ---- form-content member creation (the cross-model hop into the editable Form) ---------------
@@ -603,50 +711,11 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
                 + "or underscore and contain only letters, digits and underscores.").toJson(); //$NON-NLS-1$
         }
 
-        // Form-member properties: title (+ language), parent (nest a visual item), the binding
-        // target for a Field (dataPath/attribute -> the form attribute) or a Button (command), and
-        // a Group's explicit type (Popup/Pages/Page/CommandBar/ButtonGroup/ColumnGroup/UsualGroup).
-        String titleVal = null;
-        String titleLang = null;
-        String parentName = null;
-        String bindTarget = null;
-        for (JsonObject prop : properties)
+        FormMemberProps fmProps = new FormMemberProps();
+        String propErr = parseFormMemberProperties(properties, kind, normReport, fmProps);
+        if (propErr != null)
         {
-            String pName = asString(prop.get("name")); //$NON-NLS-1$
-            if (pName == null || pName.isEmpty())
-            {
-                return ToolResult.error(ERR_PROPERTY_NEEDS_NAME).toJson();
-            }
-            switch (pName.toLowerCase())
-            {
-                case "title": //$NON-NLS-1$
-                    titleVal = normReport.apply("title", asString(prop.get(KEY_VALUE))); //$NON-NLS-1$
-                    titleLang = asString(prop.get(KEY_LANGUAGE));
-                    break;
-                case "parent": //$NON-NLS-1$
-                    parentName = asString(prop.get(KEY_VALUE));
-                    break;
-                case "type": //$NON-NLS-1$
-                    if (kind != FormElementWriter.Kind.GROUP)
-                    {
-                        return ToolResult.error("Property 'type' is supported at creation only for " //$NON-NLS-1$
-                            + "a form Group (the group kind, e.g. Popup or Pages). Set other " //$NON-NLS-1$
-                            + "elements' types via modify_metadata.").toJson(); //$NON-NLS-1$
-                    }
-                    bindTarget = asString(prop.get(KEY_VALUE));
-                    break;
-                case "datapath": //$NON-NLS-1$
-                case "attribute": //$NON-NLS-1$
-                case "command": //$NON-NLS-1$
-                    bindTarget = asString(prop.get(KEY_VALUE));
-                    break;
-                default:
-                    return ToolResult.error(ERR_PROPERTY_PREFIX + pName + "' is not supported for a form " //$NON-NLS-1$
-                        + "element. This version applies: title (with optional language), parent " //$NON-NLS-1$
-                        + "(nest a visual item), dataPath/attribute (a Field's bound attribute), " //$NON-NLS-1$
-                        + "command (a Button's bound command), type (a Group's kind). Set other " //$NON-NLS-1$
-                        + "properties via modify_metadata.").toJson(); //$NON-NLS-1$
-            }
+            return propErr;
         }
 
         ProjectContext ctx = resolveProjectAndConfig(projectName);
@@ -658,9 +727,9 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         Configuration config = ctx.config;
 
         final FormElementWriter.Kind fKind = kind;
-        final String parent = parentName;
-        final String bind = bindTarget;
-        final String titleText = titleVal;
+        final String parent = fmProps.parentName;
+        final String bind = fmProps.bindTarget;
+        final String titleText = fmProps.titleVal;
         // The designer's auto-children (extended tooltip / context menu) get script-variant
         // localized name suffixes, like FormObjectDefaultNameProvider.
         final boolean russianAutoNames = config.getScriptVariant() == ScriptVariant.RUSSIAN;
@@ -677,8 +746,8 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
             final String titleLanguage;
             try
             {
-                titleLanguage = MetadataLanguageUtils.resolveSynonymLanguage(config, titleVal,
-                    titleLang, "the title"); //$NON-NLS-1$
+                titleLanguage = MetadataLanguageUtils.resolveSynonymLanguage(config, fmProps.titleVal,
+                    fmProps.titleLang, "the title"); //$NON-NLS-1$
             }
             catch (IllegalArgumentException e)
             {
@@ -715,6 +784,69 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
             .put(KEY_PERSISTED, persisted);
         normReport.addTo(formResult);
         return formResult.put(McpKeys.MESSAGE, "Created " + normFqn).toJson(); //$NON-NLS-1$
+    }
+
+    /**
+     * The parsed creation-time properties of a form member: the title (+ language), the parent to
+     * nest under, and the binding target (a Field's dataPath/attribute, a Button's command, or a
+     * Group's kind).
+     */
+    private static final class FormMemberProps
+    {
+        String titleVal;
+        String titleLang;
+        String parentName;
+        String bindTarget;
+    }
+
+    /**
+     * Parses the form-member {@code properties} array into {@code out}, applying the 'ё'->'е'
+     * report to the title. Side-effect-free apart from filling {@code out}: returns a JSON error
+     * string when a property is malformed, unsupported, or (for {@code type}) used on a non-Group,
+     * or {@code null} on success.
+     */
+    private String parseFormMemberProperties(List<JsonObject> properties, FormElementWriter.Kind kind,
+        MdNameNormalizer.Report normReport, FormMemberProps out)
+    {
+        for (JsonObject prop : properties)
+        {
+            String pName = asString(prop.get("name")); //$NON-NLS-1$
+            if (pName == null || pName.isEmpty())
+            {
+                return ToolResult.error(ERR_PROPERTY_NEEDS_NAME).toJson();
+            }
+            switch (pName.toLowerCase())
+            {
+                case "title": //$NON-NLS-1$
+                    out.titleVal = normReport.apply("title", asString(prop.get(KEY_VALUE))); //$NON-NLS-1$
+                    out.titleLang = asString(prop.get(KEY_LANGUAGE));
+                    break;
+                case "parent": //$NON-NLS-1$
+                    out.parentName = asString(prop.get(KEY_VALUE));
+                    break;
+                case "type": //$NON-NLS-1$
+                    if (kind != FormElementWriter.Kind.GROUP)
+                    {
+                        return ToolResult.error("Property 'type' is supported at creation only for " //$NON-NLS-1$
+                            + "a form Group (the group kind, e.g. Popup or Pages). Set other " //$NON-NLS-1$
+                            + "elements' types via modify_metadata.").toJson(); //$NON-NLS-1$
+                    }
+                    out.bindTarget = asString(prop.get(KEY_VALUE));
+                    break;
+                case "datapath": //$NON-NLS-1$
+                case "attribute": //$NON-NLS-1$
+                case "command": //$NON-NLS-1$
+                    out.bindTarget = asString(prop.get(KEY_VALUE));
+                    break;
+                default:
+                    return ToolResult.error(ERR_PROPERTY_PREFIX + pName + "' is not supported for a form " //$NON-NLS-1$
+                        + "element. This version applies: title (with optional language), parent " //$NON-NLS-1$
+                        + "(nest a visual item), dataPath/attribute (a Field's bound attribute), " //$NON-NLS-1$
+                        + "command (a Button's bound command), type (a Group's kind). Set other " //$NON-NLS-1$
+                        + "properties via modify_metadata.").toJson(); //$NON-NLS-1$
+            }
+        }
+        return null;
     }
 
     // ---- form-OBJECT creation (the BasicForm mdo + its renderable content Form) ------------------
@@ -767,18 +899,10 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
             return ToolResult.error("Owner object is not a BM object").toJson(); //$NON-NLS-1$
         }
 
-        // The same duplicate / stale-intent precondition every other create applies (the main branch
-        // checks via resolveExisting; a 4-part form FQN resolves on the owner's forms collection).
-        // The in-transaction "Form already exists" guard below stays as the race-safety net.
-        if (FormElementWriter.findOwnedForm(owner, ref.formName) != null)
+        String existsErr = checkFormObjectNotExists(owner, ref.formName, normFqn, expectedNotExists);
+        if (existsErr != null)
         {
-            if (expectedNotExists)
-            {
-                return ToolResult.error("Precondition failed: you set expectedNotExists, but " + normFqn //$NON-NLS-1$
-                    + " already exists. Your snapshot is stale - re-read with get_metadata_objects, " //$NON-NLS-1$
-                    + "then update the existing node instead of creating a duplicate.").toJson(); //$NON-NLS-1$
-            }
-            return ToolResult.error("Node already exists: " + normFqn).toJson(); //$NON-NLS-1$
+            return existsErr;
         }
 
         // Resolve the synonym language now (needs the configuration); only when a synonym was given.
@@ -793,30 +917,10 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
             return ToolResult.error(e.getMessage()).toJson();
         }
 
-        IV8ProjectManager v8ProjectManager = Activator.getDefault().getV8ProjectManager();
-        IModelObjectFactory mdFactory = Activator.getDefault().getModelObjectFactory();
-        IModelObjectFactory formFactory = Activator.getDefault().getFormModelObjectFactory();
-        ITopObjectFqnGenerator fqnGenerator = Activator.getDefault().getTopObjectFqnGenerator();
-        IBmModelManager bmModelManager = Activator.getDefault().getBmModelManager();
-        if (v8ProjectManager == null || mdFactory == null || bmModelManager == null)
+        FormObjectServices svc = resolveFormObjectServices(project, projectName);
+        if (svc.hasError())
         {
-            return ToolResult.error(ERR_SERVICES_UNAVAILABLE).toJson();
-        }
-        if (fqnGenerator == null)
-        {
-            return ToolResult.error("ITopObjectFqnGenerator not available (needed to attach the content " //$NON-NLS-1$
-                + "form under its canonical FQN)").toJson(); //$NON-NLS-1$
-        }
-        IV8Project v8Project = v8ProjectManager.getProject(project);
-        if (v8Project == null)
-        {
-            return ToolResult.error(ERR_NO_V8_PROJECT + projectName).toJson();
-        }
-        final Version version = v8Project.getVersion();
-        IBmModel bmModel = bmModelManager.getModel(project);
-        if (bmModel == null)
-        {
-            return ToolResult.error(ERR_NO_BM_MODEL + projectName).toJson();
+            return svc.error;
         }
 
         final long ownerBmId = ((IBmObject)owner).bmGetId();
@@ -832,7 +936,7 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         final String contentFormFqn;
         try
         {
-            contentFormFqn = BmTransactions.<String>write(bmModel, "CreateFormObject", (tx, pm) -> //$NON-NLS-1$
+            contentFormFqn = BmTransactions.<String>write(svc.bmModel, "CreateFormObject", (tx, pm) -> //$NON-NLS-1$
             {
                 EObject txOwner = (EObject)tx.getObjectById(ownerBmId);
                 if (!(txOwner instanceof MdObject))
@@ -840,8 +944,8 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
                     throw new RuntimeException("Owner object not found in transaction"); //$NON-NLS-1$
                 }
                 return FormElementWriter.createForm(tx, (MdObject)txOwner, formName, synonymLanguage,
-                    synonym, comment, fSetAsDefault, mdFactory, formFactory, fqnGenerator, version,
-                    russianAutoNames);
+                    synonym, comment, fSetAsDefault, svc.mdFactory, svc.formFactory, svc.fqnGenerator,
+                    svc.version, russianAutoNames);
             });
         }
         catch (Exception e)
@@ -852,6 +956,103 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
 
         // Persist BOTH the content form's own Form.form (its FQN, generated inside the tx) and the owner
         // .mdo (which registers the new form in its <forms> and, when setAsDefault, the default-form ref).
+        List<String> dirty = formObjectDirtyFqns(contentFormFqn, ownerFqn);
+        boolean persisted = !dirty.isEmpty() && BmTransactions.forceExportToDisk(project, dirty);
+
+        return buildFormObjectResult(normFqn, formName, persisted, setAsDefault, props,
+            synonymLanguage, normReport);
+    }
+
+    /**
+     * Applies the duplicate / stale-intent precondition for a form OBJECT create (a 4-part form FQN
+     * resolves on the owner's forms collection). Side-effect-free: returns a JSON error string when
+     * the form already exists (a sharper message when {@code expectedNotExists}), or {@code null}
+     * when it does not.
+     */
+    private static String checkFormObjectNotExists(MdObject owner, String formName, String normFqn,
+        boolean expectedNotExists)
+    {
+        if (FormElementWriter.findOwnedForm(owner, formName) == null)
+        {
+            return null;
+        }
+        if (expectedNotExists)
+        {
+            return ToolResult.error("Precondition failed: you set expectedNotExists, but " + normFqn //$NON-NLS-1$
+                + " already exists. Your snapshot is stale - re-read with get_metadata_objects, " //$NON-NLS-1$
+                + "then update the existing node instead of creating a duplicate.").toJson(); //$NON-NLS-1$
+        }
+        return ToolResult.error("Node already exists: " + normFqn).toJson(); //$NON-NLS-1$
+    }
+
+    /**
+     * The EDT services a form OBJECT create needs (the mdclass and form model-object factories, the
+     * top-object FQN generator, the BM model and the platform version), or a ready-to-return JSON
+     * error when any required service is unavailable.
+     */
+    private static final class FormObjectServices
+    {
+        IModelObjectFactory mdFactory;
+        IModelObjectFactory formFactory;
+        ITopObjectFqnGenerator fqnGenerator;
+        IBmModel bmModel;
+        Version version;
+        /** Non-null when resolution failed: a JSON error to return verbatim. */
+        String error;
+
+        boolean hasError()
+        {
+            return error != null;
+        }
+    }
+
+    /**
+     * Resolves the services needed to create a form OBJECT for {@code project} (named
+     * {@code projectName} for error messages), or returns a holder carrying a JSON error when any
+     * required service is unavailable. Side-effect-free.
+     */
+    private static FormObjectServices resolveFormObjectServices(IProject project, String projectName)
+    {
+        FormObjectServices svc = new FormObjectServices();
+        IV8ProjectManager v8ProjectManager = Activator.getDefault().getV8ProjectManager();
+        svc.mdFactory = Activator.getDefault().getModelObjectFactory();
+        svc.formFactory = Activator.getDefault().getFormModelObjectFactory();
+        svc.fqnGenerator = Activator.getDefault().getTopObjectFqnGenerator();
+        IBmModelManager bmModelManager = Activator.getDefault().getBmModelManager();
+        if (v8ProjectManager == null || svc.mdFactory == null || bmModelManager == null)
+        {
+            svc.error = ToolResult.error(ERR_SERVICES_UNAVAILABLE).toJson();
+            return svc;
+        }
+        if (svc.fqnGenerator == null)
+        {
+            svc.error = ToolResult.error("ITopObjectFqnGenerator not available (needed to attach the " //$NON-NLS-1$
+                + "content form under its canonical FQN)").toJson(); //$NON-NLS-1$
+            return svc;
+        }
+        IV8Project v8Project = v8ProjectManager.getProject(project);
+        if (v8Project == null)
+        {
+            svc.error = ToolResult.error(ERR_NO_V8_PROJECT + projectName).toJson();
+            return svc;
+        }
+        svc.version = v8Project.getVersion();
+        svc.bmModel = bmModelManager.getModel(project);
+        if (svc.bmModel == null)
+        {
+            svc.error = ToolResult.error(ERR_NO_BM_MODEL + projectName).toJson();
+            return svc;
+        }
+        return svc;
+    }
+
+    /**
+     * Builds the force-export dirty list for a form OBJECT create: the content form's own Form.form
+     * (its FQN, generated inside the tx) and the owner .mdo (which registers the form), each when
+     * present. Side-effect-free.
+     */
+    private static List<String> formObjectDirtyFqns(String contentFormFqn, String ownerFqn)
+    {
         java.util.List<String> dirty = new java.util.ArrayList<>();
         if (contentFormFqn != null && !contentFormFqn.isEmpty())
         {
@@ -861,8 +1062,13 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         {
             dirty.add(ownerFqn);
         }
-        boolean persisted = !dirty.isEmpty() && BmTransactions.forceExportToDisk(project, dirty);
+        return dirty;
+    }
 
+    /** Builds the success JSON for a created form OBJECT. Side-effect-free: pure formatting. */
+    private String buildFormObjectResult(String normFqn, String formName, boolean persisted,
+        boolean setAsDefault, Props props, String synonymLanguage, MdNameNormalizer.Report normReport)
+    {
         ToolResult result = ToolResult.success()
             .put(McpKeys.ACTION, VAL_CREATED)
             .put("fqn", normFqn) //$NON-NLS-1$
@@ -928,21 +1134,12 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         final String langCode = MetadataLanguageUtils.resolveLanguageCode(config, null);
 
         final String eventName = ref.name;
-        final String fProc = procName;
-        final String fCallType = callType;
+        final String[] createdKind = new String[1];
         final boolean commandOwner =
             FormElementWriter.kindForToken(ref.itemKindToken) == FormElementWriter.Kind.COMMAND;
-        final String[] createdKind = new String[1];
-
-        // For an EXTENSION event handler the most likely cause of a missing form is that the base form
-        // was never adopted into the extension, so the not-found advisory points at adopt_metadata_object.
-        String formNotFound = "Form not found for '" + normFqn + "'. Address a form as " //$NON-NLS-1$ //$NON-NLS-2$
-            + "'Type.Object.Form.FormName' or 'CommonForm.FormName'."; //$NON-NLS-1$
-        if (extensionHandler)
-        {
-            formNotFound += " If this is a base form, adopt it into the extension first via " //$NON-NLS-1$
-                + "adopt_metadata_object."; //$NON-NLS-1$
-        }
+        final HandlerWriteSpec spec = new HandlerWriteSpec(ref, eventName, procName, version,
+            langCode, callType, commandOwner, createdKind);
+        final String formNotFound = handlerFormNotFound(normFqn, extensionHandler);
 
         final boolean persisted;
         try
@@ -950,28 +1147,7 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
             FormElementWriter.FormEditContext fctx = FormElementWriter.resolveForEdit(project, config,
                 ref.formPath, formNotFound);
             persisted = FormElementWriter.writeEditableForm(fctx, "CreateFormHandler", //$NON-NLS-1$
-                (formModel, tx) ->
-                {
-                    // Form-level handlers attach to the form root; item-level handlers
-                    // (Type.Object.Form.F.Field.Item.Handler.Event) attach to the named item; a
-                    // COMMAND ref (Type.Object.Form.F.Command.C.Handler.Action) attaches to the
-                    // form command.
-                    EObject container = FormElementWriter.resolveHandlerContainer(formModel, ref);
-                    if (container == null)
-                    {
-                        throw new IllegalStateException(commandOwner
-                            ? "Form command not found: " + ref.itemName //$NON-NLS-1$
-                                + ". Create the command first, then add the handler." //$NON-NLS-1$
-                            : "Form item not found: " + ref.itemName //$NON-NLS-1$
-                                + ". Create the item first, then add the handler."); //$NON-NLS-1$
-                    }
-                    String err = FormElementWriter.createHandler(container, eventName, fProc, version,
-                        langCode, fCallType, createdKind);
-                    if (err != null)
-                    {
-                        throw new IllegalStateException(err);
-                    }
-                });
+                (formModel, tx) -> writeHandler(formModel, spec));
         }
         catch (Exception e)
         {
@@ -984,8 +1160,83 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
             return ToolResult.error("Failed to create form handler: " + unwrapCauseMessage(e)).toJson(); //$NON-NLS-1$
         }
 
-        return buildHandlerResult(ref, normFqn, eventName, fProc, callType, extensionHandler,
-            createdKind[0], persisted);
+        return buildHandlerResult(new HandlerResultInfo(ref, normFqn, eventName, procName, callType,
+            extensionHandler, createdKind[0], persisted));
+    }
+
+    /**
+     * Immutable inputs for writing a form event handler inside the write transaction, grouping the
+     * arguments so {@link #writeHandler(EObject, HandlerWriteSpec)} stays within the parameter limit.
+     */
+    private static final class HandlerWriteSpec
+    {
+        final FormElementWriter.FormMemberRef ref;
+        final String eventName;
+        final String procName;
+        final Version version;
+        final String langCode;
+        final String callType;
+        final boolean commandOwner;
+        final String[] createdKind;
+
+        HandlerWriteSpec(FormElementWriter.FormMemberRef ref, String eventName, String procName,
+            Version version, String langCode, String callType, boolean commandOwner,
+            String[] createdKind)
+        {
+            this.ref = ref;
+            this.eventName = eventName;
+            this.procName = procName;
+            this.version = version;
+            this.langCode = langCode;
+            this.callType = callType;
+            this.commandOwner = commandOwner;
+            this.createdKind = createdKind;
+        }
+    }
+
+    /**
+     * Builds the "form not found" advisory for a handler create. For an EXTENSION event handler the
+     * most likely cause is that the base form was never adopted, so the message points at
+     * adopt_metadata_object. Side-effect-free.
+     */
+    private static String handlerFormNotFound(String normFqn, boolean extensionHandler)
+    {
+        String formNotFound = "Form not found for '" + normFqn + "'. Address a form as " //$NON-NLS-1$ //$NON-NLS-2$
+            + "'Type.Object.Form.FormName' or 'CommonForm.FormName'."; //$NON-NLS-1$
+        if (extensionHandler)
+        {
+            formNotFound += " If this is a base form, adopt it into the extension first via " //$NON-NLS-1$
+                + "adopt_metadata_object."; //$NON-NLS-1$
+        }
+        return formNotFound;
+    }
+
+    /**
+     * Resolves the handler's container (form root, the named item, or the form command) on the
+     * re-fetched content form and writes the handler. Form-level handlers attach to the form root;
+     * item-level handlers ({@code ...Form.F.Field.Item.Handler.Event}) to the named item; a COMMAND
+     * ref ({@code ...Form.F.Command.C.Handler.Action}) to the form command. Performs the BM mutation
+     * inside the write transaction.
+     *
+     * @throws IllegalStateException if the container is missing or the writer rejects the event
+     */
+    private static void writeHandler(EObject formModel, HandlerWriteSpec spec)
+    {
+        EObject container = FormElementWriter.resolveHandlerContainer(formModel, spec.ref);
+        if (container == null)
+        {
+            throw new IllegalStateException(spec.commandOwner
+                ? "Form command not found: " + spec.ref.itemName //$NON-NLS-1$
+                    + ". Create the command first, then add the handler." //$NON-NLS-1$
+                : "Form item not found: " + spec.ref.itemName //$NON-NLS-1$
+                    + ". Create the item first, then add the handler."); //$NON-NLS-1$
+        }
+        String err = FormElementWriter.createHandler(container, spec.eventName, spec.procName,
+            spec.version, spec.langCode, spec.callType, spec.createdKind);
+        if (err != null)
+        {
+            throw new IllegalStateException(err);
+        }
     }
 
     /**
@@ -1019,38 +1270,68 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
     }
 
     /**
+     * Immutable description of a created form event handler, grouping the result inputs so
+     * {@link #buildHandlerResult(HandlerResultInfo)} takes one holder instead of a long argument
+     * list.
+     */
+    private static final class HandlerResultInfo
+    {
+        final FormElementWriter.FormMemberRef ref;
+        final String normFqn;
+        final String eventName;
+        final String fProc;
+        final String callType;
+        final boolean extensionHandler;
+        /** The kind reported by the writer ({@code null} =&gt; {@code "EventHandler"}). */
+        final String createdKind;
+        final boolean persisted;
+
+        HandlerResultInfo(FormElementWriter.FormMemberRef ref, String normFqn, String eventName,
+            String fProc, String callType, boolean extensionHandler, String createdKind,
+            boolean persisted)
+        {
+            this.ref = ref;
+            this.normFqn = normFqn;
+            this.eventName = eventName;
+            this.fProc = fProc;
+            this.callType = callType;
+            this.extensionHandler = extensionHandler;
+            this.createdKind = createdKind;
+            this.persisted = persisted;
+        }
+    }
+
+    /**
      * Builds the success JSON for a created form event handler (location string, message and result
      * fields). Side-effect-free: pure formatting of the already-applied change.
-     *
-     * @param createdKind the kind reported by the writer ({@code null} =&gt; {@code "EventHandler"})
      */
-    private String buildHandlerResult(FormElementWriter.FormMemberRef ref, String normFqn,
-        String eventName, String fProc, String callType, boolean extensionHandler,
-        String createdKind, boolean persisted)
+    private String buildHandlerResult(HandlerResultInfo info)
     {
-        String location = ref.isItemLevel() ? ref.formPath + "." + ref.itemName : ref.formPath; //$NON-NLS-1$
-        String effectiveProc = (fProc == null || fProc.isEmpty()) ? eventName : fProc;
+        String location = info.ref.isItemLevel()
+            ? info.ref.formPath + "." + info.ref.itemName : info.ref.formPath; //$NON-NLS-1$
+        String effectiveProc =
+            (info.fProc == null || info.fProc.isEmpty()) ? info.eventName : info.fProc;
         String message;
-        if (extensionHandler)
+        if (info.extensionHandler)
         {
-            message = "Created extension (" + callType + ") handler for event '" + eventName //$NON-NLS-1$ //$NON-NLS-2$
+            message = "Created extension (" + info.callType + ") handler for event '" + info.eventName //$NON-NLS-1$ //$NON-NLS-2$
                 + "' on " + location + ". Add the BSL procedure '" + effectiveProc //$NON-NLS-1$ //$NON-NLS-2$
                 + "' to the extension form module via write_module_source."; //$NON-NLS-1$
         }
         else
         {
-            message = "Created handler for event '" + eventName + "' on " + location; //$NON-NLS-1$ //$NON-NLS-2$
+            message = "Created handler for event '" + info.eventName + "' on " + location; //$NON-NLS-1$ //$NON-NLS-2$
         }
         ToolResult result = ToolResult.success()
             .put(McpKeys.ACTION, VAL_CREATED)
-            .put("fqn", normFqn) //$NON-NLS-1$
-            .put("kind", createdKind != null ? createdKind : "EventHandler") //$NON-NLS-1$ //$NON-NLS-2$
-            .put("name", eventName) //$NON-NLS-1$
-            .put(KEY_PERSISTED, persisted)
+            .put("fqn", info.normFqn) //$NON-NLS-1$
+            .put("kind", info.createdKind != null ? info.createdKind : "EventHandler") //$NON-NLS-1$ //$NON-NLS-2$
+            .put("name", info.eventName) //$NON-NLS-1$
+            .put(KEY_PERSISTED, info.persisted)
             .put(McpKeys.MESSAGE, message);
-        if (extensionHandler)
+        if (info.extensionHandler)
         {
-            result.put(KEY_CALL_TYPE, callType);
+            result.put(KEY_CALL_TYPE, info.callType);
         }
         return result.toJson();
     }
@@ -1074,6 +1355,58 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
     }
 
     // ---- helpers --------------------------------------------------------------------------------
+
+    /**
+     * The EDT services a BM-backed create needs (the model-object factory, the BM model, the platform
+     * version), or a ready-to-return JSON error when any is unavailable. Resolved once by
+     * {@link #resolveBmContext} so the creation methods stay free of the repeated service-lookup
+     * guards.
+     */
+    private static final class BmContext
+    {
+        IModelObjectFactory factory;
+        IBmModel bmModel;
+        Version version;
+        /** Non-null when resolution failed: a JSON error to return verbatim. */
+        String error;
+
+        boolean hasError()
+        {
+            return error != null;
+        }
+    }
+
+    /**
+     * Resolves the model-object factory, BM model and platform version for {@code project} (named
+     * {@code projectName} for error messages), or returns a holder carrying a JSON error when any
+     * service is unavailable. Side-effect-free.
+     */
+    private static BmContext resolveBmContext(IProject project, String projectName)
+    {
+        BmContext ctx = new BmContext();
+        IV8ProjectManager v8ProjectManager = Activator.getDefault().getV8ProjectManager();
+        ctx.factory = Activator.getDefault().getModelObjectFactory();
+        IBmModelManager bmModelManager = Activator.getDefault().getBmModelManager();
+        if (v8ProjectManager == null || ctx.factory == null || bmModelManager == null)
+        {
+            ctx.error = ToolResult.error(ERR_SERVICES_UNAVAILABLE).toJson();
+            return ctx;
+        }
+        IV8Project v8Project = v8ProjectManager.getProject(project);
+        if (v8Project == null)
+        {
+            ctx.error = ToolResult.error(ERR_NO_V8_PROJECT + projectName).toJson();
+            return ctx;
+        }
+        ctx.version = v8Project.getVersion();
+        ctx.bmModel = bmModelManager.getModel(project);
+        if (ctx.bmModel == null)
+        {
+            ctx.error = ToolResult.error(ERR_NO_BM_MODEL + projectName).toJson();
+            return ctx;
+        }
+        return ctx;
+    }
 
     /** The supported, parsed properties. */
     private static final class Props
@@ -1179,33 +1512,62 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         return parts.length >= 2 ? parts[0] + "." + parts[1] : normFqn; //$NON-NLS-1$
     }
 
-    private String success(String fqn, EClass kind, String name, boolean persisted, Props props,
-        String synonymLanguage, TypeSpecific typeSpecific, MdNameNormalizer.Report normReport)
+    /**
+     * Immutable description of a successfully created mdclass node, grouping the success-result
+     * inputs so {@link #success(SuccessInfo)} takes one holder instead of a long argument list.
+     */
+    private static final class SuccessInfo
+    {
+        final String fqn;
+        final EClass kind;
+        final String name;
+        final boolean persisted;
+        final Props props;
+        final String synonymLanguage;
+        /** Type-specific options to echo back; {@code null} for a member create. */
+        final TypeSpecific typeSpecific;
+        final MdNameNormalizer.Report normReport;
+
+        SuccessInfo(String fqn, EClass kind, String name, boolean persisted, Props props,
+            String synonymLanguage, TypeSpecific typeSpecific, MdNameNormalizer.Report normReport)
+        {
+            this.fqn = fqn;
+            this.kind = kind;
+            this.name = name;
+            this.persisted = persisted;
+            this.props = props;
+            this.synonymLanguage = synonymLanguage;
+            this.typeSpecific = typeSpecific;
+            this.normReport = normReport;
+        }
+    }
+
+    private String success(SuccessInfo info)
     {
         ToolResult result = ToolResult.success()
             .put(McpKeys.ACTION, VAL_CREATED)
-            .put("fqn", fqn) //$NON-NLS-1$
-            .put("kind", kind != null ? kind.getName() : null) //$NON-NLS-1$
-            .put("name", name) //$NON-NLS-1$
-            .put(KEY_PERSISTED, persisted);
-        if (props.synonym != null && !props.synonym.isEmpty() && synonymLanguage != null)
+            .put("fqn", info.fqn) //$NON-NLS-1$
+            .put("kind", info.kind != null ? info.kind.getName() : null) //$NON-NLS-1$
+            .put("name", info.name) //$NON-NLS-1$
+            .put(KEY_PERSISTED, info.persisted);
+        if (info.props.synonym != null && !info.props.synonym.isEmpty() && info.synonymLanguage != null)
         {
-            result.put(KEY_SYNONYM, props.synonym).put(KEY_LANGUAGE, synonymLanguage);
+            result.put(KEY_SYNONYM, info.props.synonym).put(KEY_LANGUAGE, info.synonymLanguage);
         }
-        if (typeSpecific != null)
+        if (info.typeSpecific != null)
         {
-            if (typeSpecific.commonModuleFlags != null)
+            if (info.typeSpecific.commonModuleFlags != null)
             {
-                result.put(KEY_COMMON_MODULE_KIND, typeSpecific.commonModuleFlags.kind.token());
+                result.put(KEY_COMMON_MODULE_KIND, info.typeSpecific.commonModuleFlags.kind.token());
             }
-            if (typeSpecific.xdtoNamespace != null)
+            if (info.typeSpecific.xdtoNamespace != null)
             {
-                result.put(KEY_TARGET_NAMESPACE, typeSpecific.xdtoNamespace);
+                result.put(KEY_TARGET_NAMESPACE, info.typeSpecific.xdtoNamespace);
             }
         }
-        normReport.addTo(result);
+        info.normReport.addTo(result);
         return result
-            .put(McpKeys.MESSAGE, "Created " + fqn) //$NON-NLS-1$
+            .put(McpKeys.MESSAGE, "Created " + info.fqn) //$NON-NLS-1$
             .toJson();
     }
 
@@ -1403,20 +1765,49 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         final boolean privileged;
         final ReturnValuesReuse returnValuesReuse;
 
-        private CommonModuleFlags(CommonModuleKind kind, boolean clientManagedApplication,
-            boolean clientOrdinaryApplication, boolean server, boolean serverCall,
-            boolean externalConnection, boolean global, boolean privileged,
-            ReturnValuesReuse returnValuesReuse)
+        /**
+         * Immutable bundle of the eight CommonModule flag features, in the canonical order
+         * clientManaged, clientOrdinary, server, serverCall, externalConnection, global, privileged,
+         * reuse. Groups them into a single value so the {@link CommonModuleFlags} constructor takes
+         * one holder instead of a long boolean argument list.
+         */
+        static final class FlagSet
+        {
+            final boolean clientManagedApplication;
+            final boolean clientOrdinaryApplication;
+            final boolean server;
+            final boolean serverCall;
+            final boolean externalConnection;
+            final boolean global;
+            final boolean privileged;
+            final ReturnValuesReuse returnValuesReuse;
+
+            FlagSet(boolean clientManagedApplication, boolean clientOrdinaryApplication,
+                boolean server, boolean serverCall, boolean externalConnection, boolean global,
+                boolean privileged, ReturnValuesReuse returnValuesReuse)
+            {
+                this.clientManagedApplication = clientManagedApplication;
+                this.clientOrdinaryApplication = clientOrdinaryApplication;
+                this.server = server;
+                this.serverCall = serverCall;
+                this.externalConnection = externalConnection;
+                this.global = global;
+                this.privileged = privileged;
+                this.returnValuesReuse = returnValuesReuse;
+            }
+        }
+
+        private CommonModuleFlags(CommonModuleKind kind, FlagSet flags)
         {
             this.kind = kind;
-            this.clientManagedApplication = clientManagedApplication;
-            this.clientOrdinaryApplication = clientOrdinaryApplication;
-            this.server = server;
-            this.serverCall = serverCall;
-            this.externalConnection = externalConnection;
-            this.global = global;
-            this.privileged = privileged;
-            this.returnValuesReuse = returnValuesReuse;
+            this.clientManagedApplication = flags.clientManagedApplication;
+            this.clientOrdinaryApplication = flags.clientOrdinaryApplication;
+            this.server = flags.server;
+            this.serverCall = flags.serverCall;
+            this.externalConnection = flags.externalConnection;
+            this.global = flags.global;
+            this.privileged = flags.privileged;
+            this.returnValuesReuse = flags.returnValuesReuse;
         }
 
         void applyTo(CommonModule module)
@@ -1491,10 +1882,21 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         private static void validateModifiers(CommonModuleKind kind, boolean serverCall,
             boolean privileged, ReturnValuesReuse reuse)
         {
+            validateServerCall(kind, serverCall);
+            validatePrivileged(kind, serverCall, privileged, reuse);
+            validateReuse(kind, reuse);
+        }
+
+        /**
+         * Rejects {@code serverCall} on a non-server kind. Side-effect-free.
+         *
+         * @throws IllegalArgumentException if serverCall is set on a kind that is not server-side
+         */
+        private static void validateServerCall(CommonModuleKind kind, boolean serverCall)
+        {
             boolean serverSideKind = kind == CommonModuleKind.SERVER
                 || kind == CommonModuleKind.SERVER_CALL
                 || kind == CommonModuleKind.CLIENT_SERVER;
-
             if (serverCall && !serverSideKind)
             {
                 // Covers every non-server kind, including 'Global' (a global module is a
@@ -1507,6 +1909,18 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
                         ? " A 'Global' module is a client module and cannot be a server-call target." //$NON-NLS-1$
                         : "")); //$NON-NLS-1$
             }
+        }
+
+        /**
+         * Rejects {@code privileged} unless it is the lone modifier on the {@code Server} kind.
+         * Side-effect-free.
+         *
+         * @throws IllegalArgumentException if privileged is combined with a non-Server kind,
+         *             serverCall or returnValuesReuse
+         */
+        private static void validatePrivileged(CommonModuleKind kind, boolean serverCall,
+            boolean privileged, ReturnValuesReuse reuse)
+        {
             if (privileged && kind != CommonModuleKind.SERVER)
             {
                 throw new IllegalArgumentException("privileged requires the 'Server' kind " //$NON-NLS-1$
@@ -1521,28 +1935,37 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
             {
                 throw new IllegalArgumentException("privileged is not valid together with returnValuesReuse."); //$NON-NLS-1$
             }
+        }
 
-            // returnValuesReuse only produces a validator-accepted module when it is either DontUse,
-            // or DuringSession on a kind that has a cached variant (Server, ServerCall, ClientManaged,
-            // ClientOrdinary). DuringRequest and reuse on Global/ClientServer have no canonical combo.
-            if (reuse != ReturnValuesReuse.DONT_USE)
+        /**
+         * Rejects a {@code returnValuesReuse} that has no validator-accepted module: only DontUse,
+         * or DuringSession on a kind with a cached variant (Server, ServerCall, ClientManaged,
+         * ClientOrdinary), is allowed. DuringRequest and reuse on Global/ClientServer have no
+         * canonical combo. Side-effect-free.
+         *
+         * @throws IllegalArgumentException if the reuse/kind combination has no canonical combo
+         */
+        private static void validateReuse(CommonModuleKind kind, ReturnValuesReuse reuse)
+        {
+            if (reuse == ReturnValuesReuse.DONT_USE)
             {
-                if (reuse == ReturnValuesReuse.DURING_REQUEST)
-                {
-                    throw new IllegalArgumentException("returnValuesReuse 'DuringRequest' has no " //$NON-NLS-1$
-                        + "standards-compliant common-module combination; use 'DuringSession' for a " //$NON-NLS-1$
-                        + "cached module, or 'DontUse'."); //$NON-NLS-1$
-                }
-                boolean reuseKind = kind == CommonModuleKind.SERVER
-                    || kind == CommonModuleKind.SERVER_CALL
-                    || kind == CommonModuleKind.CLIENT_MANAGED
-                    || kind == CommonModuleKind.CLIENT_ORDINARY;
-                if (!reuseKind)
-                {
-                    throw new IllegalArgumentException("returnValuesReuse 'DuringSession' is only valid " //$NON-NLS-1$
-                        + "for the 'Server', 'ServerCall', 'ClientManaged' or 'ClientOrdinary' kinds; " //$NON-NLS-1$
-                        + "it is not valid for kind '" + kind.token() + "'."); //$NON-NLS-1$ //$NON-NLS-2$
-                }
+                return;
+            }
+            if (reuse == ReturnValuesReuse.DURING_REQUEST)
+            {
+                throw new IllegalArgumentException("returnValuesReuse 'DuringRequest' has no " //$NON-NLS-1$
+                    + "standards-compliant common-module combination; use 'DuringSession' for a " //$NON-NLS-1$
+                    + "cached module, or 'DontUse'."); //$NON-NLS-1$
+            }
+            boolean reuseKind = kind == CommonModuleKind.SERVER
+                || kind == CommonModuleKind.SERVER_CALL
+                || kind == CommonModuleKind.CLIENT_MANAGED
+                || kind == CommonModuleKind.CLIENT_ORDINARY;
+            if (!reuseKind)
+            {
+                throw new IllegalArgumentException("returnValuesReuse 'DuringSession' is only valid " //$NON-NLS-1$
+                    + "for the 'Server', 'ServerCall', 'ClientManaged' or 'ClientOrdinary' kinds; " //$NON-NLS-1$
+                    + "it is not valid for kind '" + kind.token() + "'."); //$NON-NLS-1$ //$NON-NLS-2$
             }
         }
 
@@ -1556,6 +1979,8 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         private static CommonModuleFlags toCanonicalFlags(CommonModuleKind kind, boolean serverCall,
             boolean privileged, boolean cached)
         {
+            ReturnValuesReuse reuse =
+                cached ? ReturnValuesReuse.DURING_SESSION : ReturnValuesReuse.DONT_USE;
             switch (kind)
             {
             case SERVER:
@@ -1563,34 +1988,34 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
                 if (privileged)
                 {
                     // SERVER_FULL_ACCESS: server-only, privileged.
-                    return new CommonModuleFlags(kind, false, false, true, false, false, false, true,
-                        ReturnValuesReuse.DONT_USE);
+                    return new CommonModuleFlags(kind, new FlagSet(false, false, true, false, false,
+                        false, true, ReturnValuesReuse.DONT_USE));
                 }
                 if (serverCall)
                 {
                     // SERVER_CALL / SERVER_CALL_CACHED: server + server call, no client flags.
-                    return new CommonModuleFlags(kind, false, false, true, true, false, false, false,
-                        cached ? ReturnValuesReuse.DURING_SESSION : ReturnValuesReuse.DONT_USE);
+                    return new CommonModuleFlags(kind, new FlagSet(false, false, true, true, false,
+                        false, false, reuse));
                 }
                 // SERVER / SERVER_CACHED: client ordinary + external connection + server.
-                return new CommonModuleFlags(kind, false, true, true, false, true, false, false,
-                    cached ? ReturnValuesReuse.DURING_SESSION : ReturnValuesReuse.DONT_USE);
+                return new CommonModuleFlags(kind, new FlagSet(false, true, true, false, true, false,
+                    false, reuse));
 
             case CLIENT_MANAGED:
             case CLIENT_ORDINARY:
                 // CLIENT / CLIENT_CACHED: both client flags set (the canonical client module).
-                return new CommonModuleFlags(kind, true, true, false, false, false, false, false,
-                    cached ? ReturnValuesReuse.DURING_SESSION : ReturnValuesReuse.DONT_USE);
+                return new CommonModuleFlags(kind, new FlagSet(true, true, false, false, false, false,
+                    false, reuse));
 
             case CLIENT_SERVER:
                 // CLIENT_SERVER: both client flags + server + external connection.
-                return new CommonModuleFlags(kind, true, true, true, false, true, false, false,
-                    ReturnValuesReuse.DONT_USE);
+                return new CommonModuleFlags(kind, new FlagSet(true, true, true, false, true, false,
+                    false, ReturnValuesReuse.DONT_USE));
 
             case GLOBAL:
                 // CLIENT_GLOBAL: both client flags + global.
-                return new CommonModuleFlags(kind, true, true, false, false, false, true, false,
-                    ReturnValuesReuse.DONT_USE);
+                return new CommonModuleFlags(kind, new FlagSet(true, true, false, false, false, true,
+                    false, ReturnValuesReuse.DONT_USE));
 
             default:
                 throw new IllegalArgumentException("Unsupported commonModuleKind: " + kind.token()); //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateProjectTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateProjectTool.java
@@ -327,8 +327,9 @@ public class CreateProjectTool implements IMcpTool
         }
 
         // 3. Validate kind-specific parameter constraints
-        String constraintErr = validateKindConstraints(projectKind, isExtension, isExternalObjects,
-            versionStr, baseProjectName, prefix, purposeStr, compatModeStr, synonym, comment, scriptVariantStr);
+        String constraintErr = validateKindConstraints(new KindConstraintInputs(projectKind, isExtension,
+            isExternalObjects, versionStr, baseProjectName, prefix, purposeStr, compatModeStr, synonym, comment,
+            scriptVariantStr));
         if (constraintErr != null)
         {
             return constraintErr;
@@ -363,20 +364,19 @@ public class CreateProjectTool implements IMcpTool
         }
 
         // Dispatch to kind-specific handler
+        CreateRequest request = new CreateRequest(configName, projectName, versionStr, baseProjectName, prefix,
+            synonym, comment, purposeStr, compatModeStr, scriptVariantStr, standardChecks, commonChecks);
         if (isExtension)
         {
-            return executeExtension(configName, projectName, baseProjectName, prefix, synonym, comment,
-                purposeStr, compatModeStr, standardChecks, commonChecks);
+            return executeExtension(request);
         }
         else if (isConfiguration)
         {
-            return executeConfiguration(configName, projectName, versionStr, synonym, comment,
-                scriptVariantStr, standardChecks, commonChecks);
+            return executeConfiguration(request);
         }
         else
         {
-            return executeExternalObjects(configName, projectName, versionStr, scriptVariantStr,
-                standardChecks, commonChecks);
+            return executeExternalObjects(request);
         }
     }
 
@@ -424,63 +424,118 @@ public class CreateProjectTool implements IMcpTool
 
     /**
      * Validates the kind-specific parameter constraints (which parameters are allowed for
-     * which {@code projectKind}) plus the strict scriptVariant value check.
+     * which {@code projectKind}) plus the strict scriptVariant value check. Thin orchestrator:
+     * delegates to the per-group validators and returns the first non-null error.
      *
      * @return a ready-to-return JSON error string when a constraint is violated, or
      *     {@code null} when all constraints pass
      */
-    private static String validateKindConstraints(String projectKind, boolean isExtension,
-        boolean isExternalObjects, String versionStr, String baseProjectName, String prefix,
-        String purposeStr, String compatModeStr, String synonym, String comment, String scriptVariantStr)
+    private static String validateKindConstraints(KindConstraintInputs in)
     {
-        if (isExtension && versionStr != null && !versionStr.isEmpty())
+        String err = validateExtensionInheritedParams(in);
+        if (err != null)
+        {
+            return err;
+        }
+        err = validateNonExtensionParams(in);
+        if (err != null)
+        {
+            return err;
+        }
+        err = validateExternalObjectsParams(in);
+        if (err != null)
+        {
+            return err;
+        }
+        return validateScriptVariantValue(in);
+    }
+
+    /**
+     * Rejects parameters that an extension always inherits from its base configuration
+     * ({@code version}, {@code scriptVariant}) when {@code projectKind=extension}.
+     *
+     * @return a ready-to-return JSON error string, or {@code null} when valid
+     */
+    private static String validateExtensionInheritedParams(KindConstraintInputs in)
+    {
+        if (in.isExtension && in.versionStr != null && !in.versionStr.isEmpty())
         {
             return ToolResult.error(
                 "'version' is not valid for projectKind=extension: " //$NON-NLS-1$
                     + "the extension always inherits the version from the base configuration. " //$NON-NLS-1$
                     + "Remove the 'version' parameter.").toJson(); //$NON-NLS-1$
         }
-        if (!isExtension && baseProjectName != null && !baseProjectName.isEmpty())
-        {
-            return ToolResult.error(
-                "'baseProjectName' is only valid for projectKind=extension. " //$NON-NLS-1$
-                    + "Remove the 'baseProjectName' parameter for kind=" + projectKind + ".").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
-        }
-        if (!isExtension && prefix != null && !prefix.isEmpty())
-        {
-            return ToolResult.error("'prefix' is only valid for projectKind=extension.").toJson(); //$NON-NLS-1$
-        }
-        if (!isExtension && purposeStr != null && !purposeStr.isEmpty())
-        {
-            return ToolResult.error("'purpose' is only valid for projectKind=extension.").toJson(); //$NON-NLS-1$
-        }
-        if (!isExtension && compatModeStr != null && !compatModeStr.isEmpty())
-        {
-            return ToolResult.error("'compatibilityMode' is only valid for projectKind=extension.").toJson(); //$NON-NLS-1$
-        }
-        if (isExternalObjects && synonym != null && !synonym.isEmpty())
-        {
-            return ToolResult.error("'synonym' is not valid for projectKind=externalObjects.").toJson(); //$NON-NLS-1$
-        }
-        if (isExternalObjects && comment != null && !comment.isEmpty())
-        {
-            return ToolResult.error("'comment' is not valid for projectKind=externalObjects.").toJson(); //$NON-NLS-1$
-        }
-        if (isExtension && scriptVariantStr != null && !scriptVariantStr.isEmpty())
+        if (in.isExtension && in.scriptVariantStr != null && !in.scriptVariantStr.isEmpty())
         {
             return ToolResult.error(
                 "'scriptVariant' is not valid for projectKind=extension: " //$NON-NLS-1$
                     + "the extension always inherits the scriptVariant from the base configuration. " //$NON-NLS-1$
                     + "Remove the 'scriptVariant' parameter.").toJson(); //$NON-NLS-1$
         }
+        return null;
+    }
 
-        // Strict scriptVariant validation: must be exactly "Russian" or "English" (case-insensitive)
-        // when supplied for configuration or externalObjects.
-        if (!isExtension && scriptVariantStr != null && !scriptVariantStr.isEmpty()
-            && !SCRIPT_RUSSIAN.equalsIgnoreCase(scriptVariantStr)
-            && !SCRIPT_ENGLISH.equalsIgnoreCase(scriptVariantStr))
+    /**
+     * Rejects extension-only parameters ({@code baseProjectName}, {@code prefix}, {@code purpose},
+     * {@code compatibilityMode}) when {@code projectKind} is not {@code extension}.
+     *
+     * @return a ready-to-return JSON error string, or {@code null} when valid
+     */
+    private static String validateNonExtensionParams(KindConstraintInputs in)
+    {
+        if (!in.isExtension && in.baseProjectName != null && !in.baseProjectName.isEmpty())
         {
-            return ToolResult.error("Invalid scriptVariant value: '" + scriptVariantStr //$NON-NLS-1$
+            return ToolResult.error(
+                "'baseProjectName' is only valid for projectKind=extension. " //$NON-NLS-1$
+                    + "Remove the 'baseProjectName' parameter for kind=" + in.projectKind + ".").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        if (!in.isExtension && in.prefix != null && !in.prefix.isEmpty())
+        {
+            return ToolResult.error("'prefix' is only valid for projectKind=extension.").toJson(); //$NON-NLS-1$
+        }
+        if (!in.isExtension && in.purposeStr != null && !in.purposeStr.isEmpty())
+        {
+            return ToolResult.error("'purpose' is only valid for projectKind=extension.").toJson(); //$NON-NLS-1$
+        }
+        if (!in.isExtension && in.compatModeStr != null && !in.compatModeStr.isEmpty())
+        {
+            return ToolResult.error("'compatibilityMode' is only valid for projectKind=extension.").toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Rejects externalObjects-incompatible parameters ({@code synonym}, {@code comment}) when
+     * {@code projectKind=externalObjects}.
+     *
+     * @return a ready-to-return JSON error string, or {@code null} when valid
+     */
+    private static String validateExternalObjectsParams(KindConstraintInputs in)
+    {
+        if (in.isExternalObjects && in.synonym != null && !in.synonym.isEmpty())
+        {
+            return ToolResult.error("'synonym' is not valid for projectKind=externalObjects.").toJson(); //$NON-NLS-1$
+        }
+        if (in.isExternalObjects && in.comment != null && !in.comment.isEmpty())
+        {
+            return ToolResult.error("'comment' is not valid for projectKind=externalObjects.").toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Strict scriptVariant value validation: must be exactly {@code "Russian"} or {@code "English"}
+     * (case-insensitive) when supplied for configuration or externalObjects.
+     *
+     * @return a ready-to-return JSON error string, or {@code null} when valid
+     */
+    private static String validateScriptVariantValue(KindConstraintInputs in)
+    {
+        if (!in.isExtension && in.scriptVariantStr != null && !in.scriptVariantStr.isEmpty()
+            && !SCRIPT_RUSSIAN.equalsIgnoreCase(in.scriptVariantStr)
+            && !SCRIPT_ENGLISH.equalsIgnoreCase(in.scriptVariantStr))
+        {
+            return ToolResult.error("Invalid scriptVariant value: '" + in.scriptVariantStr //$NON-NLS-1$
                 + "'. Allowed values: 'Russian', 'English'.").toJson(); //$NON-NLS-1$
         }
         return null;
@@ -488,17 +543,19 @@ public class CreateProjectTool implements IMcpTool
 
     // ─────────────────────── EXTENSION path ──────────────────────────────────
 
-    private String executeExtension(String configName, String projectName, String baseProjectName,
-        String prefix, String synonym, String comment, String purposeStr, String compatModeStr,
-        boolean standardChecks, boolean commonChecks)
+    private String executeExtension(CreateRequest req)
     {
+        String configName = req.configName;
+        String prefix = req.prefix;
+
         // Validate the base project and new project name (read-only)
-        BaseProjectResolution baseResolution = validateExtensionBaseProject(configName, projectName, baseProjectName);
+        BaseProjectResolution baseResolution =
+            validateExtensionBaseProject(configName, req.projectName, req.baseProjectName);
         if (baseResolution.error != null)
         {
             return baseResolution.error;
         }
-        baseProjectName = baseResolution.baseProjectName;
+        String baseProjectName = baseResolution.baseProjectName;
         String effectiveProjectName = baseResolution.effectiveProjectName;
         IProject baseIProject = baseResolution.baseIProject;
 
@@ -515,7 +572,7 @@ public class CreateProjectTool implements IMcpTool
         ScriptVariant scriptVariant = services.scriptVariant;
 
         // Validate purpose
-        PurposeResolution purposeResolution = resolveExtensionPurpose(purposeStr);
+        PurposeResolution purposeResolution = resolveExtensionPurpose(req.purposeStr);
         if (purposeResolution.error != null)
         {
             return purposeResolution.error;
@@ -523,7 +580,7 @@ public class CreateProjectTool implements IMcpTool
         ConfigurationExtensionPurpose purpose = purposeResolution.purpose;
 
         // Validate CompatibilityMode if supplied
-        CompatModeResolution compatModeResolution = resolveCompatibilityMode(compatModeStr);
+        CompatModeResolution compatModeResolution = resolveCompatibilityMode(req.compatModeStr);
         if (compatModeResolution.error != null)
         {
             return compatModeResolution.error;
@@ -544,13 +601,10 @@ public class CreateProjectTool implements IMcpTool
         {
             config.setConfigurationExtensionCompatibilityMode(compatMode);
         }
-        if (comment != null && !comment.isEmpty())
-        {
-            config.setComment(comment);
-        }
+        applyComment(config, req.comment);
 
         // Set synonym via language-code-keyed EMap
-        boolean synonymApplied = applyExtensionSynonym(config, baseConfig, configName, synonym);
+        boolean synonymApplied = applyExtensionSynonym(config, baseConfig, configName, req.synonym);
 
         // Create the extension project in a background Job
         final IProject[] createdHolder = new IProject[1];
@@ -578,15 +632,14 @@ public class CreateProjectTool implements IMcpTool
             }
         };
 
-        final ScriptVariant finalScriptVariant = scriptVariant;
-        final ConfigurationExtensionPurpose finalPurpose = purpose;
+        ExtensionResponseData responseData = new ExtensionResponseData(finalEffectiveProjectName, configName,
+            baseProjectName, prefix, purpose, scriptVariant, version, synonymApplied);
 
         CreateJobResult jobResult = runCreateJob(createJob, finalEffectiveProjectName, KIND_EXTENSION);
         if (jobResult.status == CreateStatus.SLOW_EXISTS)
         {
             // Creation completed past the wait window — build the full extension response
-            return buildExtensionSlowResponse(finalEffectiveProjectName, configName, baseProjectName, prefix,
-                finalPurpose, finalScriptVariant, version, synonymApplied);
+            return buildExtensionSlowResponse(responseData);
         }
         if (jobResult.errorJson != null)
         {
@@ -608,19 +661,20 @@ public class CreateProjectTool implements IMcpTool
         String projectState = waitForLifecycle(finalEffectiveProjectName, createdHolder[0], KIND_EXTENSION);
 
         // Apply v8codestyle preferences
-        Map<String, Object> codestyleMap = applyCodestylePrefs(finalEffectiveProjectName, standardChecks, commonChecks);
+        Map<String, Object> codestyleMap =
+            applyCodestylePrefs(finalEffectiveProjectName, req.standardChecks, req.commonChecks);
 
-        return buildExtensionSuccessResponse(finalEffectiveProjectName, configName, baseProjectName, prefix,
-            finalPurpose, finalScriptVariant, version, projectState, codestyleMap, synonymApplied);
+        return buildExtensionSuccessResponse(responseData, projectState, codestyleMap);
     }
 
     // ─────────────────────── CONFIGURATION path ──────────────────────────────
 
-    private String executeConfiguration(String configName, String projectName, String versionStr,
-        String synonym, String comment, String scriptVariantStr, boolean standardChecks, boolean commonChecks)
+    private String executeConfiguration(CreateRequest req)
     {
+        String configName = req.configName;
+
         // Derive default EDT project name: <configName>
-        String effectiveProjectName = (projectName != null) ? projectName : configName;
+        String effectiveProjectName = (req.projectName != null) ? req.projectName : configName;
 
         // Check the new project name does not already exist
         if (ProjectContext.of(effectiveProjectName).exists())
@@ -629,40 +683,26 @@ public class CreateProjectTool implements IMcpTool
                 + ERR_PROJECT_EXISTS_SUFFIX).toJson();
         }
 
-        // Parse version
-        Version version;
-        try
+        // Parse version (read-only)
+        VersionResolution versionResolution = parseVersion(req.versionStr);
+        if (versionResolution.error != null)
         {
-            version = (versionStr != null) ? new Version(versionStr) : Version.LATEST;
+            return versionResolution.error;
         }
-        catch (Exception e)
-        {
-            return ToolResult.error("Invalid version string '" + versionStr //$NON-NLS-1$
-                + "'. Use a dot-separated version like '8.3.27'. " //$NON-NLS-1$
-                + "Original error: " + e.getMessage()).toJson(); //$NON-NLS-1$
-        }
+        Version version = versionResolution.version;
 
-        // Resolve MD factory
-        IModelObjectFactory factory = Activator.getDefault().getModelObjectFactory();
-        if (factory == null)
+        // Resolve MD factory and IConfigurationProjectManager (read-only)
+        ConfigurationServices services = resolveConfigurationServices();
+        if (services.error != null)
         {
-            return ToolResult.error("IModelObjectFactory (MD) not available. MdPlugin may not be ready.").toJson(); //$NON-NLS-1$
+            return services.error;
         }
+        IModelObjectFactory factory = services.factory;
+        IConfigurationProjectManager configMgr = services.configMgr;
 
-        // Resolve IConfigurationProjectManager
-        IConfigurationProjectManager configMgr = Activator.getDefault().getConfigurationProjectManager();
-        if (configMgr == null)
-        {
-            return ToolResult.error(
-                "IConfigurationProjectManager service not available. The EDT platform may not be ready.").toJson(); //$NON-NLS-1$
-        }
-
-        // Resolve scriptVariant
-        boolean isRussian = scriptVariantStr == null || scriptVariantStr.isEmpty()
-            || SCRIPT_RUSSIAN.equalsIgnoreCase(scriptVariantStr);
-        ScriptVariant scriptVariant = isRussian ? ScriptVariant.RUSSIAN : ScriptVariant.ENGLISH;
-        String langCode = isRussian ? "ru" : "en"; //$NON-NLS-1$ //$NON-NLS-2$
-        String langName = isRussian ? SCRIPT_RUSSIAN : SCRIPT_ENGLISH;
+        // Resolve scriptVariant and language tokens (read-only)
+        ConfigurationScript script = resolveConfigurationScript(req.scriptVariantStr);
+        ScriptVariant scriptVariant = script.scriptVariant;
 
         // Build Configuration model object (NOT inside a BM transaction)
         Configuration config = (Configuration) factory.create(MdClassPackage.Literals.CONFIGURATION, version);
@@ -674,24 +714,13 @@ public class CreateProjectTool implements IMcpTool
 
         // Ensure the configuration has a default Language (per ConfigurationWizard recipe)
         // If fillDefaultReferences already produced a language, reuse it; otherwise create one.
-        String effectiveLangCode = langCode;
-        setupConfigurationLanguage(config, langCode, langName);
+        setupConfigurationLanguage(config, script.langCode, script.langName);
 
         // Optional attributes
-        if (comment != null && !comment.isEmpty())
-        {
-            config.setComment(comment);
-        }
+        applyComment(config, req.comment);
 
         // Set synonym via language-code-keyed EMap
-        String synonymValue = (synonym != null && !synonym.isEmpty()) ? synonym : configName;
-        boolean synonymApplied = false;
-        EMap<String, String> synonymMap = config.getSynonym();
-        if (synonymMap != null)
-        {
-            synonymMap.put(effectiveLangCode, synonymValue);
-            synonymApplied = true;
-        }
+        boolean synonymApplied = applyConfigurationSynonym(config, script.langCode, req.synonym, configName);
 
         // Create the configuration project in a background Job
         final IProject[] createdHolder = new IProject[1];
@@ -718,14 +747,12 @@ public class CreateProjectTool implements IMcpTool
             }
         };
 
-        final ScriptVariant finalScriptVariant = scriptVariant;
-
         CreateJobResult jobResult = runCreateJob(createJob, finalEffectiveProjectName, KIND_CONFIGURATION);
         if (jobResult.status == CreateStatus.SLOW_EXISTS)
         {
             // Creation completed past the wait window — build the full configuration response
             return buildConfigurationSlowResponse(finalEffectiveProjectName, configName,
-                finalScriptVariant, finalVersion, synonymApplied);
+                scriptVariant, finalVersion, synonymApplied);
         }
         if (jobResult.errorJson != null)
         {
@@ -745,18 +772,68 @@ public class CreateProjectTool implements IMcpTool
         String projectState = waitForLifecycle(finalEffectiveProjectName, createdHolder[0], KIND_CONFIGURATION);
 
         // Apply v8codestyle preferences
-        Map<String, Object> codestyleMap = applyCodestylePrefs(finalEffectiveProjectName, standardChecks, commonChecks);
+        Map<String, Object> codestyleMap =
+            applyCodestylePrefs(finalEffectiveProjectName, req.standardChecks, req.commonChecks);
 
+        return buildConfigurationSuccessResponse(finalEffectiveProjectName, configName, scriptVariant,
+            finalVersion, projectState, codestyleMap, synonymApplied);
+    }
+
+    /**
+     * Maps the {@code scriptVariant} parameter string to a {@link ScriptVariant} plus its
+     * language code/name tokens (read-only). Defaults to Russian when blank.
+     */
+    private static ConfigurationScript resolveConfigurationScript(String scriptVariantStr)
+    {
+        boolean isRussian = scriptVariantStr == null || scriptVariantStr.isEmpty()
+            || SCRIPT_RUSSIAN.equalsIgnoreCase(scriptVariantStr);
+        ScriptVariant scriptVariant = isRussian ? ScriptVariant.RUSSIAN : ScriptVariant.ENGLISH;
+        String langCode = isRussian ? "ru" : "en"; //$NON-NLS-1$ //$NON-NLS-2$
+        String langName = isRussian ? SCRIPT_RUSSIAN : SCRIPT_ENGLISH;
+        return new ConfigurationScript(scriptVariant, langCode, langName);
+    }
+
+    /**
+     * Applies the synonym to the in-memory standalone {@link Configuration} via its
+     * language-code-keyed {@code synonym} EMap (in-memory model mutation only). The synonym
+     * value defaults to {@code configName} when {@code synonym} is blank.
+     *
+     * @return {@code true} when the synonym was applied; {@code false} when no synonym map
+     *     was available on the new Configuration
+     */
+    private static boolean applyConfigurationSynonym(Configuration config, String langCode, String synonym,
+        String configName)
+    {
+        String synonymValue = (synonym != null && !synonym.isEmpty()) ? synonym : configName;
+        EMap<String, String> synonymMap = config.getSynonym();
+        if (synonymMap != null)
+        {
+            synonymMap.put(langCode, synonymValue);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Builds the normal success JSON response for a created standalone configuration project
+     * (read-only), adding {@code synonymNote} when the synonym could not be applied.
+     *
+     * @return the response JSON string
+     */
+    private static String buildConfigurationSuccessResponse(String effectiveProjectName, String configName,
+        ScriptVariant scriptVariant, Version version, String projectState, Map<String, Object> codestyleMap,
+        boolean synonymApplied)
+    {
         ToolResult result = ToolResult.success()
             .put(McpKeys.ACTION, VAL_CREATED)
-            .put(McpKeys.PROJECT, finalEffectiveProjectName)
+            .put(McpKeys.PROJECT, effectiveProjectName)
             .put(KEY_PROJECT_KIND, KIND_CONFIGURATION)
             .put("name", configName) //$NON-NLS-1$
-            .put(KEY_SCRIPT_VARIANT, finalScriptVariant.getLiteral())
-            .put(KEY_VERSION, finalVersion.toString())
+            .put(KEY_SCRIPT_VARIANT, scriptVariant.getLiteral())
+            .put(KEY_VERSION, version.toString())
             .put(KEY_STATE, projectState)
             .put(KEY_CODESTYLE, codestyleMap)
-            .put(McpKeys.MESSAGE, "Configuration project '" + finalEffectiveProjectName + "' created."); //$NON-NLS-1$ //$NON-NLS-2$
+            .put(McpKeys.MESSAGE, "Configuration project '" + effectiveProjectName + "' created."); //$NON-NLS-1$ //$NON-NLS-2$
         if (!synonymApplied)
         {
             result.put(KEY_SYNONYM_NOTE,
@@ -844,11 +921,13 @@ public class CreateProjectTool implements IMcpTool
 
     // ─────────────────────── EXTERNAL OBJECTS path ───────────────────────────
 
-    private String executeExternalObjects(String configName, String projectName, String versionStr,
-        String scriptVariantStr, boolean standardChecks, boolean commonChecks)
+    private String executeExternalObjects(CreateRequest req)
     {
+        String configName = req.configName;
+        String scriptVariantStr = req.scriptVariantStr;
+
         // Derive default EDT project name: <configName>
-        String effectiveProjectName = (projectName != null) ? projectName : configName;
+        String effectiveProjectName = (req.projectName != null) ? req.projectName : configName;
 
         // Check the new project name does not already exist
         if (ProjectContext.of(effectiveProjectName).exists())
@@ -857,18 +936,13 @@ public class CreateProjectTool implements IMcpTool
                 + ERR_PROJECT_EXISTS_SUFFIX).toJson();
         }
 
-        // Parse version
-        Version version;
-        try
+        // Parse version (read-only)
+        VersionResolution versionResolution = parseVersion(req.versionStr);
+        if (versionResolution.error != null)
         {
-            version = (versionStr != null) ? new Version(versionStr) : Version.LATEST;
+            return versionResolution.error;
         }
-        catch (Exception e)
-        {
-            return ToolResult.error("Invalid version string '" + versionStr //$NON-NLS-1$
-                + "'. Use a dot-separated version like '8.3.27'. " //$NON-NLS-1$
-                + "Original error: " + e.getMessage()).toJson(); //$NON-NLS-1$
-        }
+        Version version = versionResolution.version;
 
         // Resolve IExternalObjectProjectManager
         IExternalObjectProjectManager extObjMgr = Activator.getDefault().getExternalObjectProjectManager();
@@ -927,34 +1001,49 @@ public class CreateProjectTool implements IMcpTool
         // Wait for lifecycle STARTED
         String projectState = waitForLifecycle(finalEffectiveProjectName, createdHolder[0], KIND_EXTERNAL_OBJECTS);
 
+        // Apply v8codestyle preferences
+        Map<String, Object> codestyleMap =
+            applyCodestylePrefs(finalEffectiveProjectName, req.standardChecks, req.commonChecks);
+
+        return buildExternalObjectsSuccessResponse(new ExternalObjectsSuccessInputs(extObjMgr,
+            finalEffectiveProjectName, configName, finalVersion, createdHolder[0], projectState,
+            scriptVariantStr, codestyleMap));
+    }
+
+    /**
+     * Builds the normal success JSON response for a created externalObjects project. Applies the
+     * requested scriptVariant post-create (non-fatal on failure, mirroring the original inline
+     * block exactly) and emits the canonical literal/note when supplied.
+     *
+     * @return the response JSON string
+     */
+    private static String buildExternalObjectsSuccessResponse(ExternalObjectsSuccessInputs in)
+    {
         // Post-create: apply scriptVariant if supplied (non-fatal on failure)
         // Input is guaranteed "Russian" or "English" (case-insensitive) by the shared validation above.
         String scriptVariantNote = null;
         ScriptVariant requestedSv = null;
-        if (scriptVariantStr != null && !scriptVariantStr.isEmpty())
+        if (in.scriptVariantStr != null && !in.scriptVariantStr.isEmpty())
         {
-            requestedSv = SCRIPT_RUSSIAN.equalsIgnoreCase(scriptVariantStr)
+            requestedSv = SCRIPT_RUSSIAN.equalsIgnoreCase(in.scriptVariantStr)
                 ? ScriptVariant.RUSSIAN : ScriptVariant.ENGLISH;
-            scriptVariantNote = applyExternalObjectsScriptVariant(extObjMgr, finalEffectiveProjectName,
-                createdHolder[0], requestedSv, projectState);
+            scriptVariantNote = applyExternalObjectsScriptVariant(in.extObjMgr, in.effectiveProjectName,
+                in.createdProject, requestedSv, in.projectState);
         }
 
-        // Apply v8codestyle preferences
-        Map<String, Object> codestyleMap = applyCodestylePrefs(finalEffectiveProjectName, standardChecks, commonChecks);
-
-        String message = "External objects project '" + finalEffectiveProjectName + "' created."; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        String message = "External objects project '" + in.effectiveProjectName + "' created."; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         if (scriptVariantNote != null)
         {
             message = message + " " + scriptVariantNote; //$NON-NLS-1$
         }
         ToolResult result = ToolResult.success()
             .put(McpKeys.ACTION, VAL_CREATED)
-            .put(McpKeys.PROJECT, finalEffectiveProjectName)
+            .put(McpKeys.PROJECT, in.effectiveProjectName)
             .put(KEY_PROJECT_KIND, KIND_EXTERNAL_OBJECTS)
-            .put("name", configName) //$NON-NLS-1$
-            .put(KEY_VERSION, finalVersion.toString())
-            .put(KEY_STATE, projectState)
-            .put(KEY_CODESTYLE, codestyleMap)
+            .put("name", in.configName) //$NON-NLS-1$
+            .put(KEY_VERSION, in.version.toString())
+            .put(KEY_STATE, in.projectState)
+            .put(KEY_CODESTYLE, in.codestyleMap)
             .put(McpKeys.MESSAGE, message);
         if (requestedSv != null)
         {
@@ -1047,6 +1136,65 @@ public class CreateProjectTool implements IMcpTool
     }
 
     // ─────────────────────── Shared helpers ──────────────────────────────────
+
+    /**
+     * Parses the optional platform-version string (read-only). A {@code null} {@code versionStr}
+     * yields {@link Version#LATEST}; a malformed value yields a ready-to-return JSON error.
+     *
+     * @return a {@link VersionResolution} carrying the parsed {@link Version}, or a ready-to-return
+     *     JSON error for a malformed value
+     */
+    private static VersionResolution parseVersion(String versionStr)
+    {
+        try
+        {
+            Version version = (versionStr != null) ? new Version(versionStr) : Version.LATEST;
+            return new VersionResolution(null, version);
+        }
+        catch (Exception e)
+        {
+            return new VersionResolution(ToolResult.error("Invalid version string '" + versionStr //$NON-NLS-1$
+                + "'. Use a dot-separated version like '8.3.27'. " //$NON-NLS-1$
+                + "Original error: " + e.getMessage()).toJson(), null); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Resolves the {@link IModelObjectFactory} and {@link IConfigurationProjectManager} services
+     * required by the standalone-configuration path (read-only lookups).
+     *
+     * @return {@link ConfigurationServices#ok} with the resolved services, or
+     *     {@link ConfigurationServices#failure} carrying a ready-to-return JSON error
+     */
+    private static ConfigurationServices resolveConfigurationServices()
+    {
+        IModelObjectFactory factory = Activator.getDefault().getModelObjectFactory();
+        if (factory == null)
+        {
+            return ConfigurationServices.failure(
+                ToolResult.error("IModelObjectFactory (MD) not available. MdPlugin may not be ready.").toJson()); //$NON-NLS-1$
+        }
+
+        IConfigurationProjectManager configMgr = Activator.getDefault().getConfigurationProjectManager();
+        if (configMgr == null)
+        {
+            return ConfigurationServices.failure(ToolResult.error(
+                "IConfigurationProjectManager service not available. The EDT platform may not be ready.").toJson()); //$NON-NLS-1$
+        }
+        return ConfigurationServices.ok(factory, configMgr);
+    }
+
+    /**
+     * Sets the optional free-text comment on the in-memory {@link Configuration} when non-blank
+     * (in-memory model mutation only). No-op when {@code comment} is {@code null} or empty.
+     */
+    private static void applyComment(Configuration config, String comment)
+    {
+        if (comment != null && !comment.isEmpty())
+        {
+            config.setComment(comment);
+        }
+    }
 
     /** Status codes returned by {@link #runCreateJob}. */
     private enum CreateStatus
@@ -1183,6 +1331,205 @@ public class CreateProjectTool implements IMcpTool
         {
             this.error = error;
             this.compatMode = compatMode;
+        }
+    }
+
+    /**
+     * Immutable bundle of the raw parameter values needed by {@link #validateKindConstraints}
+     * and its per-group sub-validators (avoids an over-long parameter list).
+     */
+    private static final class KindConstraintInputs
+    {
+        final String projectKind;
+        final boolean isExtension;
+        final boolean isExternalObjects;
+        final String versionStr;
+        final String baseProjectName;
+        final String prefix;
+        final String purposeStr;
+        final String compatModeStr;
+        final String synonym;
+        final String comment;
+        final String scriptVariantStr;
+
+        private KindConstraintInputs(String projectKind, boolean isExtension, boolean isExternalObjects,
+            String versionStr, String baseProjectName, String prefix, String purposeStr, String compatModeStr,
+            String synonym, String comment, String scriptVariantStr)
+        {
+            this.projectKind = projectKind;
+            this.isExtension = isExtension;
+            this.isExternalObjects = isExternalObjects;
+            this.versionStr = versionStr;
+            this.baseProjectName = baseProjectName;
+            this.prefix = prefix;
+            this.purposeStr = purposeStr;
+            this.compatModeStr = compatModeStr;
+            this.synonym = synonym;
+            this.comment = comment;
+            this.scriptVariantStr = scriptVariantStr;
+        }
+    }
+
+    /**
+     * Immutable bundle of the normalized request parameters passed to the kind-specific
+     * {@code executeXxx} handlers (avoids an over-long parameter list). Field values are the
+     * post-normalization values computed in {@link #execute}.
+     */
+    private static final class CreateRequest
+    {
+        final String configName;
+        final String projectName;
+        final String versionStr;
+        final String baseProjectName;
+        final String prefix;
+        final String synonym;
+        final String comment;
+        final String purposeStr;
+        final String compatModeStr;
+        final String scriptVariantStr;
+        final boolean standardChecks;
+        final boolean commonChecks;
+
+        private CreateRequest(String configName, String projectName, String versionStr, String baseProjectName,
+            String prefix, String synonym, String comment, String purposeStr, String compatModeStr,
+            String scriptVariantStr, boolean standardChecks, boolean commonChecks)
+        {
+            this.configName = configName;
+            this.projectName = projectName;
+            this.versionStr = versionStr;
+            this.baseProjectName = baseProjectName;
+            this.prefix = prefix;
+            this.synonym = synonym;
+            this.comment = comment;
+            this.purposeStr = purposeStr;
+            this.compatModeStr = compatModeStr;
+            this.scriptVariantStr = scriptVariantStr;
+            this.standardChecks = standardChecks;
+            this.commonChecks = commonChecks;
+        }
+    }
+
+    /**
+     * Immutable bundle of the common fields shared by the extension success and slow-path
+     * response builders (avoids an over-long parameter list).
+     */
+    private static final class ExtensionResponseData
+    {
+        final String effectiveProjectName;
+        final String configName;
+        final String baseProjectName;
+        final String prefix;
+        final ConfigurationExtensionPurpose purpose;
+        final ScriptVariant scriptVariant;
+        final Version version;
+        final boolean synonymApplied;
+
+        private ExtensionResponseData(String effectiveProjectName, String configName, String baseProjectName,
+            String prefix, ConfigurationExtensionPurpose purpose, ScriptVariant scriptVariant, Version version,
+            boolean synonymApplied)
+        {
+            this.effectiveProjectName = effectiveProjectName;
+            this.configName = configName;
+            this.baseProjectName = baseProjectName;
+            this.prefix = prefix;
+            this.purpose = purpose;
+            this.scriptVariant = scriptVariant;
+            this.version = version;
+            this.synonymApplied = synonymApplied;
+        }
+    }
+
+    /**
+     * Outcome of {@link #parseVersion}: either a ready-to-return JSON {@code error}, or the
+     * parsed {@link Version}. Exactly one field is non-null.
+     */
+    private static final class VersionResolution
+    {
+        final String error;
+        final Version version;
+
+        private VersionResolution(String error, Version version)
+        {
+            this.error = error;
+            this.version = version;
+        }
+    }
+
+    /**
+     * Outcome of {@link #resolveConfigurationServices}: either a ready-to-return JSON {@code error},
+     * or the resolved {@link IModelObjectFactory} and {@link IConfigurationProjectManager}. The
+     * value fields are non-null exactly when {@code error} is null.
+     */
+    private static final class ConfigurationServices
+    {
+        final String error;
+        final IModelObjectFactory factory;
+        final IConfigurationProjectManager configMgr;
+
+        private ConfigurationServices(String error, IModelObjectFactory factory,
+            IConfigurationProjectManager configMgr)
+        {
+            this.error = error;
+            this.factory = factory;
+            this.configMgr = configMgr;
+        }
+
+        static ConfigurationServices failure(String error)
+        {
+            return new ConfigurationServices(error, null, null);
+        }
+
+        static ConfigurationServices ok(IModelObjectFactory factory, IConfigurationProjectManager configMgr)
+        {
+            return new ConfigurationServices(null, factory, configMgr);
+        }
+    }
+
+    /**
+     * Immutable result of {@link #resolveConfigurationScript}: the {@link ScriptVariant} plus the
+     * language code and name tokens for the default Language.
+     */
+    private static final class ConfigurationScript
+    {
+        final ScriptVariant scriptVariant;
+        final String langCode;
+        final String langName;
+
+        private ConfigurationScript(ScriptVariant scriptVariant, String langCode, String langName)
+        {
+            this.scriptVariant = scriptVariant;
+            this.langCode = langCode;
+            this.langName = langName;
+        }
+    }
+
+    /**
+     * Immutable bundle of the inputs needed by {@link #buildExternalObjectsSuccessResponse}
+     * (avoids an over-long parameter list).
+     */
+    private static final class ExternalObjectsSuccessInputs
+    {
+        final IExternalObjectProjectManager extObjMgr;
+        final String effectiveProjectName;
+        final String configName;
+        final Version version;
+        final IProject createdProject;
+        final String projectState;
+        final String scriptVariantStr;
+        final Map<String, Object> codestyleMap;
+
+        private ExternalObjectsSuccessInputs(IExternalObjectProjectManager extObjMgr, String effectiveProjectName,
+            String configName, Version version, IProject createdProject, String projectState,
+            String scriptVariantStr, Map<String, Object> codestyleMap)
+        {
+            this.extObjMgr = extObjMgr;
+            this.effectiveProjectName = effectiveProjectName;
+            this.configName = configName;
+            this.version = version;
+            this.createdProject = createdProject;
+            this.projectState = projectState;
+            this.scriptVariantStr = scriptVariantStr;
+            this.codestyleMap = codestyleMap;
         }
     }
 
@@ -1464,28 +1811,26 @@ public class CreateProjectTool implements IMcpTool
      * Mirrors the normal success response, adding {@code synonymNote} when the synonym could not
      * be applied.
      */
-    private static String buildExtensionSlowResponse(String effectiveProjectName, String configName,
-        String baseProjectName, String prefix, ConfigurationExtensionPurpose purpose, ScriptVariant scriptVariant,
-        Version version, boolean synonymApplied)
+    private static String buildExtensionSlowResponse(ExtensionResponseData data)
     {
         ToolResult slowResult = ToolResult.success()
             .put(McpKeys.ACTION, VAL_CREATED)
-            .put(McpKeys.PROJECT, effectiveProjectName)
+            .put(McpKeys.PROJECT, data.effectiveProjectName)
             .put(KEY_PROJECT_KIND, KIND_EXTENSION)
-            .put("name", configName) //$NON-NLS-1$
-            .put(KEY_BASE_PROJECT, baseProjectName)
-            .put(KEY_PREFIX, prefix)
-            .put(KEY_PURPOSE, purpose.getLiteral())
-            .put(KEY_SCRIPT_VARIANT, scriptVariant.getLiteral())
-            .put(KEY_VERSION, version.toString())
+            .put("name", data.configName) //$NON-NLS-1$
+            .put(KEY_BASE_PROJECT, data.baseProjectName)
+            .put(KEY_PREFIX, data.prefix)
+            .put(KEY_PURPOSE, data.purpose.getLiteral())
+            .put(KEY_SCRIPT_VARIANT, data.scriptVariant.getLiteral())
+            .put(KEY_VERSION, data.version.toString())
             .put(KEY_STATE, VAL_CREATED)
             .put(KEY_CODESTYLE, slowPathCodestyleMap())
-            .put(McpKeys.MESSAGE, "Extension project '" + effectiveProjectName //$NON-NLS-1$
-                + "' created and bound to '" + baseProjectName //$NON-NLS-1$
+            .put(McpKeys.MESSAGE, "Extension project '" + data.effectiveProjectName //$NON-NLS-1$
+                + "' created and bound to '" + data.baseProjectName //$NON-NLS-1$
                 + "' (creation completed past the " //$NON-NLS-1$
                 + (CREATE_TIMEOUT_MS / 1000) + MSG_WAIT_WINDOW_SUFFIX);
         // Mirror the normal success path: report when the synonym could not be applied.
-        if (!synonymApplied)
+        if (!data.synonymApplied)
         {
             slowResult.put(KEY_SYNONYM_NOTE,
                 "Synonym was not applied: could not determine a language code from " //$NON-NLS-1$
@@ -1498,25 +1843,24 @@ public class CreateProjectTool implements IMcpTool
      * Builds the normal success JSON response for a created extension project (read-only),
      * adding {@code synonymNote} when the synonym could not be applied.
      */
-    private static String buildExtensionSuccessResponse(String effectiveProjectName, String configName,
-        String baseProjectName, String prefix, ConfigurationExtensionPurpose purpose, ScriptVariant scriptVariant,
-        Version version, String projectState, Map<String, Object> codestyleMap, boolean synonymApplied)
+    private static String buildExtensionSuccessResponse(ExtensionResponseData data, String projectState,
+        Map<String, Object> codestyleMap)
     {
         ToolResult result = ToolResult.success()
             .put(McpKeys.ACTION, VAL_CREATED)
-            .put(McpKeys.PROJECT, effectiveProjectName)
+            .put(McpKeys.PROJECT, data.effectiveProjectName)
             .put(KEY_PROJECT_KIND, KIND_EXTENSION)
-            .put("name", configName) //$NON-NLS-1$
-            .put(KEY_BASE_PROJECT, baseProjectName)
-            .put(KEY_PREFIX, prefix)
-            .put(KEY_PURPOSE, purpose.getLiteral())
-            .put(KEY_SCRIPT_VARIANT, scriptVariant.getLiteral())
-            .put(KEY_VERSION, version.toString())
+            .put("name", data.configName) //$NON-NLS-1$
+            .put(KEY_BASE_PROJECT, data.baseProjectName)
+            .put(KEY_PREFIX, data.prefix)
+            .put(KEY_PURPOSE, data.purpose.getLiteral())
+            .put(KEY_SCRIPT_VARIANT, data.scriptVariant.getLiteral())
+            .put(KEY_VERSION, data.version.toString())
             .put(KEY_STATE, projectState)
             .put(KEY_CODESTYLE, codestyleMap)
-            .put(McpKeys.MESSAGE, "Extension project '" + effectiveProjectName //$NON-NLS-1$
-                + "' created and bound to '" + baseProjectName + "'."); //$NON-NLS-1$ //$NON-NLS-2$
-        if (!synonymApplied)
+            .put(McpKeys.MESSAGE, "Extension project '" + data.effectiveProjectName //$NON-NLS-1$
+                + "' created and bound to '" + data.baseProjectName + "'."); //$NON-NLS-1$ //$NON-NLS-2$
+        if (!data.synonymApplied)
         {
             result.put(KEY_SYNONYM_NOTE,
                 "Synonym was not applied: could not determine a language code from " //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugStatusTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugStatusTool.java
@@ -214,45 +214,83 @@ public class DebugStatusTool implements IMcpTool
      */
     private static void appendSuspendState(Map<String, Object> entry, IDebugTarget[] targets)
     {
-        int threadCount = 0;
-        boolean anySuspended = false;
-        String suspendedAt = null;
+        SuspendState state = new SuspendState();
         for (IDebugTarget t : targets)
         {
             if (t == null || t.isTerminated())
             {
                 continue;
             }
-            try
-            {
-                for (IThread th : t.getThreads())
-                {
-                    threadCount++;
-                    if (th.isSuspended())
-                    {
-                        anySuspended = true;
-                        if (suspendedAt == null)
-                        {
-                            IStackFrame top = th.getTopStackFrame();
-                            if (top != null)
-                            {
-                                suspendedAt = top.getName() + " @ " + top.getLineNumber(); //$NON-NLS-1$
-                            }
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                // best-effort
-            }
+            scanTargetThreads(t, state);
         }
-        entry.put("threadCount", threadCount); //$NON-NLS-1$
-        entry.put("suspended", anySuspended); //$NON-NLS-1$
-        if (suspendedAt != null)
+        entry.put("threadCount", state.threadCount); //$NON-NLS-1$
+        entry.put("suspended", state.anySuspended); //$NON-NLS-1$
+        if (state.suspendedAt != null)
         {
-            entry.put("suspendedAt", suspendedAt); //$NON-NLS-1$
+            entry.put("suspendedAt", state.suspendedAt); //$NON-NLS-1$
         }
+    }
+
+    /**
+     * Walks one debug target's threads (best-effort, swallowing per-target exceptions
+     * exactly as the original inline loop) and folds the result into {@code state}:
+     * increments the thread count, flags any suspended thread, and records the
+     * {@code name @ line} of the first suspended thread's top frame. Read-only with
+     * respect to the target; only the accumulator is mutated.
+     *
+     * @param target the (non-null, non-terminated) debug target to scan
+     * @param state the accumulator to fold thread results into
+     */
+    private static void scanTargetThreads(IDebugTarget target, SuspendState state)
+    {
+        try
+        {
+            for (IThread th : target.getThreads())
+            {
+                foldThread(th, state);
+            }
+        }
+        catch (Exception ex)
+        {
+            // best-effort
+        }
+    }
+
+    /**
+     * Folds a single thread into the accumulator, mirroring the innermost block of the
+     * original suspend scan: counts the thread, flags suspension, and — only while no
+     * suspend location has been recorded yet — captures the {@code name @ line} of its
+     * top stack frame.
+     *
+     * @param th the thread to inspect (may throw on access; caller swallows)
+     * @param state the accumulator to update
+     * @throws org.eclipse.debug.core.DebugException if the thread or frame cannot be read
+     */
+    private static void foldThread(IThread th, SuspendState state) throws org.eclipse.debug.core.DebugException
+    {
+        state.threadCount++;
+        if (!th.isSuspended())
+        {
+            return;
+        }
+        state.anySuspended = true;
+        if (state.suspendedAt != null)
+        {
+            return;
+        }
+        IStackFrame top = th.getTopStackFrame();
+        if (top != null)
+        {
+            state.suspendedAt = top.getName() + " @ " + top.getLineNumber(); //$NON-NLS-1$
+        }
+    }
+
+    /** Mutable accumulator for the aggregated suspend state across a launch's targets. */
+    private static final class SuspendState
+    {
+        int threadCount;
+        boolean anySuspended;
+        String suspendedAt;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteInfobaseTool.java
@@ -229,14 +229,47 @@ public class DeleteInfobaseTool implements IMcpTool
                 deleteRegistration, deleteDatabaseFiles, confirm);
         }
 
+        // Resolve the file-infobase target (cast-check, on-disk directory, shared-files guard) -
+        // read-only. On a non-file/non-server application it carries the SAME refusal JSON.
+        FileDeletionPlan ibPlan = resolveFileDeletionPlan(targetApp, project, appManager,
+            projectName, deleteRegistration, deleteDatabaseFiles);
+        if (ibPlan.error != null)
+        {
+            return ibPlan.error;
+        }
+
+        // --- Confirm-preview gate ---
+        if (!confirm)
+        {
+            return buildPreviewResult(
+                new IbIdentity(projectName, ibPlan.resolvedId, ibPlan.resolvedName),
+                deleteRegistration, deleteDatabaseFiles, ibPlan.dbDir, ibPlan.dbSharedWithOthers);
+        }
+
+        return performFileInfobaseDeletion(projectName, project, assocManager, ibManager,
+            deleteDatabaseFiles, ibPlan);
+    }
+
+    /**
+     * Resolves the file-infobase deletion target (read-only): verifies the application is a file
+     * infobase (not some other unmanaged type), reads its {@link InfobaseReference}, the on-disk
+     * database directory and the shared-files guard. Returns a {@link FileDeletionPlan} whose
+     * {@code error} carries the SAME refusal JSON the inline cast-check produced when the application
+     * is neither a file infobase nor a standalone server; otherwise {@code error} is {@code null} and
+     * the plan fields are populated. Extracted verbatim from {@link #deleteInfobase}.
+     */
+    private static FileDeletionPlan resolveFileDeletionPlan(IApplication targetApp, IProject project,
+            IApplicationManager appManager, String projectName, boolean deleteRegistration,
+            boolean deleteDatabaseFiles)
+    {
         // Verify it is a file infobase application (not some other type we do not manage here).
         if (!(targetApp instanceof IInfobaseApplication))
         {
-            return ToolResult.error("Application '" + targetApp.getName() //$NON-NLS-1$
+            return FileDeletionPlan.error(ToolResult.error("Application '" + targetApp.getName() //$NON-NLS-1$
                 + "' (id=" + targetApp.getId() //$NON-NLS-1$
                 + ") is neither a file infobase (" + INFOBASE_APP_TYPE //$NON-NLS-1$
                 + ") nor a standalone server (" + StandaloneServerSupport.WST_SERVER_APP_TYPE //$NON-NLS-1$
-                + ") application; this tool cannot remove it.").toJson(); //$NON-NLS-1$
+                + ") application; this tool cannot remove it.").toJson()); //$NON-NLS-1$
         }
         IInfobaseApplication ibApp = (IInfobaseApplication) targetApp;
         InfobaseReference ibRef = ibApp.getInfobase();
@@ -249,16 +282,27 @@ public class DeleteInfobaseTool implements IMcpTool
         // uses this infobase — if so we keep the files.
         final boolean dbSharedWithOthers = deleteDatabaseFiles && dbDir != null
             && isSharedWithOtherProjects(appManager, project, dbDir);
+        return FileDeletionPlan.of(ibRef, resolvedName, resolvedId, dbDir, dbSharedWithOthers,
+            deleteRegistration);
+    }
 
-        // --- Confirm-preview gate ---
-        if (!confirm)
-        {
-            return buildPreviewResult(projectName, resolvedId, resolvedName, deleteRegistration,
-                deleteDatabaseFiles, dbDir, dbSharedWithOthers);
-        }
+    /**
+     * Performs the file-infobase deletion (confirm already granted): dissociate, optional
+     * deregister, optional on-disk file deletion — every destructive call stays INLINE at the same
+     * point under the same guards. Extracted verbatim from {@link #deleteInfobase}; the early-returns
+     * (dissociate failure, deregister partial-failure) return the SAME JSON in the SAME case.
+     */
+    private String performFileInfobaseDeletion(String projectName, IProject project,
+            IInfobaseAssociationManager assocManager, IInfobaseManager ibManager,
+            boolean deleteDatabaseFiles, FileDeletionPlan plan)
+    {
+        final InfobaseReference ibRef = plan.ibRef;
+        final IbIdentity id = new IbIdentity(projectName, plan.resolvedId, plan.resolvedName);
+        final Path dbDir = plan.dbDir;
+        final boolean dbSharedWithOthers = plan.dbSharedWithOthers;
 
         // --- Perform deletion ---
-        Activator.logInfo("delete_infobase: dissociating '" + resolvedName //$NON-NLS-1$
+        Activator.logInfo("delete_infobase: dissociating '" + id.resolvedName //$NON-NLS-1$
             + "' from project " + projectName); //$NON-NLS-1$
 
         // Step 1: dissociate from the project (removes the infobase Application).
@@ -270,11 +314,46 @@ public class DeleteInfobaseTool implements IMcpTool
         catch (Exception e)
         {
             Activator.logError("delete_infobase: dissociate failed", e); //$NON-NLS-1$
-            return ToolResult.error("Failed to dissociate infobase '" + resolvedName //$NON-NLS-1$
+            return ToolResult.error("Failed to dissociate infobase '" + id.resolvedName //$NON-NLS-1$
                 + "' from project '" + projectName + "': " + e.getMessage()).toJson(); //$NON-NLS-1$ //$NON-NLS-2$
         }
 
-        // Step 2: optionally deregister from the global EDT infobases list.
+        // Step 2: optionally deregister from the global EDT infobases list. A non-null result is the
+        // partial-failure JSON returned as-is (the database files are then KEPT); null = continue.
+        String deregisterFailed = deregisterFileInfobase(ibManager, ibRef, id, deleteDatabaseFiles,
+            plan.deleteRegistration);
+        if (deregisterFailed != null)
+        {
+            return deregisterFailed;
+        }
+
+        // Step 3: optionally delete the infobase database files from disk (IRREVERSIBLE).
+        // Skip when the same on-disk database is still referenced by other workspace projects —
+        // deleting it would break those projects (a file infobase can be shared).
+        boolean dbFilesDeleted = false;
+        if (deleteDatabaseFiles && dbDir != null && !dbSharedWithOthers)
+        {
+            dbFilesDeleted = deleteDatabaseDirBestEffort(dbDir);
+        }
+
+        Activator.logInfo("delete_infobase: done, resolvedId=" + id.resolvedId //$NON-NLS-1$
+            + " (dbFilesDeleted=" + dbFilesDeleted + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        return buildDeleteSuccessResult(id, plan.deleteRegistration,
+            new DbFileOutcome(deleteDatabaseFiles, dbDir, dbFilesDeleted, dbSharedWithOthers));
+    }
+
+    /**
+     * Step 2 of the file-infobase deletion: optionally deregister the infobase from the global EDT
+     * infobases list. The {@code ibManager.delete} destructive call stays INLINE here under the same
+     * {@code deleteRegistration && ibRef != null} guard. A missing {@code IInfobaseManager} is logged
+     * and treated as non-fatal (the dissociation already succeeded). Returns the partial-failure JSON
+     * (which the caller returns as-is — the database files are then KEPT) when the delete throws, or
+     * {@code null} to continue. Extracted verbatim from {@link #deleteInfobase}.
+     */
+    private String deregisterFileInfobase(IInfobaseManager ibManager, InfobaseReference ibRef,
+            IbIdentity id, boolean deleteDatabaseFiles, boolean deleteRegistration)
+    {
         if (deleteRegistration && ibRef != null)
         {
             if (ibManager == null)
@@ -296,26 +375,11 @@ public class DeleteInfobaseTool implements IMcpTool
                     // Non-fatal: return success but note the partial deletion. We deliberately do NOT
                     // delete the database files here even if requested — deregistration failed, so the
                     // safe choice is to leave the data and say so explicitly (schema-consistent).
-                    return buildDeregisterFailedResult(projectName, resolvedId, resolvedName,
-                        deleteDatabaseFiles, e);
+                    return buildDeregisterFailedResult(id, deleteDatabaseFiles, e);
                 }
             }
         }
-
-        // Step 3: optionally delete the infobase database files from disk (IRREVERSIBLE).
-        // Skip when the same on-disk database is still referenced by other workspace projects —
-        // deleting it would break those projects (a file infobase can be shared).
-        boolean dbFilesDeleted = false;
-        if (deleteDatabaseFiles && dbDir != null && !dbSharedWithOthers)
-        {
-            dbFilesDeleted = deleteDatabaseDirBestEffort(dbDir);
-        }
-
-        Activator.logInfo("delete_infobase: done, resolvedId=" + resolvedId //$NON-NLS-1$
-            + " (dbFilesDeleted=" + dbFilesDeleted + ")"); //$NON-NLS-1$ //$NON-NLS-2$
-
-        return buildDeleteSuccessResult(projectName, resolvedId, resolvedName, deleteRegistration,
-            deleteDatabaseFiles, dbDir, dbFilesDeleted, dbSharedWithOthers);
+        return null;
     }
 
     /**
@@ -419,21 +483,63 @@ public class DeleteInfobaseTool implements IMcpTool
     }
 
     /**
+     * Identity quartet shared by the result-builders: the project name plus the resolved application
+     * id / name (and, for the success builders, the deleteRegistration flag is passed alongside). A
+     * parameter-object that keeps the builders below the 7-parameter bar; carries no behaviour.
+     */
+    private static final class IbIdentity
+    {
+        final String projectName;
+        final String resolvedId;
+        final String resolvedName;
+
+        IbIdentity(String projectName, String resolvedId, String resolvedName)
+        {
+            this.projectName = projectName;
+            this.resolvedId = resolvedId;
+            this.resolvedName = resolvedName;
+        }
+    }
+
+    /**
+     * The on-disk database-files outcome cluster shared by the success result-builders and
+     * {@link #databaseResultNote}: whether deletion was requested, the resolved directory (may be
+     * {@code null}), whether it was actually deleted and whether it was kept because shared. A
+     * parameter-object that keeps the builders below the 7-parameter bar; carries no behaviour.
+     */
+    private static final class DbFileOutcome
+    {
+        final boolean deleteDatabaseFiles;
+        final Path dbDir;
+        final boolean dbFilesDeleted;
+        final boolean dbSharedWithOthers;
+
+        DbFileOutcome(boolean deleteDatabaseFiles, Path dbDir, boolean dbFilesDeleted,
+                boolean dbSharedWithOthers)
+        {
+            this.deleteDatabaseFiles = deleteDatabaseFiles;
+            this.dbDir = dbDir;
+            this.dbFilesDeleted = dbFilesDeleted;
+            this.dbSharedWithOthers = dbSharedWithOthers;
+        }
+    }
+
+    /**
      * Builds the confirm-preview tool-result JSON for a file infobase (no change is made). Byte-for-byte
      * identical to the inline preview the {@code !confirm} gate produced.
      */
-    private static String buildPreviewResult(String projectName, String resolvedId, String resolvedName,
-            boolean deleteRegistration, boolean deleteDatabaseFiles, Path dbDir, boolean dbSharedWithOthers)
+    private static String buildPreviewResult(IbIdentity id, boolean deleteRegistration,
+            boolean deleteDatabaseFiles, Path dbDir, boolean dbSharedWithOthers)
     {
         return ToolResult.success()
             .put(McpKeys.ACTION, "preview") //$NON-NLS-1$
             .put(KEY_CONFIRMATION_REQUIRED, true)
-            .put(McpKeys.PROJECT, projectName)
-            .put(McpKeys.APPLICATION_ID, resolvedId)
-            .put(KEY_INFOBASE_NAME, resolvedName)
+            .put(McpKeys.PROJECT, id.projectName)
+            .put(McpKeys.APPLICATION_ID, id.resolvedId)
+            .put(KEY_INFOBASE_NAME, id.resolvedName)
             .put(KEY_DELETE_REGISTRATION, deleteRegistration)
-            .put(McpKeys.MESSAGE, "PREVIEW: this would dissociate infobase '" + resolvedName //$NON-NLS-1$
-                + "' from project '" + projectName + "'" //$NON-NLS-1$ //$NON-NLS-2$
+            .put(McpKeys.MESSAGE, "PREVIEW: this would dissociate infobase '" + id.resolvedName //$NON-NLS-1$
+                + "' from project '" + id.projectName + "'" //$NON-NLS-1$ //$NON-NLS-2$
                 + (deleteRegistration
                     ? " AND deregister it from the EDT infobases list" //$NON-NLS-1$
                     : " (EDT infobases list entry kept)") //$NON-NLS-1$
@@ -448,18 +554,18 @@ public class DeleteInfobaseTool implements IMcpTool
      * deregister-failure catch produced; the database files are reported as KEPT (the safe choice when
      * deregistration failed). Read-only — the dissociation has already happened at the call site.
      */
-    private static String buildDeregisterFailedResult(String projectName, String resolvedId,
-            String resolvedName, boolean deleteDatabaseFiles, Exception e)
+    private static String buildDeregisterFailedResult(IbIdentity id, boolean deleteDatabaseFiles,
+            Exception e)
     {
         return ToolResult.success()
             .put(McpKeys.ACTION, VAL_DELETED)
-            .put(McpKeys.PROJECT, projectName)
-            .put(McpKeys.APPLICATION_ID, resolvedId)
-            .put(KEY_INFOBASE_NAME, resolvedName)
+            .put(McpKeys.PROJECT, id.projectName)
+            .put(McpKeys.APPLICATION_ID, id.resolvedId)
+            .put(KEY_INFOBASE_NAME, id.resolvedName)
             .put(KEY_DELETE_REGISTRATION, false)
             .put(KEY_DATABASE_FILES_DELETED, false)
-            .put(McpKeys.MESSAGE, "Infobase '" + resolvedName //$NON-NLS-1$
-                + "' was dissociated from project '" + projectName //$NON-NLS-1$
+            .put(McpKeys.MESSAGE, "Infobase '" + id.resolvedName //$NON-NLS-1$
+                + "' was dissociated from project '" + id.projectName //$NON-NLS-1$
                 + "' but could not be deregistered from the EDT list: " //$NON-NLS-1$
                 + e.getMessage()
                 + ". You can remove it manually from the Infobases view in EDT." //$NON-NLS-1$
@@ -475,22 +581,21 @@ public class DeleteInfobaseTool implements IMcpTool
      * identical to the inline result the success path produced. Read-only — all mutations
      * (dissociate / deregister / file deletion) have already happened at the call site.
      */
-    private static String buildDeleteSuccessResult(String projectName, String resolvedId,
-            String resolvedName, boolean deleteRegistration, boolean deleteDatabaseFiles, Path dbDir,
-            boolean dbFilesDeleted, boolean dbSharedWithOthers)
+    private static String buildDeleteSuccessResult(IbIdentity id, boolean deleteRegistration,
+            DbFileOutcome db)
     {
         return ToolResult.success()
             .put(McpKeys.ACTION, VAL_DELETED)
-            .put(McpKeys.PROJECT, projectName)
-            .put(McpKeys.APPLICATION_ID, resolvedId)
-            .put(KEY_INFOBASE_NAME, resolvedName)
+            .put(McpKeys.PROJECT, id.projectName)
+            .put(McpKeys.APPLICATION_ID, id.resolvedId)
+            .put(KEY_INFOBASE_NAME, id.resolvedName)
             .put(KEY_DELETE_REGISTRATION, deleteRegistration)
-            .put(KEY_DATABASE_FILES_DELETED, dbFilesDeleted)
-            .put(McpKeys.MESSAGE, "Infobase '" + resolvedName //$NON-NLS-1$
-                + "' removed from project '" + projectName + "'" //$NON-NLS-1$ //$NON-NLS-2$
+            .put(KEY_DATABASE_FILES_DELETED, db.dbFilesDeleted)
+            .put(McpKeys.MESSAGE, "Infobase '" + id.resolvedName //$NON-NLS-1$
+                + "' removed from project '" + id.projectName + "'" //$NON-NLS-1$ //$NON-NLS-2$
                 + (deleteRegistration ? " and deregistered from the EDT infobases list." //$NON-NLS-1$
                     : " (EDT infobases list entry kept).") //$NON-NLS-1$
-                + databaseResultNote(deleteDatabaseFiles, dbDir, dbFilesDeleted, dbSharedWithOthers))
+                + databaseResultNote(db))
             .toJson();
     }
 
@@ -558,6 +663,50 @@ public class DeleteInfobaseTool implements IMcpTool
     }
 
     /**
+     * Holder for the file-infobase deletion resolved by
+     * {@link #resolveFileDeletionPlan(IApplication, IProject, IApplicationManager, String, boolean,
+     * boolean)}: the {@link InfobaseReference}, the resolved name / id, the on-disk database directory,
+     * the shared-files guard and the deleteRegistration flag. When {@code error} is non-null it carries
+     * a ready tool-result JSON (the cast-check refusal) and the other fields are unset; otherwise
+     * {@code error} is {@code null} and the fields are populated ({@code ibRef} / {@code dbDir} may be
+     * {@code null} as in the original inline code).
+     */
+    private static final class FileDeletionPlan
+    {
+        final String error;
+        final InfobaseReference ibRef;
+        final String resolvedName;
+        final String resolvedId;
+        final Path dbDir;
+        final boolean dbSharedWithOthers;
+        final boolean deleteRegistration;
+
+        private FileDeletionPlan(String error, InfobaseReference ibRef, String resolvedName,
+                String resolvedId, Path dbDir, boolean dbSharedWithOthers, boolean deleteRegistration)
+        {
+            this.error = error;
+            this.ibRef = ibRef;
+            this.resolvedName = resolvedName;
+            this.resolvedId = resolvedId;
+            this.dbDir = dbDir;
+            this.dbSharedWithOthers = dbSharedWithOthers;
+            this.deleteRegistration = deleteRegistration;
+        }
+
+        static FileDeletionPlan error(String error)
+        {
+            return new FileDeletionPlan(error, null, null, null, null, false, false);
+        }
+
+        static FileDeletionPlan of(InfobaseReference ibRef, String resolvedName, String resolvedId,
+                Path dbDir, boolean dbSharedWithOthers, boolean deleteRegistration)
+        {
+            return new FileDeletionPlan(null, ibRef, resolvedName, resolvedId, dbDir,
+                dbSharedWithOthers, deleteRegistration);
+        }
+    }
+
+    /**
      * Deletes a standalone (WST) server application — the inverse of
      * {@code create_infobase applicationKind=standaloneServer}. Mirrors EDT's "Delete server" UI action
      * via {@code IStandaloneServerService.deleteServer(...)} (resolved reflectively): it stops the server,
@@ -574,6 +723,7 @@ public class DeleteInfobaseTool implements IMcpTool
     {
         final String resolvedName = targetApp.getName();
         final String resolvedId = targetApp.getId();
+        final IbIdentity id = new IbIdentity(projectName, resolvedId, resolvedName);
 
         // Resolve the standalone-server service, backing WST server, infobaseId and served-DB
         // directory (read-only: acquires services and reads paths; deletes nothing). On a
@@ -591,7 +741,7 @@ public class DeleteInfobaseTool implements IMcpTool
         final boolean dbSharedWithOthers = deletionCtx.dbSharedWithOthers;
 
         // --- Confirm-preview gate ---
-        String preview = buildStandaloneServerPreview(confirm, projectName, resolvedId, resolvedName,
+        String preview = buildStandaloneServerPreview(confirm, id,
             deleteRegistration, deleteDatabaseFiles, dbDir, dbSharedWithOthers);
         if (preview != null)
         {
@@ -683,8 +833,9 @@ public class DeleteInfobaseTool implements IMcpTool
         // Read-back: confirm THIS deletion via a count decrease (tolerant of same-id twins).
         boolean removed = confirmApplicationRemoved(appManager, project, resolvedId, beforeCount);
 
-        return buildDeletedResult(projectName, resolvedId, resolvedName, deleteRegistration,
-            deleteDatabaseFiles, dbDir, dbFilesDeleted, dbSharedWithOthers, cleanup, removed);
+        return buildDeletedResult(id, deleteRegistration,
+            new DbFileOutcome(deleteDatabaseFiles, dbDir, dbFilesDeleted, dbSharedWithOthers),
+            cleanup, removed);
     }
 
     /**
@@ -760,8 +911,8 @@ public class DeleteInfobaseTool implements IMcpTool
      *
      * @return the preview JSON payload, or {@code null} when {@code confirm} is true
      */
-    private String buildStandaloneServerPreview(boolean confirm, String projectName, String resolvedId,
-        String resolvedName, boolean deleteRegistration, boolean deleteDatabaseFiles, Path dbDir,
+    private String buildStandaloneServerPreview(boolean confirm, IbIdentity id,
+        boolean deleteRegistration, boolean deleteDatabaseFiles, Path dbDir,
         boolean dbSharedWithOthers)
     {
         if (confirm)
@@ -772,16 +923,16 @@ public class DeleteInfobaseTool implements IMcpTool
             .put(McpKeys.ACTION, "preview") //$NON-NLS-1$
             .put(KEY_CONFIRMATION_REQUIRED, true)
             .put(KEY_APPLICATION_KIND, "standaloneServer") //$NON-NLS-1$
-            .put(McpKeys.PROJECT, projectName)
-            .put(McpKeys.APPLICATION_ID, resolvedId)
-            .put(KEY_INFOBASE_NAME, resolvedName)
+            .put(McpKeys.PROJECT, id.projectName)
+            .put(McpKeys.APPLICATION_ID, id.resolvedId)
+            .put(KEY_INFOBASE_NAME, id.resolvedName)
             .put(KEY_DELETE_REGISTRATION, deleteRegistration)
-            .put(McpKeys.MESSAGE, "PREVIEW: this would delete standalone server '" + resolvedName //$NON-NLS-1$
+            .put(McpKeys.MESSAGE, "PREVIEW: this would delete standalone server '" + id.resolvedName //$NON-NLS-1$
                 + "' (stop it, remove the WST server and its server config folder)" //$NON-NLS-1$
                 + (deleteRegistration ? " AND clean its infobases.yaml registry entry" //$NON-NLS-1$
                     : " (infobases.yaml entry kept)") //$NON-NLS-1$
                 + databasePreviewNote(deleteDatabaseFiles, dbDir, dbSharedWithOthers)
-                + " for project '" + projectName //$NON-NLS-1$
+                + " for project '" + id.projectName //$NON-NLS-1$
                 + "'. This is irreversible. Re-call with confirm=true to apply.") //$NON-NLS-1$
             .toJson();
     }
@@ -824,24 +975,23 @@ public class DeleteInfobaseTool implements IMcpTool
      *
      * @return the success JSON payload
      */
-    private String buildDeletedResult(String projectName, String resolvedId, String resolvedName,
-        boolean deleteRegistration, boolean deleteDatabaseFiles, Path dbDir, boolean dbFilesDeleted,
-        boolean dbSharedWithOthers, StandaloneServerSupport.RegistryCleanup cleanup, boolean removed)
+    private String buildDeletedResult(IbIdentity id, boolean deleteRegistration, DbFileOutcome db,
+        StandaloneServerSupport.RegistryCleanup cleanup, boolean removed)
     {
         return ToolResult.success()
             .put(McpKeys.ACTION, VAL_DELETED)
             .put(KEY_APPLICATION_KIND, "standaloneServer") //$NON-NLS-1$
-            .put(McpKeys.PROJECT, projectName)
-            .put(McpKeys.APPLICATION_ID, resolvedId)
-            .put(KEY_INFOBASE_NAME, resolvedName)
+            .put(McpKeys.PROJECT, id.projectName)
+            .put(McpKeys.APPLICATION_ID, id.resolvedId)
+            .put(KEY_INFOBASE_NAME, id.resolvedName)
             .put(KEY_DELETE_REGISTRATION, deleteRegistration)
-            .put(KEY_DATABASE_FILES_DELETED, dbFilesDeleted)
-            .put(McpKeys.MESSAGE, "Standalone server '" + resolvedName //$NON-NLS-1$
-                + "' deleted from project '" + projectName //$NON-NLS-1$
+            .put(KEY_DATABASE_FILES_DELETED, db.dbFilesDeleted)
+            .put(McpKeys.MESSAGE, "Standalone server '" + id.resolvedName //$NON-NLS-1$
+                + "' deleted from project '" + id.projectName //$NON-NLS-1$
                 + "' (server stopped, WST server and its server config folder removed)" //$NON-NLS-1$
                 + (deleteRegistration ? registryNote(cleanup)
                     : " (infobases.yaml registry entry kept).") //$NON-NLS-1$
-                + databaseResultNote(deleteDatabaseFiles, dbDir, dbFilesDeleted, dbSharedWithOthers)
+                + databaseResultNote(db)
                 + (removed ? "" : " NOTE: it may still appear in get_applications briefly.")) //$NON-NLS-1$ //$NON-NLS-2$
             .toJson();
     }
@@ -1151,25 +1301,24 @@ public class DeleteInfobaseTool implements IMcpTool
     }
 
     /** Result-message fragment describing the actual outcome of the database-files deletion. */
-    private static String databaseResultNote(boolean deleteDatabaseFiles, Path dbDir, boolean deleted,
-            boolean sharedWithOthers)
+    private static String databaseResultNote(DbFileOutcome db)
     {
-        if (!deleteDatabaseFiles)
+        if (!db.deleteDatabaseFiles)
         {
             return " The database files on disk were kept (pass deleteDatabaseFiles=true to remove them)."; //$NON-NLS-1$
         }
-        if (dbDir == null)
+        if (db.dbDir == null)
         {
             return " No database directory could be resolved, so nothing was deleted from disk."; //$NON-NLS-1$
         }
-        if (sharedWithOthers)
+        if (db.dbSharedWithOthers)
         {
             return " The database files were KEPT: this infobase is still used by other project(s) in " //$NON-NLS-1$
                 + "the workspace; deleting them would break those projects."; //$NON-NLS-1$
         }
-        return deleted
-            ? " The database files at '" + dbDir + "' were deleted from disk." //$NON-NLS-1$ //$NON-NLS-2$
-            : " The database files at '" + dbDir //$NON-NLS-1$
+        return db.dbFilesDeleted
+            ? " The database files at '" + db.dbDir + "' were deleted from disk." //$NON-NLS-1$ //$NON-NLS-2$
+            : " The database files at '" + db.dbDir //$NON-NLS-1$
                 + "' were NOT deleted (locked, already absent, or not a recognised infobase directory " //$NON-NLS-1$
                 + "without a 1Cv8.1CD) — check/remove the directory manually."; //$NON-NLS-1$
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GenerateTranslationStringsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GenerateTranslationStringsTool.java
@@ -117,99 +117,25 @@ public class GenerateTranslationStringsTool implements IMcpTool
     {
         String projectName = JsonUtils.extractStringArgument(params, McpKeys.PROJECT_NAME);
         List<String> targetLanguages = JsonUtils.extractArrayArgument(params, TARGET_LANGUAGES);
-        String storageId = JsonUtils.extractStringArgument(params, STORAGE_ID);
         boolean collectInterface = JsonUtils.extractBooleanArgument(params, COLLECT_INTERFACE, true);
         boolean collectModel = JsonUtils.extractBooleanArgument(params, COLLECT_MODEL, true);
-        String collectModelType = JsonUtils.extractStringArgument(params, COLLECT_MODEL_TYPE);
-        String fillUpType = JsonUtils.extractStringArgument(params, FILL_UP_TYPE);
-        String providerId = JsonUtils.extractStringArgument(params, "providerId"); //$NON-NLS-1$
 
-        String err = JsonUtils.requireArgument(params, McpKeys.PROJECT_NAME);
-        if (err != null)
+        // Parse + default + validate the scalar/string arguments (no side effects).
+        Options opts = parseOptions(params, projectName, targetLanguages);
+        if (opts.error != null)
         {
-            return err;
-        }
-        if (targetLanguages == null || targetLanguages.isEmpty())
-        {
-            return ToolResult.error("targetLanguages is required (e.g. [\"en\"])").toJson(); //$NON-NLS-1$
-        }
-
-        // Apply defaults for optional parameters.
-        if (storageId == null || storageId.isEmpty()) storageId = DEFAULT_STORAGE_ID;
-        if (collectModelType == null || collectModelType.isEmpty()) collectModelType = DEFAULT_COLLECT_MODEL_TYPE;
-        if (fillUpType == null || fillUpType.isEmpty()) fillUpType = DEFAULT_FILL_UP_TYPE;
-        if (providerId == null) providerId = ""; //$NON-NLS-1$
-
-        if (FILL_UP_FROM_PROVIDER.equals(fillUpType) && providerId.isEmpty())
-        {
-            return ToolResult.error(
-                "providerId is required when fillUpType=FROM_PROVIDER. " //$NON-NLS-1$
-              + "Use get_translation_project_info to list available providers.").toJson(); //$NON-NLS-1$
+            return opts.error;
         }
 
         try
         {
-            // Resolve the IProject first so AI clients get the most specific
-            // diagnostic ("Project not found" / "Project is closed") for bad
-            // names. The readiness pre-check below refuses only the transient
-            // BUILDING state and returns null for a missing/closed/unknown
-            // project, so a bad name reaches these value-naming branches.
-            ProjectContext ctx = ProjectContext.of(projectName);
-            if (!ctx.exists())
+            // Resolve the configuration project and the LanguageTool API (no side
+            // effects; same value/case errors as before).
+            Resolved resolved = resolveProjectAndApi(projectName);
+            if (resolved.error != null)
             {
-                return ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson();
+                return resolved.error;
             }
-            if (!ctx.isOpen())
-            {
-                return ToolResult.error("Project is closed: " + projectName).toJson(); //$NON-NLS-1$
-            }
-            IProject project = ctx.project();
-
-            // Refuse only the transient BUILDING state; a missing/closed project
-            // falls through to the value-naming "Project not found" below.
-            String building = ProjectStateChecker.buildingErrorOrNull(projectName);
-            if (building != null)
-            {
-                return ToolResult.error(building).toJson();
-            }
-
-            // Reject dictionary storage projects, extensions and any
-            // non-configuration EDT project — they would either resolve to a
-            // non-null IDtProject and fail deep inside LangTool with a
-            // confusing error, or simply do nothing useful.
-            if (!project.hasNature(V8_CONFIGURATION_NATURE))
-            {
-                return ToolResult.error(
-                    "Not a V8 configuration project: " + projectName //$NON-NLS-1$
-                  + ". This action must be run on the configuration project (V8ConfigurationNature), " //$NON-NLS-1$
-                  + "not on a dictionary storage project or extension.").toJson(); //$NON-NLS-1$
-            }
-
-            IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
-            IDtProject dtProject = dtProjectManager != null ? dtProjectManager.getDtProject(project) : null;
-            if (dtProject == null)
-            {
-                return ToolResult.error(
-                    "EDT has not yet resolved an IDtProject for: " + projectName //$NON-NLS-1$
-                  + ". The project may still be indexing — please retry.").toJson(); //$NON-NLS-1$
-            }
-
-            Object api = Activator.getDefault().getGenerateTranslationStringsApi();
-            if (api == null)
-            {
-                return ToolResult.error(
-                    "LanguageTool IGenerateTranslationStringsApi is not available. " //$NON-NLS-1$
-                  + "Install LanguageTool in EDT.").toJson(); //$NON-NLS-1$
-            }
-
-            // Build fillUpAndProviderId argument. Provider suffix is meaningful
-            // only for FROM_PROVIDER (other modes ignore providerId — appending
-            // it would produce malformed values like FROM_SOURCE_LANGUAGE:foo).
-            // The earlier validation already enforced non-empty providerId when
-            // fillUpType is FROM_PROVIDER, so no extra check is needed here.
-            String fillUpAndProviderId = FILL_UP_FROM_PROVIDER.equals(fillUpType)
-                ? fillUpType + ":" + providerId //$NON-NLS-1$
-                : fillUpType;
 
             // Reflection call:
             // IGenerateTranslationStringsApi.generateTranslationStrings(
@@ -223,38 +149,227 @@ public class GenerateTranslationStringsTool implements IMcpTool
             //     String collectModelType,       // ANY|NONE|COMPUTED_ONLY|UNKNOWN_ONLY|TAGS_ONLY
             //     boolean checkTranslationsInAnyAvailableStorage,
             //     Map<String,String> filterParameters)
-            Method method = api.getClass().getMethod("generateTranslationStrings", //$NON-NLS-1$
+            Method method = resolved.api.getClass().getMethod("generateTranslationStrings", //$NON-NLS-1$
                 IDtProject.class, List.class, String.class, String.class, Path.class,
                 boolean.class, boolean.class, String.class, boolean.class, Map.class);
-            method.invoke(api,
-                dtProject,
+            method.invoke(resolved.api,
+                resolved.dtProject,
                 targetLanguages,
-                storageId,
-                fillUpAndProviderId,
+                opts.storageId,
+                opts.fillUpAndProviderId(),
                 null,
                 collectModel,
                 collectInterface,
-                collectModelType,
+                opts.collectModelType,
                 Boolean.FALSE,
                 Collections.emptyMap());
 
-            BuildUtils.waitForDerivedData(project);
+            BuildUtils.waitForDerivedData(resolved.project);
 
             return FrontMatter.create()
                 .put("tool", NAME) //$NON-NLS-1$
                 .put(McpKeys.PROJECT, projectName)
                 .put(TARGET_LANGUAGES, String.join(", ", targetLanguages)) //$NON-NLS-1$
-                .put(STORAGE_ID, storageId)
+                .put(STORAGE_ID, opts.storageId)
                 .put(COLLECT_INTERFACE, collectInterface)
                 .put(COLLECT_MODEL, collectModel)
-                .put(COLLECT_MODEL_TYPE, collectModelType)
-                .put(FILL_UP_TYPE, fillUpType)
+                .put(COLLECT_MODEL_TYPE, opts.collectModelType)
+                .put(FILL_UP_TYPE, opts.fillUpType)
                 .put("status", "success") //$NON-NLS-1$ //$NON-NLS-2$
                 .wrapContent("Translation strings generated."); //$NON-NLS-1$
         }
         catch (Exception e)
         {
             return CliReflectionErrors.toErrorJson(e, "Generate translation strings", "LanguageTool"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+    }
+
+    /**
+     * Extracts, defaults and validates the scalar/string options (no side
+     * effects). Returns a holder carrying either the populated {@link Options} or
+     * the exact error JSON the inline guards produced (same value, same case); the
+     * caller re-checks {@code error}. {@code projectName}/{@code targetLanguages}
+     * are passed in already-extracted and validated here for the required-argument
+     * and non-empty-languages checks.
+     */
+    private static Options parseOptions(Map<String, String> params, String projectName, List<String> targetLanguages)
+    {
+        String storageId = JsonUtils.extractStringArgument(params, STORAGE_ID);
+        String collectModelType = JsonUtils.extractStringArgument(params, COLLECT_MODEL_TYPE);
+        String fillUpType = JsonUtils.extractStringArgument(params, FILL_UP_TYPE);
+        String providerId = JsonUtils.extractStringArgument(params, "providerId"); //$NON-NLS-1$
+
+        String err = JsonUtils.requireArgument(params, McpKeys.PROJECT_NAME);
+        if (err != null)
+        {
+            return Options.error(err);
+        }
+        if (targetLanguages == null || targetLanguages.isEmpty())
+        {
+            return Options.error(
+                ToolResult.error("targetLanguages is required (e.g. [\"en\"])").toJson()); //$NON-NLS-1$
+        }
+
+        // Apply defaults for optional parameters.
+        if (storageId == null || storageId.isEmpty()) storageId = DEFAULT_STORAGE_ID;
+        if (collectModelType == null || collectModelType.isEmpty()) collectModelType = DEFAULT_COLLECT_MODEL_TYPE;
+        if (fillUpType == null || fillUpType.isEmpty()) fillUpType = DEFAULT_FILL_UP_TYPE;
+        if (providerId == null) providerId = ""; //$NON-NLS-1$
+
+        if (FILL_UP_FROM_PROVIDER.equals(fillUpType) && providerId.isEmpty())
+        {
+            return Options.error(ToolResult.error(
+                "providerId is required when fillUpType=FROM_PROVIDER. " //$NON-NLS-1$
+              + "Use get_translation_project_info to list available providers.").toJson()); //$NON-NLS-1$
+        }
+
+        return Options.of(storageId, collectModelType, fillUpType, providerId);
+    }
+
+    /**
+     * Resolves the configuration {@link IProject}, its {@link IDtProject} and the
+     * LanguageTool API for {@code projectName}, in the same order and with the same
+     * value/case diagnostics as the original inline chain (most-specific
+     * "Project not found"/"closed" first, then BUILDING, then nature, then
+     * IDtProject, then API). No side effects. Returns a holder carrying either the
+     * resolved trio or the exact error JSON; the caller re-checks {@code error}.
+     *
+     * @throws org.eclipse.core.runtime.CoreException from {@code IProject.hasNature}
+     */
+    private static Resolved resolveProjectAndApi(String projectName) throws org.eclipse.core.runtime.CoreException
+    {
+        // Resolve the IProject first so AI clients get the most specific
+        // diagnostic ("Project not found" / "Project is closed") for bad
+        // names. The readiness pre-check below refuses only the transient
+        // BUILDING state and returns null for a missing/closed/unknown
+        // project, so a bad name reaches these value-naming branches.
+        ProjectContext ctx = ProjectContext.of(projectName);
+        if (!ctx.exists())
+        {
+            return Resolved.error(ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson());
+        }
+        if (!ctx.isOpen())
+        {
+            return Resolved.error(ToolResult.error("Project is closed: " + projectName).toJson()); //$NON-NLS-1$
+        }
+        IProject project = ctx.project();
+
+        // Refuse only the transient BUILDING state; a missing/closed project
+        // falls through to the value-naming "Project not found" below.
+        String building = ProjectStateChecker.buildingErrorOrNull(projectName);
+        if (building != null)
+        {
+            return Resolved.error(ToolResult.error(building).toJson());
+        }
+
+        // Reject dictionary storage projects, extensions and any
+        // non-configuration EDT project — they would either resolve to a
+        // non-null IDtProject and fail deep inside LangTool with a
+        // confusing error, or simply do nothing useful.
+        if (!project.hasNature(V8_CONFIGURATION_NATURE))
+        {
+            return Resolved.error(ToolResult.error(
+                "Not a V8 configuration project: " + projectName //$NON-NLS-1$
+              + ". This action must be run on the configuration project (V8ConfigurationNature), " //$NON-NLS-1$
+              + "not on a dictionary storage project or extension.").toJson()); //$NON-NLS-1$
+        }
+
+        IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
+        IDtProject dtProject = dtProjectManager != null ? dtProjectManager.getDtProject(project) : null;
+        if (dtProject == null)
+        {
+            return Resolved.error(ToolResult.error(
+                "EDT has not yet resolved an IDtProject for: " + projectName //$NON-NLS-1$
+              + ". The project may still be indexing — please retry.").toJson()); //$NON-NLS-1$
+        }
+
+        Object api = Activator.getDefault().getGenerateTranslationStringsApi();
+        if (api == null)
+        {
+            return Resolved.error(ToolResult.error(
+                "LanguageTool IGenerateTranslationStringsApi is not available. " //$NON-NLS-1$
+              + "Install LanguageTool in EDT.").toJson()); //$NON-NLS-1$
+        }
+
+        return Resolved.of(project, dtProject, api);
+    }
+
+    /**
+     * Holder for the parsed/defaulted/validated scalar options (no side effects):
+     * exactly one of the value fields / {@code error} is meaningful. {@code error}
+     * carries the same error JSON (same case) the inline guards returned.
+     */
+    private static final class Options
+    {
+        final String storageId;
+        final String collectModelType;
+        final String fillUpType;
+        final String providerId;
+        final String error;
+
+        private Options(String storageId, String collectModelType, String fillUpType, String providerId,
+            String error)
+        {
+            this.storageId = storageId;
+            this.collectModelType = collectModelType;
+            this.fillUpType = fillUpType;
+            this.providerId = providerId;
+            this.error = error;
+        }
+
+        static Options of(String storageId, String collectModelType, String fillUpType, String providerId)
+        {
+            return new Options(storageId, collectModelType, fillUpType, providerId, null);
+        }
+
+        static Options error(String error)
+        {
+            return new Options(null, null, null, null, error);
+        }
+
+        /**
+         * Builds the {@code fillUpAndProviderId} argument. Provider suffix is
+         * meaningful only for FROM_PROVIDER (other modes ignore providerId —
+         * appending it would produce malformed values like
+         * FROM_SOURCE_LANGUAGE:foo). The earlier validation already enforced
+         * non-empty providerId when fillUpType is FROM_PROVIDER.
+         */
+        String fillUpAndProviderId()
+        {
+            return FILL_UP_FROM_PROVIDER.equals(fillUpType)
+                ? fillUpType + ":" + providerId //$NON-NLS-1$
+                : fillUpType;
+        }
+    }
+
+    /**
+     * Holder for the resolved configuration project / IDtProject / LanguageTool
+     * API: exactly one of the value trio / {@code error} is non-null. {@code error}
+     * carries the same error JSON (same case) the inline guards returned.
+     */
+    private static final class Resolved
+    {
+        final IProject project;
+        final IDtProject dtProject;
+        final Object api;
+        final String error;
+
+        private Resolved(IProject project, IDtProject dtProject, Object api, String error)
+        {
+            this.project = project;
+            this.dtProject = dtProject;
+            this.api = api;
+            this.error = error;
+        }
+
+        static Resolved of(IProject project, IDtProject dtProject, Object api)
+        {
+            return new Resolved(project, dtProject, api, null);
+        }
+
+        static Resolved error(String error)
+        {
+            return new Resolved(null, null, null, error);
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetContentAssistTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetContentAssistTool.java
@@ -206,26 +206,50 @@ public class GetContentAssistTool implements IMcpTool
         int offset = Math.max(0, JsonUtils.extractIntArgument(params, "offset", 0)); //$NON-NLS-1$
         
         boolean extendedDocumentation = "true".equalsIgnoreCase(extendedDocStr); //$NON-NLS-1$
-        
-        return getContentAssist(projectName, filePath, line, column, limit, offset, containsFilter, extendedDocumentation);
+
+        ContentAssistRequest request =
+            new ContentAssistRequest(line, column, limit, offset, containsFilter, extendedDocumentation);
+        return getContentAssist(projectName, filePath, request);
     }
-    
+
+    /**
+     * Immutable bundle of the per-call content-assist request parameters (caret
+     * position plus pagination/filter/format options), threaded unchanged from
+     * {@link #getContentAssist} into {@link #executeOnUiThread}. Field values and
+     * read order match the previous flat parameter lists exactly.
+     */
+    private static final class ContentAssistRequest
+    {
+        final int line;
+        final int column;
+        final int maxProposals;
+        final int proposalOffset;
+        final String containsFilter;
+        final boolean extendedDocumentation;
+
+        ContentAssistRequest(int line, int column, int maxProposals, int proposalOffset,
+                String containsFilter, boolean extendedDocumentation)
+        {
+            this.line = line;
+            this.column = column;
+            this.maxProposals = maxProposals;
+            this.proposalOffset = proposalOffset;
+            this.containsFilter = containsFilter;
+            this.extendedDocumentation = extendedDocumentation;
+        }
+    }
+
     /**
      * Gets content assist proposals at the specified position.
      * Must run on UI thread to access editors.
-     * 
+     *
      * @param projectName EDT project name
      * @param filePath relative path from project's src folder (e.g. 'CommonModules/MyModule/Module.bsl')
-     * @param line line number (1-based)
-     * @param column column number (1-based)
-     * @param limit maximum proposals to return
-     * @param offset number of proposals to skip (for pagination)
-     * @param containsFilter comma-separated substrings to filter proposals
-     * @param extendedDocumentation whether to include full documentation
+     * @param request the caret position and pagination/filter/format options
      * @return JSON result
      */
-    private String getContentAssist(String projectName, String filePath, int line, int column, 
-                                    int limit, int offset, String containsFilter, boolean extendedDocumentation)
+    private String getContentAssist(String projectName, String filePath,
+                                    ContentAssistRequest request)
     {
         // Find the project
         ProjectContext ctx = ProjectContext.of(projectName);
@@ -241,7 +265,7 @@ public class GetContentAssistTool implements IMcpTool
         }
 
         IProject project = ctx.project();
-        
+
         // Build the full path: project/src/filePath
         IFile file = BslModuleUtils.resolveModuleFile(project, filePath);
 
@@ -249,24 +273,17 @@ public class GetContentAssistTool implements IMcpTool
         {
             return ToolResult.error("File not found: " + file.getProjectRelativePath().toString() + " in project " + projectName).toJson(); //$NON-NLS-1$ //$NON-NLS-2$
         }
-        
+
         final IFile targetFile = file;
-        final int targetLine = line;
-        final int targetColumn = column;
-        final int maxProposals = limit;
-        final int proposalOffset = offset;
-        final String filter = containsFilter;
-        final boolean extendedDoc = extendedDocumentation;
-        
+
         AtomicReference<String> resultRef = new AtomicReference<>();
-        
+
         // Execute on UI thread
         Display display = PlatformUI.getWorkbench().getDisplay();
         display.syncExec(() -> {
             try
             {
-                String result = executeOnUiThread(targetFile, targetLine, targetColumn, maxProposals, 
-                                                   proposalOffset, filter, extendedDoc);
+                String result = executeOnUiThread(targetFile, request);
                 resultRef.set(result);
             }
             catch (Exception e)
@@ -275,15 +292,14 @@ public class GetContentAssistTool implements IMcpTool
                 resultRef.set(ToolResult.error(e.getMessage()).toJson()); //$NON-NLS-1$
             }
         });
-        
+
         return resultRef.get();
     }
-    
+
     /**
      * Executes content assist on UI thread.
      */
-    private String executeOnUiThread(IFile file, int line, int column, int maxProposals, 
-                                     int proposalOffset, String containsFilter, boolean extendedDocumentation) throws Exception
+    private String executeOnUiThread(IFile file, ContentAssistRequest request) throws Exception
     {
         IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
         if (window == null)
@@ -327,9 +343,9 @@ public class GetContentAssistTool implements IMcpTool
         int offset;
         try
         {
-            int lineOffset = document.getLineOffset(line - 1);
-            offset = lineOffset + column - 1;
-            
+            int lineOffset = document.getLineOffset(request.line - 1);
+            offset = lineOffset + request.column - 1;
+
             // Validate offset is within document
             if (offset < 0 || offset > document.getLength())
             {
@@ -338,7 +354,7 @@ public class GetContentAssistTool implements IMcpTool
         }
         catch (BadLocationException e)
         {
-            return ToolResult.error("Invalid line number: " + line).toJson(); //$NON-NLS-1$
+            return ToolResult.error("Invalid line number: " + request.line).toJson(); //$NON-NLS-1$
         }
         
         // Set cursor position
@@ -393,8 +409,9 @@ public class GetContentAssistTool implements IMcpTool
         ICompletionProposal[] proposals = computeStableProposals(processor, sourceViewer, offset);
 
         // Format results
-        return formatProposals(proposals, maxProposals, proposalOffset, containsFilter, extendedDocumentation,
-                               line, column, file.getFullPath().toString());
+        return formatProposals(proposals, request.maxProposals, request.proposalOffset,
+                               request.containsFilter, request.extendedDocumentation,
+                               request.line, request.column, file.getFullPath().toString());
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMarkersTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMarkersTool.java
@@ -182,8 +182,9 @@ public class GetMarkersTool implements IMcpTool
                 projects = ProjectContext.allProjects();
             }
 
-            collectMarkerRows(projects, includeBookmarks, includeTasks, filePath, priorityFilter,
-                limit, rows, seenTasks);
+            MarkerScan scan = new MarkerScan(includeBookmarks, includeTasks, filePath,
+                priorityFilter, limit);
+            collectMarkerRows(projects, scan, rows, seenTasks);
 
             appendMarkersTable(md, rows, limit);
         }
@@ -202,16 +203,11 @@ public class GetMarkersTool implements IMcpTool
      * {@code seenTasks}). Stops once {@code limit} rows have been gathered.
      *
      * @param projects the projects to scan (already resolved/filtered)
-     * @param includeBookmarks whether to scan bookmark markers
-     * @param includeTasks whether to scan task markers
-     * @param filePath case-insensitive path-substring filter (null/empty = no filter)
-     * @param priorityFilter task priority filter (null = no filter); ignored for bookmarks
-     * @param limit maximum number of rows to collect (already clamped)
+     * @param scan the immutable scan criteria (marker families, filters and limit)
      * @param rows accumulator the collected rows are appended to
      * @param seenTasks dedup set shared across the two task marker types
      */
-    private static void collectMarkerRows(IProject[] projects, boolean includeBookmarks,
-        boolean includeTasks, String filePath, Integer priorityFilter, int limit,
+    private static void collectMarkerRows(IProject[] projects, MarkerScan scan,
         List<MarkerRow> rows, Set<String> seenTasks)
     {
         for (IProject project : projects)
@@ -221,23 +217,48 @@ public class GetMarkersTool implements IMcpTool
                 continue;
             }
 
-            if (includeBookmarks && rows.size() < limit)
+            if (scan.includeBookmarks && rows.size() < scan.limit)
             {
-                collectBookmarks(project, rows, filePath, limit);
+                collectBookmarks(project, rows, scan.filePath, scan.limit);
             }
-            if (includeTasks && rows.size() < limit)
+            if (scan.includeTasks && rows.size() < scan.limit)
             {
-                collectTasks(project, TASK_MARKER_TYPE, rows, seenTasks, filePath, priorityFilter, limit);
-                if (rows.size() < limit)
+                collectTasks(project, TASK_MARKER_TYPE, rows, seenTasks, scan.filePath, scan.priorityFilter, scan.limit);
+                if (rows.size() < scan.limit)
                 {
-                    collectTasks(project, XTEXT_TASK_MARKER_TYPE, rows, seenTasks, filePath, priorityFilter, limit);
+                    collectTasks(project, XTEXT_TASK_MARKER_TYPE, rows, seenTasks, scan.filePath, scan.priorityFilter, scan.limit);
                 }
             }
 
-            if (rows.size() >= limit)
+            if (rows.size() >= scan.limit)
             {
                 break;
             }
+        }
+    }
+
+    /**
+     * Immutable holder for the marker-scan criteria threaded through
+     * {@link #collectMarkerRows}: which marker families to scan, the path/priority
+     * filters and the (already clamped) row limit. Bundles the parameters without
+     * changing any value or scan behaviour.
+     */
+    private static final class MarkerScan
+    {
+        final boolean includeBookmarks;
+        final boolean includeTasks;
+        final String filePath;
+        final Integer priorityFilter;
+        final int limit;
+
+        MarkerScan(boolean includeBookmarks, boolean includeTasks, String filePath,
+            Integer priorityFilter, int limit)
+        {
+            this.includeBookmarks = includeBookmarks;
+            this.includeTasks = includeTasks;
+            this.filePath = filePath;
+            this.priorityFilter = priorityFilter;
+            this.limit = limit;
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataDetailsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataDetailsTool.java
@@ -196,11 +196,14 @@ public class GetMetadataDetailsTool implements IMcpTool
         // for whole-call failures such as a missing project or configuration).
         List<String[]> failures = new ArrayList<>();
 
+        // Per-request render context, constant across every FQN in the loop.
+        RenderContext ctx = new RenderContext(config, bmModel, effectiveLanguage, full, assignable,
+            isExtensionProject);
+
         // Process each FQN
         for (String fqn : objectFqns)
         {
-            processFqn(fqn, sb, failures, config, bmModel, effectiveLanguage, full, assignable,
-                isExtensionProject);
+            processFqn(fqn, sb, failures, ctx);
         }
 
         if (!failures.isEmpty())
@@ -217,14 +220,13 @@ public class GetMetadataDetailsTool implements IMcpTool
      * {@link #getMetadataDetailsInternal} loop body; a per-object failure is not a whole-call
      * failure, so this method never throws on a resolution miss.
      */
-    private void processFqn(String fqn, StringBuilder sb, List<String[]> failures, Configuration config,
-        IBmModel bmModel, String effectiveLanguage, boolean full, boolean assignable, boolean isExtensionProject)
+    private void processFqn(String fqn, StringBuilder sb, List<String[]> failures, RenderContext ctx)
     {
         // Assignable-schema mode: resolve the node (top object OR member) via the shared
         // resolver and render its assignable-property table - what modify_metadata can set.
-        if (assignable)
+        if (ctx.assignable)
         {
-            MetadataNodeResolver.MetadataNode node = MetadataNodeResolver.resolveExisting(config, fqn);
+            MetadataNodeResolver.MetadataNode node = MetadataNodeResolver.resolveExisting(ctx.config, fqn);
             if (node == null || node.object == null)
             {
                 failures.add(new String[] { fqn, describeResolutionFailure(fqn) });
@@ -242,7 +244,7 @@ public class GetMetadataDetailsTool implements IMcpTool
         String formPath = FormElementWriter.parseFormPath(MetadataTypeUtils.normalizeFqn(fqn));
         if (formPath != null)
         {
-            String formStructure = renderFormStructure(config, bmModel, formPath, effectiveLanguage);
+            String formStructure = renderFormStructure(ctx.config, ctx.bmModel, formPath, ctx.effectiveLanguage);
             if (formStructure == null)
             {
                 failures.add(new String[] { fqn, "the form has no editable content model (it may " //$NON-NLS-1$
@@ -254,20 +256,48 @@ public class GetMetadataDetailsTool implements IMcpTool
             return;
         }
 
-        MdObject mdObject = resolveObject(config, fqn);
+        MdObject mdObject = resolveObject(ctx.config, fqn);
         if (mdObject == null)
         {
             failures.add(new String[] { fqn, describeResolutionFailure(fqn) });
             return;
         }
-        sb.append(MetadataFormatterRegistry.format(mdObject, full, effectiveLanguage));
+        sb.append(MetadataFormatterRegistry.format(mdObject, ctx.full, ctx.effectiveLanguage));
         // ORIGIN footer: core / core (adopted) / extension. For a base
         // configuration this is always "core"; for an extension it distinguishes
         // an adopted base object from one the extension itself owns.
         sb.append("\n**Origin:** ") //$NON-NLS-1$
-            .append(ExtensionOriginUtils.originLabel(mdObject.getObjectBelonging(), isExtensionProject))
+            .append(ExtensionOriginUtils.originLabel(mdObject.getObjectBelonging(), ctx.isExtensionProject))
             .append("\n"); //$NON-NLS-1$
         sb.append(SECTION_SEPARATOR);
+    }
+
+    /**
+     * Immutable per-request render context threaded through {@link #processFqn}: the resolved
+     * configuration, the (best-effort) BM model used only for a form's cross-model hop, the
+     * effective synonym language code and the three rendering flags. Computed once in
+     * {@link #getMetadataDetailsInternal} and constant across every FQN. Bundles the parameters
+     * without changing any value or rendering behaviour.
+     */
+    private static final class RenderContext
+    {
+        final Configuration config;
+        final IBmModel bmModel;
+        final String effectiveLanguage;
+        final boolean full;
+        final boolean assignable;
+        final boolean isExtensionProject;
+
+        RenderContext(Configuration config, IBmModel bmModel, String effectiveLanguage,
+            boolean full, boolean assignable, boolean isExtensionProject)
+        {
+            this.config = config;
+            this.bmModel = bmModel;
+            this.effectiveLanguage = effectiveLanguage;
+            this.full = full;
+            this.assignable = assignable;
+            this.isExtensionProject = isExtensionProject;
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
@@ -222,6 +222,9 @@ public class GetMethodCallHierarchyTool implements IMcpTool
         List<CallerInfo> callers = new ArrayList<>();
         int totalReferences = 0;
 
+        // Loop-invariant identity of the target method (same across every candidate).
+        CallerSearch search = new CallerSearch(methodUri, methodName, targetModuleName, limit);
+
         for (IFile candidate : candidates)
         {
             String relToSrc = candidate.getProjectRelativePath().removeFirstSegments(1).toString();
@@ -245,8 +248,8 @@ public class GetMethodCallHierarchyTool implements IMcpTool
             }
 
             boolean candidateIsTarget = relToSrc.equalsIgnoreCase(modulePath);
-            totalReferences += scanCandidateInvocations(candidateModule, methodUri, methodName,
-                targetModuleName, candidateIsTarget, relToSrc, callers, limit);
+            totalReferences += scanCandidateInvocations(candidateModule, search,
+                candidateIsTarget, relToSrc, callers);
         }
 
         return formatCallersOutput(modulePath, methodName, callers, totalReferences);
@@ -260,18 +263,14 @@ public class GetMethodCallHierarchyTool implements IMcpTool
      * loop-local {@code continue} statements stay confined to this scan.
      *
      * @param candidateModule the module to scan
-     * @param methodUri the URI of the target method
-     * @param methodName the target method name
-     * @param targetModuleName the simple name of the module declaring the target method
+     * @param search the loop-invariant target-method identity (URI, name, declaring module, limit)
      * @param candidateIsTarget {@code true} when this candidate is the module declaring the method
      * @param relToSrc the candidate's source-relative path, used when building a {@link CallerInfo}
      * @param callers the shared accumulator of matched callers (appended to, never reassigned)
-     * @param limit the maximum number of callers to retain in {@code callers}
      * @return the number of invocations in this candidate that target the method
      */
-    private int scanCandidateInvocations(Module candidateModule, URI methodUri, String methodName,
-        String targetModuleName, boolean candidateIsTarget, String relToSrc, List<CallerInfo> callers,
-        int limit)
+    private int scanCandidateInvocations(Module candidateModule, CallerSearch search,
+        boolean candidateIsTarget, String relToSrc, List<CallerInfo> callers)
     {
         int matched = 0;
         for (Iterator<EObject> iter = candidateModule.eAllContents(); iter.hasNext();)
@@ -282,17 +281,40 @@ public class GetMethodCallHierarchyTool implements IMcpTool
                 continue;
             }
             Invocation inv = (Invocation)obj;
-            if (!invocationTargetsMethod(inv, methodUri, methodName, targetModuleName, candidateIsTarget))
+            if (!invocationTargetsMethod(inv, search.methodUri, search.methodName,
+                search.targetModuleName, candidateIsTarget))
             {
                 continue;
             }
             matched++;
-            if (callers.size() < limit)
+            if (callers.size() < search.limit)
             {
-                callers.add(buildCallerInfo(inv, relToSrc, methodName));
+                callers.add(buildCallerInfo(inv, relToSrc, search.methodName));
             }
         }
         return matched;
+    }
+
+    /**
+     * Immutable holder for the loop-invariant identity of the target method shared by every
+     * candidate scan in {@link #findCallers}: the method URI, its name, the simple name of the
+     * declaring module and the caller {@code limit}. Bundles the parameters without changing any
+     * value.
+     */
+    private static final class CallerSearch
+    {
+        final URI methodUri;
+        final String methodName;
+        final String targetModuleName;
+        final int limit;
+
+        CallerSearch(URI methodUri, String methodName, String targetModuleName, int limit)
+        {
+            this.methodUri = methodUri;
+            this.methodName = methodName;
+            this.targetModuleName = targetModuleName;
+            this.limit = limit;
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetModuleStructureTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetModuleStructureTool.java
@@ -328,23 +328,50 @@ public class GetModuleStructureTool implements IMcpTool
         int idx = 1;
         for (MethodInfo m : methods)
         {
-            sb.append("| ").append(idx++); //$NON-NLS-1$
-            sb.append(" | ").append(m.isFunction ? "Function" : "Procedure"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-            sb.append(" | ").append(MarkdownUtils.escapeForTable(m.name)); //$NON-NLS-1$
-            sb.append(" | ").append(m.isExport ? "Yes" : "-"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-            sb.append(" | ").append(m.executionContext != null ? MarkdownUtils.escapeForTable(m.executionContext) : "-"); //$NON-NLS-1$ //$NON-NLS-2$
-            sb.append(" | ").append(m.startLine).append("-").append(m.endLine); //$NON-NLS-1$ //$NON-NLS-2$
-            if (detailed)
-            {
-                sb.append(" | ").append(MarkdownUtils.escapeForTable(m.paramsString)); //$NON-NLS-1$
-            }
-            sb.append(" | ").append(m.region != null ? MarkdownUtils.escapeForTable(m.region) : "-"); //$NON-NLS-1$ //$NON-NLS-2$
-            if (showComments)
-            {
-                sb.append(" | ").append(m.docComment != null ? MarkdownUtils.escapeForTable(m.docComment) : "-"); //$NON-NLS-1$ //$NON-NLS-2$
-            }
-            sb.append(" |\n"); //$NON-NLS-1$
+            appendMethodRow(sb, m, idx++, detailed, showComments);
         }
+    }
+
+    /**
+     * Appends one markdown table row for a single method. The Parameters cell is emitted only in
+     * {@code detailed} mode and the Description cell only when {@code showComments}, matching the
+     * column set advertised by {@link #appendMethodsTableHeader}. Behaviour-identical to the former
+     * inline loop body.
+     *
+     * @param sb           output buffer
+     * @param m            the method to render
+     * @param idx          the 1-based row number shown in the first column
+     * @param detailed     whether the Parameters column is present
+     * @param showComments whether the Description column is present
+     */
+    private void appendMethodRow(StringBuilder sb, MethodInfo m, int idx,
+        boolean detailed, boolean showComments)
+    {
+        sb.append("| ").append(idx); //$NON-NLS-1$
+        sb.append(" | ").append(m.isFunction ? "Function" : "Procedure"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        sb.append(" | ").append(MarkdownUtils.escapeForTable(m.name)); //$NON-NLS-1$
+        sb.append(" | ").append(m.isExport ? "Yes" : "-"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        sb.append(" | ").append(m.executionContext != null ? MarkdownUtils.escapeForTable(m.executionContext) : "-"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append(" | ").append(m.startLine).append("-").append(m.endLine); //$NON-NLS-1$ //$NON-NLS-2$
+        if (detailed)
+        {
+            sb.append(" | ").append(MarkdownUtils.escapeForTable(m.paramsString)); //$NON-NLS-1$
+        }
+        sb.append(" | ").append(escapeOrDash(m.region)); //$NON-NLS-1$
+        if (showComments)
+        {
+            sb.append(" | ").append(escapeOrDash(m.docComment)); //$NON-NLS-1$
+        }
+        sb.append(" |\n"); //$NON-NLS-1$
+    }
+
+    /**
+     * Escapes a nullable cell value for a markdown table, returning {@code "-"} for {@code null}.
+     * Mirrors the original inline {@code x != null ? escapeForTable(x) : "-"} guard.
+     */
+    private static String escapeOrDash(String value)
+    {
+        return value != null ? MarkdownUtils.escapeForTable(value) : "-"; //$NON-NLS-1$
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProfilingResultsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProfilingResultsTool.java
@@ -182,9 +182,19 @@ public class GetProfilingResultsTool implements IMcpTool
             Method getDurability = timeHolderClass.getMethod("getDurability"); //$NON-NLS-1$
             Method getPureDurability = timeHolderClass.getMethod("getPureDurability"); //$NON-NLS-1$
 
-            ProfilingReflection refl = new ProfilingReflection(getResultName, getTotalDurability,
-                getProfilingResults, getFrequency, getModuleName, getLineNo, getPercentage,
-                getDurability, getPureDurability, getLine, getMethodSignature);
+            ProfilingReflection refl = ProfilingReflection.builder()
+                .resultName(getResultName)
+                .totalDurability(getTotalDurability)
+                .profilingResults(getProfilingResults)
+                .frequency(getFrequency)
+                .moduleName(getModuleName)
+                .lineNo(getLineNo)
+                .percentage(getPercentage)
+                .durability(getDurability)
+                .pureDurability(getPureDurability)
+                .line(getLine)
+                .methodSignature(getMethodSignature)
+                .build();
 
             List<Map<String, Object>> resultSummaries = new ArrayList<>();
 
@@ -331,7 +341,9 @@ public class GetProfilingResultsTool implements IMcpTool
 
     /**
      * Immutable holder for the reflective {@code Method} handles used while summarizing a profiling
-     * result. Groups them so the per-result / per-line helpers keep a small signature.
+     * result. Groups them so the per-result / per-line helpers keep a small signature. Built via
+     * {@link Builder} so the construction site has no long parameter list; the field values are
+     * exactly the {@code Method} handles assigned to the builder.
      */
     private static final class ProfilingReflection
     {
@@ -347,21 +359,61 @@ public class GetProfilingResultsTool implements IMcpTool
         final Method getLine;
         final Method getMethodSignature;
 
-        ProfilingReflection(Method getResultName, Method getTotalDurability, Method getProfilingResults,
-            Method getFrequency, Method getModuleName, Method getLineNo, Method getPercentage,
-            Method getDurability, Method getPureDurability, Method getLine, Method getMethodSignature)
+        private ProfilingReflection(Builder b)
         {
-            this.getResultName = getResultName;
-            this.getTotalDurability = getTotalDurability;
-            this.getProfilingResults = getProfilingResults;
-            this.getFrequency = getFrequency;
-            this.getModuleName = getModuleName;
-            this.getLineNo = getLineNo;
-            this.getPercentage = getPercentage;
-            this.getDurability = getDurability;
-            this.getPureDurability = getPureDurability;
-            this.getLine = getLine;
-            this.getMethodSignature = getMethodSignature;
+            this.getResultName = b.getResultName;
+            this.getTotalDurability = b.getTotalDurability;
+            this.getProfilingResults = b.getProfilingResults;
+            this.getFrequency = b.getFrequency;
+            this.getModuleName = b.getModuleName;
+            this.getLineNo = b.getLineNo;
+            this.getPercentage = b.getPercentage;
+            this.getDurability = b.getDurability;
+            this.getPureDurability = b.getPureDurability;
+            this.getLine = b.getLine;
+            this.getMethodSignature = b.getMethodSignature;
+        }
+
+        static Builder builder()
+        {
+            return new Builder();
+        }
+
+        /**
+         * Mutable builder that collects the reflective {@code Method} handles before they are
+         * frozen into an immutable {@link ProfilingReflection}. Exists solely to keep the
+         * construction site free of an 11-argument call; it carries no logic.
+         */
+        private static final class Builder
+        {
+            private Method getResultName;
+            private Method getTotalDurability;
+            private Method getProfilingResults;
+            private Method getFrequency;
+            private Method getModuleName;
+            private Method getLineNo;
+            private Method getPercentage;
+            private Method getDurability;
+            private Method getPureDurability;
+            private Method getLine;
+            private Method getMethodSignature;
+
+            Builder resultName(Method m) { this.getResultName = m; return this; }
+            Builder totalDurability(Method m) { this.getTotalDurability = m; return this; }
+            Builder profilingResults(Method m) { this.getProfilingResults = m; return this; }
+            Builder frequency(Method m) { this.getFrequency = m; return this; }
+            Builder moduleName(Method m) { this.getModuleName = m; return this; }
+            Builder lineNo(Method m) { this.getLineNo = m; return this; }
+            Builder percentage(Method m) { this.getPercentage = m; return this; }
+            Builder durability(Method m) { this.getDurability = m; return this; }
+            Builder pureDurability(Method m) { this.getPureDurability = m; return this; }
+            Builder line(Method m) { this.getLine = m; return this; }
+            Builder methodSignature(Method m) { this.getMethodSignature = m; return this; }
+
+            ProfilingReflection build()
+            {
+                return new ProfilingReflection(this);
+            }
         }
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -218,9 +218,11 @@ public class GetProjectErrorsTool implements IMcpTool
             final int[] unresolvedShown = {0};
             final int[] unresolvedFilteredOut = {0};
 
+            final CollectContext collectContext = new CollectContext(finalSeverityFilter,
+                finalCheckId, finalObjects, checkRepository, limit, unresolvedShown,
+                unresolvedFilteredOut);
             final List<ErrorInfo> errors = collectErrors(markersByProject, bmModelManager,
-                finalSeverityFilter, finalCheckId, finalObjects, checkRepository, limit,
-                unresolvedShown, unresolvedFilteredOut);
+                collectContext);
 
             // Build Markdown response for better readability and context efficiency
             StringBuilder md = new StringBuilder();
@@ -330,30 +332,23 @@ public class GetProjectErrorsTool implements IMcpTool
      *
      * @param markersByProject the markers grouped by project, in processing order
      * @param bmModelManager the BM model manager, may be {@code null}
-     * @param severityFilter the severity filter, or {@code null} for all severities
-     * @param checkId the checkId substring filter, may be {@code null}/empty
-     * @param objects the normalized object FQN variants (empty for no object filter)
-     * @param checkRepository the check repository for symbolic id resolution, may be {@code null}
-     * @param limit the maximum number of collected errors
-     * @param unresolvedShown out-counter for markers reported with a placeholder location
-     * @param unresolvedFilteredOut out-counter for markers excluded by an active object filter
-     * @return the collected errors, capped at {@code limit}
+     * @param context the immutable collection context (filters, repository, limit and the
+     *     two unresolved-marker out-counters)
+     * @return the collected errors, capped at {@code context.limit}
      */
     private static List<ErrorInfo> collectErrors(Map<IProject, List<Marker>> markersByProject,
-        IBmModelManager bmModelManager, MarkerSeverity severityFilter, String checkId,
-        Set<String> objects, ICheckRepository checkRepository, int limit,
-        int[] unresolvedShown, int[] unresolvedFilteredOut)
+        IBmModelManager bmModelManager, CollectContext context)
     {
         final List<ErrorInfo> errors = new ArrayList<>();
         for (Map.Entry<IProject, List<Marker>> entry : markersByProject.entrySet())
         {
-            if (errors.size() >= limit)
+            if (errors.size() >= context.limit)
             {
                 break;
             }
 
             final List<Marker> projectMarkers = entry.getValue();
-            final int remaining = limit - errors.size();
+            final int remaining = context.limit - errors.size();
 
             // Resolve the project's BM model so getObjectPresentation() can lazily
             // resolve the marker target inside a read transaction. The getModel(IProject)
@@ -362,8 +357,9 @@ public class GetProjectErrorsTool implements IMcpTool
             IBmModel bmModel = bmModelManager != null ? bmModelManager.getModel(entry.getKey()) : null;
 
             Runnable collector = () -> projectMarkers.stream()
-                .map(marker -> buildIfMatches(marker, severityFilter, checkId,
-                    objects, checkRepository, unresolvedShown, unresolvedFilteredOut))
+                .map(marker -> buildIfMatches(marker, context.severityFilter, context.checkId,
+                    context.objects, context.checkRepository, context.unresolvedShown,
+                    context.unresolvedFilteredOut))
                 .filter(error -> error != null)
                 .limit(remaining)
                 .forEach(errors::add);
@@ -383,6 +379,36 @@ public class GetProjectErrorsTool implements IMcpTool
             }
         }
         return errors;
+    }
+
+    /**
+     * Immutable holder for the per-call collection context threaded through {@link #collectErrors}:
+     * the severity / checkId / objects filters, the check repository, the result {@code limit} and
+     * the two unresolved-marker out-counters. The {@code int[]} counters are shared references whose
+     * contents are advanced exactly as before. Bundles the parameters without changing any value.
+     */
+    private static final class CollectContext
+    {
+        final MarkerSeverity severityFilter;
+        final String checkId;
+        final Set<String> objects;
+        final ICheckRepository checkRepository;
+        final int limit;
+        final int[] unresolvedShown;
+        final int[] unresolvedFilteredOut;
+
+        CollectContext(MarkerSeverity severityFilter, String checkId, Set<String> objects,
+            ICheckRepository checkRepository, int limit, int[] unresolvedShown,
+            int[] unresolvedFilteredOut)
+        {
+            this.severityFilter = severityFilter;
+            this.checkId = checkId;
+            this.objects = objects;
+            this.checkRepository = checkRepository;
+            this.limit = limit;
+            this.unresolvedShown = unresolvedShown;
+            this.unresolvedFilteredOut = unresolvedFilteredOut;
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetVariablesTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetVariablesTool.java
@@ -89,76 +89,156 @@ public class GetVariablesTool implements IMcpTool
 
         try
         {
-            IStackFrame frame = null;
-            if (frameRef > 0)
+            FrameResolution fr = resolveFrame(registry, frameRef, threadId, frameIndex);
+            if (fr.error != null)
             {
-                frame = registry.getFrame(frameRef);
-                if (frame == null)
-                {
-                    return ToolResult.error("stale frameRef — call wait_for_break again").toJson(); //$NON-NLS-1$
-                }
+                return fr.error;
             }
-            else if (threadId > 0)
-            {
-                IThread thread = registry.getThread(threadId);
-                if (thread == null)
-                {
-                    return ToolResult.error("stale threadId — call wait_for_break again").toJson(); //$NON-NLS-1$
-                }
-                IStackFrame[] frames = thread.getStackFrames();
-                if (frameIndex < 0 || frameIndex >= frames.length)
-                {
-                    return ToolResult.error("frameIndex out of range (0.." //$NON-NLS-1$
-                            + (frames.length - 1) + ")").toJson(); //$NON-NLS-1$
-                }
-                frame = frames[frameIndex];
-            }
-            else
-            {
-                // Fallback: auto-resolve the single active debug session through the
-                // SAME blank-id policy every applicationId-based tool uses
-                // (DebugTargetResolver: the lone Eclipse launch, else the lone
-                // server target) and read its snapshot under the canonical key —
-                // replaces a hand-rolled condensed copy of that policy.
-                DebugTargetResolver.Resolution res = DebugTargetResolver.resolve(null);
-                DebugSessionRegistry.SuspendSnapshot snap =
-                    res != null ? registry.getSnapshot(res.canonicalId) : null;
-                if (snap == null)
-                {
-                    return ToolResult.error("Provide frameRef or threadId — no single suspended debug " //$NON-NLS-1$
-                        + "session available for auto-resolution. Call wait_for_break first.").toJson(); //$NON-NLS-1$
-                }
-                IStackFrame[] frames = snap.thread.getStackFrames();
-                if (frames.length == 0)
-                {
-                    return ToolResult.error("suspended thread has no stack frames").toJson(); //$NON-NLS-1$
-                }
-                frame = frames[Math.min(Math.max(frameIndex, 0), frames.length - 1)];
-            }
-
-            List<Map<String, Object>> vars;
-            if (expandPath != null && !expandPath.isEmpty())
-            {
-                IVariable resolved = VariableSerializer.resolvePath(frame, expandPath);
-                if (resolved == null)
-                {
-                    return ToolResult.error("expandPath not found: " + expandPath).toJson(); //$NON-NLS-1$
-                }
-                vars = VariableSerializer.serializeChildren(resolved, registry);
-            }
-            else
-            {
-                vars = VariableSerializer.serializeFrame(frame, registry);
-            }
-            return ToolResult.success()
-                .put("variables", vars) //$NON-NLS-1$
-                .put("count", vars.size()) //$NON-NLS-1$
-                .toJson();
+            return serializeVariables(registry, fr.frame, expandPath);
         }
         catch (Exception e)
         {
             Activator.logError("Error in get_variables", e); //$NON-NLS-1$
             return ToolResult.error(e.getMessage()).toJson(); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Resolves the target stack frame from (in priority order) {@code frameRef},
+     * {@code threadId + frameIndex}, or the auto-resolved single active debug
+     * session. Returns a holder carrying either the resolved frame or the exact
+     * error JSON the original inline branch produced — the caller re-checks
+     * {@code error} and returns it unchanged.
+     *
+     * @return a {@link FrameResolution} with a non-null {@code frame} on success,
+     *         or a non-null {@code error} (same value/case as before) otherwise
+     */
+    private static FrameResolution resolveFrame(DebugSessionRegistry registry, long frameRef, long threadId,
+        int frameIndex)
+        throws org.eclipse.debug.core.DebugException
+    {
+        if (frameRef > 0)
+        {
+            return resolveByFrameRef(registry, frameRef);
+        }
+        if (threadId > 0)
+        {
+            return resolveByThreadId(registry, threadId, frameIndex);
+        }
+        return resolveByAutoSession(registry, frameIndex);
+    }
+
+    /** Resolves the frame stored under a stable {@code frameRef} from wait_for_break. */
+    private static FrameResolution resolveByFrameRef(DebugSessionRegistry registry, long frameRef)
+    {
+        IStackFrame frame = registry.getFrame(frameRef);
+        if (frame == null)
+        {
+            return FrameResolution.error(
+                ToolResult.error("stale frameRef — call wait_for_break again").toJson()); //$NON-NLS-1$
+        }
+        return FrameResolution.frame(frame);
+    }
+
+    /** Resolves the {@code frameIndex}-th frame of the live thread {@code threadId}. */
+    private static FrameResolution resolveByThreadId(DebugSessionRegistry registry, long threadId, int frameIndex)
+        throws org.eclipse.debug.core.DebugException
+    {
+        IThread thread = registry.getThread(threadId);
+        if (thread == null)
+        {
+            return FrameResolution.error(
+                ToolResult.error("stale threadId — call wait_for_break again").toJson()); //$NON-NLS-1$
+        }
+        IStackFrame[] frames = thread.getStackFrames();
+        if (frameIndex < 0 || frameIndex >= frames.length)
+        {
+            return FrameResolution.error(ToolResult.error("frameIndex out of range (0.." //$NON-NLS-1$
+                + (frames.length - 1) + ")").toJson()); //$NON-NLS-1$
+        }
+        return FrameResolution.frame(frames[frameIndex]);
+    }
+
+    /**
+     * Fallback: auto-resolve the single active debug session through the SAME
+     * blank-id policy every applicationId-based tool uses (DebugTargetResolver:
+     * the lone Eclipse launch, else the lone server target) and read its snapshot
+     * under the canonical key — replaces a hand-rolled condensed copy of that
+     * policy. The frame index is clamped into range.
+     */
+    private static FrameResolution resolveByAutoSession(DebugSessionRegistry registry, int frameIndex)
+        throws org.eclipse.debug.core.DebugException
+    {
+        DebugTargetResolver.Resolution res = DebugTargetResolver.resolve(null);
+        DebugSessionRegistry.SuspendSnapshot snap =
+            res != null ? registry.getSnapshot(res.canonicalId) : null;
+        if (snap == null)
+        {
+            return FrameResolution.error(
+                ToolResult.error("Provide frameRef or threadId — no single suspended debug " //$NON-NLS-1$
+                    + "session available for auto-resolution. Call wait_for_break first.").toJson()); //$NON-NLS-1$
+        }
+        IStackFrame[] frames = snap.thread.getStackFrames();
+        if (frames.length == 0)
+        {
+            return FrameResolution.error(
+                ToolResult.error("suspended thread has no stack frames").toJson()); //$NON-NLS-1$
+        }
+        return FrameResolution.frame(frames[Math.min(Math.max(frameIndex, 0), frames.length - 1)]);
+    }
+
+    /**
+     * Serializes either the children of the variable at {@code expandPath} (when
+     * non-empty) or the whole frame, returning the success JSON — or the exact
+     * "expandPath not found" error the inline branch produced.
+     */
+    private static String serializeVariables(DebugSessionRegistry registry, IStackFrame frame, String expandPath)
+        throws Exception
+    {
+        List<Map<String, Object>> vars;
+        if (expandPath != null && !expandPath.isEmpty())
+        {
+            IVariable resolved = VariableSerializer.resolvePath(frame, expandPath);
+            if (resolved == null)
+            {
+                return ToolResult.error("expandPath not found: " + expandPath).toJson(); //$NON-NLS-1$
+            }
+            vars = VariableSerializer.serializeChildren(resolved, registry);
+        }
+        else
+        {
+            vars = VariableSerializer.serializeFrame(frame, registry);
+        }
+        return ToolResult.success()
+            .put("variables", vars) //$NON-NLS-1$
+            .put("count", vars.size()) //$NON-NLS-1$
+            .toJson();
+    }
+
+    /**
+     * Holder threading a frame-resolution early-return out of {@link #resolveFrame}:
+     * exactly one of {@code frame} / {@code error} is non-null. {@code error} carries
+     * the same error JSON (same case) the inline branches returned.
+     */
+    private static final class FrameResolution
+    {
+        final IStackFrame frame;
+        final String error;
+
+        private FrameResolution(IStackFrame frame, String error)
+        {
+            this.frame = frame;
+            this.error = error;
+        }
+
+        static FrameResolution frame(IStackFrame frame)
+        {
+            return new FrameResolution(frame, null);
+        }
+
+        static FrameResolution error(String error)
+        {
+            return new FrameResolution(null, error);
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListModulesTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListModulesTool.java
@@ -188,75 +188,77 @@ public class ListModulesTool implements IMcpTool
         }
         Configuration config = resolved.configuration();
 
+        CollectContext scanCtx = new CollectContext(project, modules, objectName, nameFilter);
+
         switch (type)
         {
             case "commonmodules": //$NON-NLS-1$
-                collectSingleModuleType(project, modules, objectName, nameFilter,
+                collectSingleModuleType(scanCtx,
                     config.getCommonModules(), CommonModule::getName,
                     "CommonModules", MODULE_BSL, MODULE, "CommonModule"); //$NON-NLS-1$ //$NON-NLS-2$
                 break;
             case "documents": //$NON-NLS-1$
-                collectMultiModuleType(project, modules, objectName, nameFilter,
+                collectMultiModuleType(scanCtx,
                     config.getDocuments(), Document::getName, "Documents", "Document"); //$NON-NLS-1$ //$NON-NLS-2$
                 break;
             case "catalogs": //$NON-NLS-1$
-                collectMultiModuleType(project, modules, objectName, nameFilter,
+                collectMultiModuleType(scanCtx,
                     config.getCatalogs(), Catalog::getName, "Catalogs", "Catalog"); //$NON-NLS-1$ //$NON-NLS-2$
                 break;
             case "informationregisters": //$NON-NLS-1$
-                collectMultiModuleType(project, modules, objectName, nameFilter,
+                collectMultiModuleType(scanCtx,
                     config.getInformationRegisters(), InformationRegister::getName,
                     "InformationRegisters", "InformationRegister"); //$NON-NLS-1$ //$NON-NLS-2$
                 break;
             case "accumulationregisters": //$NON-NLS-1$
-                collectMultiModuleType(project, modules, objectName, nameFilter,
+                collectMultiModuleType(scanCtx,
                     config.getAccumulationRegisters(), AccumulationRegister::getName,
                     "AccumulationRegisters", "AccumulationRegister"); //$NON-NLS-1$ //$NON-NLS-2$
                 break;
             case "reports": //$NON-NLS-1$
-                collectMultiModuleType(project, modules, objectName, nameFilter,
+                collectMultiModuleType(scanCtx,
                     config.getReports(), Report::getName, "Reports", "Report"); //$NON-NLS-1$ //$NON-NLS-2$
                 break;
             case "dataprocessors": //$NON-NLS-1$
-                collectMultiModuleType(project, modules, objectName, nameFilter,
+                collectMultiModuleType(scanCtx,
                     config.getDataProcessors(), DataProcessor::getName,
                     "DataProcessors", "DataProcessor"); //$NON-NLS-1$ //$NON-NLS-2$
                 break;
             case "exchangeplans": //$NON-NLS-1$
-                collectMultiModuleType(project, modules, objectName, nameFilter,
+                collectMultiModuleType(scanCtx,
                     config.getExchangePlans(), ExchangePlan::getName,
                     "ExchangePlans", "ExchangePlan"); //$NON-NLS-1$ //$NON-NLS-2$
                 break;
             case "businessprocesses": //$NON-NLS-1$
-                collectMultiModuleType(project, modules, objectName, nameFilter,
+                collectMultiModuleType(scanCtx,
                     config.getBusinessProcesses(), BusinessProcess::getName,
                     "BusinessProcesses", "BusinessProcess"); //$NON-NLS-1$ //$NON-NLS-2$
                 break;
             case "tasks": //$NON-NLS-1$
-                collectMultiModuleType(project, modules, objectName, nameFilter,
+                collectMultiModuleType(scanCtx,
                     config.getTasks(), Task::getName, "Tasks", "Task"); //$NON-NLS-1$ //$NON-NLS-2$
                 break;
             case "constants": //$NON-NLS-1$
-                collectMultiModuleType(project, modules, objectName, nameFilter,
+                collectMultiModuleType(scanCtx,
                     config.getConstants(), Constant::getName, "Constants", "Constant"); //$NON-NLS-1$ //$NON-NLS-2$
                 break;
             case "commoncommands": //$NON-NLS-1$
-                collectSingleModuleType(project, modules, objectName, nameFilter,
+                collectSingleModuleType(scanCtx,
                     config.getCommonCommands(), CommonCommand::getName,
                     "CommonCommands", "CommandModule.bsl", "CommandModule", "CommonCommand"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
                 break;
             case "commonforms": //$NON-NLS-1$
-                collectSingleModuleType(project, modules, objectName, nameFilter,
+                collectSingleModuleType(scanCtx,
                     config.getCommonForms(), CommonForm::getName,
                     "CommonForms", MODULE_BSL, "FormModule", "CommonForm"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
                 break;
             case "webservices": //$NON-NLS-1$
-                collectSingleModuleType(project, modules, objectName, nameFilter,
+                collectSingleModuleType(scanCtx,
                     config.getWebServices(), WebService::getName,
                     "WebServices", MODULE_BSL, MODULE, "WebService"); //$NON-NLS-1$ //$NON-NLS-2$
                 break;
             case "httpservices": //$NON-NLS-1$
-                collectSingleModuleType(project, modules, objectName, nameFilter,
+                collectSingleModuleType(scanCtx,
                     config.getHttpServices(), HTTPService::getName,
                     "HTTPServices", MODULE_BSL, MODULE, "HTTPService"); //$NON-NLS-1$ //$NON-NLS-2$
                 break;
@@ -274,13 +276,34 @@ public class ListModulesTool implements IMcpTool
     // ========== Generic collection methods ==========
 
     /**
+     * Invariant inputs shared by every per-type collector call: the target
+     * project, the accumulating module list, and the two optional filters
+     * ({@code objectName} / {@code nameFilter}). Identical across all metadata
+     * types, so bundled once per {@code execute} and threaded into the generic
+     * collectors. Fields and read order match the previous flat parameters.
+     */
+    private static final class CollectContext
+    {
+        final IProject project;
+        final List<ModuleInfo> modules;
+        final String objectName;
+        final String nameFilter;
+
+        CollectContext(IProject project, List<ModuleInfo> modules, String objectName,
+                String nameFilter)
+        {
+            this.project = project;
+            this.modules = modules;
+            this.objectName = objectName;
+            this.nameFilter = nameFilter;
+        }
+    }
+
+    /**
      * Generic collector for metadata types with a single known BSL module file.
      * Used for CommonModules, CommonCommands, CommonForms, WebServices, HTTPServices.
      *
-     * @param project the workspace project
-     * @param modules target list for collected module info
-     * @param objectName optional filter by object name (case-insensitive)
-     * @param nameFilter optional filter by module path substring
+     * @param ctx the invariant scan context (project, target list, filters)
      * @param objects the metadata objects to iterate
      * @param nameGetter function to extract the name from a metadata object
      * @param folderName the folder name in src/ (e.g. "CommonModules", "WebServices")
@@ -288,20 +311,21 @@ public class ListModulesTool implements IMcpTool
      * @param moduleType the module type label (e.g. "Module", "FormModule", "CommandModule")
      * @param parentType the parent type label (e.g. "CommonModule", "WebService")
      */
-    private <T> void collectSingleModuleType(IProject project, List<ModuleInfo> modules,
-        String objectName, String nameFilter, Iterable<T> objects, Function<T, String> nameGetter,
-        String folderName, String fileName, String moduleType, String parentType)
+    private <T> void collectSingleModuleType(CollectContext ctx, Iterable<T> objects,
+        Function<T, String> nameGetter, String folderName, String fileName, String moduleType,
+        String parentType)
     {
         for (T obj : objects)
         {
             String name = nameGetter.apply(obj);
-            if (objectName != null && !objectName.isEmpty()
-                && !name.equalsIgnoreCase(objectName))
+            if (ctx.objectName != null && !ctx.objectName.isEmpty()
+                && !name.equalsIgnoreCase(ctx.objectName))
             {
                 continue;
             }
             String path = folderName + "/" + name + "/" + fileName; //$NON-NLS-1$ //$NON-NLS-2$
-            addIfExists(project, modules, path, moduleType, parentType, name, nameFilter);
+            addIfExists(ctx.project, ctx.modules, path, moduleType, parentType, name,
+                ctx.nameFilter);
         }
     }
 
@@ -310,29 +334,25 @@ public class ListModulesTool implements IMcpTool
      * Recursively scans the object directory for all .bsl files.
      * Used for Documents, Catalogs, Registers, Reports, DataProcessors, etc.
      *
-     * @param project the workspace project
-     * @param modules target list for collected module info
-     * @param objectName optional filter by object name (case-insensitive)
-     * @param nameFilter optional filter by module path substring
+     * @param ctx the invariant scan context (project, target list, filters)
      * @param objects the metadata objects to iterate
      * @param nameGetter function to extract the name from a metadata object
      * @param folderName the folder name in src/ (e.g. "Documents", "Catalogs")
      * @param parentType the parent type label (e.g. "Document", "Catalog")
      */
-    private <T> void collectMultiModuleType(IProject project, List<ModuleInfo> modules,
-        String objectName, String nameFilter, Iterable<T> objects, Function<T, String> nameGetter,
-        String folderName, String parentType)
+    private <T> void collectMultiModuleType(CollectContext ctx, Iterable<T> objects,
+        Function<T, String> nameGetter, String folderName, String parentType)
     {
         for (T obj : objects)
         {
             String name = nameGetter.apply(obj);
-            if (objectName != null && !objectName.isEmpty()
-                && !name.equalsIgnoreCase(objectName))
+            if (ctx.objectName != null && !ctx.objectName.isEmpty()
+                && !name.equalsIgnoreCase(ctx.objectName))
             {
                 continue;
             }
-            collectAllBslModules(project, modules, folderName + "/" + name, //$NON-NLS-1$
-                parentType, name, nameFilter);
+            collectAllBslModules(ctx.project, ctx.modules, folderName + "/" + name, //$NON-NLS-1$
+                parentType, name, ctx.nameFilter);
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -472,6 +472,25 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             return moveFormItem(ctx, normFqn, ref, properties);
         }
 
+        // Ordinary property modify: the remaining (non-handler, non-command, non-move) case.
+        return modifyFormMemberProperties(ctx, normFqn, ref, properties, normReport);
+    }
+
+    /**
+     * Modifies the ordinary (non-handler, non-command, non-move) properties of a form member, the
+     * remaining case of {@link #modifyFormMember} once those three structural branches are ruled out.
+     * Resolves the platform version, then validates + applies every property inside ONE BM write
+     * transaction (the member is re-navigated by name inside the tx; a validation failure throws
+     * {@link FormValidationException} carrying its JSON error BEFORE any {@code eSet}, so the tx rolls
+     * back with no partial mutation) and force-exports the CONTENT form to disk. Extracted verbatim
+     * from {@link #modifyFormMember}: the BM write transaction (apply loop + forceExport via
+     * {@code writeEditableForm}) stays INLINE here, and the early-returns return the SAME JSON in the
+     * SAME case.
+     */
+    private String modifyFormMemberProperties(ProjectContext ctx, String normFqn,
+        FormElementWriter.FormMemberRef ref, List<JsonObject> properties,
+        MdNameNormalizer.Report normReport)
+    {
         Configuration config = ctx.config;
         IV8ProjectManager v8ProjectManager = Activator.getDefault().getV8ProjectManager();
         IV8Project v8Project = v8ProjectManager != null ? v8ProjectManager.getProject(ctx.project) : null;
@@ -1283,6 +1302,25 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
 
     // ---- helpers --------------------------------------------------------------------------------
 
+    /**
+     * The STYLE_VALUE-only binding of a {@link PreparedChange}: the sibling {@code type} feature
+     * (Color / Font) and the {@link StyleElementType} to set on it alongside the value, so the style
+     * item's type stays consistent with the value it holds. A parameter-object that keeps the
+     * {@link PreparedChange} constructor below the 7-parameter bar; {@code null} for every non-style
+     * change. Carries no behaviour.
+     */
+    private static final class StyleBinding
+    {
+        private final EStructuralFeature typeFeature;
+        private final StyleElementType type;
+
+        StyleBinding(EStructuralFeature typeFeature, StyleElementType type)
+        {
+            this.typeFeature = typeFeature;
+            this.type = type;
+        }
+    }
+
     /** A validated, coerced change ready to apply to the re-fetched target inside the write tx. */
     private static final class PreparedChange
     {
@@ -1295,14 +1333,12 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         private final String localizedValue;
         /** For a REFERENCE: the target's bmId. For a MANY_REFERENCE: the targets' bmIds in order. */
         private final List<Long> referenceBmIds;
-        /** For a STYLE_VALUE: the sibling `type` feature (Color / Font), set alongside the value. */
-        private final EStructuralFeature styleTypeFeature;
-        /** For a STYLE_VALUE: the StyleElementType to set on {@link #styleTypeFeature}. */
-        private final StyleElementType styleType;
+        /** For a STYLE_VALUE: the sibling `type` feature + StyleElementType; {@code null} otherwise. */
+        private final StyleBinding styleBinding;
 
         private PreparedChange(EStructuralFeature feature, Kind kind, Object scalarValue,
             String language, String localizedValue, List<Long> referenceBmIds,
-            EStructuralFeature styleTypeFeature, StyleElementType styleType)
+            StyleBinding styleBinding)
         {
             this.feature = feature;
             this.kind = kind;
@@ -1310,30 +1346,29 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             this.localizedLanguage = language;
             this.localizedValue = localizedValue;
             this.referenceBmIds = referenceBmIds;
-            this.styleTypeFeature = styleTypeFeature;
-            this.styleType = styleType;
+            this.styleBinding = styleBinding;
         }
 
         static PreparedChange scalar(EStructuralFeature feature, Object value)
         {
-            return new PreparedChange(feature, Kind.SCALAR, value, null, null, null, null, null);
+            return new PreparedChange(feature, Kind.SCALAR, value, null, null, null, null);
         }
 
         static PreparedChange localized(EStructuralFeature feature, String language, String value)
         {
-            return new PreparedChange(feature, Kind.LOCALIZED, null, language, value, null, null, null);
+            return new PreparedChange(feature, Kind.LOCALIZED, null, language, value, null, null);
         }
 
         static PreparedChange reference(EStructuralFeature feature, long targetBmId)
         {
             return new PreparedChange(feature, Kind.REFERENCE, null, null, null,
-                java.util.Collections.singletonList(targetBmId), null, null);
+                java.util.Collections.singletonList(targetBmId), null);
         }
 
         static PreparedChange manyReference(EStructuralFeature feature, List<Long> targetBmIds)
         {
             return new PreparedChange(feature, Kind.MANY_REFERENCE, null, null, null, targetBmIds,
-                null, null);
+                null);
         }
 
         /**
@@ -1346,7 +1381,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             Value styleValue, StyleElementType type)
         {
             return new PreparedChange(valueFeature, Kind.STYLE_VALUE, styleValue, null, null, null,
-                typeFeature, type);
+                new StyleBinding(typeFeature, type));
         }
 
         String featureName()
@@ -1392,9 +1427,10 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 {
                     // Keep the style item's `type` consistent with the value it now holds (Color / Font),
                     // then set the freshly-built (detached) mcore Value as its containment `value`.
-                    if (styleTypeFeature != null && styleType != null)
+                    if (styleBinding != null && styleBinding.typeFeature != null
+                        && styleBinding.type != null)
                     {
-                        target.eSet(styleTypeFeature, styleType);
+                        target.eSet(styleBinding.typeFeature, styleBinding.type);
                     }
                     target.eSet(feature, scalarValue);
                     return;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
@@ -261,8 +261,45 @@ public class RunYaxunitTestsTool implements IMcpTool
         ensureLaunchListenerRegistered();
         purgeTerminatedLaunches();
 
-        return runTests(configName, projectName, applicationId, extensions, modules, tests,
-            timeout, updateBeforeLaunch, updateScope, debug);
+        return runTests(new RunRequest(configName, projectName, applicationId, extensions, modules,
+            tests, timeout, updateBeforeLaunch, updateScope, debug));
+    }
+
+    /**
+     * Immutable carrier for the parsed {@code execute} arguments threaded through
+     * {@link #runTests} and {@link #spawnOrReuseLaunch}. Pure value object — bundling
+     * these keeps both methods below the 7-parameter limit without changing any value
+     * (the resolved {@code projectName}/{@code applicationId} derived from the launch
+     * config are kept as method locals in {@link #runTests}, never written back here).
+     */
+    private static final class RunRequest
+    {
+        final String configName;
+        final String projectName;
+        final String applicationId;
+        final String extensions;
+        final String modules;
+        final String tests;
+        final int timeout;
+        final boolean updateBeforeLaunch;
+        final String updateScope;
+        final boolean debug;
+
+        RunRequest(String configName, String projectName, String applicationId, String extensions,
+                String modules, String tests, int timeout, boolean updateBeforeLaunch,
+                String updateScope, boolean debug)
+        {
+            this.configName = configName;
+            this.projectName = projectName;
+            this.applicationId = applicationId;
+            this.extensions = extensions;
+            this.modules = modules;
+            this.tests = tests;
+            this.timeout = timeout;
+            this.updateBeforeLaunch = updateBeforeLaunch;
+            this.updateScope = updateScope;
+            this.debug = debug;
+        }
     }
 
     /**
@@ -288,9 +325,7 @@ public class RunYaxunitTestsTool implements IMcpTool
      * The temp directory is NEVER deleted in finally — a Pending re-call can fetch the result. Old
      * runs are cleaned up automatically before starting a new launch.
      */
-    private String runTests(String configName, String projectName, String applicationId,
-            String extensions, String modules, String tests, int timeout, boolean updateBeforeLaunch,
-            String updateScope, boolean debug)
+    private String runTests(RunRequest req)
     {
         try
         {
@@ -300,44 +335,46 @@ public class RunYaxunitTestsTool implements IMcpTool
                 return ToolResult.error("Launch manager is not available").toJson(); //$NON-NLS-1$
             }
 
-            String earlyScopeError = validateUpdateScopeEarly(projectName, updateScope, updateBeforeLaunch);
+            String earlyScopeError = validateUpdateScopeEarly(req.projectName, req.updateScope,
+                req.updateBeforeLaunch);
             if (earlyScopeError != null)
             {
                 return earlyScopeError;
             }
 
-            LaunchContext context = resolveLaunchContext(launchManager, configName, projectName, applicationId);
+            LaunchContext context = resolveLaunchContext(launchManager, req.configName,
+                req.projectName, req.applicationId);
             if (context.error != null)
             {
                 return context.error;
             }
             ILaunchConfiguration matchingConfig = context.config;
-            projectName = context.projectName;
-            applicationId = context.applicationId;
+            String projectName = context.projectName;
+            String applicationId = context.applicationId;
             IProject project = context.project;
             IApplicationManager appManager = context.appManager;
 
             // DEBUG mode shares the whole setup above (resolve/validate/effective
             // project+app), then spawns a DEBUG launch and returns at once for
             // wait_for_break — no polling, no run-key reuse cache.
-            if (debug)
+            if (req.debug)
             {
                 return launchDebugMode(matchingConfig, project, projectName, applicationId,
-                    appManager, launchManager, extensions, modules, tests, updateBeforeLaunch,
-                    updateScope);
+                    appManager, launchManager, req.extensions, req.modules, req.tests,
+                    req.updateBeforeLaunch, req.updateScope);
             }
 
             // Use the launch config name as the run-key root — stable across
             // (project, applicationId) vs. launchConfigurationName call styles.
             String runKey = matchingConfig.getName() + ":" //$NON-NLS-1$
-                    + sha1(safe(extensions) + "|" + safe(modules) + "|" + safe(tests)); //$NON-NLS-1$ //$NON-NLS-2$
+                    + sha1(safe(req.extensions) + "|" + safe(req.modules) + "|" + safe(req.tests)); //$NON-NLS-1$ //$NON-NLS-2$
             Path reportDir = stableReportDir(runKey);
 
             // If a launch is already running for this key, just poll it.
             ILaunch existing = ACTIVE_LAUNCHES.get(runKey);
             if (existing != null)
             {
-                return handleExistingLaunch(existing, reportDir, timeout, runKey,
+                return handleExistingLaunch(existing, reportDir, req.timeout, runKey,
                         projectName, applicationId);
             }
 
@@ -371,20 +408,15 @@ public class RunYaxunitTestsTool implements IMcpTool
             PreLaunchResult preLaunch = null;
             if (launch == null)
             {
-                if (updateBeforeLaunch)
+                if (req.updateBeforeLaunch)
                 {
                     String prepKey = LaunchLifecycleUtils.prepKeyFor(projectName, applicationId);
-                    final ILaunchManager finalLaunchManager = launchManager;
-                    final IProject finalProject = project;
-                    final String finalApplicationId = applicationId;
-                    final IApplicationManager finalAppManager = appManager;
-                    final String finalUpdateScope = updateScope;
                     final PreLaunchResult[] resultHolder = new PreLaunchResult[1];
+                    PrepRequest prepReq = new PrepRequest(projectName, launchManager, project,
+                        applicationId, appManager, req.updateScope,
+                        "YAXUnit pre-launch preparation for " + projectName); //$NON-NLS-1$
 
-                    String pendingOrError = awaitPreparedOrPending(prepKey, projectName,
-                        finalLaunchManager, finalProject, finalApplicationId, finalAppManager,
-                        finalUpdateScope, "YAXUnit pre-launch preparation for " + projectName, //$NON-NLS-1$
-                        resultHolder);
+                    String pendingOrError = awaitPreparedOrPending(prepKey, prepReq, resultHolder);
                     if (pendingOrError != null)
                     {
                         return pendingOrError;
@@ -392,77 +424,21 @@ public class RunYaxunitTestsTool implements IMcpTool
                     preLaunch = resultHolder[0];
                 }
 
+                // Phase 3 (spawn-or-reuse) runs under the per-key lock — the spawn
+                // body itself (re-check racer / cleanup+write-params+launch+register)
+                // is extracted but stays INLINE under the SAME two locks here so the
+                // lock scopes are byte-for-byte the inline behaviour.
                 synchronized (LaunchLifecycleUtils.lockFor(projectName, applicationId))
                 {
-                    // Phase 3: re-check ACTIVE_LAUNCHES under JVM-wide sync (another
-                    // thread may have spawned for the same runKey while we waited
-                    // on the per-key lock), then either reuse or spawn.
                     synchronized (ACTIVE_LAUNCHES)
                     {
-                        ILaunch racer = ACTIVE_LAUNCHES.get(runKey);
-                        if (racer != null && !racer.isTerminated())
-                        {
-                            Activator.logInfo("Reusing YAXUnit launch spawned during auto-chain: runKey=" //$NON-NLS-1$
-                                + runKey);
-                            launch = racer;
-                        }
-                        else
-                        {
-                            cleanupTempDir(reportDir);
-                            Files.createDirectories(reportDir);
-                            Path paramsFile = reportDir.resolve("xUnitParams.json"); //$NON-NLS-1$
-                            String paramsJson = buildParamsJson(reportDir.resolve(VAL_JUNIT_XML).toString(),
-                                    extensions, modules, tests);
-                            Files.write(paramsFile, paramsJson.getBytes(StandardCharsets.UTF_8));
-                            Activator.logInfo("YAXUnit params written to: " + paramsFile); //$NON-NLS-1$
-
-                            ILaunchConfigurationWorkingCopy workingCopy = matchingConfig.getWorkingCopy();
-                            String startupOption = "RunUnitTests=" + paramsFile.toString(); //$NON-NLS-1$
-                            workingCopy.setAttribute(LaunchConfigUtils.ATTR_STARTUP_OPTION, startupOption);
-                            // Stamp the resolved applicationId onto the launch so the spawned
-                            // client carries it (an app-less config would otherwise launch with
-                            // an empty id), keeping it matchable by the terminate-before-launch
-                            // sweep keyed on applicationId.
-                            if (applicationId != null && !applicationId.isEmpty())
-                            {
-                                workingCopy.setAttribute(LaunchConfigUtils.ATTR_APPLICATION_ID, applicationId);
-                            }
-
-                            Activator.logInfo("Launching YAXUnit tests: config=" + matchingConfig.getName() //$NON-NLS-1$
-                                    + ", startup=" + startupOption); //$NON-NLS-1$
-
-                            // Auto-confirm EDT's blocking "Application update" modal
-                            // for the duration of this launch only (the dependent
-                            // test extension keeps the app in INCREMENTAL_UPDATE_REQUIRED,
-                            // which no pre-update durably clears) — but ONLY when the
-                            // caller did not opt out via updateBeforeLaunch=false:
-                            // auto-pressing "Update then run" would silently perform
-                            // the very DB update the caller disabled, so with the
-                            // opt-out the platform's dialogs are left for a human.
-                            // Manual EDT launches outside this window still prompt
-                            // normally.
-                            boolean[] armFlags = runPathArmFlags(updateBeforeLaunch);
-                            LaunchUpdateDialogAutoConfirmer.arm(armFlags[0], armFlags[1]);
-                            try
-                            {
-                                launch = workingCopy.launch(ILaunchManager.RUN_MODE,
-                                    new NullProgressMonitor());
-                            }
-                            finally
-                            {
-                                LaunchUpdateDialogAutoConfirmer.disarm(armFlags[0], armFlags[1]);
-                            }
-                            // Register BEFORE leaving the per-key lock so a concurrent
-                            // auto-chain on the same IB sees this launch as owned and
-                            // refuses to terminate it.
-                            LaunchLifecycleUtils.registerOwnedLaunch(launch);
-                            ACTIVE_LAUNCHES.put(runKey, launch);
-                        }
+                        launch = spawnOrReuseLaunch(req, matchingConfig, applicationId,
+                            runKey, reportDir);
                     }
                 }
             }
 
-            String pollResult = pollLaunch(launch, reportDir, timeout, runKey,
+            String pollResult = pollLaunch(launch, reportDir, req.timeout, runKey,
                     projectName, applicationId);
             if (pollResult != null)
             {
@@ -491,6 +467,83 @@ public class RunYaxunitTestsTool implements IMcpTool
             Activator.logError("Unexpected error running YAXUnit tests", e); //$NON-NLS-1$
             return ToolResult.error(e.getMessage()).toJson();
         }
+    }
+
+    /**
+     * Phase 3 reuse-or-spawn body for the RUN path — extracted verbatim from the
+     * inner {@code synchronized (ACTIVE_LAUNCHES)} block of {@link #runTests}. The
+     * CALLER still holds BOTH locks ({@code lockFor(project, applicationId)} then
+     * {@code ACTIVE_LAUNCHES}); this method runs entirely inside that scope, so the
+     * mutating {@code workingCopy.launch} + {@code registerOwnedLaunch} +
+     * {@code ACTIVE_LAUNCHES.put} sequence keeps the exact same serialisation it had
+     * inline. Re-checks {@link #ACTIVE_LAUNCHES} for a launch a racing identical call
+     * spawned during the auto-chain and reuses it; otherwise cleans the report dir,
+     * writes the params file and spawns a fresh RUN-mode launch.
+     *
+     * @return the reused or freshly spawned launch (never {@code null})
+     */
+    private ILaunch spawnOrReuseLaunch(RunRequest req, ILaunchConfiguration matchingConfig,
+            String applicationId, String runKey, Path reportDir) throws CoreException, IOException
+    {
+        ILaunch racer = ACTIVE_LAUNCHES.get(runKey);
+        if (racer != null && !racer.isTerminated())
+        {
+            Activator.logInfo("Reusing YAXUnit launch spawned during auto-chain: runKey=" //$NON-NLS-1$
+                + runKey);
+            return racer;
+        }
+
+        cleanupTempDir(reportDir);
+        Files.createDirectories(reportDir);
+        Path paramsFile = reportDir.resolve("xUnitParams.json"); //$NON-NLS-1$
+        String paramsJson = buildParamsJson(reportDir.resolve(VAL_JUNIT_XML).toString(),
+                req.extensions, req.modules, req.tests);
+        Files.write(paramsFile, paramsJson.getBytes(StandardCharsets.UTF_8));
+        Activator.logInfo("YAXUnit params written to: " + paramsFile); //$NON-NLS-1$
+
+        ILaunchConfigurationWorkingCopy workingCopy = matchingConfig.getWorkingCopy();
+        String startupOption = "RunUnitTests=" + paramsFile.toString(); //$NON-NLS-1$
+        workingCopy.setAttribute(LaunchConfigUtils.ATTR_STARTUP_OPTION, startupOption);
+        // Stamp the resolved applicationId onto the launch so the spawned
+        // client carries it (an app-less config would otherwise launch with
+        // an empty id), keeping it matchable by the terminate-before-launch
+        // sweep keyed on applicationId.
+        if (applicationId != null && !applicationId.isEmpty())
+        {
+            workingCopy.setAttribute(LaunchConfigUtils.ATTR_APPLICATION_ID, applicationId);
+        }
+
+        Activator.logInfo("Launching YAXUnit tests: config=" + matchingConfig.getName() //$NON-NLS-1$
+                + ", startup=" + startupOption); //$NON-NLS-1$
+
+        // Auto-confirm EDT's blocking "Application update" modal
+        // for the duration of this launch only (the dependent
+        // test extension keeps the app in INCREMENTAL_UPDATE_REQUIRED,
+        // which no pre-update durably clears) — but ONLY when the
+        // caller did not opt out via updateBeforeLaunch=false:
+        // auto-pressing "Update then run" would silently perform
+        // the very DB update the caller disabled, so with the
+        // opt-out the platform's dialogs are left for a human.
+        // Manual EDT launches outside this window still prompt
+        // normally.
+        boolean[] armFlags = runPathArmFlags(req.updateBeforeLaunch);
+        LaunchUpdateDialogAutoConfirmer.arm(armFlags[0], armFlags[1]);
+        ILaunch launch;
+        try
+        {
+            launch = workingCopy.launch(ILaunchManager.RUN_MODE,
+                new NullProgressMonitor());
+        }
+        finally
+        {
+            LaunchUpdateDialogAutoConfirmer.disarm(armFlags[0], armFlags[1]);
+        }
+        // Register BEFORE leaving the per-key lock so a concurrent
+        // auto-chain on the same IB sees this launch as owned and
+        // refuses to terminate it.
+        LaunchLifecycleUtils.registerOwnedLaunch(launch);
+        ACTIVE_LAUNCHES.put(runKey, launch);
+        return launch;
     }
 
     /**
@@ -599,6 +652,22 @@ public class RunYaxunitTestsTool implements IMcpTool
                 + "' is not a runtime-client config — YAXUnit tests require one.").toJson()); //$NON-NLS-1$
         }
 
+        return deriveLaunchContext(matchingConfig, projectName, applicationId);
+    }
+
+    /**
+     * Second half of {@link #resolveLaunchContext} (extracted, behaviour-identical):
+     * derives the effective project/application from the already-validated runtime-client
+     * config, then runs the project-state / existence / open / application-manager /
+     * application-exists gates in the SAME order, returning the first failure or a
+     * populated success. Pure (read-only) — no launch is spawned.
+     *
+     * @return a {@link LaunchContext} whose {@link LaunchContext#error} is non-{@code null}
+     *         when the caller must return that JSON payload, otherwise a populated success
+     */
+    private LaunchContext deriveLaunchContext(ILaunchConfiguration matchingConfig,
+            String projectName, String applicationId)
+    {
         // Derive effective project/application from the resolved config.
         String effectiveProject = LaunchConfigUtils.readAttribute(matchingConfig,
             LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
@@ -618,23 +687,12 @@ public class RunYaxunitTestsTool implements IMcpTool
                 + "' has no project attribute set").toJson()); //$NON-NLS-1$
         }
 
-        String notReadyError = ProjectStateChecker.checkReadyOrError(projectName);
-        if (notReadyError != null)
+        LaunchContext projectError = checkProjectGate(projectName);
+        if (projectError != null)
         {
-            return LaunchContext.failure(ToolResult.error(notReadyError).toJson());
+            return projectError;
         }
-
-        ProjectContext ctx = ProjectContext.of(projectName);
-        if (!ctx.exists())
-        {
-            return LaunchContext.failure(ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson());
-        }
-
-        if (!ctx.isOpen())
-        {
-            return LaunchContext.failure(ToolResult.error("Project is closed: " + projectName).toJson()); //$NON-NLS-1$
-        }
-        IProject project = ctx.project();
+        IProject project = ProjectContext.of(projectName).project();
 
         IApplicationManager appManager = Activator.getDefault().getApplicationManager();
         if (appManager == null)
@@ -659,6 +717,34 @@ public class RunYaxunitTestsTool implements IMcpTool
         }
 
         return LaunchContext.success(matchingConfig, projectName, applicationId, project, appManager);
+    }
+
+    /**
+     * Runs the project-readiness / existence / open gates for {@code projectName}
+     * in the exact order {@link #deriveLaunchContext} previously ran them inline.
+     *
+     * @return a failure {@link LaunchContext} for the first gate that fails, or
+     *         {@code null} when the project is ready, present and open
+     */
+    private static LaunchContext checkProjectGate(String projectName)
+    {
+        String notReadyError = ProjectStateChecker.checkReadyOrError(projectName);
+        if (notReadyError != null)
+        {
+            return LaunchContext.failure(ToolResult.error(notReadyError).toJson());
+        }
+
+        ProjectContext ctx = ProjectContext.of(projectName);
+        if (!ctx.exists())
+        {
+            return LaunchContext.failure(ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson());
+        }
+
+        if (!ctx.isOpen())
+        {
+            return LaunchContext.failure(ToolResult.error("Project is closed: " + projectName).toJson()); //$NON-NLS-1$
+        }
+        return null;
     }
 
     /**
@@ -810,11 +896,11 @@ public class RunYaxunitTestsTool implements IMcpTool
         {
             String prepKey = LaunchLifecycleUtils.prepKeyFor(projectName, applicationId);
             final PreLaunchResult[] resultHolder = new PreLaunchResult[1];
+            PrepRequest prepReq = new PrepRequest(projectName, launchManager, project,
+                applicationId, appManager, updateScope,
+                "YAXUnit debug pre-launch preparation for " + projectName); //$NON-NLS-1$
 
-            String pendingOrError = awaitPreparedOrPending(prepKey, projectName,
-                launchManager, project, applicationId, appManager,
-                updateScope, "YAXUnit debug pre-launch preparation for " + projectName, //$NON-NLS-1$
-                resultHolder);
+            String pendingOrError = awaitPreparedOrPending(prepKey, prepReq, resultHolder);
             if (pendingOrError != null)
             {
                 return pendingOrError;
@@ -925,18 +1011,11 @@ public class RunYaxunitTestsTool implements IMcpTool
      * </ol>
      *
      * @param prepKey          the in-flight map key (project\u0000applicationId)
-     * @param projectName      project name (for log messages)
-     * @param launchManager    Eclipse launch manager passed through to
-     *                         {@link LaunchLifecycleUtils#prepareForFreshLaunch}
-     * @param project          project handle passed through to
-     *                         {@link LaunchLifecycleUtils#prepareForFreshLaunch}
-     * @param applicationId    application id passed through to
-     *                         {@link LaunchLifecycleUtils#prepareForFreshLaunch}
-     * @param appManager       application manager passed through to
-     *                         {@link LaunchLifecycleUtils#prepareForFreshLaunch}
-     * @param updateScope      updateScope value passed through to
-     *                         {@link LaunchLifecycleUtils#prepareForFreshLaunch}
-     * @param jobName          display name for the background Job
+     * @param req              the pre-launch preparation pass-throughs (project name,
+     *                         launch manager, project, application id, application
+     *                         manager and updateScope forwarded to
+     *                         {@link LaunchLifecycleUtils#prepareForFreshLaunch}, plus
+     *                         the background Job display name)
      * @param resultHolder     single-element array; on success the
      *                         {@link PreLaunchResult} is stored in {@code [0]}
      * @return a non-{@code null} string (a Pending or error message) when the
@@ -944,42 +1023,16 @@ public class RunYaxunitTestsTool implements IMcpTool
      *         {@code null} when preparation completed successfully and the caller
      *         may proceed
      */
-    private static String awaitPreparedOrPending(String prepKey, String projectName,
-            ILaunchManager launchManager, IProject project, String applicationId,
-            IApplicationManager appManager, String updateScope, String jobName,
+    private static String awaitPreparedOrPending(String prepKey, PrepRequest req,
             PreLaunchResult[] resultHolder)
     {
         // Stale-entry eviction loop: if an expired or done-with-error entry is in
         // the map, remove it atomically so the computeIfAbsent below creates a fresh
         // one. At most two iterations: one to detect + remove, one to proceed.
-        while (true)
+        String staleError = evictStalePrepEntry(prepKey);
+        if (staleError != null)
         {
-            PrepInFlight existing = LaunchLifecycleUtils.PREP_INFLIGHT.get(prepKey);
-            if (existing == null)
-            {
-                break; // nothing stale — fall through to computeIfAbsent
-            }
-            if (existing.done && existing.error != null)
-            {
-                // Surface the error ONCE; clear the entry so the next call retries.
-                if (LaunchLifecycleUtils.PREP_INFLIGHT.remove(prepKey, existing))
-                {
-                    return ToolResult.error("Pre-launch preparation failed: " + existing.error //$NON-NLS-1$
-                        + "\n\nIf the previous launch is stuck, call `terminate_launch` " //$NON-NLS-1$
-                        + "with `force=true` and retry. As a last resort, pass " //$NON-NLS-1$
-                        + "`updateBeforeLaunch=false` — but the EDT launch delegate may " //$NON-NLS-1$
-                        + "then pop a modal dialog that blocks the MCP call.").toJson(); //$NON-NLS-1$
-                }
-                continue; // another thread already replaced it — re-check
-            }
-            if (existing.isExpired())
-            {
-                // Atomically replace the expired entry; on failure another thread
-                // already replaced it, so re-check.
-                LaunchLifecycleUtils.PREP_INFLIGHT.remove(prepKey, existing);
-                continue;
-            }
-            break; // active (not done, not expired) — fall through to computeIfAbsent
+            return staleError;
         }
 
         // Atomically get-or-create.  Only the thread that wins
@@ -990,46 +1043,7 @@ public class RunYaxunitTestsTool implements IMcpTool
         if (entry.started.compareAndSet(false, true))
         {
             // This thread won: create and schedule the background Job.
-            final PrepInFlight jobEntry = entry;
-            Job prepJob = new Job(jobName)
-            {
-                @Override
-                protected IStatus run(IProgressMonitor monitor)
-                {
-                    try
-                    {
-                        jobEntry.phase = "recompute"; //$NON-NLS-1$
-                        int terminateTimeout =
-                            LaunchLifecycleUtils.getDefaultTerminateTimeoutSeconds();
-                        PreLaunchResult result = LaunchLifecycleUtils.prepareForFreshLaunch(
-                            launchManager, project, applicationId,
-                            appManager, terminateTimeout, updateScope);
-                        jobEntry.phase = "db-update"; //$NON-NLS-1$
-                        resultHolder[0] = result;
-                        if (!result.isOk())
-                        {
-                            jobEntry.error = result.getError();
-                        }
-                    }
-                    catch (Throwable e) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
-                    {
-                        // Throwable, not Exception: an Error escaping the prep must still
-                        // surface as a prep failure — otherwise the retry call would see
-                        // done-without-error and proceed as if preparation succeeded.
-                        jobEntry.error = e.getMessage() != null ? e.getMessage()
-                            : e.getClass().getSimpleName();
-                        Activator.logError("Pre-launch preparation job failed: " + projectName, e); //$NON-NLS-1$
-                    }
-                    finally
-                    {
-                        jobEntry.done = true;
-                        jobEntry.latch.countDown();
-                    }
-                    return Status.OK_STATUS;
-                }
-            };
-            prepJob.setPriority(Job.INTERACTIVE);
-            prepJob.schedule();
+            schedulePrepJob(entry, req, resultHolder);
         }
         // else: another thread is already running the Job — just await the latch.
 
@@ -1053,15 +1067,144 @@ public class RunYaxunitTestsTool implements IMcpTool
         LaunchLifecycleUtils.PREP_INFLIGHT.remove(prepKey, entry);
         if (entry.error != null)
         {
-            return ToolResult.error("Pre-launch preparation failed: " + entry.error //$NON-NLS-1$
-                + "\n\nIf the previous launch is stuck, call `terminate_launch` " //$NON-NLS-1$
-                + "with `force=true` and retry. As a last resort, pass " //$NON-NLS-1$
-                + "`updateBeforeLaunch=false` — but the EDT launch delegate may " //$NON-NLS-1$
-                + "then pop a modal dialog that blocks the MCP call.").toJson(); //$NON-NLS-1$
+            return prepFailedError(entry.error);
         }
         // resultHolder[0] already set by the Job; null for the concurrent-waiter path
         // (the original job-starter holds the result, but launch can proceed either way).
         return null; // success — caller may proceed to launch
+    }
+
+    /**
+     * Immutable carrier for the pre-launch preparation pass-throughs (everything
+     * the background {@link #schedulePrepJob} hands to
+     * {@link LaunchLifecycleUtils#prepareForFreshLaunch}, plus the project name for
+     * logging and the Job display name). Bundling these keeps
+     * {@link #awaitPreparedOrPending} and {@link #schedulePrepJob} below the
+     * 7-parameter limit without changing any value or order.
+     */
+    private static final class PrepRequest
+    {
+        final String projectName;
+        final ILaunchManager launchManager;
+        final IProject project;
+        final String applicationId;
+        final IApplicationManager appManager;
+        final String updateScope;
+        final String jobName;
+
+        PrepRequest(String projectName, ILaunchManager launchManager, IProject project,
+                String applicationId, IApplicationManager appManager, String updateScope,
+                String jobName)
+        {
+            this.projectName = projectName;
+            this.launchManager = launchManager;
+            this.project = project;
+            this.applicationId = applicationId;
+            this.appManager = appManager;
+            this.updateScope = updateScope;
+            this.jobName = jobName;
+        }
+    }
+
+    /**
+     * Stale-entry eviction loop for {@link #awaitPreparedOrPending}: if an expired
+     * or done-with-error {@link PrepInFlight} entry is in {@link LaunchLifecycleUtils#PREP_INFLIGHT},
+     * removes it atomically so the caller's {@code computeIfAbsent} creates a fresh
+     * one. At most two iterations: one to detect + remove, one to proceed.
+     *
+     * @return a ready {@link ToolResult#error} JSON payload when a done-with-error
+     *         entry was surfaced (caller returns it verbatim), otherwise {@code null}
+     *         once no stale entry blocks the path
+     */
+    private static String evictStalePrepEntry(String prepKey)
+    {
+        while (true)
+        {
+            PrepInFlight existing = LaunchLifecycleUtils.PREP_INFLIGHT.get(prepKey);
+            if (existing == null)
+            {
+                return null; // nothing stale — caller falls through to computeIfAbsent
+            }
+            if (existing.done && existing.error != null)
+            {
+                // Surface the error ONCE; clear the entry so the next call retries.
+                if (LaunchLifecycleUtils.PREP_INFLIGHT.remove(prepKey, existing))
+                {
+                    return prepFailedError(existing.error);
+                }
+                continue; // another thread already replaced it — re-check
+            }
+            if (existing.isExpired())
+            {
+                // Atomically replace the expired entry; on failure another thread
+                // already replaced it, so re-check.
+                LaunchLifecycleUtils.PREP_INFLIGHT.remove(prepKey, existing);
+                continue;
+            }
+            return null; // active (not done, not expired) — caller falls through
+        }
+    }
+
+    /**
+     * Creates and schedules the single background preparation Job for the entry the
+     * calling thread won (the {@link PrepInFlight#started} CAS). The Job runs
+     * {@link LaunchLifecycleUtils#prepareForFreshLaunch}, stores the
+     * {@link PreLaunchResult} in {@code resultHolder[0]} and always counts down the
+     * entry's latch — identical to the inline body it replaces.
+     */
+    private static void schedulePrepJob(PrepInFlight entry, PrepRequest req,
+            PreLaunchResult[] resultHolder)
+    {
+        final PrepInFlight jobEntry = entry;
+        Job prepJob = new Job(req.jobName)
+        {
+            @Override
+            protected IStatus run(IProgressMonitor monitor)
+            {
+                try
+                {
+                    jobEntry.phase = "recompute"; //$NON-NLS-1$
+                    int terminateTimeout =
+                        LaunchLifecycleUtils.getDefaultTerminateTimeoutSeconds();
+                    PreLaunchResult result = LaunchLifecycleUtils.prepareForFreshLaunch(
+                        req.launchManager, req.project, req.applicationId,
+                        req.appManager, terminateTimeout, req.updateScope);
+                    jobEntry.phase = "db-update"; //$NON-NLS-1$
+                    resultHolder[0] = result;
+                    if (!result.isOk())
+                    {
+                        jobEntry.error = result.getError();
+                    }
+                }
+                catch (Throwable e) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+                {
+                    // Throwable, not Exception: an Error escaping the prep must still
+                    // surface as a prep failure — otherwise the retry call would see
+                    // done-without-error and proceed as if preparation succeeded.
+                    jobEntry.error = e.getMessage() != null ? e.getMessage()
+                        : e.getClass().getSimpleName();
+                    Activator.logError("Pre-launch preparation job failed: " + req.projectName, e); //$NON-NLS-1$
+                }
+                finally
+                {
+                    jobEntry.done = true;
+                    jobEntry.latch.countDown();
+                }
+                return Status.OK_STATUS;
+            }
+        };
+        prepJob.setPriority(Job.INTERACTIVE);
+        prepJob.schedule();
+    }
+
+    /** Shared "Pre-launch preparation failed" error payload (identical wording in both surfacing sites). */
+    private static String prepFailedError(String error)
+    {
+        return ToolResult.error("Pre-launch preparation failed: " + error //$NON-NLS-1$
+            + "\n\nIf the previous launch is stuck, call `terminate_launch` " //$NON-NLS-1$
+            + "with `force=true` and retry. As a last resort, pass " //$NON-NLS-1$
+            + "`updateBeforeLaunch=false` — but the EDT launch delegate may " //$NON-NLS-1$
+            + "then pop a modal dialog that blocks the MCP call.").toJson(); //$NON-NLS-1$
     }
 
     /** Markdown launch handle returned by DEBUG mode — readable, with the wait_for_break next step. */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetBreakpointTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetBreakpointTool.java
@@ -99,20 +99,54 @@ public class SetBreakpointTool implements IMcpTool
             : JsonUtils.extractStringArgument(params, KEY_MODULE);
         int lineNumber = JsonUtils.extractIntArgument(params, KEY_LINE_NUMBER, -1);
 
+        ResolvedTarget target = validateAndResolve(projectName, module, lineNumber);
+        if (target.error != null)
+        {
+            return target.error;
+        }
+
+        try
+        {
+            IBreakpoint bp = BreakpointUtils.createLineBreakpoint(target.file, lineNumber);
+            return buildSuccessResult(bp, target.file, module, lineNumber);
+        }
+        catch (Exception e)
+        {
+            Activator.logError("Failed to set breakpoint", e); //$NON-NLS-1$
+            return ToolResult.error("Failed to set breakpoint: " + e.getMessage()).toJson(); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Validates the input arguments and resolves the target {@code .bsl} file —
+     * the side-effect-free pre-flight extracted from {@link #execute}. Returns a
+     * holder carrying either the resolved {@link IFile} or the exact error JSON the
+     * inline guards produced (same value, same case); the caller re-checks
+     * {@code error} and returns it unchanged, leaving the mutating
+     * {@code createLineBreakpoint} call inline.
+     *
+     * @param projectName the EDT project (required for module-relative paths)
+     * @param module the module identifier (already collapsed from modulePath/alias)
+     * @param lineNumber the requested 1-based line
+     * @return a {@link ResolvedTarget} with a non-null {@code file} on success,
+     *         or a non-null {@code error} otherwise
+     */
+    private static ResolvedTarget validateAndResolve(String projectName, String module, int lineNumber)
+    {
         if (module == null || module.isEmpty())
         {
-            return ToolResult.error("modulePath is required").toJson(); //$NON-NLS-1$
+            return ResolvedTarget.error(ToolResult.error("modulePath is required").toJson()); //$NON-NLS-1$
         }
         if (lineNumber < 1)
         {
-            return ToolResult.error("lineNumber must be >= 1").toJson(); //$NON-NLS-1$
+            return ResolvedTarget.error(ToolResult.error("lineNumber must be >= 1").toJson()); //$NON-NLS-1$
         }
 
         boolean modulePathStyle = !BreakpointUtils.looksLikeAbsolutePath(module);
         if (modulePathStyle && (projectName == null || projectName.isEmpty()))
         {
-            return ToolResult.error(
-                    "projectName is required when modulePath is given as an EDT module path").toJson(); //$NON-NLS-1$
+            return ResolvedTarget.error(ToolResult.error(
+                "projectName is required when modulePath is given as an EDT module path").toJson()); //$NON-NLS-1$
         }
 
         if (modulePathStyle)
@@ -122,26 +156,44 @@ public class SetBreakpointTool implements IMcpTool
             String building = ProjectStateChecker.buildingErrorOrNull(projectName);
             if (building != null)
             {
-                return ToolResult.error(building).toJson();
+                return ResolvedTarget.error(ToolResult.error(building).toJson());
             }
         }
 
         IFile file = BreakpointUtils.resolveModuleFile(projectName, module);
         if (file == null || !file.exists())
         {
-            return ToolResult.error("Module file not found: " + module //$NON-NLS-1$
-                    + (modulePathStyle ? " in project " + projectName : "")).toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+            return ResolvedTarget.error(ToolResult.error("Module file not found: " + module //$NON-NLS-1$
+                + (modulePathStyle ? " in project " + projectName : "")).toJson()); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return ResolvedTarget.file(file);
+    }
+
+    /**
+     * Holder threading the validation/resolution early-return out of
+     * {@link #validateAndResolve}: exactly one of {@code file} / {@code error} is
+     * non-null. {@code error} carries the same error JSON (same case) the inline
+     * guards returned.
+     */
+    private static final class ResolvedTarget
+    {
+        final IFile file;
+        final String error;
+
+        private ResolvedTarget(IFile file, String error)
+        {
+            this.file = file;
+            this.error = error;
         }
 
-        try
+        static ResolvedTarget file(IFile file)
         {
-            IBreakpoint bp = BreakpointUtils.createLineBreakpoint(file, lineNumber);
-            return buildSuccessResult(bp, file, module, lineNumber);
+            return new ResolvedTarget(file, null);
         }
-        catch (Exception e)
+
+        static ResolvedTarget error(String error)
         {
-            Activator.logError("Failed to set breakpoint", e); //$NON-NLS-1$
-            return ToolResult.error("Failed to set breakpoint: " + e.getMessage()).toJson(); //$NON-NLS-1$
+            return new ResolvedTarget(null, error);
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/TerminateLaunchTool.java
@@ -226,8 +226,9 @@ public class TerminateLaunchTool implements IMcpTool
                 return ToolResult.error("Launch manager is not available.").toJson(); //$NON-NLS-1$
             }
 
-            List<ILaunch> targets = selectTargets(launchManager, configName, projectName,
+            SelectionCriteria criteria = new SelectionCriteria(configName, projectName,
                 applicationId, all, hasName, hasProject, hasAppId);
+            List<ILaunch> targets = selectTargets(launchManager, criteria);
 
             // Second pass: the live-selection helpers skip
             // terminated launches by design, so an ALREADY-terminated launch
@@ -342,29 +343,30 @@ public class TerminateLaunchTool implements IMcpTool
         return null;
     }
 
-    private static List<ILaunch> selectTargets(ILaunchManager launchManager, String configName,
-            String projectName, String applicationId, boolean all, boolean hasName,
-            boolean hasProject, boolean hasAppId)
+    private static List<ILaunch> selectTargets(ILaunchManager launchManager,
+            SelectionCriteria criteria)
     {
         List<ILaunch> targets = new ArrayList<>();
-        if (hasName)
+        if (criteria.hasName)
         {
-            ILaunch launch = LaunchConfigUtils.findLiveLaunchByName(launchManager, configName);
+            ILaunch launch =
+                LaunchConfigUtils.findLiveLaunchByName(launchManager, criteria.configName);
             if (launch != null)
             {
                 targets.add(launch);
             }
             return targets;
         }
-        if (hasProject && hasAppId)
+        if (criteria.hasProject && criteria.hasAppId)
         {
             // Scope search to the project first, then match applicationId. Avoids a false
             // not_found if some other project happens to carry the same applicationId
             // (ATTR_APPLICATION_ID is an arbitrary EDT-assigned string with per-project
             // uniqueness only).
-            for (ILaunch launch : LaunchConfigUtils.getAllLiveLaunches(launchManager, projectName))
+            for (ILaunch launch : LaunchConfigUtils.getAllLiveLaunches(launchManager,
+                criteria.projectName))
             {
-                if (applicationId.equals(LaunchConfigUtils.getApplicationIdFor(launch)))
+                if (criteria.applicationId.equals(LaunchConfigUtils.getApplicationIdFor(launch)))
                 {
                     targets.add(launch);
                     break;
@@ -372,12 +374,44 @@ public class TerminateLaunchTool implements IMcpTool
             }
             return targets;
         }
-        if (all)
+        if (criteria.all)
         {
-            String projectFilter = hasProject ? projectName : null;
+            String projectFilter = criteria.hasProject ? criteria.projectName : null;
             targets.addAll(LaunchConfigUtils.getAllLiveLaunches(launchManager, projectFilter));
         }
         return targets;
+    }
+
+    /**
+     * Immutable bundle of the seven selection-criteria fields shared by the live
+     * ({@link #selectTargets}) and stale ({@link #matchesStaleSelection}) target
+     * selectors. Carries the three raw inputs ({@code configName} /
+     * {@code projectName} / {@code applicationId}, the {@code all} flag) together
+     * with their pre-computed presence flags ({@code hasName} / {@code hasProject}
+     * / {@code hasAppId}), so the selectors read the very same values in the very
+     * same order as the previous flat parameter lists.
+     */
+    private static final class SelectionCriteria
+    {
+        final String configName;
+        final String projectName;
+        final String applicationId;
+        final boolean all;
+        final boolean hasName;
+        final boolean hasProject;
+        final boolean hasAppId;
+
+        SelectionCriteria(String configName, String projectName, String applicationId,
+                boolean all, boolean hasName, boolean hasProject, boolean hasAppId)
+        {
+            this.configName = configName;
+            this.projectName = projectName;
+            this.applicationId = applicationId;
+            this.all = all;
+            this.hasName = hasName;
+            this.hasProject = hasProject;
+            this.hasAppId = hasAppId;
+        }
     }
 
     /**
@@ -416,10 +450,11 @@ public class TerminateLaunchTool implements IMcpTool
         {
             return stale;
         }
+        SelectionCriteria criteria = new SelectionCriteria(configName, projectName, applicationId,
+            all, hasName, hasProject, hasAppId);
         for (ILaunch launch : launches)
         {
-            if (matchesStaleSelection(launch, alreadySelected, configName, projectName,
-                applicationId, all, hasName, hasProject, hasAppId))
+            if (matchesStaleSelection(launch, alreadySelected, criteria))
             {
                 stale.add(launch);
             }
@@ -436,11 +471,11 @@ public class TerminateLaunchTool implements IMcpTool
      *
      * @param launch          candidate launch (may be {@code null})
      * @param alreadySelected launches the live selection already picked
+     * @param criteria        the shared selection criteria
      * @return {@code true} if the launch should be added to the stale list
      */
     private static boolean matchesStaleSelection(ILaunch launch, List<ILaunch> alreadySelected,
-            String configName, String projectName, String applicationId, boolean all,
-            boolean hasName, boolean hasProject, boolean hasAppId)
+            SelectionCriteria criteria)
     {
         // Live launches are the primary selection's job; the identity skip
         // covers a launch that terminated between the two scans.
@@ -454,20 +489,20 @@ public class TerminateLaunchTool implements IMcpTool
         {
             return false;
         }
-        if (hasName)
+        if (criteria.hasName)
         {
-            return configName.equals(config.getName());
+            return criteria.configName.equals(config.getName());
         }
-        if (hasProject && hasAppId)
+        if (criteria.hasProject && criteria.hasAppId)
         {
             String project = LaunchConfigUtils.readAttribute(config,
                 LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
-            return projectName.equals(project)
-                && applicationId.equals(LaunchConfigUtils.getApplicationIdFor(launch));
+            return criteria.projectName.equals(project)
+                && criteria.applicationId.equals(LaunchConfigUtils.getApplicationIdFor(launch));
         }
-        if (all)
+        if (criteria.all)
         {
-            return matchesAllScope(config, projectName, hasProject);
+            return matchesAllScope(config, criteria.projectName, criteria.hasProject);
         }
         return false;
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
@@ -135,125 +135,189 @@ public class WriteModuleSourceTool implements IMcpTool
     @Override
     public String execute(Map<String, String> params)
     {
-        // 1. Extract parameters
-        String projectName = JsonUtils.extractStringArgument(params, PROJECT_NAME);
-        String modulePath = JsonUtils.extractStringArgument(params, MODULE_PATH);
-        String objectName = JsonUtils.extractStringArgument(params, "objectName"); //$NON-NLS-1$
-        String moduleType = JsonUtils.extractStringArgument(params, "moduleType"); //$NON-NLS-1$
-        String source = JsonUtils.extractStringArgument(params, "source"); //$NON-NLS-1$
-        String oldSource = JsonUtils.extractStringArgument(params, "oldSource"); //$NON-NLS-1$
-        String mode = JsonUtils.extractStringArgument(params, "mode"); //$NON-NLS-1$
-        String formName = JsonUtils.extractStringArgument(params, "formName"); //$NON-NLS-1$
-        String commandName = JsonUtils.extractStringArgument(params, "commandName"); //$NON-NLS-1$
-        boolean skipSyntaxCheck = JsonUtils.extractBooleanArgument(params, "skipSyntaxCheck", false); //$NON-NLS-1$
-        String expectedSource = JsonUtils.extractStringArgument(params, "expectedSource"); //$NON-NLS-1$
-        boolean overwrite = JsonUtils.extractBooleanArgument(params, "overwrite", false); //$NON-NLS-1$
-        String expectedHash = JsonUtils.extractStringArgument(params, "expectedHash"); //$NON-NLS-1$
+        // 1. Extract and default the request parameters.
+        WriteRequest req = WriteRequest.from(params);
 
         // 2. Validate required parameters
-        if (mode == null || mode.isEmpty())
-        {
-            mode = MODE_SEARCH_REPLACE;
-        }
-        String argError = validateWriteArguments(params, source, mode, oldSource);
+        String argError = validateWriteArguments(params, req.source, req.mode, req.oldSource);
         if (argError != null)
         {
             return argError;
         }
 
         // 3. Resolve the module target.
-        ModuleTargetResult target = resolveModuleTarget(modulePath, objectName, moduleType,
-            formName, commandName);
+        ModuleTargetResult target = resolveModuleTarget(req.modulePath, req.objectName,
+            req.moduleType, req.formName, req.commandName);
         if (target.error != null)
         {
             return target.error;
         }
-        modulePath = target.modulePath;
+        req.modulePath = target.modulePath;
 
         // 4. Validate project
-        ProjectContext ctx = ProjectContext.of(projectName);
+        ProjectContext ctx = ProjectContext.of(req.projectName);
         if (!ctx.exists())
         {
-            return ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson();
+            return ToolResult.error(ProjectContext.notFoundMessage(req.projectName)).toJson();
         }
         IProject project = ctx.project();
 
         // 5. Get file
-        IFile file = BslModuleUtils.resolveModuleFile(project, modulePath);
+        IFile file = BslModuleUtils.resolveModuleFile(project, req.modulePath);
         boolean fileExists = file.exists();
 
         // For non-replace modes, file must exist
-        if (!fileExists && !MODE_REPLACE.equals(mode))
+        if (!fileExists && !MODE_REPLACE.equals(req.mode))
         {
-            return ToolResult.error("File not found: src/" + modulePath + //$NON-NLS-1$
+            return ToolResult.error("File not found: src/" + req.modulePath + //$NON-NLS-1$
                 ". Only 'replace' mode can create new files.").toJson(); //$NON-NLS-1$
         }
 
         try
         {
-            // Normalize source: \r\n -> \n
-            source = source.replace("\r\n", "\n"); //$NON-NLS-1$ //$NON-NLS-2$
-
-            // 6. Read current content (if file exists)
-            List<String> originalLines;
-            boolean hasBom;
-            if (fileExists)
-            {
-                originalLines = BslModuleUtils.readFileLines(file);
-                hasBom = detectBom(file);
-            }
-            else
-            {
-                originalLines = new ArrayList<>();
-                hasBom = true; // New BSL files should have BOM
-            }
-
-            // 6b. Optimistic-lock guard (any mode): when the caller carried an
-            // expectedHash from its last read, reject if the module changed since —
-            // a cheap lost-update check that complements searchReplace's oldSource
-            // match and replace's expectedSource. Read the canonical text the same way
-            // those guards do (readFileText, \n-normalized) so the hashes always agree; // NOSONAR explanatory comment, not commented-out code
-            // skipped entirely when no expectedHash is given.
-            String currentTextForHash = (expectedHash != null && !expectedHash.isEmpty() && fileExists)
-                ? BslModuleUtils.readFileText(file).replace("\r\n", "\n") //$NON-NLS-1$ //$NON-NLS-2$
-                : null;
-            String hashError = evaluateExpectedHash(currentTextForHash, expectedHash, fileExists);
-            if (hashError != null)
-            {
-                return hashError;
-            }
-
-            // 7. Compute new content based on mode
-            int totalOriginal = originalLines.size();
-            NewLinesResult computed = computeNewLines(mode, file, fileExists, originalLines,
-                source, oldSource, expectedHash, expectedSource, overwrite);
-            if (computed.error != null)
-            {
-                return computed.error;
-            }
-            List<String> newLines = computed.newLines;
-
-            // 8. BSL syntax check
-            if (!skipSyntaxCheck)
-            {
-                String syntaxError = runSyntaxCheck(newLines);
-                if (syntaxError != null)
-                {
-                    return syntaxError;
-                }
-            }
-
-            // 9. Write file
-            writeFile(file, newLines, hasBom, fileExists);
-
-            // 10. Return success
-            return buildSuccessResponse(projectName, modulePath, mode, skipSyntaxCheck,
-                newLines, fileExists, totalOriginal);
+            return writeModule(req, file, fileExists);
         }
         catch (Exception e)
         {
             return ToolResult.error("Failed to write file: " + e.getMessage()).toJson(); //$NON-NLS-1$
         }
+    }
+
+    /**
+     * Parsed and defaulted {@code write_module_source} request inputs, bundled into one
+     * holder so the write helpers take a single seam instead of a long parameter list
+     * (avoids the &gt;7-parameter smell on {@link #computeNewLines}). {@code mode} is
+     * defaulted to {@link #MODE_SEARCH_REPLACE} at construction exactly as the inline flow
+     * did; {@code modulePath} is mutable because {@link #resolveModuleTarget} may resolve it
+     * from {@code objectName}.
+     */
+    private static final class WriteRequest
+    {
+        final String projectName;
+        String modulePath;
+        final String objectName;
+        final String moduleType;
+        String source;
+        final String oldSource;
+        final String mode;
+        final String formName;
+        final String commandName;
+        final boolean skipSyntaxCheck;
+        final String expectedSource;
+        final boolean overwrite;
+        final String expectedHash;
+
+        private WriteRequest(Map<String, String> params)
+        {
+            this.projectName = JsonUtils.extractStringArgument(params, PROJECT_NAME);
+            this.modulePath = JsonUtils.extractStringArgument(params, MODULE_PATH);
+            this.objectName = JsonUtils.extractStringArgument(params, "objectName"); //$NON-NLS-1$
+            this.moduleType = JsonUtils.extractStringArgument(params, "moduleType"); //$NON-NLS-1$
+            // Kept RAW here (NOT \r\n-normalized) so validateWriteArguments measures the
+            // exact same length the inline flow did; the \r\n->\n normalization happens in
+            // writeModule, just like the original try block did, before any content compute.
+            this.source = JsonUtils.extractStringArgument(params, "source"); //$NON-NLS-1$
+            this.oldSource = JsonUtils.extractStringArgument(params, "oldSource"); //$NON-NLS-1$
+            String rawMode = JsonUtils.extractStringArgument(params, "mode"); //$NON-NLS-1$
+            this.mode = (rawMode == null || rawMode.isEmpty()) ? MODE_SEARCH_REPLACE : rawMode;
+            this.formName = JsonUtils.extractStringArgument(params, "formName"); //$NON-NLS-1$
+            this.commandName = JsonUtils.extractStringArgument(params, "commandName"); //$NON-NLS-1$
+            this.skipSyntaxCheck = JsonUtils.extractBooleanArgument(params, "skipSyntaxCheck", false); //$NON-NLS-1$
+            this.expectedSource = JsonUtils.extractStringArgument(params, "expectedSource"); //$NON-NLS-1$
+            this.overwrite = JsonUtils.extractBooleanArgument(params, "overwrite", false); //$NON-NLS-1$
+            this.expectedHash = JsonUtils.extractStringArgument(params, "expectedHash"); //$NON-NLS-1$
+        }
+
+        static WriteRequest from(Map<String, String> params)
+        {
+            return new WriteRequest(params);
+        }
+    }
+
+    /**
+     * The body of {@link #execute} that runs once the project/file is resolved: reads the
+     * current content, applies the optimistic-lock + syntax guards, then WRITES the module
+     * and builds the success response. Kept under {@link #execute}'s {@code try} so any
+     * {@link Exception} reaches the SAME {@code catch} as before; declares
+     * {@code throws Exception} because {@link #computeNewLines}/{@link #writeFile} do.
+     *
+     * @param req the parsed request (its {@code modulePath} is already resolved)
+     * @param file the resolved module file
+     * @param fileExists whether {@code file} already exists on disk
+     * @return the success response, or a ready {@link ToolResult#error} JSON payload from a
+     *         guard (returned verbatim) — the same value in the same case as the inline flow
+     */
+    private String writeModule(WriteRequest req, IFile file, boolean fileExists) throws Exception
+    {
+        // Normalize source: \r\n -> \n (same point and order as the inline try block,
+        // i.e. AFTER validateWriteArguments measured the raw length).
+        req.source = req.source.replace("\r\n", "\n"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        // Read current content (if file exists)
+        List<String> originalLines;
+        boolean hasBom;
+        if (fileExists)
+        {
+            originalLines = BslModuleUtils.readFileLines(file);
+            hasBom = detectBom(file);
+        }
+        else
+        {
+            originalLines = new ArrayList<>();
+            hasBom = true; // New BSL files should have BOM
+        }
+
+        String hashError = checkExpectedHashGuard(req, file, fileExists);
+        if (hashError != null)
+        {
+            return hashError;
+        }
+
+        // Compute new content based on mode
+        int totalOriginal = originalLines.size();
+        NewLinesResult computed = computeNewLines(req, file, fileExists, originalLines);
+        if (computed.error != null)
+        {
+            return computed.error;
+        }
+        List<String> newLines = computed.newLines;
+
+        // BSL syntax check
+        if (!req.skipSyntaxCheck)
+        {
+            String syntaxError = runSyntaxCheck(newLines);
+            if (syntaxError != null)
+            {
+                return syntaxError;
+            }
+        }
+
+        // Write file (the mutating step — kept inline under the passed guards)
+        writeFile(file, newLines, hasBom, fileExists);
+
+        // Return success
+        return buildSuccessResponse(req.projectName, req.modulePath, req.mode, req.skipSyntaxCheck,
+            newLines, fileExists, totalOriginal);
+    }
+
+    /**
+     * Optimistic-lock guard (any mode): when the caller carried an {@code expectedHash} from
+     * its last read, reject if the module changed since — a cheap lost-update check that
+     * complements searchReplace's {@code oldSource} match and replace's {@code expectedSource}.
+     * Reads the canonical text the same way those guards do (readFileText, {@code \n}-normalized)
+     * so the hashes always agree; skipped entirely when no {@code expectedHash} is given.
+     *
+     * @return a ready {@link ToolResult#error} JSON payload to return verbatim, or {@code null}
+     *         when the guard passes (or is disabled)
+     */
+    private static String checkExpectedHashGuard(WriteRequest req, IFile file, boolean fileExists)
+        throws Exception
+    {
+        String currentTextForHash =
+            (req.expectedHash != null && !req.expectedHash.isEmpty() && fileExists)
+                ? BslModuleUtils.readFileText(file).replace("\r\n", "\n") //$NON-NLS-1$ //$NON-NLS-2$
+                : null;
+        return evaluateExpectedHash(currentTextForHash, req.expectedHash, fileExists);
     }
 
     /**
@@ -398,7 +462,7 @@ public class WriteModuleSourceTool implements IMcpTool
     }
 
     /**
-     * Computes the new module content for the given mode (read-only — no file is
+     * Computes the new module content for the request's mode (read-only — no file is
      * written; only the already-read {@code file}/{@code originalLines} content is
      * consulted). Mirrors the inline {@code switch} exactly, including the replace
      * lost-update precondition and the searchReplace not-found / multiple-match errors.
@@ -410,11 +474,11 @@ public class WriteModuleSourceTool implements IMcpTool
      * @return a {@link NewLinesResult} whose {@link NewLinesResult#error} is non-{@code null}
      *         when the caller must return that JSON payload, otherwise the lines to write
      */
-    private NewLinesResult computeNewLines(String mode, IFile file, boolean fileExists,
-        List<String> originalLines, String source, String oldSource, String expectedHash,
-        String expectedSource, boolean overwrite) throws Exception
+    private NewLinesResult computeNewLines(WriteRequest req, IFile file, boolean fileExists,
+        List<String> originalLines) throws Exception
     {
-        switch (mode)
+        String source = req.source;
+        switch (req.mode)
         {
             case MODE_REPLACE:
             {
@@ -425,11 +489,11 @@ public class WriteModuleSourceTool implements IMcpTool
                 // (the whole-file token proves the agent saw the current state) and
                 // was ALREADY validated at step 6b — so when one was supplied, the
                 // expectedSource/overwrite precondition is satisfied and skipped.
-                boolean hashGuardSatisfied = expectedHash != null && !expectedHash.isEmpty();
+                boolean hashGuardSatisfied = req.expectedHash != null && !req.expectedHash.isEmpty();
                 if (fileExists && !hashGuardSatisfied)
                 {
                     String preconditionError =
-                        checkReplacePrecondition(file, expectedSource, overwrite);
+                        checkReplacePrecondition(file, req.expectedSource, req.overwrite);
                     if (preconditionError != null)
                     {
                         return new NewLinesResult(preconditionError, null);
@@ -448,7 +512,7 @@ public class WriteModuleSourceTool implements IMcpTool
             case MODE_SEARCH_REPLACE:
             {
                 // Normalize oldSource
-                oldSource = oldSource.replace("\r\n", "\n"); //$NON-NLS-1$ //$NON-NLS-2$
+                String oldSource = req.oldSource.replace("\r\n", "\n"); //$NON-NLS-1$ //$NON-NLS-2$
 
                 // Read the raw file content (preserves the trailing newline that
                 // writeFile always adds). Reconstructing it from originalLines via
@@ -476,7 +540,7 @@ public class WriteModuleSourceTool implements IMcpTool
             }
 
             default:
-                return new NewLinesResult(ToolResult.error("unsupported mode: " + mode).toJson(), null); //$NON-NLS-1$
+                return new NewLinesResult(ToolResult.error("unsupported mode: " + req.mode).toJson(), null); //$NON-NLS-1$
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/AbstractMetadataFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/AbstractMetadataFormatter.java
@@ -442,35 +442,67 @@ public abstract class AbstractMetadataFormatter implements IMetadataFormatter
         List<EStructuralFeature> features = eObject.eClass().getEAllStructuralFeatures();
         for (EStructuralFeature feature : features)
         {
-            if (feature.isDerived() || feature.isTransient() || feature.isVolatile())
+            if (isUnclassifiableFeature(eObject, feature))
             {
                 continue;
             }
-            if (!eObject.eIsSet(feature))
-            {
-                continue;
-            }
+            classifyFeatureInto(feature, simpleAttributes, singleReferences, crossReferences);
+        }
+    }
 
-            if (feature instanceof EAttribute)
+    /**
+     * Tests whether a feature is excluded from {@link #classifySetFeatures} before any
+     * bucket routing: derived/transient/volatile (computed, not stored) and unset
+     * features are skipped, matching the two leading {@code continue} guards of the
+     * original inline loop.
+     *
+     * @param eObject the object whose feature-set state is checked
+     * @param feature the structural feature to test
+     * @return {@code true} if the feature should not be classified
+     */
+    private static boolean isUnclassifiableFeature(EObject eObject, EStructuralFeature feature)
+    {
+        if (feature.isDerived() || feature.isTransient() || feature.isVolatile())
+        {
+            return true;
+        }
+        return !eObject.eIsSet(feature);
+    }
+
+    /**
+     * Routes one set, stored feature into its bucket: {@link EAttribute}s to
+     * {@code simpleAttributes}, single non-containment references to
+     * {@code singleReferences}, and many non-containment references to
+     * {@code crossReferences}; containment references and non-attribute/reference
+     * features are dropped. Matches the per-feature body of {@link #classifySetFeatures}.
+     *
+     * @param feature the feature to route
+     * @param simpleAttributes receives a matching {@link EAttribute}
+     * @param singleReferences receives a matching single non-containment reference
+     * @param crossReferences receives a matching many non-containment reference
+     */
+    private static void classifyFeatureInto(EStructuralFeature feature, List<EAttribute> simpleAttributes,
+        List<EReference> singleReferences, List<EReference> crossReferences)
+    {
+        if (feature instanceof EAttribute)
+        {
+            simpleAttributes.add((EAttribute) feature);
+        }
+        else if (feature instanceof EReference)
+        {
+            EReference ref = (EReference) feature;
+            if (ref.isContainment())
             {
-                simpleAttributes.add((EAttribute) feature);
+                // Containment references are typically handled separately.
+                return;
             }
-            else if (feature instanceof EReference)
+            if (!ref.isMany())
             {
-                EReference ref = (EReference) feature;
-                if (ref.isContainment())
-                {
-                    // Containment references are typically handled separately.
-                    continue;
-                }
-                if (!ref.isMany())
-                {
-                    singleReferences.add(ref);
-                }
-                else
-                {
-                    crossReferences.add(ref);
-                }
+                singleReferences.add(ref);
+            }
+            else
+            {
+                crossReferences.add(ref);
             }
         }
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
@@ -633,63 +633,50 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
     {
         addSectionHeader(sb, name);
         startTable(sb, "Index", "Characteristic Types", "Key Field", "Types Filter Field", "Types Filter Value", "Characteristic Values", "Object Field", "Type Field", "Value Field"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$
-        
+
         int index = 0;
         for (Object item : items)
         {
             if (item instanceof CharacteristicsDescription)
             {
-                CharacteristicsDescription charDesc = (CharacteristicsDescription) item;
-                
-                // CharacteristicTypes (MdObject)
-                String typesSource = DASH;
-                if (charDesc.getCharacteristicTypes() != null)
-                {
-                    typesSource = formatEObjectReference(charDesc.getCharacteristicTypes());
-                }
-                
-                // KeyField (Field)
-                String keyField = charDesc.getKeyField() != null ? formatEObjectReference(charDesc.getKeyField()) : DASH;
-                
-                // TypesFilterField (Field)
-                String typesFilterField = charDesc.getTypesFilterField() != null ? formatEObjectReference(charDesc.getTypesFilterField()) : DASH;
-                
-                // TypesFilterValue (Value)
-                String filterValue = DASH;
-                if (charDesc.getTypesFilterValue() != null)
-                {
-                    filterValue = formatEObjectReference(charDesc.getTypesFilterValue());
-                }
-                
-                // CharacteristicValues (MdObject) 
-                String valuesSource = DASH;
-                if (charDesc.getCharacteristicValues() != null)
-                {
-                    valuesSource = formatEObjectReference(charDesc.getCharacteristicValues());
-                }
-                
-                // ObjectField (Field)
-                String objectField = charDesc.getObjectField() != null ? formatEObjectReference(charDesc.getObjectField()) : DASH;
-                
-                // TypeField (Field)
-                String typeField = charDesc.getTypeField() != null ? formatEObjectReference(charDesc.getTypeField()) : DASH;
-                
-                // ValueField (Field)
-                String valueField = charDesc.getValueField() != null ? formatEObjectReference(charDesc.getValueField()) : DASH;
-                
-                addTableRow(sb, 
-                    String.valueOf(index++),
-                    typesSource,
-                    keyField,
-                    typesFilterField,
-                    filterValue,
-                    valuesSource,
-                    objectField,
-                    typeField,
-                    valueField
-                );
+                appendCharacteristicRow(sb, (CharacteristicsDescription) item, index++);
             }
         }
+    }
+
+    /**
+     * Appends one table row for a single {@link CharacteristicsDescription}. Each reference cell is
+     * rendered via {@link #refOrDash(EObject)} (a {@code null} reference becomes {@link #DASH}); the
+     * column order matches the header in {@link #formatCharacteristicsCollection}. Behaviour-identical
+     * to the former inline body.
+     *
+     * @param sb       output buffer
+     * @param charDesc the characteristics description to render
+     * @param index    the 0-based row index shown in the first column
+     */
+    private void appendCharacteristicRow(StringBuilder sb, CharacteristicsDescription charDesc, int index)
+    {
+        addTableRow(sb,
+            String.valueOf(index),
+            refOrDash(charDesc.getCharacteristicTypes()),
+            refOrDash(charDesc.getKeyField()),
+            refOrDash(charDesc.getTypesFilterField()),
+            refOrDash(charDesc.getTypesFilterValue()),
+            refOrDash(charDesc.getCharacteristicValues()),
+            refOrDash(charDesc.getObjectField()),
+            refOrDash(charDesc.getTypeField()),
+            refOrDash(charDesc.getValueField())
+        );
+    }
+
+    /**
+     * Renders an {@link EObject} reference cell: {@link #formatEObjectReference(EObject)} when present,
+     * otherwise {@link #DASH}. Mirrors the original per-field {@code x != null ? format(x) : DASH}
+     * guard so empty references keep showing a dash.
+     */
+    private String refOrDash(EObject ref)
+    {
+        return ref != null ? formatEObjectReference(ref) : DASH;
     }
     
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/reference/MetadataReferenceService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/reference/MetadataReferenceService.java
@@ -803,6 +803,31 @@ public class MetadataReferenceService
             String className = object.eClass().getName();
 
             // Map class names to readable categories
+            String category = mapClassNameToCategory(className);
+            if (category != null)
+            {
+                return category;
+            }
+
+            // Check if it's an MdObject
+            if (object instanceof MdObject)
+            {
+                MdObject mdObject = (MdObject) object;
+                return mdObject.eClass().getName();
+            }
+
+            return className;
+        }
+
+        /**
+         * Maps an EClass name to a readable reference category by the same ordered
+         * {@code contains} checks as the original inline chain (first match wins),
+         * or {@code null} when none matches. Pure helper extracted from
+         * {@link #getCategoryFromObject}; the {@code null} result lets the caller
+         * apply the unchanged MdObject / raw-class-name fallback.
+         */
+        private static String mapClassNameToCategory(String className)
+        {
             if (className.contains("Subsystem")) return "Subsystems"; //$NON-NLS-1$ //$NON-NLS-2$
             if (className.contains("Role")) return "Roles"; //$NON-NLS-1$ //$NON-NLS-2$
             if (className.contains("CommonModule")) return "Common modules"; //$NON-NLS-1$ //$NON-NLS-2$
@@ -819,15 +844,7 @@ public class MetadataReferenceService
             if (className.contains("TypeDescription")) return "Type descriptions"; //$NON-NLS-1$ //$NON-NLS-2$
             if (className.contains("FunctionalOption")) return "Functional options"; //$NON-NLS-1$ //$NON-NLS-2$
             if (className.contains("Template")) return "Templates"; //$NON-NLS-1$ //$NON-NLS-2$
-
-            // Check if it's an MdObject
-            if (object instanceof MdObject)
-            {
-                MdObject mdObject = (MdObject) object;
-                return mdObject.eClass().getName();
-            }
-
-            return className;
+            return null;
         }
 
         /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
@@ -160,7 +160,9 @@ public class MetadataRenameService
 
         // Phase 2: build markdown with YAML frontmatter
         StringBuilder sb = new StringBuilder();
-        appendFrontmatter(sb, objectFqn, newName, allChanges, allProblems, exactMatches, enabledCount, shown);
+        PreviewSummary summary = new PreviewSummary(objectFqn, newName, allChanges.size(), enabledCount,
+            allProblems.size(), exactMatches.size(), shown);
+        appendFrontmatter(sb, summary);
         appendChangePointsTable(sb, allChanges, shown);
         appendCodeContext(sb, allChanges, shown);
         appendProblemsSection(sb, allProblems);
@@ -205,15 +207,17 @@ public class MetadataRenameService
                 Change nativeChange = nativeItem.getNativeChange();
                 if (nativeChange != null)
                 {
-                    collectFlatChanges(nativeChange, null, null, exactMatches, allChanges, indexCounter, title,
+                    ScanContext ctx = new ScanContext(exactMatches, allChanges, indexCounter, title,
                         item.isOptional(), oldName);
+                    collectFlatChanges(nativeChange, null, null, ctx);
                 }
             }
             else
             {
                 allChanges.add(new ChangePoint(
-                    indexCounter[0]++, "rename", null, null, //$NON-NLS-1$
-                    item.getName(), item.isOptional(), item.isChecked(), title));
+                    indexCounter[0]++, "rename", //$NON-NLS-1$
+                    item.getName(), item.isOptional(), item.isChecked(), title,
+                    CodeLocation.of(null, null)));
             }
         }
     }
@@ -266,31 +270,58 @@ public class MetadataRenameService
         return pb.toString();
     }
 
+    /**
+     * Immutable bundle of the preview header totals: the rename identity ({@code objectFqn} /
+     * {@code newName}) and the four counts rendered in the YAML frontmatter (total / enabled change
+     * points, problems, debug exact matches) plus {@code shown}. Carried so {@link #appendFrontmatter}
+     * reads exactly the same values in the same order while staying within the parameter limit.
+     */
+    private static final class PreviewSummary
+    {
+        final String objectFqn;
+        final String newName;
+        final int totalChanges;
+        final long enabledCount;
+        final int problemCount;
+        final int exactMatchCount;
+        final int shown;
+
+        PreviewSummary(String objectFqn, String newName, int totalChanges, long enabledCount,
+            int problemCount, int exactMatchCount, int shown)
+        {
+            this.objectFqn = objectFqn;
+            this.newName = newName;
+            this.totalChanges = totalChanges;
+            this.enabledCount = enabledCount;
+            this.problemCount = problemCount;
+            this.exactMatchCount = exactMatchCount;
+            this.shown = shown;
+        }
+    }
+
     /** Appends the YAML frontmatter, title, totals and (when truncated) the "showing N of M" note. */
-    private void appendFrontmatter(StringBuilder sb, String objectFqn, String newName,
-        List<ChangePoint> allChanges, List<String> allProblems, Map<String, ExactMatchInfo> exactMatches,
-        long enabledCount, int shown)
+    private void appendFrontmatter(StringBuilder sb, PreviewSummary summary)
     {
         sb.append("---\n"); //$NON-NLS-1$
         sb.append("action: preview\n"); //$NON-NLS-1$
-        sb.append("objectFqn: ").append(objectFqn).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-        sb.append("newName: ").append(newName).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-        sb.append("totalChanges: ").append(allChanges.size()).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-        sb.append("enabledChanges: ").append(enabledCount).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-        sb.append("problems: ").append(allProblems.size()).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
-        sb.append("debugExactMatches: ").append(exactMatches.size()).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("objectFqn: ").append(summary.objectFqn).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("newName: ").append(summary.newName).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("totalChanges: ").append(summary.totalChanges).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("enabledChanges: ").append(summary.enabledCount).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("problems: ").append(summary.problemCount).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("debugExactMatches: ").append(summary.exactMatchCount).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
         sb.append("---\n\n"); //$NON-NLS-1$
 
-        sb.append("# Refactoring Preview: Rename `").append(objectFqn) //$NON-NLS-1$
-          .append("` \u2192 `").append(newName).append("`\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("# Refactoring Preview: Rename `").append(summary.objectFqn) //$NON-NLS-1$
+          .append("` \u2192 `").append(summary.newName).append("`\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
 
-        sb.append("**Total change points:** ").append(allChanges.size()) //$NON-NLS-1$
-          .append(" | **Enabled by default:** ").append(enabledCount).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append("**Total change points:** ").append(summary.totalChanges) //$NON-NLS-1$
+          .append(" | **Enabled by default:** ").append(summary.enabledCount).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
 
-        if (allChanges.size() > shown)
+        if (summary.totalChanges > summary.shown)
         {
-            sb.append("_Showing ").append(shown).append(" of ").append(allChanges.size()) //$NON-NLS-1$ //$NON-NLS-2$
-              .append(" changes. Pass `maxResults=").append(allChanges.size()) //$NON-NLS-1$
+            sb.append("_Showing ").append(summary.shown).append(" of ").append(summary.totalChanges) //$NON-NLS-1$ //$NON-NLS-2$
+              .append(" changes. Pass `maxResults=").append(summary.totalChanges) //$NON-NLS-1$
               .append("` to see all._\n\n"); //$NON-NLS-1$
         }
     }
@@ -393,6 +424,40 @@ public class MetadataRenameService
             + "(optional only; one index may span several context rows - skipping it skips them all).\n"); //$NON-NLS-1$
     }
 
+    /**
+     * Immutable holder for the source-location coordinates of a preview row / exact match:
+     * the owning object FQN and project plus the (1-based) line/column, the surrounding code
+     * snippet and the containing method name. Bundled so the {@link ChangePoint} and
+     * {@link ExactMatchInfo} constructors stay within the parameter limit while reading the
+     * same values in the same order. A "no location" instance uses {@code -1}/{@code null}.
+     */
+    private static final class CodeLocation
+    {
+        final String fqn;
+        final String project;
+        final int lineNumber;
+        final int columnNumber;
+        final String codeContext;
+        final String methodName;
+
+        CodeLocation(String fqn, String project, int lineNumber, int columnNumber, String codeContext,
+            String methodName)
+        {
+            this.fqn = fqn;
+            this.project = project;
+            this.lineNumber = lineNumber;
+            this.columnNumber = columnNumber;
+            this.codeContext = codeContext;
+            this.methodName = methodName;
+        }
+
+        /** Location carrying only fqn/project (no line/column/context/method). */
+        static CodeLocation of(String fqn, String project)
+        {
+            return new CodeLocation(fqn, project, -1, -1, null, null);
+        }
+    }
+
     /** Simple data holder for a single change point in preview. */
     private static class ChangePoint
     {
@@ -408,27 +473,20 @@ public class MetadataRenameService
         final String codeContext;
         final String methodName;
 
-        ChangePoint(int index, String type, String fqn, String project, String description,
-            boolean optional, boolean enabled, String ignored)
-        {
-            this(index, type, fqn, project, description, optional, enabled, ignored, -1, -1, null, null);
-        }
-
-        ChangePoint(int index, String type, String fqn, String project, String description,
-            boolean optional, boolean enabled, String ignored,
-            int lineNumber, int columnNumber, String codeContext, String methodName)
+        ChangePoint(int index, String type, String description,
+            boolean optional, boolean enabled, String ignored, CodeLocation location)
         {
             this.index = index;
             this.type = type;
-            this.fqn = fqn;
-            this.project = project;
+            this.fqn = location.fqn;
+            this.project = location.project;
             this.description = description;
             this.optional = optional;
             this.enabled = enabled;
-            this.lineNumber = lineNumber;
-            this.columnNumber = columnNumber;
-            this.codeContext = codeContext;
-            this.methodName = methodName;
+            this.lineNumber = location.lineNumber;
+            this.columnNumber = location.columnNumber;
+            this.codeContext = location.codeContext;
+            this.methodName = location.methodName;
         }
     }
 
@@ -443,17 +501,16 @@ public class MetadataRenameService
         final String fqn;
         final String project;
 
-        ExactMatchInfo(String filePath, int matchOffset, int lineNumber, int columnNumber, String codeContext,
-            String methodName, String fqn, String project)
+        ExactMatchInfo(String filePath, int matchOffset, CodeLocation location)
         {
             this.filePath = filePath;
             this.matchOffset = matchOffset;
-            this.lineNumber = lineNumber;
-            this.columnNumber = columnNumber;
-            this.codeContext = codeContext;
-            this.methodName = methodName;
-            this.fqn = fqn;
-            this.project = project;
+            this.lineNumber = location.lineNumber;
+            this.columnNumber = location.columnNumber;
+            this.codeContext = location.codeContext;
+            this.methodName = location.methodName;
+            this.fqn = location.fqn;
+            this.project = location.project;
         }
     }
 
@@ -482,12 +539,38 @@ public class MetadataRenameService
     }
 
     /**
+     * Immutable per-scan context threaded through the change-tree walk and the per-leaf scan helpers.
+     * Bundles the state that stays constant for one top-level refactoring item: the exact-match index,
+     * the change-point accumulator, the shared leaf-index counter, the refactoring title, the optional
+     * flag and the old object name. Carried so the recursive/scan helpers stay within the parameter
+     * limit while reading exactly the same values in the same order as before.
+     */
+    private static final class ScanContext
+    {
+        final Map<String, ExactMatchInfo> exactMatches;
+        final List<ChangePoint> result;
+        final int[] indexCounter;
+        final String refactoringTitle;
+        final boolean optional;
+        final String oldName;
+
+        ScanContext(Map<String, ExactMatchInfo> exactMatches, List<ChangePoint> result, int[] indexCounter,
+            String refactoringTitle, boolean optional, String oldName)
+        {
+            this.exactMatches = exactMatches;
+            this.result = result;
+            this.indexCounter = indexCounter;
+            this.refactoringTitle = refactoringTitle;
+            this.optional = optional;
+            this.oldName = oldName;
+        }
+    }
+
+    /**
      * Recursively collects leaf changes from LTK change tree into a flat list with global indices.
      * Extracts line number and code context (±3 lines + containing method) for TextChange leaves.
      */
-    private void collectFlatChanges(Change change, String currentFqn, String currentProject,
-        Map<String, ExactMatchInfo> exactMatches, List<ChangePoint> result, int[] indexCounter,
-        String refactoringTitle, boolean optional, String oldName)
+    private void collectFlatChanges(Change change, String currentFqn, String currentProject, ScanContext ctx)
     {
         if (change instanceof BmObjectTextContentCompositeChange<?> bmComposite)
         {
@@ -500,28 +583,24 @@ public class MetadataRenameService
         }
         if (change instanceof CompositeChange composite)
         {
-            recurseComposite(composite, currentFqn, currentProject, exactMatches, result, indexCounter,
-                refactoringTitle, optional, oldName);
+            recurseComposite(composite, currentFqn, currentProject, ctx);
         }
         else
         {
-            collectLeafChange(change, currentFqn, currentProject, exactMatches, result, indexCounter,
-                refactoringTitle, optional);
+            collectLeafChange(change, currentFqn, currentProject, ctx);
         }
     }
 
     /** Recurses into the children of a composite change, preserving the inherited fqn/project context. */
     private void recurseComposite(CompositeChange composite, String currentFqn, String currentProject,
-        Map<String, ExactMatchInfo> exactMatches, List<ChangePoint> result, int[] indexCounter,
-        String refactoringTitle, boolean optional, String oldName)
+        ScanContext ctx)
     {
         Change[] children = composite.getChildren();
         if (children != null && children.length > 0)
         {
             for (Change child : children)
             {
-                collectFlatChanges(child, currentFqn, currentProject, exactMatches, result, indexCounter,
-                    refactoringTitle, optional, oldName);
+                collectFlatChanges(child, currentFqn, currentProject, ctx);
             }
         }
     }
@@ -531,34 +610,32 @@ public class MetadataRenameService
      * either the exact-match rows, the BSL/source extracted rows, or the bare fallback row. Mirrors
      * the leaf numbering of {@link #walkLeafChanges} so a preview {@code #index} stays a stable handle.
      */
-    private void collectLeafChange(Change change, String currentFqn, String currentProject,
-        Map<String, ExactMatchInfo> exactMatches, List<ChangePoint> result, int[] indexCounter,
-        String refactoringTitle, boolean optional)
+    private void collectLeafChange(Change change, String currentFqn, String currentProject, ScanContext ctx)
     {
         // One index per leaf change - this MUST match the leaf numbering in
         // walkLeafChanges()/applyDisableToChange() so a preview index stays a
         // stable cross-call handle for disableIndices. A leaf may render as
         // several display rows (multiple exact matches / text edits) or none
         // (suppressed), but it always consumes exactly one index. (card A2)
-        int leafIndex = indexCounter[0]++;
-        boolean hasExactMatches = exactMatches != null && !exactMatches.isEmpty();
+        int leafIndex = ctx.indexCounter[0]++;
+        boolean hasExactMatches = ctx.exactMatches != null && !ctx.exactMatches.isEmpty();
         boolean isBslReferenceChange = isBslReferenceChange(change, currentFqn);
         boolean isFullTextSearchChange = isFullTextSearchSourceFileChange(change);
         LeafScan scan = new LeafScan(currentFqn, currentProject);
-        List<ExactMatchInfo> exactMatchInfos = findExactMatchInfos(change, exactMatches);
+        List<ExactMatchInfo> exactMatchInfos = findExactMatchInfos(change, ctx.exactMatches);
         logPreviewMapping(change, scan.fqn, scan.project, exactMatchInfos.size());
         if (!exactMatchInfos.isEmpty())
         {
-            addExactMatchChangePoints(change, leafIndex, scan, exactMatchInfos, result, refactoringTitle, optional);
+            addExactMatchChangePoints(change, leafIndex, scan, exactMatchInfos, ctx);
             return;
         }
         else if (change instanceof BmObjectTextContentChange<?> bmChange)
         {
-            scanBmTextContentChange(change, bmChange, leafIndex, scan, result, refactoringTitle, optional);
+            scanBmTextContentChange(change, bmChange, leafIndex, scan, ctx);
         }
         else
         {
-            scanSourceFileChange(change, leafIndex, scan, result, refactoringTitle, optional);
+            scanSourceFileChange(change, leafIndex, scan, ctx);
         }
 
         if (scan.addedFallbackChange)
@@ -571,24 +648,25 @@ public class MetadataRenameService
             return;
         }
 
-        result.add(new ChangePoint(
-            indexCounter[0]++, BSL_REF, scan.fqn, scan.project,
-            change.getName(), optional, change.isEnabled(), refactoringTitle,
-            -1, -1, null, null));
+        ctx.result.add(new ChangePoint(
+            ctx.indexCounter[0]++, BSL_REF,
+            change.getName(), ctx.optional, change.isEnabled(), ctx.refactoringTitle,
+            CodeLocation.of(scan.fqn, scan.project)));
     }
 
     /** Emits one change point per resolved exact-match, defaulting fqn/project to the leaf context. */
     private void addExactMatchChangePoints(Change change, int leafIndex, LeafScan scan,
-        List<ExactMatchInfo> exactMatchInfos, List<ChangePoint> result, String refactoringTitle, boolean optional)
+        List<ExactMatchInfo> exactMatchInfos, ScanContext ctx)
     {
         for (ExactMatchInfo exactMatch : exactMatchInfos)
         {
             String exactFqn = exactMatch.fqn != null ? exactMatch.fqn : scan.fqn;
             String exactProject = exactMatch.project != null ? exactMatch.project : scan.project;
-            result.add(new ChangePoint(
-                leafIndex, BSL_REF, exactFqn, exactProject,
-                change.getName(), optional, change.isEnabled(), refactoringTitle,
-                exactMatch.lineNumber, exactMatch.columnNumber, exactMatch.codeContext, exactMatch.methodName));
+            ctx.result.add(new ChangePoint(
+                leafIndex, BSL_REF,
+                change.getName(), ctx.optional, change.isEnabled(), ctx.refactoringTitle,
+                new CodeLocation(exactFqn, exactProject, exactMatch.lineNumber, exactMatch.columnNumber,
+                    exactMatch.codeContext, exactMatch.methodName)));
         }
     }
 
@@ -597,7 +675,7 @@ public class MetadataRenameService
      * adding one change point per leaf edit. Swallows extraction errors exactly as before (logs only).
      */
     private void scanBmTextContentChange(Change change, BmObjectTextContentChange<?> bmChange, int leafIndex,
-        LeafScan scan, List<ChangePoint> result, String refactoringTitle, boolean optional)
+        LeafScan scan, ScanContext ctx)
     {
         try
         {
@@ -616,8 +694,7 @@ public class MetadataRenameService
                 if (!leafEdits.isEmpty())
                 {
                     Module module = bmObj instanceof Module bslModule ? bslModule : null;
-                    addLeafEditChangePoints(change, leafIndex, scan, leafEdits, content, module, result,
-                        refactoringTitle, optional);
+                    addLeafEditChangePoints(change, leafIndex, scan, leafEdits, content, module, ctx);
                     scan.addedFallbackChange = true;
                 }
             }
@@ -632,8 +709,7 @@ public class MetadataRenameService
      * Extracts line/column/context for a source-file change, refining scan.fqn/project and adding one
      * change point per leaf edit. Swallows extraction errors exactly as before (logs only).
      */
-    private void scanSourceFileChange(Change change, int leafIndex, LeafScan scan, List<ChangePoint> result,
-        String refactoringTitle, boolean optional)
+    private void scanSourceFileChange(Change change, int leafIndex, LeafScan scan, ScanContext ctx)
     {
         try
         {
@@ -655,8 +731,7 @@ public class MetadataRenameService
                     {
                         Module module = BslModuleUtils.loadModule(file.getProject(),
                             BslModuleUtils.extractModulePath(file.getFullPath().toString()));
-                        addLeafEditChangePoints(change, leafIndex, scan, leafEdits, content, module, result,
-                            refactoringTitle, optional);
+                        addLeafEditChangePoints(change, leafIndex, scan, leafEdits, content, module, ctx);
                         scan.addedFallbackChange = true;
                     }
                 }
@@ -673,7 +748,7 @@ public class MetadataRenameService
      * appends a change point carrying the leaf's shared global index and the refined fqn/project.
      */
     private void addLeafEditChangePoints(Change change, int leafIndex, LeafScan scan, List<TextEdit> leafEdits,
-        String content, Module module, List<ChangePoint> result, String refactoringTitle, boolean optional)
+        String content, Module module, ScanContext ctx)
     {
         for (TextEdit leafEdit : leafEdits)
         {
@@ -681,10 +756,11 @@ public class MetadataRenameService
             int matchedColumnNumber = computeColumnNumber(content, leafEdit.getOffset());
             String matchedCodeContext = extractContext(content, matchedLineNumber);
             String matchedMethodName = resolveContainingMethod(module, content, matchedLineNumber);
-            result.add(new ChangePoint(
-                leafIndex, BSL_REF, scan.fqn, scan.project,
-                change.getName(), optional, change.isEnabled(), refactoringTitle,
-                matchedLineNumber, matchedColumnNumber, matchedCodeContext, matchedMethodName));
+            ctx.result.add(new ChangePoint(
+                leafIndex, BSL_REF,
+                change.getName(), ctx.optional, change.isEnabled(), ctx.refactoringTitle,
+                new CodeLocation(scan.fqn, scan.project, matchedLineNumber, matchedColumnNumber,
+                    matchedCodeContext, matchedMethodName)));
         }
     }
 
@@ -833,8 +909,9 @@ public class MetadataRenameService
 
             List<ChangePoint> edtChanges = new ArrayList<>();
             int[] indexCounter = {0};
-            collectFlatChanges(edtChange, null, null, exactMatches, edtChanges, indexCounter, "edt-preview", false, //$NON-NLS-1$
+            ScanContext ctx = new ScanContext(exactMatches, edtChanges, indexCounter, "edt-preview", false, //$NON-NLS-1$
                 targetObject.getName());
+            collectFlatChanges(edtChange, null, null, ctx);
             return edtChanges;
         }
         catch (Exception e)
@@ -890,16 +967,17 @@ public class MetadataRenameService
             ChangePoint edt = edtBslPreviewChanges.get(i);
             allChanges.set(changeIndex, new ChangePoint(
                 original.index, original.type,
-                edt.fqn != null ? edt.fqn : original.fqn,
-                edt.project != null ? edt.project : original.project,
                 original.description,
                 original.optional,
                 original.enabled,
                 null,
-                edt.lineNumber,
-                edt.columnNumber,
-                edt.codeContext,
-                edt.methodName));
+                new CodeLocation(
+                    edt.fqn != null ? edt.fqn : original.fqn,
+                    edt.project != null ? edt.project : original.project,
+                    edt.lineNumber,
+                    edt.columnNumber,
+                    edt.codeContext,
+                    edt.methodName)));
         }
     }
 
@@ -961,8 +1039,8 @@ public class MetadataRenameService
             {
                 methodName = findContainingMethodText(content, lineNumber);
             }
-            return new ExactMatchInfo(file.getFullPath().toString(), fileOffset, lineNumber, columnNumber,
-                codeContext, methodName, fqn, project);
+            return new ExactMatchInfo(file.getFullPath().toString(), fileOffset,
+                new CodeLocation(fqn, project, lineNumber, columnNumber, codeContext, methodName));
         }
         catch (Exception e)
         {
@@ -996,8 +1074,8 @@ public class MetadataRenameService
             int columnNumber = computeColumnNumber(content, textOffset);
             String project = object instanceof IBmObject bmObject ? bmObject.bmGetEngine().getId() : null;
             String fqn = object instanceof IBmObject bmObject ? bmObject.bmGetTopObject().bmGetFqn() : null;
-            return new ExactMatchInfo(null, textOffset, lineNumber, columnNumber, extractContext(content, lineNumber),
-                null, fqn, project);
+            return new ExactMatchInfo(null, textOffset,
+                new CodeLocation(fqn, project, lineNumber, columnNumber, extractContext(content, lineNumber), null));
         }
         catch (Exception e)
         {
@@ -1645,25 +1723,37 @@ public class MetadataRenameService
                 continue;
             for (IRefactoringItem item : items)
             {
-                if (item instanceof INativeChangeRefactoringItem nativeItem)
-                {
-                    Change nativeChange = nativeItem.getNativeChange();
-                    if (nativeChange != null)
-                    {
-                        applyDisableToChange(nativeChange, disableIndices, indexCounter);
-                    }
-                    // If all leaf changes under this native item are disabled, uncheck the item itself
-                    if (nativeChange != null && nativeItem.isOptional() && isCompletelyDisabled(nativeChange))
-                    {
-                        nativeItem.setChecked(false);
-                    }
-                }
-                else
-                {
-                    // Regular rename item — not skippable (non-optional), just advance index
-                    indexCounter[0]++;
-                }
+                applyDisableToItem(item, disableIndices, indexCounter);
             }
+        }
+    }
+
+    /**
+     * Applies {@code disableIndices} to a single refactoring item, advancing {@code indexCounter} by the
+     * same amount as the preview-side walk: native items disable their matching leaf changes (and uncheck
+     * the optional item when every leaf is disabled), while plain rename items consume one index. Extracted
+     * verbatim from {@link #applyDisableIndices} so it mutates the same in-memory state at the same point.
+     */
+    private void applyDisableToItem(IRefactoringItem item, java.util.Set<Integer> disableIndices,
+        int[] indexCounter)
+    {
+        if (item instanceof INativeChangeRefactoringItem nativeItem)
+        {
+            Change nativeChange = nativeItem.getNativeChange();
+            if (nativeChange != null)
+            {
+                applyDisableToChange(nativeChange, disableIndices, indexCounter);
+            }
+            // If all leaf changes under this native item are disabled, uncheck the item itself
+            if (nativeChange != null && nativeItem.isOptional() && isCompletelyDisabled(nativeChange))
+            {
+                nativeItem.setChecked(false);
+            }
+        }
+        else
+        {
+            // Regular rename item — not skippable (non-optional), just advance index
+            indexCounter[0]++;
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BreakpointUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BreakpointUtils.java
@@ -192,41 +192,67 @@ public final class BreakpointUtils
             IBreakpointManager bpManager)
     {
         Bundle debugCoreBundle = Platform.getBundle(BSL_DEBUG_CORE_BUNDLE);
-        if (debugCoreBundle != null)
-        {
-            for (String className : BSL_BREAKPOINT_CLASSES)
-            {
-                try
-                {
-                    Class<?> cls = debugCoreBundle.loadClass(className);
-                    Constructor<?> ctor = findConstructor(cls);
-                    if (ctor != null)
-                    {
-                        Object instance = ctor.newInstance(file, lineNumber);
-                        if (instance instanceof IBreakpoint)
-                        {
-                            IBreakpoint bp = (IBreakpoint) instance;
-                            // EDT's constructor creates the marker but does not register
-                            // with the breakpoint manager — do it explicitly.
-                            bpManager.addBreakpoint(bp);
-                            return bp;
-                        }
-                    }
-                }
-                catch (ClassNotFoundException cnf)
-                {
-                    // try next class name
-                }
-                catch (Exception ex)
-                {
-                    Activator.logError("Failed to instantiate " + className, ex); //$NON-NLS-1$
-                }
-            }
-        }
-        else
+        if (debugCoreBundle == null)
         {
             Activator.logError("Bundle " + BSL_DEBUG_CORE_BUNDLE //$NON-NLS-1$
                     + " not found — falling back to marker", new IllegalStateException("bundle missing")); //$NON-NLS-1$ //$NON-NLS-2$
+            return null;
+        }
+
+        for (String className : BSL_BREAKPOINT_CLASSES)
+        {
+            IBreakpoint bp = tryCreateEdtBreakpointFor(debugCoreBundle, className, file, lineNumber, bpManager);
+            if (bp != null)
+            {
+                return bp;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Attempts a single candidate class: loads it from {@code debugCoreBundle}, finds an
+     * {@code (IResource/IFile, int)} constructor, instantiates the breakpoint and registers it with the
+     * manager (EDT's constructor creates the marker but does not register). Returns the created
+     * breakpoint, or {@code null} when the class/constructor is unavailable or instantiation fails — so
+     * the caller falls through to the next candidate. {@link ClassNotFoundException} is silent (try next
+     * name); any other failure is logged, exactly as in the former inline loop body.
+     *
+     * @param debugCoreBundle the owning bundle whose class loader resolves {@code className}
+     * @param className        the candidate fully-qualified breakpoint class name
+     * @param file             the resource the breakpoint is on
+     * @param lineNumber       the 1-based line number
+     * @param bpManager        the breakpoint manager to register with
+     * @return the created EDT breakpoint, or {@code null} to try the next candidate
+     */
+    private static IBreakpoint tryCreateEdtBreakpointFor(Bundle debugCoreBundle, String className,
+            IFile file, int lineNumber, IBreakpointManager bpManager)
+    {
+        try
+        {
+            Class<?> cls = debugCoreBundle.loadClass(className);
+            Constructor<?> ctor = findConstructor(cls);
+            if (ctor == null)
+            {
+                return null;
+            }
+            Object instance = ctor.newInstance(file, lineNumber);
+            if (instance instanceof IBreakpoint)
+            {
+                IBreakpoint bp = (IBreakpoint) instance;
+                // EDT's constructor creates the marker but does not register
+                // with the breakpoint manager — do it explicitly.
+                bpManager.addBreakpoint(bp);
+                return bp;
+            }
+        }
+        catch (ClassNotFoundException cnf)
+        {
+            // try next class name
+        }
+        catch (Exception ex)
+        {
+            Activator.logError("Failed to instantiate " + className, ex); //$NON-NLS-1$
         }
         return null;
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
@@ -742,37 +742,145 @@ public final class BslModuleUtils
             int lineNum = i + 1;
             String line = allLines.get(i);
 
-            Matcher startMatcher = REGION_START_PATTERN.matcher(line);
-            if (startMatcher.find())
+            RegionScanResult result = scanRegionLine(line, lineNum, targetLine, regionStack);
+            if (result.resolved)
             {
-                regionStack.add(startMatcher.group(1));
-                if (lineNum >= targetLine)
-                {
-                    return regionStack.get(regionStack.size() - 1);
-                }
-                continue;
-            }
-
-            if (REGION_END_PATTERN.matcher(line).find())
-            {
-                if (lineNum >= targetLine && !regionStack.isEmpty())
-                {
-                    return regionStack.get(regionStack.size() - 1);
-                }
-                if (!regionStack.isEmpty())
-                {
-                    regionStack.remove(regionStack.size() - 1);
-                }
-                continue;
-            }
-
-            if (lineNum >= targetLine)
-            {
-                return regionStack.isEmpty() ? null : regionStack.get(regionStack.size() - 1);
+                return result.regionName;
             }
         }
 
         return null;
+    }
+
+    /**
+     * Carries the outcome of scanning a single line in {@link #findRegionForLine}.
+     * When {@link #resolved} is {@code true} the scan has reached the target line
+     * and {@link #regionName} (which may be {@code null}) is the final answer;
+     * otherwise the loop must continue.
+     */
+    private static final class RegionScanResult
+    {
+        final boolean resolved;
+        final String regionName;
+
+        private RegionScanResult(boolean resolved, String regionName)
+        {
+            this.resolved = resolved;
+            this.regionName = regionName;
+        }
+
+        /** Keep scanning: the target line has not been reached yet. */
+        static RegionScanResult keepScanning()
+        {
+            return new RegionScanResult(false, null);
+        }
+
+        /** Target reached: {@code regionName} (possibly null) is the final answer. */
+        static RegionScanResult resolved(String regionName)
+        {
+            return new RegionScanResult(true, regionName);
+        }
+    }
+
+    /**
+     * Processes one line of the region scan, mutating {@code regionStack} for
+     * #Region/#EndRegion directives. Returns a {@link RegionScanResult} telling the
+     * caller whether the target line has been reached (and, if so, the enclosing
+     * region name) or whether it should keep scanning.
+     *
+     * @param line       the raw source line
+     * @param lineNum    1-based number of {@code line}
+     * @param targetLine the 1-based line whose region is sought
+     * @param regionStack the running stack of open region names (mutated in place)
+     * @return the scan result for this line
+     */
+    private static RegionScanResult scanRegionLine(String line, int lineNum, int targetLine,
+        List<String> regionStack)
+    {
+        RegionScanResult startResult = handleRegionStart(line, lineNum, targetLine, regionStack);
+        if (startResult != null)
+        {
+            return startResult;
+        }
+
+        RegionScanResult endResult = handleRegionEnd(line, lineNum, targetLine, regionStack);
+        if (endResult != null)
+        {
+            return endResult;
+        }
+
+        // Plain line: resolve once the target is reached, otherwise keep scanning.
+        if (lineNum >= targetLine)
+        {
+            return RegionScanResult.resolved(topRegion(regionStack));
+        }
+        return RegionScanResult.keepScanning();
+    }
+
+    /**
+     * Handles a #Region/#Область start directive: pushes the region name and, if the
+     * target line has been reached, resolves to the (now innermost) region.
+     *
+     * @param line       the raw source line
+     * @param lineNum    1-based number of {@code line}
+     * @param targetLine the 1-based line whose region is sought
+     * @param regionStack the running stack of open region names (mutated in place)
+     * @return a scan result if this is a start directive, or {@code null} otherwise
+     */
+    private static RegionScanResult handleRegionStart(String line, int lineNum, int targetLine,
+        List<String> regionStack)
+    {
+        Matcher startMatcher = REGION_START_PATTERN.matcher(line);
+        if (!startMatcher.find())
+        {
+            return null;
+        }
+        regionStack.add(startMatcher.group(1));
+        if (lineNum >= targetLine)
+        {
+            return RegionScanResult.resolved(topRegion(regionStack));
+        }
+        return RegionScanResult.keepScanning();
+    }
+
+    /**
+     * Handles a #EndRegion/#КонецОбласти end directive: if the target line has been
+     * reached it resolves to the innermost open region; otherwise it pops the stack.
+     *
+     * @param line       the raw source line
+     * @param lineNum    1-based number of {@code line}
+     * @param targetLine the 1-based line whose region is sought
+     * @param regionStack the running stack of open region names (mutated in place)
+     * @return a scan result if this is an end directive, or {@code null} otherwise
+     */
+    private static RegionScanResult handleRegionEnd(String line, int lineNum, int targetLine,
+        List<String> regionStack)
+    {
+        if (!REGION_END_PATTERN.matcher(line).find())
+        {
+            return null;
+        }
+        if (lineNum >= targetLine && !regionStack.isEmpty())
+        {
+            return RegionScanResult.resolved(topRegion(regionStack));
+        }
+        if (!regionStack.isEmpty())
+        {
+            regionStack.remove(regionStack.size() - 1);
+        }
+        return RegionScanResult.keepScanning();
+    }
+
+    /**
+     * Returns the innermost (top-of-stack) open region name, or {@code null} when no
+     * region is currently open.
+     *
+     * @param regionStack the stack of open region names
+     * @return the top region name, or {@code null} if the stack is empty
+     */
+    private static String topRegion(List<String> regionStack)
+    {
+        return regionStack.isEmpty() ? null : regionStack.get(regionStack.size() - 1);
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
@@ -1436,13 +1436,56 @@ public final class LaunchLifecycleUtils
             return ApplicationUpdateState.UNKNOWN;
         }
 
-        // Latest state pushed by an UPDATE_STATE_CHANGED event (or read directly).
-        AtomicReference<ApplicationUpdateState> observed =
-            new AtomicReference<>(ApplicationUpdateState.UNKNOWN);
-        // Signals every time a relevant event arrives so the waiter re-evaluates.
-        AtomicReference<CountDownLatch> signal = new AtomicReference<>(new CountDownLatch(1));
+        AwaitState awaitState = new AwaitState();
+        IApplicationListener listener = buildUpdateStateListener(application, awaitState);
 
-        IApplicationListener listener = event -> {
+        appManager.addAppllicationListener(listener);
+        try
+        {
+            // An event may already have fired before registration — read once now.
+            ApplicationUpdateState current = readUpdateState(appManager, application);
+            awaitState.observed.set(current);
+            if (done.test(current))
+            {
+                return current;
+            }
+
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            return pollUpdateStateUntilDone(appManager, application, done, deadline, awaitState);
+        }
+        finally
+        {
+            appManager.removeAppllicationListener(listener);
+        }
+    }
+
+    /**
+     * Mutable holder shared between {@link #awaitUpdateState}'s listener and its
+     * wait loop: {@link #observed} is the latest state pushed by an
+     * {@link ApplicationEventType#UPDATE_STATE_CHANGED} event (or read directly), and
+     * {@link #signal} is re-set on every relevant event so the waiter re-evaluates.
+     * Bundled into one object so the loop helper takes a single seam rather than two
+     * loose references.
+     */
+    private static final class AwaitState
+    {
+        final AtomicReference<ApplicationUpdateState> observed =
+            new AtomicReference<>(ApplicationUpdateState.UNKNOWN);
+        final AtomicReference<CountDownLatch> signal =
+            new AtomicReference<>(new CountDownLatch(1));
+    }
+
+    /**
+     * Builds the {@link IApplicationListener} that {@link #awaitUpdateState} registers:
+     * an {@link ApplicationEventType#UPDATE_STATE_CHANGED} event for {@code application}
+     * records the pushed state into {@code awaitState.observed} and wakes the waiter by
+     * counting down {@code awaitState.signal}; every other event is ignored. Same filter
+     * and side effects as the original inline lambda.
+     */
+    private static IApplicationListener buildUpdateStateListener(IApplication application,
+            AwaitState awaitState)
+    {
+        return event -> {
             if (event == null || event.getEventType() != ApplicationEventType.UPDATE_STATE_CHANGED
                 || !isSameApplication(event.getApplication(), application))
             {
@@ -1451,71 +1494,84 @@ public final class LaunchLifecycleUtils
             ApplicationUpdateState pushed = event.getUpdateState();
             if (pushed != null)
             {
-                observed.set(pushed);
+                awaitState.observed.set(pushed);
             }
             // Wake the waiter; it re-reads `observed` and re-evaluates `done`.
-            signal.get().countDown();
+            awaitState.signal.get().countDown();
         };
+    }
 
-        appManager.addAppllicationListener(listener);
-        try
+    /**
+     * The wait loop of {@link #awaitUpdateState}: blocks on the event latch (re-waking
+     * every {@link #syncPollIntervalMs} as a missed-event safety net) until {@code done}
+     * is satisfied or {@code deadline} passes. Preserves the original control flow
+     * exactly — including returning the last observed state on timeout and on an
+     * interruption (after re-asserting the interrupt flag).
+     *
+     * @return the last observed {@link ApplicationUpdateState} once {@code done} holds,
+     *         or the last observed state when {@code deadline} elapses / the wait breaks
+     */
+    private static ApplicationUpdateState pollUpdateStateUntilDone(IApplicationManager appManager,
+            IApplication application, Predicate<ApplicationUpdateState> done, long deadline,
+            AwaitState awaitState)
+    {
+        while (true)
         {
-            // An event may already have fired before registration — read once now.
-            ApplicationUpdateState current = readUpdateState(appManager, application);
-            observed.set(current);
-            if (done.test(current))
+            long remaining = deadline - System.currentTimeMillis();
+            if (remaining <= 0)
             {
-                return current;
+                return awaitState.observed.get();
             }
-
-            long deadline = System.currentTimeMillis() + timeoutMs;
-            while (true)
+            CountDownLatch latch = awaitState.signal.get();
+            // Wake on the event OR every syncPollIntervalMs (safety net for a
+            // missed event), whichever comes first.
+            long waitMs = Math.min(remaining, Math.max(1L, syncPollIntervalMs));
+            boolean signalled;
+            try
             {
-                long remaining = deadline - System.currentTimeMillis();
-                if (remaining <= 0)
-                {
-                    return observed.get();
-                }
-                CountDownLatch latch = signal.get();
-                // Wake on the event OR every syncPollIntervalMs (safety net for a
-                // missed event), whichever comes first.
-                long waitMs = Math.min(remaining, Math.max(1L, syncPollIntervalMs));
-                boolean signalled;
-                try
-                {
-                    signalled = latch.await(waitMs, TimeUnit.MILLISECONDS);
-                }
-                catch (InterruptedException e)
-                {
-                    Thread.currentThread().interrupt();
-                    return observed.get();
-                }
-                if (signalled)
-                {
-                    // Reset the latch for the next event before re-evaluating, so an
-                    // event arriving during evaluation is not lost.
-                    signal.set(new CountDownLatch(1));
-                    if (done.test(observed.get()))
-                    {
-                        return observed.get();
-                    }
-                }
-                else
-                {
-                    // Timed wake — re-read the cached state as a fallback.
-                    ApplicationUpdateState polled = readUpdateState(appManager, application);
-                    observed.set(polled);
-                    if (done.test(polled))
-                    {
-                        return polled;
-                    }
-                }
+                signalled = latch.await(waitMs, TimeUnit.MILLISECONDS);
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+                return awaitState.observed.get();
+            }
+            ApplicationUpdateState reached =
+                evaluateAwaitWake(appManager, application, done, signalled, awaitState);
+            if (reached != null)
+            {
+                return reached;
             }
         }
-        finally
+    }
+
+    /**
+     * Evaluates one wake of {@link #pollUpdateStateUntilDone}. On a signalled wake the
+     * event latch is reset (so an event arriving during evaluation is not lost) and the
+     * pushed {@code observed} state is tested; on a timed wake the cached state is
+     * re-read into {@code observed} and tested. Returns the satisfying state when
+     * {@code done} now holds, otherwise {@code null} to keep waiting.
+     *
+     * @param signalled {@code true} when the latch fired (event), {@code false} on a
+     *            timed safety-net wake
+     * @return the state that satisfied {@code done}, or {@code null} to continue the loop
+     */
+    private static ApplicationUpdateState evaluateAwaitWake(IApplicationManager appManager,
+            IApplication application, Predicate<ApplicationUpdateState> done, boolean signalled,
+            AwaitState awaitState)
+    {
+        if (signalled)
         {
-            appManager.removeAppllicationListener(listener);
+            // Reset the latch for the next event before re-evaluating, so an
+            // event arriving during evaluation is not lost.
+            awaitState.signal.set(new CountDownLatch(1));
+            ApplicationUpdateState observed = awaitState.observed.get();
+            return done.test(observed) ? observed : null;
         }
+        // Timed wake — re-read the cached state as a fallback.
+        ApplicationUpdateState polled = readUpdateState(appManager, application);
+        awaitState.observed.set(polled);
+        return done.test(polled) ? polled : null;
     }
 
     /**
@@ -1647,159 +1703,221 @@ public final class LaunchLifecycleUtils
             // permanently block future auto-chains.
             OWNED_LAUNCHES.removeIf(ILaunch::isTerminated);
 
-            int terminated = 0;
-            for (ILaunch live : LaunchConfigUtils.getAllLiveLaunches(launchManager,
-                project.getName()))
+            TerminationOutcome outcome = new TerminationOutcome();
+            terminateMatchingLiveLaunches(launchManager, project, applicationId,
+                terminateTimeoutSeconds, outcome);
+            if (outcome.error != null)
             {
-                if (!applicationId.equals(LaunchConfigUtils.getApplicationIdFor(live)))
-                {
-                    continue;
-                }
-                String name = live.getLaunchConfiguration() != null
-                    ? live.getLaunchConfiguration().getName() : UNKNOWN_LABEL;
-                // Identity-equals lookup against the OWNED registry — relies on
-                // the invariant that callers pass the exact ILaunch instance
-                // returned by workingCopy.launch() to registerOwnedLaunch.
-                if (OWNED_LAUNCHES.contains(live))
-                {
-                    return new PreLaunchResult(false, terminated,
-                        "Another test run is already in progress for this IB " //$NON-NLS-1$
-                            + "(launch '" + name + "'). Wait for it to finish " //$NON-NLS-1$ //$NON-NLS-2$
-                            + "(call this tool again later with the same arguments), " //$NON-NLS-1$
-                            + "or call `terminate_launch` to stop it first."); //$NON-NLS-1$
-                }
-                boolean done = terminateAndWait(live, terminateTimeoutSeconds);
-                if (!done)
-                {
-                    return new PreLaunchResult(false, terminated,
-                        "Could not terminate previous launch '" + name //$NON-NLS-1$
-                            + "' within " + terminateTimeoutSeconds //$NON-NLS-1$
-                            + "s. Call `terminate_launch` with `force=true` to kill " //$NON-NLS-1$
-                            + "the stuck process, then retry."); //$NON-NLS-1$
-                }
-                terminated++;
+                return new PreLaunchResult(false, outcome.terminated, outcome.error);
             }
 
-            // Second pass: stale Attach launches on the same project. Attach
-            // configs don't carry a real ATTR_APPLICATION_ID — getApplicationIdFor
-            // synthesises "attach:<name>", which never equals a runtime client's
-            // UUID, so the per-applicationId loop above never sweeps them. A
-            // lingering Attach (e.g. left over from a previous debug session) can
-            // mask which 1C client really holds the IB and clutter diagnostics,
-            // so disconnect it before the new spawn. Killing an Attach launch is
-            // just a debugger disconnect — the 1C server keeps running, no
-            // unsaved state is at risk.
-            for (ILaunch live : LaunchConfigUtils.getAllLiveLaunches(launchManager,
-                project.getName()))
+            sweepStaleAttachLaunches(launchManager, project, terminateTimeoutSeconds, outcome);
+            if (outcome.error != null)
             {
-                if (!LaunchConfigUtils.isAttachConfig(live.getLaunchConfiguration()))
-                {
-                    continue;
-                }
-                String name = live.getLaunchConfiguration() != null
-                    ? live.getLaunchConfiguration().getName() : UNKNOWN_LABEL;
-                // Defensive: today both YAXUnit tools register only runtime
-                // launches, so an Attach in OWNED is purely hypothetical. If a
-                // future tool starts registering Attach launches as owned, we
-                // intentionally fast-fail here rather than skipping — at the
-                // attach-pass level we don't know which IB the foreign attach
-                // targets, and silent skip would risk a spawn that hangs on a
-                // locked IB until the MCP timeout. The error message points the
-                // caller at terminate_launch, which is the right escape hatch.
-                if (OWNED_LAUNCHES.contains(live))
-                {
-                    return new PreLaunchResult(false, terminated,
-                        "An Attach debug session for this project is owned by another " //$NON-NLS-1$
-                            + "MCP tool (launch '" + name + "'). Wait for it to finish, " //$NON-NLS-1$ //$NON-NLS-2$
-                            + "or call `terminate_launch` to disconnect it first."); //$NON-NLS-1$
-                }
-                boolean done = terminateAndWait(live, terminateTimeoutSeconds);
-                if (!done)
-                {
-                    // An Attach disconnect that doesn't complete is unusual but
-                    // not fatal to the test run: Attach launches don't hold the
-                    // IB lock (the foreign 1C client does), so a stuck disconnect
-                    // shouldn't block the new spawn. Log and continue.
-                    Activator.logError("Could not disconnect stale Attach launch '" //$NON-NLS-1$
-                        + name + "' within " + terminateTimeoutSeconds //$NON-NLS-1$
-                        + "s, continuing with the auto-chain", null); //$NON-NLS-1$
-                    continue;
-                }
-                // Surface attach disconnects in the log because the per-call
-                // PreLaunchResult counter slips them into the same total as
-                // runtime terminations — without this line, post-mortems can't
-                // tell which launches the second pass swept.
-                Activator.logInfo("Pre-launch auto-chain disconnected stale Attach launch '" //$NON-NLS-1$
-                    + name + "' on project " + project.getName()); //$NON-NLS-1$
-                terminated++;
+                return new PreLaunchResult(false, outcome.terminated, outcome.error);
             }
 
-            // Selectively force a derived-data recompute of projects that have
-            // had file changes since the last successful prepare (dirty projects).
-            // Clean projects get only a cheap derived-data drain. Without the
-            // forced recompute for dirty projects, an extension (.cfe) edited just
-            // before the launch is never regenerated (the derived-data wait no-ops
-            // when nothing is scheduled) and appManager.update() consumes the
-            // stale export artifact — so the first test run executes the old
-            // extension, missing freshly added tests. updateScope narrows the
-            // project scope FIRST; the dirty filter is applied within that scope.
-            //
-            // The snapshot is taken INSIDE recomputeAndSettleIfDirty, BEFORE the
-            // recompute begins. We receive it back so we can pass it to
-            // markPrepared on the success paths — a change arriving DURING the
-            // recompute bumps the generation counter; the conditional remove in
-            // markPrepared then fails and the project stays dirty (stale-.cfe fix).
-            List<IProject> scopeProjects = resolveUpdateScope(project, updateScope);
-            Map<String, Long> dirtySnapshot = recomputeAndSettleIfDirty(scopeProjects);
+            return finalizeFreshLaunchPrep(project, applicationId, appManager, updateScope,
+                outcome.terminated);
+        }
+    }
 
-            // A STANDALONE-SERVER application (literal
-            // "ServerApplication." id prefix) must NOT be DB-updated out-of-band
-            // here. IApplicationManager.update on a ServerApplication routes through
-            // ServerApplicationBehaviourDelegate.update →
-            // JobBasedServerModulePublisher.publish, which STARTS the standalone
-            // server in RUN mode and caches a live designer-agent connection in the
-            // global DesignerSessionPool; the launch delegate then needs the server
-            // in DEBUG mode, and the restart's teardown of that cached connection
-            // wedges the launch. Defer to the delegate's coordinated path instead —
-            // EDT's native ApplicationUiSupport.ensureUpdated prepares the server
-            // directly in the target mode FIRST and only then updates (no restart).
-            // Both YAXUnit tools arm LaunchUpdateDialogAutoConfirmer around
-            // workingCopy.launch, so the delegate's "Application update" dialog
-            // (shown only when the IB is stale) is auto-pressed; when the IB is in
-            // sync there is no dialog at all. The terminate-stale passes and the
-            // recompute/settle above still ran — they do not open IB connections.
-            if (DebugServerTargetSupport.isServerApplicationId(applicationId))
-            {
-                Activator.logInfo("Pre-launch auto-chain: server application: deferring DB update " //$NON-NLS-1$
-                    + "to the launch delegate's coordinated path (auto-confirmed): applicationId=" //$NON-NLS-1$
-                    + applicationId);
-                // Success path: mark all scope projects as prepared with the
-                // generation-keyed snapshot so the next call skips the recompute
-                // when nothing changed (and keeps dirty flag on a change-during-recompute).
-                PreLaunchChangeTracker.markPrepared(scopeProjects, dirtySnapshot);
-                return new PreLaunchResult(true, terminated, null);
-            }
+    /**
+     * Mutable accumulator threaded through the {@link #prepareForFreshLaunch} sweep
+     * helpers: {@link #terminated} is the running count of swept launches, and
+     * {@link #error} is set to the first blocking error message (a populated value tells
+     * the caller to abort with {@code new PreLaunchResult(false, terminated, error)},
+     * exactly the inline early-returns did).
+     */
+    private static final class TerminationOutcome
+    {
+        int terminated;
+        String error;
+    }
 
-            // settleAfterPossibleRecompute=true: we JUST forced a recompute, so a cached
-            // UPDATED may lag the freshly regenerated .cfe — wait out the settle window
-            // before trusting "no update needed". The settle is kept
-            // UNCONDITIONALLY: the lagging UPDATE_STATE_CHANGED push this window
-            // exists for arrives AFTER the recompute drain (it is emitted by the
-            // applications-layer infobase-sync checker, which the drained build /
-            // derived-data job families do NOT cover), so no during-drain probe can
-            // prove it will not come. The plain debug_launch path passes false
-            // (immediate return on UPDATED) to avoid that ~5s cost.
-            Optional<String> updateErr = updateApplicationIfNeeded(project, applicationId,
-                appManager, true);
-            if (updateErr.isPresent())
+    /**
+     * First pass of {@link #prepareForFreshLaunch}: politely terminates every live launch
+     * whose application id matches {@code applicationId}, incrementing
+     * {@code outcome.terminated} per success. Sets {@code outcome.error} (and stops) when a
+     * matching launch is MCP-owned (another test run in progress) or fails to terminate in
+     * time — the SAME two messages the inline loop returned. Leaves {@code outcome.error}
+     * {@code null} when the pass completes cleanly.
+     */
+    private static void terminateMatchingLiveLaunches(ILaunchManager launchManager,
+            IProject project, String applicationId, int terminateTimeoutSeconds,
+            TerminationOutcome outcome)
+    {
+        for (ILaunch live : LaunchConfigUtils.getAllLiveLaunches(launchManager,
+            project.getName()))
+        {
+            if (!applicationId.equals(LaunchConfigUtils.getApplicationIdFor(live)))
             {
-                // Error path: do NOT mark prepared — the next call must recompute.
-                return new PreLaunchResult(false, terminated, updateErr.get());
+                continue;
             }
-            // Success path: mark prepared with the generation-keyed snapshot.
+            String name = live.getLaunchConfiguration() != null
+                ? live.getLaunchConfiguration().getName() : UNKNOWN_LABEL;
+            // Identity-equals lookup against the OWNED registry — relies on
+            // the invariant that callers pass the exact ILaunch instance
+            // returned by workingCopy.launch() to registerOwnedLaunch.
+            if (OWNED_LAUNCHES.contains(live))
+            {
+                outcome.error = "Another test run is already in progress for this IB " //$NON-NLS-1$
+                    + "(launch '" + name + "'). Wait for it to finish " //$NON-NLS-1$ //$NON-NLS-2$
+                    + "(call this tool again later with the same arguments), " //$NON-NLS-1$
+                    + "or call `terminate_launch` to stop it first."; //$NON-NLS-1$
+                return;
+            }
+            boolean done = terminateAndWait(live, terminateTimeoutSeconds);
+            if (!done)
+            {
+                outcome.error = "Could not terminate previous launch '" + name //$NON-NLS-1$
+                    + "' within " + terminateTimeoutSeconds //$NON-NLS-1$
+                    + "s. Call `terminate_launch` with `force=true` to kill " //$NON-NLS-1$
+                    + "the stuck process, then retry."; //$NON-NLS-1$
+                return;
+            }
+            outcome.terminated++;
+        }
+    }
+
+    /**
+     * Second pass of {@link #prepareForFreshLaunch}: disconnects stale Attach launches on
+     * the project. Attach configs don't carry a real {@code ATTR_APPLICATION_ID}
+     * ({@code getApplicationIdFor} synthesises {@code "attach:<name>"}, which never equals a
+     * runtime client's UUID, so the first pass never sweeps them); a lingering Attach can
+     * mask which 1C client holds the IB. Killing an Attach launch is just a debugger
+     * disconnect — the 1C server keeps running. Sets {@code outcome.error} only for an
+     * MCP-owned Attach (the same fast-fail message as before); a non-confirming disconnect
+     * is logged and skipped (best-effort), and each confirmed disconnect increments
+     * {@code outcome.terminated}.
+     */
+    private static void sweepStaleAttachLaunches(ILaunchManager launchManager, IProject project,
+            int terminateTimeoutSeconds, TerminationOutcome outcome)
+    {
+        for (ILaunch live : LaunchConfigUtils.getAllLiveLaunches(launchManager,
+            project.getName()))
+        {
+            if (!LaunchConfigUtils.isAttachConfig(live.getLaunchConfiguration()))
+            {
+                continue;
+            }
+            String name = live.getLaunchConfiguration() != null
+                ? live.getLaunchConfiguration().getName() : UNKNOWN_LABEL;
+            // Defensive: today both YAXUnit tools register only runtime
+            // launches, so an Attach in OWNED is purely hypothetical. If a
+            // future tool starts registering Attach launches as owned, we
+            // intentionally fast-fail here rather than skipping — at the
+            // attach-pass level we don't know which IB the foreign attach
+            // targets, and silent skip would risk a spawn that hangs on a
+            // locked IB until the MCP timeout. The error message points the
+            // caller at terminate_launch, which is the right escape hatch.
+            if (OWNED_LAUNCHES.contains(live))
+            {
+                outcome.error = "An Attach debug session for this project is owned by another " //$NON-NLS-1$
+                    + "MCP tool (launch '" + name + "'). Wait for it to finish, " //$NON-NLS-1$ //$NON-NLS-2$
+                    + "or call `terminate_launch` to disconnect it first."; //$NON-NLS-1$
+                return;
+            }
+            boolean done = terminateAndWait(live, terminateTimeoutSeconds);
+            if (!done)
+            {
+                // An Attach disconnect that doesn't complete is unusual but
+                // not fatal to the test run: Attach launches don't hold the
+                // IB lock (the foreign 1C client does), so a stuck disconnect
+                // shouldn't block the new spawn. Log and continue.
+                Activator.logError("Could not disconnect stale Attach launch '" //$NON-NLS-1$
+                    + name + "' within " + terminateTimeoutSeconds //$NON-NLS-1$
+                    + "s, continuing with the auto-chain", null); //$NON-NLS-1$
+                continue;
+            }
+            // Surface attach disconnects in the log because the per-call
+            // PreLaunchResult counter slips them into the same total as
+            // runtime terminations — without this line, post-mortems can't
+            // tell which launches the second pass swept.
+            Activator.logInfo("Pre-launch auto-chain disconnected stale Attach launch '" //$NON-NLS-1$
+                + name + "' on project " + project.getName()); //$NON-NLS-1$
+            outcome.terminated++;
+        }
+    }
+
+    /**
+     * Final stage of {@link #prepareForFreshLaunch} after the terminate passes: forces the
+     * scoped derived-data recompute, then either defers the DB update to the launch
+     * delegate (standalone-server applications) or runs {@link #updateApplicationIfNeeded}
+     * and gates on it, marking the scope prepared on the success paths only. Returns the
+     * SAME {@link PreLaunchResult} (ok / error, with the supplied {@code terminated} count)
+     * the inline tail produced.
+     *
+     * @param terminated the swept-launch count accumulated by the terminate passes
+     */
+    private static PreLaunchResult finalizeFreshLaunchPrep(IProject project, String applicationId,
+            IApplicationManager appManager, String updateScope, int terminated)
+    {
+        // Selectively force a derived-data recompute of projects that have
+        // had file changes since the last successful prepare (dirty projects).
+        // Clean projects get only a cheap derived-data drain. Without the
+        // forced recompute for dirty projects, an extension (.cfe) edited just
+        // before the launch is never regenerated (the derived-data wait no-ops
+        // when nothing is scheduled) and appManager.update() consumes the
+        // stale export artifact — so the first test run executes the old
+        // extension, missing freshly added tests. updateScope narrows the
+        // project scope FIRST; the dirty filter is applied within that scope.
+        //
+        // The snapshot is taken INSIDE recomputeAndSettleIfDirty, BEFORE the
+        // recompute begins. We receive it back so we can pass it to
+        // markPrepared on the success paths — a change arriving DURING the
+        // recompute bumps the generation counter; the conditional remove in
+        // markPrepared then fails and the project stays dirty (stale-.cfe fix).
+        List<IProject> scopeProjects = resolveUpdateScope(project, updateScope);
+        Map<String, Long> dirtySnapshot = recomputeAndSettleIfDirty(scopeProjects);
+
+        // A STANDALONE-SERVER application (literal
+        // "ServerApplication." id prefix) must NOT be DB-updated out-of-band
+        // here. IApplicationManager.update on a ServerApplication routes through
+        // ServerApplicationBehaviourDelegate.update →
+        // JobBasedServerModulePublisher.publish, which STARTS the standalone
+        // server in RUN mode and caches a live designer-agent connection in the
+        // global DesignerSessionPool; the launch delegate then needs the server
+        // in DEBUG mode, and the restart's teardown of that cached connection
+        // wedges the launch. Defer to the delegate's coordinated path instead —
+        // EDT's native ApplicationUiSupport.ensureUpdated prepares the server
+        // directly in the target mode FIRST and only then updates (no restart).
+        // Both YAXUnit tools arm LaunchUpdateDialogAutoConfirmer around
+        // workingCopy.launch, so the delegate's "Application update" dialog
+        // (shown only when the IB is stale) is auto-pressed; when the IB is in
+        // sync there is no dialog at all. The terminate-stale passes and the
+        // recompute/settle above still ran — they do not open IB connections.
+        if (DebugServerTargetSupport.isServerApplicationId(applicationId))
+        {
+            Activator.logInfo("Pre-launch auto-chain: server application: deferring DB update " //$NON-NLS-1$
+                + "to the launch delegate's coordinated path (auto-confirmed): applicationId=" //$NON-NLS-1$
+                + applicationId);
+            // Success path: mark all scope projects as prepared with the
+            // generation-keyed snapshot so the next call skips the recompute
+            // when nothing changed (and keeps dirty flag on a change-during-recompute).
             PreLaunchChangeTracker.markPrepared(scopeProjects, dirtySnapshot);
             return new PreLaunchResult(true, terminated, null);
         }
+
+        // settleAfterPossibleRecompute=true: we JUST forced a recompute, so a cached
+        // UPDATED may lag the freshly regenerated .cfe — wait out the settle window
+        // before trusting "no update needed". The settle is kept
+        // UNCONDITIONALLY: the lagging UPDATE_STATE_CHANGED push this window
+        // exists for arrives AFTER the recompute drain (it is emitted by the
+        // applications-layer infobase-sync checker, which the drained build /
+        // derived-data job families do NOT cover), so no during-drain probe can
+        // prove it will not come. The plain debug_launch path passes false
+        // (immediate return on UPDATED) to avoid that ~5s cost.
+        Optional<String> updateErr = updateApplicationIfNeeded(project, applicationId,
+            appManager, true);
+        if (updateErr.isPresent())
+        {
+            // Error path: do NOT mark prepared — the next call must recompute.
+            return new PreLaunchResult(false, terminated, updateErr.get());
+        }
+        // Success path: mark prepared with the generation-keyed snapshot.
+        PreLaunchChangeTracker.markPrepared(scopeProjects, dirtySnapshot);
+        return new PreLaunchResult(true, terminated, null);
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
@@ -724,35 +724,57 @@ public final class LaunchUpdateDialogAutoConfirmer
         {
             return null;
         }
-        String firstSeen = null;
-        String text = labelLikeText(control);
-        if (text != null && !text.trim().isEmpty())
+        // This control's own label-like text: a 1003-prefix match short-circuits;
+        // otherwise it is the running best-effort fallback.
+        String firstSeen = ownLabelMatch(control);
+        if (firstSeen != null && isDebugSessionExistsBody(firstSeen))
         {
-            if (isDebugSessionExistsBody(text))
-            {
-                return text;
-            }
-            firstSeen = text;
+            return firstSeen;
         }
         if (control instanceof Composite)
         {
-            for (Control child : ((Composite)control).getChildren())
+            return scanChildren((Composite)control, depth, firstSeen);
+        }
+        return firstSeen;
+    }
+
+    /**
+     * The control's OWN label-like text when non-blank, else {@code null}. Pure
+     * sub-block of {@link #findBodyText}: a {@link #isDebugSessionExistsBody}
+     * prefix match is preserved for the caller to short-circuit on.
+     */
+    private static String ownLabelMatch(Control control)
+    {
+        String text = labelLikeText(control);
+        return text != null && !text.trim().isEmpty() ? text : null;
+    }
+
+    /**
+     * Pre-order scan of a composite's children for {@link #findBodyText}: returns
+     * the first child text matching a 1003 prefix, else {@code firstSeen} (the
+     * parent's running best-effort fallback, kept if the parent already had one or
+     * promoted to the first non-blank child text otherwise). Same skipping and
+     * first-wins fallback semantics as the inline loop it replaces.
+     */
+    private static String scanChildren(Composite composite, int depth, String firstSeen)
+    {
+        String best = firstSeen;
+        for (Control child : composite.getChildren())
+        {
+            String childText = findBodyText(child, depth + 1);
+            if (childText != null)
             {
-                String childText = findBodyText(child, depth + 1);
-                if (childText != null)
+                if (isDebugSessionExistsBody(childText))
                 {
-                    if (isDebugSessionExistsBody(childText))
-                    {
-                        return childText;
-                    }
-                    if (firstSeen == null)
-                    {
-                        firstSeen = childText;
-                    }
+                    return childText;
+                }
+                if (best == null)
+                {
+                    best = childText;
                 }
             }
         }
-        return firstSeen;
+        return best;
     }
 
     /** @return the text of a {@link Label}/{@link CLabel}/{@link Text}/{@link Link}, else {@code null}. */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataNodeResolver.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataNodeResolver.java
@@ -209,14 +209,35 @@ public final class MetadataNodeResolver
         /** Concrete element type to instantiate; {@code null} for a top-level create. */
         public final EClass elementType;
 
-        private CreateTarget(boolean topLevel, String childName, String topLevelType,
-            String configFeatureName, EObject owner, MdObject topObject, EReference feature,
-            EClass elementType)
+        /**
+         * Top-level create target: {@link #topLevel} is {@code true} and only the top-level
+         * fields are set; the child-navigation fields stay {@code null}. Matches the field
+         * values the former 8-arg constructor produced for {@link #forTopLevel}.
+         */
+        private CreateTarget(String topLevelType, String configFeatureName, String childName)
         {
-            this.topLevel = topLevel;
+            this.topLevel = true;
             this.childName = childName;
             this.topLevelType = topLevelType;
             this.configFeatureName = configFeatureName;
+            this.owner = null;
+            this.topObject = null;
+            this.feature = null;
+            this.elementType = null;
+        }
+
+        /**
+         * Child create target: {@link #topLevel} is {@code false} and only the child-navigation
+         * fields are set; the top-level fields stay {@code null}. Matches the field values the
+         * former 8-arg constructor produced for {@link #forChild}.
+         */
+        private CreateTarget(EObject owner, MdObject topObject, EReference feature,
+            EClass elementType, String childName)
+        {
+            this.topLevel = false;
+            this.childName = childName;
+            this.topLevelType = null;
+            this.configFeatureName = null;
             this.owner = owner;
             this.topObject = topObject;
             this.feature = feature;
@@ -225,13 +246,13 @@ public final class MetadataNodeResolver
 
         static CreateTarget forTopLevel(String topLevelType, String configFeatureName, String childName)
         {
-            return new CreateTarget(true, childName, topLevelType, configFeatureName, null, null, null, null);
+            return new CreateTarget(topLevelType, configFeatureName, childName);
         }
 
         static CreateTarget forChild(EObject owner, MdObject topObject, EReference feature,
             EClass elementType, String childName)
         {
-            return new CreateTarget(false, childName, null, null, owner, topObject, feature, elementType);
+            return new CreateTarget(owner, topObject, feature, elementType, childName);
         }
     }
 


### PR DESCRIPTION
A **second, more aggressive** complexity pass. The first pass (#172-181) cut these methods a lot, but several stayed above SonarCloud's **S3776** limit because the hand cognitive-complexity estimates were optimistic (e.g. `runTests` actually landed at ~24, not ~12). This pass re-extracts each flagged method into a **thin orchestrator targeting cc ≤ 8** (margin under 15), and clears the **S107** 'too many parameters' findings — many of which were *introduced* by the first pass's multi-param helpers — by bundling related params into small immutable **holder objects**.\n\n- ~40 S3776 methods reduced (Create*/Modify*/Delete* tools, RunYaxunitTestsTool, LaunchLifecycleUtils, formatters, group/debug/breakpoint tools, BslModuleUtils, …).\n- S107 private helpers → holders (RunRequest/PrepRequest, ScanContext/CodeLocation/PreviewSummary, CreateRequest, CollectContext, …).\n- File-disjoint implement agents → `mvn clean verify` (**2698 tests, green**). Zero behaviour change; mutating calls stay **inline** under the same guard; lock scopes + checked-exception `throws` preserved; no public/@Override signature changed.\n\nA few S107 methods are deliberately **left** (unit-test contracts: `formatProposals`, `selectStaleTerminated`, `formatOutput`, `launchDebugMode`) — those are suppressed in the companion NOSONAR PR. Follows #166-173, #176, #179-181, #184.