### PR TITLE
Switch false-positive suppression from // NOSONAR to @SuppressWarnings (SonarCloud ignores NOSONAR)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/Activator.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/Activator.java
@@ -61,10 +61,11 @@ public class Activator extends AbstractUIPlugin
     private final StartupOrchestrator orchestrator = new StartupOrchestrator();
 
     @Override
+    @SuppressWarnings("java:S2696")
     public void start(BundleContext context) throws Exception
     {
         super.start(context);
-        plugin = this; // NOSONAR Eclipse singleton/Activator init pattern; method cannot be static
+        plugin = this;
         mcpServer = new McpServer();
 
         // In Tycho headless test runtime, avoid eager workspace/UI/platform initialization.
@@ -90,6 +91,7 @@ public class Activator extends AbstractUIPlugin
     }
 
     @Override
+    @SuppressWarnings("java:S2696")
     public void stop(BundleContext context) throws Exception
     {
         if (mcpServer != null && mcpServer.isRunning())
@@ -105,7 +107,7 @@ public class Activator extends AbstractUIPlugin
         orchestrator.stop(isHeadless());
 
         logInfo("EDT MCP Server plugin stopped"); //$NON-NLS-1$
-        plugin = null; // NOSONAR Eclipse singleton/Activator init pattern; method cannot be static
+        plugin = null;
         super.stop(context);
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/EdtServices.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/EdtServices.java
@@ -219,10 +219,11 @@ public class EdtServices
      * activator used to close them. Behaviour-preserving extraction of the
      * tracker close block from {@code Activator.stop(BundleContext)}.
      */
+    @SuppressWarnings("java:S125")
     public void dispose()
     {
         // Close service trackers (each closeTracker() closes when non-null and returns null,
-        // exactly reproducing the former "if (t != null) { t.close(); t = null; }" per-field block). // NOSONAR explanatory comment, not commented-out code
+        // exactly reproducing the former "if (t != null) { t.close(); t = null; }" per-field block).
         v8ProjectManagerTracker = closeTracker(v8ProjectManagerTracker);
         dtProjectManagerTracker = closeTracker(dtProjectManagerTracker);
         configurationProviderTracker = closeTracker(configurationProviderTracker);
@@ -577,6 +578,7 @@ public class EdtServices
      *
      * @return the form-model object factory, or {@code null} if unavailable
      */
+    @SuppressWarnings("java:S125")
     public IModelObjectFactory getFormModelObjectFactory()
     {
         if (formModelObjectFactoryTracker == null)
@@ -586,7 +588,7 @@ public class EdtServices
         IModelObjectFactory factory = formModelObjectFactoryTracker.getService();
         if (factory == null)
         {
-            // The form bundle is lazily activated and registers its services in start(); // NOSONAR explanatory comment, not commented-out code
+            // The form bundle is lazily activated and registers its services in start();
             // trip the activation, then re-read the tracker.
             Bundle formBundle = Platform.getBundle(FORM_BUNDLE_ID);
             if (formBundle == null)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/UpdateChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/UpdateChecker.java
@@ -226,6 +226,7 @@ public final class UpdateChecker
      * Fetches release info from the GitHub Releases API.
      * @return String[3]: [0]=tag_name, [1]=body (release notes), [2]=html_url; or null on error.
      */
+    @SuppressWarnings("java:S1168")
     private String[] fetchReleaseInfo() throws Exception
     {
         URL url = new URL(RELEASES_API_URL);
@@ -242,7 +243,7 @@ public final class UpdateChecker
         if (responseCode != HttpURLConnection.HTTP_OK)
         {
             Activator.logInfo("EDT MCP Server update check: GitHub API returned HTTP " + responseCode); //$NON-NLS-1$
-            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+            return null;
         }
 
         StringBuilder sb = new StringBuilder();
@@ -283,7 +284,7 @@ public final class UpdateChecker
                 return new String[] { tagName, body, htmlUrl };
             }
         }
-        return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+        return null;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/NewGroupHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/handlers/NewGroupHandler.java
@@ -228,7 +228,8 @@ public class NewGroupHandler extends AbstractHandler {
      * Returns the model object name (e.g. "CommonModule", "Catalog"), or
      * {@code null} when the method is absent or does not return a String.
      */
-    private String invokeGetModelObjectName(Object adapter) throws Exception { // NOSONAR propagates checked exceptions across the reflective boundary by design
+    @SuppressWarnings("java:S112")
+    private String invokeGetModelObjectName(Object adapter) throws Exception {
         try {
             Method getModelObjectNameMethod = adapter.getClass().getMethod("getModelObjectName");
             Object result = getModelObjectNameMethod.invoke(adapter);
@@ -247,7 +248,8 @@ public class NewGroupHandler extends AbstractHandler {
      * reflective {@code getParent(Object)} method is absent this is treated as a
      * top-level collection (returns {@code false}).
      */
-    private boolean isNestedCollection(Object adapter) throws Exception { // NOSONAR propagates checked exceptions across the reflective boundary by design
+    @SuppressWarnings("java:S112")
+    private boolean isNestedCollection(Object adapter) throws Exception {
         try {
             Method getParentMethod = adapter.getClass().getMethod("getParent", Object.class);
             Object parent = getParentMethod.invoke(adapter, adapter);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupNavigatorAdapter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupNavigatorAdapter.java
@@ -78,13 +78,14 @@ public class GroupNavigatorAdapter extends WorkbenchAdapter implements IAdaptabl
     }
     
     @Override
+    @SuppressWarnings("java:S2696")
     public ImageDescriptor getImageDescriptor(Object object) {
         if (folderIcon == null) {
             try {
                 Bundle bundle = Activator.getDefault().getBundle();
                 URL url = bundle.getEntry("icons/group.png");
                 if (url != null) {
-                    folderIcon = ImageDescriptor.createFromURL(url); // NOSONAR Eclipse singleton/Activator init pattern; method cannot be static
+                    folderIcon = ImageDescriptor.createFromURL(url);
                 }
             } catch (Exception e) {
                 Activator.logError("Failed to load folder icon", e);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/JsonUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/JsonUtils.java
@@ -249,17 +249,18 @@ public final class JsonUtils
      * @param argumentName the argument name to extract
      * @return list of strings or null if not found
      */
+    @SuppressWarnings("java:S1168")
     public static List<String> extractArrayArgument(Map<String, String> params, String argumentName)
     {
         if (params == null || argumentName == null)
         {
-            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+            return null;
         }
-        
+
         String value = params.get(argumentName);
         if (value == null || value.isEmpty())
         {
-            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+            return null;
         }
         
         value = value.trim();
@@ -294,6 +295,7 @@ public final class JsonUtils
      * JSON array, or {@code null} when it is not an array or cannot be parsed — the {@code null} signals
      * {@link #extractArrayArgument} to fall through to comma-separated parsing.
      */
+    @SuppressWarnings("java:S1168")
     private static List<String> parseJsonStringArray(String value)
     {
         try
@@ -317,7 +319,7 @@ public final class JsonUtils
         {
             // Fall through to comma-separated parsing
         }
-        return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+        return null;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/jsonrpc/JsonRpcRequest.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/jsonrpc/JsonRpcRequest.java
@@ -74,19 +74,19 @@ public class JsonRpcRequest
     /**
      * Gets the nested "arguments" map from params (for tools/call).
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "java:S1168"})
     public Map<String, Object> getArguments()
     {
         if (params == null)
         {
-            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+            return null;
         }
         Object args = params.get("arguments"); //$NON-NLS-1$
         if (args instanceof Map)
         {
             return (Map<String, Object>) args;
         }
-        return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+        return null;
     }
     
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/Messages.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/Messages.java
@@ -11,24 +11,25 @@ import org.eclipse.osgi.util.NLS;
 /**
  * Messages for tag UI components.
  */
+@SuppressWarnings({"java:S1444", "java:S3008"})
 public class Messages extends NLS {
     
     private static final String BUNDLE_NAME = "com.ditrix.edt.mcp.server.tags.ui.messages"; //$NON-NLS-1$
     
     // FilterByTagDialog
-    public static String FilterByTagDialog_Title; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
-    public static String FilterByTagDialog_Description; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
-    public static String FilterByTagDialog_SetButton; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
-    public static String FilterByTagDialog_TurnOffButton; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
-    public static String FilterByTagDialog_SelectAll; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
-    public static String FilterByTagDialog_DeselectAll; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
-    public static String FilterByTagDialog_SearchPlaceholder; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
-    public static String FilterByTagDialog_EditTag; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
-    public static String FilterByTagDialog_ShowUntaggedOnly; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
-    public static String FilterByTagDialog_ShowUntaggedOnlyTooltip; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
+    public static String FilterByTagDialog_Title;
+    public static String FilterByTagDialog_Description;
+    public static String FilterByTagDialog_SetButton;
+    public static String FilterByTagDialog_TurnOffButton;
+    public static String FilterByTagDialog_SelectAll;
+    public static String FilterByTagDialog_DeselectAll;
+    public static String FilterByTagDialog_SearchPlaceholder;
+    public static String FilterByTagDialog_EditTag;
+    public static String FilterByTagDialog_ShowUntaggedOnly;
+    public static String FilterByTagDialog_ShowUntaggedOnlyTooltip;
     
     // FilterByTagManager
-    public static String FilterByTagManager_FilterName; // NOSONAR Eclipse NLS field: value injected by NLS.initializeMessages, cannot be final; Eclipse NLS field name must equal its .properties key
+    public static String FilterByTagManager_FilterName;
     
     static {
         NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagSearchFilter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tags/ui/TagSearchFilter.java
@@ -512,24 +512,25 @@ public class TagSearchFilter extends ViewerFilter {
      * @param element the folder element
      * @return true if folder should be visible, false if not, null if not a nested folder
      */
+    @SuppressWarnings("java:S2447")
     private Boolean checkNestedObjectFolder(Object element) {
         try {
             // First get the parent EObject
             EObject parent = resolveNestedFolderParent(element);
             if (parent == null) {
-                return null; // Not a nested folder // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
+                return null; // Not a nested folder
             }
 
             // Get the parent's FQN
             String parentFqn = TagUtils.extractFqn(parent);
             if (parentFqn == null) {
-                return null; // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
+                return null;
             }
 
             // Get the model object name (Attribute, EnumValue, TabularSection, etc.)
             String modelObjectName = resolveModelObjectName(element);
             if (modelObjectName == null) {
-                return null; // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
+                return null;
             }
 
             Set<String> projectFqns = getCurrentMatchingFqns();
@@ -543,7 +544,7 @@ public class TagSearchFilter extends ViewerFilter {
 
         } catch (Exception e) {
             Activator.logError("Error checking nested folder", e);
-            return null; // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
+            return null;
         }
     }
 
@@ -554,7 +555,8 @@ public class TagSearchFilter extends ViewerFilter {
      * {@link NoSuchMethodException} reflection failures propagate to the caller (preserving
      * the original outer try/catch behaviour).
      */
-    private static EObject resolveNestedFolderParent(Object element) throws Exception { // NOSONAR propagates checked exceptions across the reflective boundary by design
+    @SuppressWarnings("java:S112")
+    private static EObject resolveNestedFolderParent(Object element) throws Exception {
         // Try getModel() or getModel(false)
         for (String methodName : new String[]{"getModel"}) {
             try {
@@ -586,7 +588,8 @@ public class TagSearchFilter extends ViewerFilter {
      * accessor is absent or yields null. Side-effect free; non-{@link NoSuchMethodException}
      * reflection failures propagate to the caller (preserving the original outer try/catch).
      */
-    private static String resolveModelObjectName(Object element) throws Exception { // NOSONAR propagates checked exceptions across the reflective boundary by design
+    @SuppressWarnings("java:S112")
+    private static String resolveModelObjectName(Object element) throws Exception {
         try {
             var method = element.getClass().getMethod("getModelObjectName");
             Object result = method.invoke(element);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/base/AbstractMetadataWriteTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/base/AbstractMetadataWriteTool.java
@@ -85,7 +85,8 @@ public abstract class AbstractMetadataWriteTool implements IMcpTool
      * @return the JSON result string
      * @throws Exception on unexpected failure
      */
-    protected abstract String executeOnUiThread(Map<String, String> params) throws Exception; // NOSONAR propagates checked exceptions across the reflective boundary by design
+    @SuppressWarnings("java:S112")
+    protected abstract String executeOnUiThread(Map<String, String> params) throws Exception;
 
     /**
      * Holds the resolved project and configuration, or a ready-to-return JSON

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/doc/PlatformDocumentationService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/doc/PlatformDocumentationService.java
@@ -194,6 +194,7 @@ public class PlatformDocumentationService
      * @param availableTypes out-param populated with up to 30 candidate names, in iteration order
      * @return the resolved (non-proxy) {@link Type}, or {@code null} when not found
      */
+    @SuppressWarnings("java:S125")
     private Type findType(IEObjectProvider typeProvider, String typeName, List<String> availableTypes)
     {
         Iterable<IEObjectDescription> descriptions = typeProvider.getEObjectDescriptions(null);
@@ -213,7 +214,7 @@ public class PlatformDocumentationService
                 availableTypes.add(lastSegment != null ? lastSegment : fullName);
             }
 
-            // Check if this is the type we're looking for (case-insensitive, check both full and last segment) // NOSONAR explanatory comment, not commented-out code
+            // Check if this is the type we're looking for (case-insensitive, check both full and last segment)
             if (fullName.equalsIgnoreCase(typeName) ||
                 (lastSegment != null && lastSegment.equalsIgnoreCase(typeName)))
             {
@@ -958,6 +959,7 @@ public class PlatformDocumentationService
      * @param availableMethods out-param populated with up to 30 candidate names, in iteration order
      * @return the resolved (non-proxy) {@link Method}, or {@code null} when not found
      */
+    @SuppressWarnings("java:S125")
     private Method findBuiltinMethod(IEObjectProvider methodProvider, String functionName,
                                      ResourceSet resourceSet, List<String> availableMethods)
     {
@@ -980,7 +982,7 @@ public class PlatformDocumentationService
                 availableMethods.add(methodName);
             }
 
-            // Check if this is the function we're looking for (case-insensitive) // NOSONAR explanatory comment, not commented-out code
+            // Check if this is the function we're looking for (case-insensitive)
             if (methodName.equalsIgnoreCase(functionName))
             {
                 Method resolvedMethod = resolveDescriptionAsMethod(desc, resourceSet);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/form/FormLayoutSnapshotService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/form/FormLayoutSnapshotService.java
@@ -297,6 +297,7 @@ public class FormLayoutSnapshotService
         return result;
     }
 
+    @SuppressWarnings("java:S1168")
     private Map<String, Object> createElementItem(EObject element, Object hippoSession, Object modelProjection,
         Object layoutProjection, Object viewProjection, boolean fullMode)
     {
@@ -305,7 +306,7 @@ public class FormLayoutSnapshotService
         Map<String, Object> bounds = getBounds(presentation, layoutProjection, viewProjection);
         if (!fullMode && !hasPositiveBounds(bounds))
         {
-            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+            return null;
         }
 
         Map<String, Object> item = new LinkedHashMap<>();
@@ -353,6 +354,7 @@ public class FormLayoutSnapshotService
         return invokeOneArg(projection, "getModel", domain); //$NON-NLS-1$
     }
 
+    @SuppressWarnings("java:S1168")
     private Map<String, Object> getBounds(Object presentation, Object layoutProjection, Object viewProjection)
     {
         Object layout = getProjectedModel(layoutProjection, presentation);
@@ -370,7 +372,7 @@ public class FormLayoutSnapshotService
             return boundsMap(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
         }
 
-        return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+        return null;
     }
 
     private String getBoundsSource(Object presentation, Object layoutProjection, Object viewProjection)
@@ -403,11 +405,12 @@ public class FormLayoutSnapshotService
             && ((Number)width).intValue() > 0 && ((Number)height).intValue() > 0;
     }
 
+    @SuppressWarnings("java:S1168")
     private Map<String, Object> getLayoutBounds(Object layout)
     {
         if (layout == null)
         {
-            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+            return null;
         }
 
         Object left = invokeNoArg(layout, "getLeft"); //$NON-NLS-1$
@@ -420,7 +423,7 @@ public class FormLayoutSnapshotService
                 ((Number)width).intValue(), ((Number)height).intValue());
         }
 
-        return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+        return null;
     }
 
     private Map<String, Object> boundsMap(int left, int top, int width, int height)
@@ -777,11 +780,12 @@ public class FormLayoutSnapshotService
         }
     }
 
+    @SuppressWarnings("java:S1168")
     private Map<String, Object> describeEObject(Object value)
     {
         if (!(value instanceof EObject))
         {
-            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+            return null;
         }
 
         EObject object = (EObject)value;
@@ -856,6 +860,7 @@ public class FormLayoutSnapshotService
         }
     }
 
+    @SuppressWarnings("java:S3011")
     private Object invokeOneArg(Object target, String methodName, Object argument)
     {
         if (target == null || argument == null)
@@ -869,7 +874,7 @@ public class FormLayoutSnapshotService
             {
                 method = target.getClass().getMethod(methodName, Object.class);
             }
-            method.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            method.setAccessible(true);
             return method.invoke(target, argument);
         }
         catch (Exception e)
@@ -878,6 +883,7 @@ public class FormLayoutSnapshotService
         }
     }
 
+    @SuppressWarnings("java:S1168")
     private Map<String, Object> getFormSize(Object wysiwygViewer, boolean refresh) throws Exception
     {
         if (refresh)
@@ -895,7 +901,7 @@ public class FormLayoutSnapshotService
             return boundsMap(0, 0, controlImageData.width, controlImageData.height);
         }
 
-        return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+        return null;
     }
 
     private int countElementsWithBounds(List<Map<String, Object>> elements)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
@@ -909,6 +909,7 @@ public class CreateInfobaseTool implements IMcpTool
      * when a matching standalone-server runtime is registered. Any reflective/availability failure is
      * treated as "no runtime" (the caller then fails fast).
      */
+    @SuppressWarnings("java:S1181")
     private static boolean ssHasRuntime(Object service, String versionMask)
     {
         try
@@ -917,7 +918,7 @@ public class CreateInfobaseTool implements IMcpTool
             Object opt = m.invoke(service, versionMask, null);
             return (opt instanceof Optional) && ((Optional<?>)opt).isPresent();
         }
-        catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+        catch (Throwable t)
         {
             Activator.logError("create_infobase: standalone-server runtime probe failed", t); //$NON-NLS-1$
             return false;
@@ -929,9 +930,10 @@ public class CreateInfobaseTool implements IMcpTool
      * {@code Pair<IServer, StandaloneServerInfobase>} as an {@code Object} (cast to {@code Pair} by the
      * caller). Unwraps and rethrows the real failure cause so the caller reports an honest error.
      */
+    @SuppressWarnings("java:S112")
     private static Object ssCreateServerWithInfobase(Object service, String versionMask,
             String projectName, InfobaseReference ib, int clusterPort, String clusterRegistryDirectory,
-            String publicationPath, IProgressMonitor monitor) throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
+            String publicationPath, IProgressMonitor monitor) throws Exception
     {
         Method m = service.getClass().getMethod("createServerWithInfobase", //$NON-NLS-1$
             String.class, String.class, InfobaseReference.class, int.class, String.class, String.class,
@@ -1012,8 +1014,9 @@ public class CreateInfobaseTool implements IMcpTool
     }
 
     /** Reflectively invokes the first public method of {@code target} matching name + arg count. */
+    @SuppressWarnings("java:S112")
     private static Object ssInvoke(Object target, String name, int argCount, Object... args)
-        throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
+        throws Exception
     {
         Method m = ssMethod(target.getClass(), name, argCount);
         if (m == null)
@@ -1075,6 +1078,7 @@ public class CreateInfobaseTool implements IMcpTool
      * match and the reported {@code infobaseName} so they reflect what EDT stored, not what was
      * requested. Returns {@code null} on any failure (the caller then falls back to the requested name).
      */
+    @SuppressWarnings("java:S1181")
     private static String ssGetInfobaseName(Object standaloneServerInfobase)
     {
         try
@@ -1083,7 +1087,7 @@ public class CreateInfobaseTool implements IMcpTool
             Object name = m.invoke(standaloneServerInfobase);
             return (name instanceof String) ? (String)name : null;
         }
-        catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+        catch (Throwable t)
         {
             Activator.logError("create_infobase: could not read standalone-server infobase name", t); //$NON-NLS-1$
             return null;
@@ -1228,6 +1232,7 @@ public class CreateInfobaseTool implements IMcpTool
      * builds the success JSON for the standalone-server path. Uses the same short bounded re-poll as
      * the file path to absorb the provision-delegate listener race.
      */
+    @SuppressWarnings("java:S125")
     private static String buildStandaloneServerResult(String projectName, Path infobaseDir,
             String infobaseName, int actualPort, String webUrl, boolean setDefault,
             IApplicationManager appManager, IProject project)
@@ -1274,7 +1279,7 @@ public class CreateInfobaseTool implements IMcpTool
             .put(KEY_INFOBASE_NAME, infobaseName)
             .put(KEY_APPLICATIONS, appsArray);
 
-        // Report the ACTUAL auto-allocated port only when we could resolve it from the web URL; // NOSONAR explanatory comment, not commented-out code
+        // Report the ACTUAL auto-allocated port only when we could resolve it from the web URL;
         // never echo the requested/hint port (EDT ignores it for a FILE-backed standalone server).
         if (actualPort > 0)
         {
@@ -1454,11 +1459,12 @@ public class CreateInfobaseTool implements IMcpTool
      *
      * @return operation instance, or {@code null} when unavailable
      */
+    @SuppressWarnings({"java:S125", "java:S3011"})
     private static IInfobaseCreationOperation resolveCreationOperation()
     {
         try
         {
-            // PlatformServicesCore is an INTERNAL class of the platform-services.core bundle; // NOSONAR explanatory comment, not commented-out code
+            // PlatformServicesCore is an INTERNAL class of the platform-services.core bundle;
             // it is not exported, so Class.forName via OUR bundle classloader cannot see it.
             // Load it through the OWNING bundle's classloader instead (the same pattern
             // EdtServices uses for the form bundle's internal service class).
@@ -1472,7 +1478,7 @@ public class CreateInfobaseTool implements IMcpTool
             // Touching a class trips the bundle's lazy activation so getDefault() is populated.
             Class<?> coreClass = psCoreBundle.loadClass(PLATFORM_SERVICES_CORE_CLASS);
             java.lang.reflect.Method getDefault = coreClass.getDeclaredMethod("getDefault"); //$NON-NLS-1$
-            getDefault.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            getDefault.setAccessible(true);
             Object coreInstance = getDefault.invoke(null);
             if (coreInstance == null)
             {
@@ -1487,7 +1493,7 @@ public class CreateInfobaseTool implements IMcpTool
             }
             java.lang.reflect.Method getInjector =
                 coreClass.getDeclaredMethod("getInjector"); //$NON-NLS-1$
-            getInjector.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            getInjector.setAccessible(true);
             Object injector = getInjector.invoke(coreInstance);
             if (injector == null)
             {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ExportConfigurationToXmlTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ExportConfigurationToXmlTool.java
@@ -73,6 +73,7 @@ public class ExportConfigurationToXmlTool implements IMcpTool
     }
 
     @Override
+    @SuppressWarnings("java:S125")
     public String execute(Map<String, String> params)
     {
         String projectName = JsonUtils.extractStringArgument(params, McpKeys.PROJECT_NAME);
@@ -100,7 +101,7 @@ public class ExportConfigurationToXmlTool implements IMcpTool
             Files.createDirectories(outputPath);
 
             // Defense-in-depth: export can write to ANY absolute path. With the
-            // server bound to loopback + optional token this is trusted-caller-only; // NOSONAR explanatory comment, not commented-out code
+            // server bound to loopback + optional token this is trusted-caller-only;
             // still flag writes outside the workspace so an injected/erroneous call
             // is visible. Non-breaking: warn, do not reject (local export to an
             // external dir is a legitimate action).

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetContentAssistTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetContentAssistTool.java
@@ -657,11 +657,12 @@ public class GetContentAssistTool implements IMcpTool
      * @param containsFilter the raw comma-separated filter, possibly null/empty
      * @return the lowercased trimmed parts, or null when no filter was supplied
      */
+    @SuppressWarnings("java:S1168")
     private static String[] parseContainsFilter(String containsFilter)
     {
         if (containsFilter == null || containsFilter.isEmpty())
         {
-            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+            return null;
         }
         String[] filterParts = containsFilter.toLowerCase().split(","); //$NON-NLS-1$
         for (int i = 0; i < filterParts.length; i++)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMarkersTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMarkersTool.java
@@ -41,6 +41,7 @@ import com.ditrix.edt.mcp.server.utils.ProjectContext;
  * marker families to scan (bookmark, task, or both); {@code priority} sub-filters
  * the task family only (a bookmark has no priority).</p>
  */
+@SuppressWarnings({"java:S1135", "java:S1134"})
 public class GetMarkersTool implements IMcpTool
 {
     public static final String NAME = "get_markers"; //$NON-NLS-1$
@@ -160,7 +161,7 @@ public class GetMarkersTool implements IMcpTool
         try
         {
             List<MarkerRow> rows = new ArrayList<>();
-            // Dedup set shared across the two task marker types: a BSL TODO/FIXME // NOSONAR tracking FIXME, intentionally retained; tracking TODO, intentionally retained
+            // Dedup set shared across the two task marker types: a BSL TODO/FIXME
             // surfaces under both the base task marker and the Xtext task marker
             // subtype and must be counted once.
             Set<String> seenTasks = new HashSet<>();
@@ -456,7 +457,7 @@ public class GetMarkersTool implements IMcpTool
         }
     }
 
-    /** Extracts the task type (TODO, FIXME, XXX, HACK) from the marker message. */ // NOSONAR tracking FIXME, intentionally retained; tracking TODO, intentionally retained
+    /** Extracts the task type (TODO, FIXME, XXX, HACK) from the marker message. */
     private static String getTaskType(String message)
     {
         if (message == null || message.isEmpty())

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetModuleStructureTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetModuleStructureTool.java
@@ -466,6 +466,7 @@ public class GetModuleStructureTool implements IMcpTool
     }
 
     /** Loads all source lines of a module's .bsl file, or {@code null} if unavailable. */
+    @SuppressWarnings("java:S1168")
     private List<String> loadSourceLines(Module module)
     {
         try
@@ -489,7 +490,7 @@ public class GetModuleStructureTool implements IMcpTool
         {
             Activator.logWarning("Failed to load source lines: " + e.getMessage()); //$NON-NLS-1$
         }
-        return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+        return null;
     }
     private List<MethodInfo> collectMethods(Module module, List<RegionInfo> regions,
         boolean includeComments, List<String> sourceLines)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProfilingResultsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProfilingResultsTool.java
@@ -214,8 +214,8 @@ public class GetProfilingResultsTool implements IMcpTool
      * — only the last measurement is meaningful. Falls back to the last element if no
      * session dates are present. Caller has already verified {@code results} is non-empty.
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private static List<?> latestOnly(List<?> results, Method getDateOfSession) throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
+    @SuppressWarnings({"unchecked", "rawtypes", "java:S112"})
+    private static List<?> latestOnly(List<?> results, Method getDateOfSession) throws Exception
     {
         Object latest = null;
         Comparable latestDate = null;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -96,13 +96,14 @@ public class GetProjectErrorsTool implements IMcpTool
     }
 
     @Override
+    @SuppressWarnings("java:S125")
     public String execute(Map<String, String> params)
     {
         String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
         String severity = JsonUtils.extractStringArgument(params, "severity"); //$NON-NLS-1$
         String checkId = JsonUtils.extractStringArgument(params, "checkId"); //$NON-NLS-1$
 
-        // Output verbosity: concise (default) trims the secondary 'Has docs' column; // NOSONAR explanatory comment, not commented-out code
+        // Output verbosity: concise (default) trims the secondary 'Has docs' column;
         // detailed renders the full historical table. Any absent/blank/unrecognized value
         // falls back to concise (the lean default), never an error.
         String responseFormat = JsonUtils.extractStringArgument(params, "responseFormat"); //$NON-NLS-1$
@@ -180,6 +181,7 @@ public class GetProjectErrorsTool implements IMcpTool
         return null;
     }
 
+    @SuppressWarnings("java:S125")
     public static String getProjectErrors(String projectName, String severity, String checkId, List<String> objects, int limit, boolean detailed)
     {
         try
@@ -212,7 +214,7 @@ public class GetProjectErrorsTool implements IMcpTool
             // Markers whose presentation could not be resolved even inside a transaction.
             // They are NOT dropped, but they are surfaced differently depending on context,
             // so we track the two cases separately to keep the warning text honest:
-            //  - unresolvedShown: reported in the table with a "<unresolved: ...>" placeholder; // NOSONAR explanatory comment, not commented-out code
+            //  - unresolvedShown: reported in the table with a "<unresolved: ...>" placeholder;
             //  - unresolvedFilteredOut: excluded from the result because an explicit objects
             //    filter is active and the location could not be resolved to test membership.
             final int[] unresolvedShown = {0};

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -1423,11 +1423,12 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         return (el != null && el.isJsonPrimitive()) ? el.getAsString() : null;
     }
 
+    @SuppressWarnings("java:S2447")
     private static Boolean parseBoolean(String value)
     {
         if (value == null)
         {
-            return null; // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
+            return null;
         }
         String v = value.trim().toLowerCase();
         if ("true".equals(v) || "1".equals(v) || "yes".equals(v)) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
@@ -1438,7 +1439,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         {
             return Boolean.FALSE;
         }
-        return null; // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
+        return null;
     }
 
     private static Integer parseInteger(String value)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskTool.java
@@ -216,6 +216,7 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
     }
 
     @Override
+    @SuppressWarnings("java:S125")
     protected String executeOnUiThread(Map<String, String> params)
     {
         String projectName = JsonUtils.extractStringArgument(params, McpKeys.PROJECT_NAME);
@@ -228,7 +229,7 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
         // Configuration.mdo, so the destructive step must be an explicit opt-in, never
         // a side effect of a diagnostic run.
         boolean cleanDangling = JsonUtils.extractBooleanArgument(params, KEY_CLEAN_DANGLING_REFERENCES, false);
-        // Default FALSE: only the objects whose .mdo is actually missing are exported; // NOSONAR explanatory comment, not commented-out code
+        // Default FALSE: only the objects whose .mdo is actually missing are exported;
         // true re-exports everything (a full disk refresh, slow on the UI thread).
         boolean fullExport = JsonUtils.extractBooleanArgument(params, KEY_FULL_EXPORT, false);
 
@@ -515,6 +516,7 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
      *            only report them
      * @return the {@link DanglingResult} (never {@code null})
      */
+    @SuppressWarnings("java:S125")
     private static DanglingResult cleanDanglingReferences(Configuration config, IBmModel bmModel,
         IProject project, boolean remove)
     {
@@ -528,7 +530,7 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
 
         // Detection (and, when remove=true, mutation) run inside one BM write task so
         // the same transaction that observes the proxies also removes them atomically.
-        // The task body only reports whether it removed anything IN the transaction; // NOSONAR explanatory comment, not commented-out code
+        // The task body only reports whether it removed anything IN the transaction;
         // the removedFromModel claim is made by runRemovalWriteTask AFTER
         // BmTransactions.write returned, i.e. only once the transaction actually
         // committed - a failed commit must not be reported as "Removed N".

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
@@ -288,6 +288,7 @@ public class RunYaxunitTestsTool implements IMcpTool
      * The temp directory is NEVER deleted in finally — a Pending re-call can fetch the result. Old
      * runs are cleaned up automatically before starting a new launch.
      */
+    @SuppressWarnings("java:S125")
     private String runTests(String configName, String projectName, String applicationId,
             String extensions, String modules, String tests, int timeout, boolean updateBeforeLaunch,
             String updateScope, boolean debug)
@@ -342,7 +343,7 @@ public class RunYaxunitTestsTool implements IMcpTool
             }
 
             // No active launch. Deliver a previously reported Pending result EXACTLY ONCE: a re-call
-            // fetching the result of a run that finished after a Pending response gets the report; // NOSONAR explanatory comment, not commented-out code
+            // fetching the result of a run that finished after a Pending response gets the report;
             // any later call with the same key falls through to a fresh run. There is NO time-based
             // cache, so a genuine re-run always re-executes the tests.
             String pendingResult = tryDeliverPendingResult(runKey, reportDir, projectName, applicationId);
@@ -994,6 +995,7 @@ public class RunYaxunitTestsTool implements IMcpTool
             Job prepJob = new Job(jobName)
             {
                 @Override
+                @SuppressWarnings("java:S1181")
                 protected IStatus run(IProgressMonitor monitor)
                 {
                     try
@@ -1011,7 +1013,7 @@ public class RunYaxunitTestsTool implements IMcpTool
                             jobEntry.error = result.getError();
                         }
                     }
-                    catch (Throwable e) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+                    catch (Throwable e)
                     {
                         // Throwable, not Exception: an Error escaping the prep must still
                         // surface as a prep failure — otherwise the retry call would see
@@ -1530,13 +1532,14 @@ public class RunYaxunitTestsTool implements IMcpTool
     /**
      * Recursively deletes a temp directory if it exists. Silent if missing.
      */
+    @SuppressWarnings("java:S125")
     private void cleanupTempDir(Path tempDir)
     {
         if (tempDir == null || !Files.exists(tempDir))
         {
             return;
         }
-        // try-with-resources releases the file-system handle held by Files.walk's stream; // NOSONAR explanatory comment, not commented-out code
+        // try-with-resources releases the file-system handle held by Files.walk's stream;
         // on Windows, leaving it open can prevent subsequent deletions of the same path.
         try (java.util.stream.Stream<Path> stream = Files.walk(tempDir))
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SearchInCodeTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SearchInCodeTool.java
@@ -138,6 +138,7 @@ public class SearchInCodeTool implements IMcpTool
     }
 
     @Override
+    @SuppressWarnings("java:S125")
     public String execute(Map<String, String> params)
     {
         String projectName = JsonUtils.extractStringArgument(params, McpKeys.PROJECT_NAME);
@@ -148,7 +149,7 @@ public class SearchInCodeTool implements IMcpTool
             .getParameterValue(NAME, KEY_MAX_RESULTS, DEFAULT_MAX_RESULTS);
         int configuredContextLines = ToolParameterSettings.getInstance()
             .getParameterValue(NAME, KEY_CONTEXT_LINES, DEFAULT_CONTEXT_LINES);
-        // Canonical param is "limit" (consistent with other paginated tools); // NOSONAR explanatory comment, not commented-out code
+        // Canonical param is "limit" (consistent with other paginated tools);
         // "maxResults" is kept as a deprecated alias (precedence: limit, then maxResults).
         int maxResultsAlias = JsonUtils.extractIntArgument(params, KEY_MAX_RESULTS, configuredMaxResults);
         int maxResults = JsonUtils.extractIntArgument(params, "limit", maxResultsAlias); //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/StandaloneServerSupport.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/StandaloneServerSupport.java
@@ -225,6 +225,7 @@ final class StandaloneServerSupport
      * Reflective {@code StandaloneServerInfobase.getInfobaseId().toString()} — the key under which the
      * entry is stored in infobases.yaml. Returns {@code null} on failure.
      */
+    @SuppressWarnings("java:S1181")
     static String infobaseIdOf(Object standaloneServerInfobaseModule)
     {
         try
@@ -233,7 +234,7 @@ final class StandaloneServerSupport
                 .invoke(standaloneServerInfobaseModule);
             return id != null ? id.toString() : null;
         }
-        catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+        catch (Throwable t)
         {
             Activator.logError("delete_infobase: could not read standalone-server infobaseId", t); //$NON-NLS-1$
             return null;
@@ -250,6 +251,7 @@ final class StandaloneServerSupport
      * (the config is torn down after). Returns {@code null} for an RDBMS-backed server (no local directory)
      * or on any reflective failure.
      */
+    @SuppressWarnings("java:S1181")
     static String databaseDirOf(Object standaloneServerInfobaseModule)
     {
         try
@@ -282,7 +284,7 @@ final class StandaloneServerSupport
             }
             return (dir instanceof String) ? (String)dir : null;
         }
-        catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+        catch (Throwable t)
         {
             Activator.logError("delete_infobase: could not read standalone-server database directory", t); //$NON-NLS-1$
             return null;
@@ -295,6 +297,7 @@ final class StandaloneServerSupport
      *
      * @return the matching {@code IServer} object, or {@code null} if none matched
      */
+    @SuppressWarnings("java:S1181")
     static Object findServerByModuleName(Object service, String appName)
     {
         try
@@ -329,7 +332,7 @@ final class StandaloneServerSupport
                 }
             }
         }
-        catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+        catch (Throwable t)
         {
             Activator.logError("delete_infobase: server-by-name scan failed", t); //$NON-NLS-1$
         }
@@ -351,6 +354,7 @@ final class StandaloneServerSupport
      *         when there was nothing to clean (no infobaseId / no matching entry), or
      *         {@link RegistryCleanup#FAILED} on a reflective failure
      */
+    @SuppressWarnings("java:S3011")
     static RegistryCleanup removeFromInfobaseRegistry(String infobaseId, IProgressMonitor monitor)
     {
         if (infobaseId == null)
@@ -400,9 +404,9 @@ final class StandaloneServerSupport
             {
                 return RegistryCleanup.FAILED;
             }
-            modulesF.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
-            mapperF.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
-            locF.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            modulesF.setAccessible(true);
+            mapperF.setAccessible(true);
+            locF.setAccessible(true);
 
             @SuppressWarnings("unchecked")
             Map<Object, Object> modules = (Map<Object, Object>)modulesF.get(delegate);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
@@ -133,6 +133,7 @@ public class WriteModuleSourceTool implements IMcpTool
     }
 
     @Override
+    @SuppressWarnings("java:S125")
     public String execute(Map<String, String> params)
     {
         // 1. Extract parameters
@@ -212,7 +213,7 @@ public class WriteModuleSourceTool implements IMcpTool
             // expectedHash from its last read, reject if the module changed since —
             // a cheap lost-update check that complements searchReplace's oldSource
             // match and replace's expectedSource. Read the canonical text the same way
-            // those guards do (readFileText, \n-normalized) so the hashes always agree; // NOSONAR explanatory comment, not commented-out code
+            // those guards do (readFileText, \n-normalized) so the hashes always agree;
             // skipped entirely when no expectedHash is given.
             String currentTextForHash = (expectedHash != null && !expectedHash.isEmpty() && fileExists)
                 ? BslModuleUtils.readFileText(file).replace("\r\n", "\n") //$NON-NLS-1$ //$NON-NLS-2$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
@@ -172,11 +172,12 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
      * {@link EReference} whose value is a {@link Collection}; otherwise returns {@code null}.
      * Mirrors the original skip guards (each {@code null} return matches a {@code continue}).
      */
+    @SuppressWarnings("java:S1168")
     private static Collection<?> eligibleContainmentCollection(EStructuralFeature feature, MdObject mdObject)
     {
         if (!(feature instanceof EReference))
         {
-            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+            return null;
         }
 
         EReference ref = (EReference) feature;
@@ -184,24 +185,24 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter
         // Only process containment many-valued references
         if (!ref.isContainment() || !ref.isMany())
         {
-            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+            return null;
         }
 
         // Skip derived, transient, volatile
         if (ref.isDerived() || ref.isTransient() || ref.isVolatile())
         {
-            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+            return null;
         }
 
         if (!mdObject.eIsSet(ref))
         {
-            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+            return null;
         }
 
         Object value = mdObject.eGet(ref);
         if (!(value instanceof Collection))
         {
-            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+            return null;
         }
 
         return (Collection<?>) value;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
@@ -1236,6 +1236,7 @@ public class MetadataRenameService
         return value instanceof String text ? text : null;
     }
 
+    @SuppressWarnings("java:S3011")
     private static Object getFieldValue(Object target, String fieldName)
     {
         if (target == null)
@@ -1248,7 +1249,7 @@ public class MetadataRenameService
             try
             {
                 java.lang.reflect.Field field = type.getDeclaredField(fieldName);
-                field.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+                field.setAccessible(true);
                 return field.get(target);
             }
             catch (Exception e)
@@ -1259,13 +1260,14 @@ public class MetadataRenameService
         return null;
     }
 
+    @SuppressWarnings({"java:S112", "java:S3011"})
     private static Object invokeMethod(Object target, String methodName, Class<?>[] parameterTypes, Object... args)
-        throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
+        throws Exception
     {
         java.lang.reflect.Method method = findMethod(target.getClass(), methodName, parameterTypes);
         if (!method.canAccess(target))
         {
-            method.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            method.setAccessible(true);
         }
         return method.invoke(target, args);
     }
@@ -1352,7 +1354,8 @@ public class MetadataRenameService
         }
     }
 
-    private static Object getBslInjector() throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
+    @SuppressWarnings("java:S112")
+    private static Object getBslInjector() throws Exception
     {
         Class<?> activatorClass = getClassOrThrow("com._1c.g5.v8.dt.bsl.ui.internal.BslActivator"); //$NON-NLS-1$
         Object activator = activatorClass.getMethod(GET_INSTANCE).invoke(null);
@@ -1360,13 +1363,15 @@ public class MetadataRenameService
             "com._1c.g5.v8.dt.bsl.Bsl"); //$NON-NLS-1$
     }
 
-    private static Object getSearchCoreInjector() throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
+    @SuppressWarnings("java:S112")
+    private static Object getSearchCoreInjector() throws Exception
     {
         Class<?> pluginClass = getClassOrThrow("com._1c.g5.v8.dt.internal.search.core.SearchCorePlugin"); //$NON-NLS-1$
         Object plugin = pluginClass.getMethod("getDefault").invoke(null); //$NON-NLS-1$
         return pluginClass.getMethod("getInjector").invoke(plugin); //$NON-NLS-1$
     }
 
+    @SuppressWarnings("java:S3011")
     private static Object createRenameElementContext(MdObject targetObject) throws Exception
     {
         Class<?> contextClass = getClassOrThrow(
@@ -1375,7 +1380,7 @@ public class MetadataRenameService
             getClassOrThrow("org.eclipse.emf.common.util.URI"), //$NON-NLS-1$
             getClassOrThrow("org.eclipse.emf.ecore.EClass"), //$NON-NLS-1$
             getClassOrThrow("com._1c.g5.v8.bm.core.IBmObject")); //$NON-NLS-1$
-        constructor.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+        constructor.setAccessible(true);
         return constructor.newInstance(EcoreUtil.getURI(targetObject), targetObject.eClass(), targetObject);
     }
 
@@ -1412,6 +1417,7 @@ public class MetadataRenameService
         return edit instanceof TextEdit textEdit ? textEdit : null;
     }
 
+    @SuppressWarnings("java:S3011")
     private static Object invokeNoArg(Object target, String methodName)
     {
         try
@@ -1419,7 +1425,7 @@ public class MetadataRenameService
             java.lang.reflect.Method method = findMethod(target.getClass(), methodName, new Class<?>[0]);
             if (!method.canAccess(target))
             {
-                method.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+                method.setAccessible(true);
             }
             return method.invoke(target);
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/symbol/SymbolInfoService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/symbol/SymbolInfoService.java
@@ -349,6 +349,7 @@ public class SymbolInfoService
      * Gets the ITextHover from the source viewer via reflection.
      * The TextViewer class stores hovers internally and provides a protected getTextHover method.
      */
+    @SuppressWarnings("java:S3011")
     private ITextHover getTextHoverViaReflection(ISourceViewer sourceViewer, int offset)
     {
         try
@@ -359,7 +360,7 @@ public class SymbolInfoService
                     "getTextHover", int.class, int.class); //$NON-NLS-1$
             if (getTextHoverMethod != null)
             {
-                getTextHoverMethod.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+                getTextHoverMethod.setAccessible(true);
                 Object result = getTextHoverMethod.invoke(sourceViewer, offset, 0);
                 if (result instanceof ITextHover)
                 {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/transport/InterruptibleToolExecutor.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/transport/InterruptibleToolExecutor.java
@@ -45,7 +45,8 @@ public class InterruptibleToolExecutor
      * @return the response, or {@code null} if the response was already sent (interrupted)
      * @throws Exception if tool execution failed (propagated to the caller for error mapping)
      */
-    public String execute(HttpExchange exchange, String requestBody) throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
+    @SuppressWarnings("java:S112")
+    public String execute(HttpExchange exchange, String requestBody) throws Exception
     {
         // Extract request ID and tool name for ActiveToolCall via the shared parser.
         JsonRpcRequest request = protocolHandler.parse(requestBody);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/ui/NavigatorToolbarCustomizer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/ui/NavigatorToolbarCustomizer.java
@@ -232,6 +232,7 @@ public class NavigatorToolbarCustomizer {
     /**
      * Dispose the customizer and remove all listeners.
      */
+    @SuppressWarnings("java:S2696")
     public void dispose() {
         // Remove window listener
         if (windowListener != null) {
@@ -267,6 +268,6 @@ public class NavigatorToolbarCustomizer {
 
         partListener = null;
         initialized = false;
-        instance = null; // NOSONAR Eclipse singleton/Activator init pattern; method cannot be static
+        instance = null;
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BreakpointUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BreakpointUtils.java
@@ -93,6 +93,7 @@ public final class BreakpointUtils
      *                    {@code "C:/full/path/to/Module.bsl"}
      * @return resolved IFile (may not exist; caller should check)
      */
+    @SuppressWarnings("java:S125")
     public static IFile resolveModuleFile(String projectName, String module)
     {
         if (module == null || module.isEmpty())
@@ -101,7 +102,7 @@ public final class BreakpointUtils
         }
         // Single shared module resolver (BslModuleUtils.resolveModuleFile) handles
         // BOTH an absolute filesystem path and a src/-relative path. For the
-        // absolute case the project is not needed (resolution is by location); // NOSONAR explanatory comment, not commented-out code
+        // absolute case the project is not needed (resolution is by location);
         // for the src/-relative case resolve the project and pass it through.
         IProject project = null;
         if (!BslModuleUtils.looksLikeAbsolutePath(module))

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
@@ -401,6 +401,7 @@ public final class BslModuleUtils
      * @return list of lines
      * @throws Exception if reading fails
      */
+    @SuppressWarnings("java:S125")
     public static List<String> readFileLines(IFile file) throws Exception
     {
         // Try IFile.getContents() first (workspace API); fall back to filesystem
@@ -423,7 +424,7 @@ public final class BslModuleUtils
         }
 
         List<String> lines = new ArrayList<>();
-        // Wrap in BufferedInputStream to support mark/reset for BOM detection; // NOSONAR explanatory comment, not commented-out code
+        // Wrap in BufferedInputStream to support mark/reset for BOM detection;
         // rawIs is closed by try-with-resources since BufferedInputStream wraps it
         try (InputStream input = new BufferedInputStream(rawIs))
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DebugServerTargetSupport.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DebugServerTargetSupport.java
@@ -202,6 +202,7 @@ public final class DebugServerTargetSupport
      *
      * @return all manager-tracked targets (possibly empty)
      */
+    @SuppressWarnings("java:S3011")
     private static List<ServerTarget> listManagedTargets()
     {
         List<ServerTarget> out = new ArrayList<>();
@@ -215,7 +216,7 @@ public final class DebugServerTargetSupport
         try
         {
             Method listMethod = manager.getClass().getMethod("listDebugTargets"); //$NON-NLS-1$
-            listMethod.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            listMethod.setAccessible(true);
             Object targets = listMethod.invoke(manager);
             if (!(targets instanceof Iterable<?>))
             {
@@ -974,16 +975,17 @@ public final class DebugServerTargetSupport
     }
 
     /** Reflectively invokes a no-arg getter and returns its {@code toString()}; null on any failure. */
+    @SuppressWarnings({"java:S3011", "java:S1181"})
     private static String reflectString(Object target, String getter)
     {
         try
         {
             Method m = target.getClass().getMethod(getter);
-            m.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            m.setAccessible(true);
             Object v = m.invoke(target);
             return v != null ? v.toString() : null;
         }
-        catch (Throwable e) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+        catch (Throwable e)
         {
             return null;
         }
@@ -1006,12 +1008,13 @@ public final class DebugServerTargetSupport
      * ({@code getApplication()}, unwrapping an {@link java.util.Optional}); null on
      * any failure or when no application is bound.
      */
+    @SuppressWarnings({"java:S3011", "java:S1181"})
     private static Object reflectApplication(Object target)
     {
         try
         {
             Method m = target.getClass().getMethod("getApplication"); //$NON-NLS-1$
-            m.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            m.setAccessible(true);
             Object app = m.invoke(target);
             if (app instanceof java.util.Optional<?>)
             {
@@ -1019,7 +1022,7 @@ public final class DebugServerTargetSupport
             }
             return app;
         }
-        catch (Throwable e) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+        catch (Throwable e)
         {
             return null;
         }
@@ -1031,12 +1034,13 @@ public final class DebugServerTargetSupport
      * {@code com.e1c.g5.dt.applications.IApplication} interface is in a different
      * bundle, so this stays reflective like the rest of this support class.
      */
+    @SuppressWarnings({"java:S3011", "java:S1181"})
     private static String reflectApplicationProjectName(Object application)
     {
         try
         {
             Method m = application.getClass().getMethod("getProject"); //$NON-NLS-1$
-            m.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            m.setAccessible(true);
             Object project = m.invoke(application);
             if (project == null)
             {
@@ -1044,7 +1048,7 @@ public final class DebugServerTargetSupport
             }
             return reflectString(project, "getName"); //$NON-NLS-1$
         }
-        catch (Throwable e) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+        catch (Throwable e)
         {
             return null;
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/EditorScreenshotHelper.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/EditorScreenshotHelper.java
@@ -162,13 +162,14 @@ public final class EditorScreenshotHelper
      * @param serviceClass the native render service class declaring the flag
      * @param bufferedFlagField the name of the static boolean flag field
      */
+    @SuppressWarnings("java:S3011")
     private static void forceBufferedRenderFlag(Class<?> serviceClass, String bufferedFlagField)
     {
         try
         {
             Field bufferedField = serviceClass.getDeclaredField(bufferedFlagField);
-            bufferedField.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
-            bufferedField.setBoolean(null, true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            bufferedField.setAccessible(true);
+            bufferedField.setBoolean(null, true);
         }
         catch (Exception e)
         {
@@ -440,6 +441,7 @@ public final class EditorScreenshotHelper
      * @param editorPart the form editor part
      * @return the main {@code FormEditorPage}, or {@code null}
      */
+    @SuppressWarnings("java:S3011")
     private static Object findFormMainPage(IEditorPart editorPart) throws Exception
     {
         Class<?> editorClass = Class.forName(FORM_EDITOR_CLASS);
@@ -452,7 +454,7 @@ public final class EditorScreenshotHelper
         {
             return null;
         }
-        findPageMethod.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+        findPageMethod.setAccessible(true);
         return findPageMethod.invoke(editorPart, FORM_MAIN_PAGE_ID);
     }
 
@@ -487,7 +489,8 @@ public final class EditorScreenshotHelper
     /**
      * Gets the active form editor page via the static FormEditor API.
      */
-    public static Object getActiveFormEditorPage() throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
+    @SuppressWarnings("java:S112")
+    public static Object getActiveFormEditorPage() throws Exception
     {
         Class<?> editorClass = Class.forName(FORM_EDITOR_CLASS);
         Method method = editorClass.getMethod("getActiveFormEditorPage"); //$NON-NLS-1$
@@ -545,6 +548,7 @@ public final class EditorScreenshotHelper
      * @param model the metadata model object
      * @return the FQN string, or {@code null}
      */
+    @SuppressWarnings("java:S3011")
     private static String bmGetFqn(Object model)
     {
         if (model == null)
@@ -558,7 +562,7 @@ public final class EditorScreenshotHelper
             {
                 return null;
             }
-            method.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            method.setAccessible(true);
             Object fqn = method.invoke(model);
             return fqn != null ? fqn.toString() : null;
         }
@@ -889,6 +893,7 @@ public final class EditorScreenshotHelper
      * @param forceRefresh {@code true} to require evidence of a re-render performed during this call
      * @return {@code true} if a (fresh, when forced) non-empty image is available within the timeout
      */
+    @SuppressWarnings("java:S125")
     static boolean ensureRenderedFormImage(Object representation, int timeoutMs, boolean forceRefresh)
     {
         if (representation == null)
@@ -955,7 +960,7 @@ public final class EditorScreenshotHelper
         }
         if (syncPathReachable)
         {
-            // The synchronous hooks are present but did not produce a (fresh) image within the budget; // NOSONAR explanatory comment, not commented-out code
+            // The synchronous hooks are present but did not produce a (fresh) image within the budget;
             // one last check (the render task may have settled while pumping events).
             return hasFreshImage(representation, baseline, requireNewInstance);
         }
@@ -1013,6 +1018,7 @@ public final class EditorScreenshotHelper
      * @param representation the {@code FormWysiwygRepresentation} instance
      * @return {@code true} when the field was found and cleared
      */
+    @SuppressWarnings("java:S3011")
     private static boolean clearFormImageData(Object representation)
     {
         try
@@ -1023,8 +1029,8 @@ public final class EditorScreenshotHelper
                 try
                 {
                     Field field = type.getDeclaredField(FORM_IMAGE_DATA_FIELD);
-                    field.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
-                    field.set(representation, null); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+                    field.setAccessible(true);
+                    field.set(representation, null);
                     return true;
                 }
                 catch (NoSuchFieldException e)
@@ -1083,6 +1089,7 @@ public final class EditorScreenshotHelper
      *         available (retry), or {@link RenderOutcome#UNREACHABLE} if the hooks do not exist on this
      *         EDT (use the async fallback)
      */
+    @SuppressWarnings("java:S3011")
     private static RenderOutcome renderRequestedFormSynchronously(Object representation)
     {
         try
@@ -1121,7 +1128,7 @@ public final class EditorScreenshotHelper
 
             // Synchronous sibling of getMappingRootAsync: compute the CommandInterfaceMapping root on
             // THIS thread instead of the background thread whose syncExec callback gets dropped.
-            getMappingRoot.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            getMappingRoot.setAccessible(true);
             Object cmiMapping = getMappingRoot.invoke(controller, cmiMappingClass);
             if (cmiMapping == null)
             {
@@ -1135,7 +1142,7 @@ public final class EditorScreenshotHelper
 
             // Invoke the private rebuildInternal(Form, CommandInterfaceMapping, NativeRenderEvent,
             // boolean) directly: this is the synchronous body the async handler would have run.
-            rebuildInternal.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            rebuildInternal.setAccessible(true);
             // updateOnly=false → force a full layout/render pass for this form.
             rebuildInternal.invoke(representation, form, cmiMapping, event, Boolean.FALSE);
 
@@ -1250,6 +1257,7 @@ public final class EditorScreenshotHelper
      * @param representation the {@code FormWysiwygRepresentation} instance
      * @return image data, or {@code null} if not available
      */
+    @SuppressWarnings("java:S3011")
     public static ImageData readFormImageData(Object representation)
     {
         if (representation == null)
@@ -1259,7 +1267,7 @@ public final class EditorScreenshotHelper
         try
         {
             Method method = representation.getClass().getDeclaredMethod(FORM_IMAGE_METHOD);
-            method.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            method.setAccessible(true);
             ImageData data = (ImageData)method.invoke(representation);
             if (data != null && data.width > 0 && data.height > 0)
             {
@@ -1405,6 +1413,7 @@ public final class EditorScreenshotHelper
      *
      * @param representation the {@code FormWysiwygRepresentation} instance
      */
+    @SuppressWarnings("java:S3011")
     public static void rebuildRepresentation(Object representation)
     {
         if (representation == null)
@@ -1414,7 +1423,7 @@ public final class EditorScreenshotHelper
         try
         {
             Method rebuildMethod = representation.getClass().getDeclaredMethod(REBUILD_METHOD, boolean.class);
-            rebuildMethod.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            rebuildMethod.setAccessible(true);
             rebuildMethod.invoke(representation, true);
 
             Display display = Display.getCurrent();
@@ -1531,6 +1540,7 @@ public final class EditorScreenshotHelper
     /**
      * Activates the main (WYSIWYG) page of the form editor via reflection.
      */
+    @SuppressWarnings("java:S3011")
     private static void activateFormMainPage(IEditorPart editorPart)
     {
         try
@@ -1545,7 +1555,7 @@ public final class EditorScreenshotHelper
                 ReflectionUtils.findMethod(editorPart.getClass(), "setActivePage", String.class); //$NON-NLS-1$
             if (setActivePageMethod != null)
             {
-                setActivePageMethod.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+                setActivePageMethod.setAccessible(true);
                 setActivePageMethod.invoke(editorPart, FORM_MAIN_PAGE_ID);
             }
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -471,7 +471,7 @@ public final class FormElementWriter
     // Every form-editing tool repeats the same ~40-line pipeline: resolve the MD-form from a form
     // path, null-check the BM services, capture the bmId, re-fetch the MD-form inside a BM
     // transaction, hop to the editable content form, run the work, then force-export the content
-    // form's own FQN (it serializes to Form.form). The scaffold below owns that pipeline ONCE; // NOSONAR explanatory comment, not commented-out code
+    // form's own FQN (it serializes to Form.form). The scaffold below owns that pipeline ONCE;
     // tools supply only the per-call work and their user-visible "form not found" message. Every
     // scaffold-level failure that carries an actionable message is thrown as a
     // FormValidationException with the READY error JSON, so callers surface it verbatim
@@ -479,6 +479,7 @@ public final class FormElementWriter
 
     /** Work executed on the re-fetched editable content form inside a BM WRITE transaction. */
     @FunctionalInterface
+    @SuppressWarnings("java:S125")
     public interface FormWork
     {
         /**
@@ -1534,7 +1535,7 @@ public final class FormElementWriter
     }
 
     /** A FormField bound to a form attribute via its dataPath (a generic InputField the user can refine). */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "java:S125"})
     private static String createField(EObject formModel, String name, String parentName,
         String attrName, String titleLanguage, String title, boolean russianAutoNames,
         String[] createdKind)
@@ -1583,7 +1584,7 @@ public final class FormElementWriter
         // own factory does before the value type is known.
         setEnumFeature(item, FEATURE_TYPE, "InputField"); //$NON-NLS-1$
         setExtInfoClassifier(formModel, item, "InputFieldExtInfo"); //$NON-NLS-1$
-        // The designer's new-field defaults (FormObjectFactory.newFormField / newInputFieldExtInfo); // NOSONAR explanatory comment, not commented-out code
+        // The designer's new-field defaults (FormObjectFactory.newFormField / newInputFieldExtInfo);
         // the booleans default to false in the model, so without them a created field renders with
         // no table header/footer, no wrap and a read-only text box. 'Auto'-valued enums are the
         // model defaults (literal 0) and stay unset, like the XMI omits them.
@@ -1994,6 +1995,7 @@ public final class FormElementWriter
      *
      * @return {@code null} on success, or a human-readable error message
      */
+    @SuppressWarnings("java:S125")
     static String bindEventHandler(EObject container, EStructuralFeature handlersFeat, EObject matched,
         String eventName, String procName, String callType, String[] createdKind)
     {
@@ -2025,7 +2027,7 @@ public final class FormElementWriter
             }
         }
         // Duplicate guard. Base path keeps the original "one handler per event" rule. Extension path lets
-        // the extension handler COEXIST with the base handler and with other-call-type extension handlers; // NOSONAR explanatory comment, not commented-out code
+        // the extension handler COEXIST with the base handler and with other-call-type extension handlers;
         // only a same-(event, callType) EventHandlerExtension is a real duplicate.
         EStructuralFeature evFeat = handlerEventFeature(handlersFeat);
         for (EObject existing : referenceList(container, KEY_HANDLERS))

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/GuideLoader.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/GuideLoader.java
@@ -121,6 +121,7 @@ public final class GuideLoader
      * @return the file content, LF-normalized and trailing-trimmed
      * @throws IOException on a read error
      */
+    @SuppressWarnings("java:S125")
     private static String read(InputStream in) throws IOException
     {
         StringBuilder sb = new StringBuilder();
@@ -133,7 +134,7 @@ public final class GuideLoader
                 sb.append(buf, 0, n);
             }
         }
-        // Trim trailing whitespace/newlines so the rendered "## Guide\n<body>" is tidy; // NOSONAR explanatory comment, not commented-out code
+        // Trim trailing whitespace/newlines so the rendered "## Guide\n<body>" is tidy;
         // keep leading content intact.
         int end = sb.length();
         while (end > 0 && Character.isWhitespace(sb.charAt(end - 1)))

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/JUnitXmlParser.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/JUnitXmlParser.java
@@ -53,6 +53,7 @@ public final class JUnitXmlParser
         return parseDocument(doc);
     }
 
+    @SuppressWarnings("java:S125")
     private static JUnitTestResults parseDocument(Document doc)
     {
         doc.getDocumentElement().normalize();
@@ -70,7 +71,7 @@ public final class JUnitXmlParser
             int attrSkipped = getIntAttr(suite, "skipped", 0); //$NON-NLS-1$
 
             // Scan the suite's testcases: record each failure/error/skipped into 'results'
-            // and return the fallback node counts {caseCount, failures, errors, skipped} // NOSONAR explanatory comment, not commented-out code
+            // and return the fallback node counts {caseCount, failures, errors, skipped}
             // for producers that omit or misreport the testsuite attributes.
             int[] nodeCounts = countSuiteCases(suite, results);
 
@@ -148,7 +149,8 @@ public final class JUnitXmlParser
         return new int[] {caseNodes.getLength(), nodeFailures, nodeErrors, nodeSkipped};
     }
 
-    private static DocumentBuilder newSecureBuilder() throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
+    @SuppressWarnings("java:S112")
+    private static DocumentBuilder newSecureBuilder() throws Exception
     {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         // Harden XML parsing against XXE/SSRF and entity-expansion attacks.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
@@ -983,6 +983,7 @@ public final class LaunchLifecycleUtils
      * (headless tests, early startup) the list degrades gracefully to just the
      * launch project, so the build wait is still performed for it.
      */
+    @SuppressWarnings("java:S125")
     static List<IProject> collectLaunchAndExtensionProjects(IProject launchProject)
     {
         Set<IProject> projects = new LinkedHashSet<>();
@@ -1013,7 +1014,7 @@ public final class LaunchLifecycleUtils
         catch (RuntimeException e)
         {
             // Discovery is best-effort: a failure here must not abort the launch.
-            // The workspace-wide build join already drained the extension build; // NOSONAR explanatory comment, not commented-out code
+            // The workspace-wide build join already drained the extension build;
             // we just skip the per-extension derived-data wait.
             Activator.logError("Error collecting extension projects for " //$NON-NLS-1$
                 + launchProject.getName(), e);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataTypeBuilder.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataTypeBuilder.java
@@ -141,6 +141,7 @@ public final class MetadataTypeBuilder
         return new Result(td, null);
     }
 
+    @SuppressWarnings("java:S125")
     private static String addType(TypeDescription td, JsonObject item, String kind,
         IEObjectProvider provider, Configuration config)
     {
@@ -158,7 +159,7 @@ public final class MetadataTypeBuilder
             {
                 // The generic getRefType(MdObject) dispatcher does NOT route Enum (it has a separate
                 // overload) and THROWS AssertionError for kinds with no ref type (registers, reports,
-                // ...). AssertionError is an Error, so it would escape the tool's catch(Exception) - // NOSONAR explanatory comment, not commented-out code
+                // ...). AssertionError is an Error, so it would escape the tool's catch(Exception) -
                 // route Enum explicitly and convert the AssertionError into a clean error Result.
                 refType = (target instanceof com._1c.g5.v8.dt.metadata.mdclass.Enum)
                     ? MdTypeUtil.getRefType((com._1c.g5.v8.dt.metadata.mdclass.Enum)target)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectContext.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectContext.java
@@ -41,6 +41,7 @@ import com.ditrix.edt.mcp.server.protocol.ToolResult;
  * @see ProjectStateChecker for the complementary readiness (building / derived
  *      data) check.
  */
+@SuppressWarnings("java:S1135")
 public final class ProjectContext
 {
     private final String projectName;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ReflectionUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ReflectionUtils.java
@@ -27,7 +27,8 @@ public final class ReflectionUtils
      * @return the invocation result
      * @throws Exception if invocation fails
      */
-    public static Object invokeMethod(Object target, String methodName) throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
+    @SuppressWarnings("java:S112")
+    public static Object invokeMethod(Object target, String methodName) throws Exception
     {
         Method method = target.getClass().getMethod(methodName);
         return method.invoke(target);
@@ -41,7 +42,8 @@ public final class ReflectionUtils
      * @return the field value, or {@code null} if not found
      * @throws Exception if access fails
      */
-    public static Object getFieldValue(Object target, String fieldName) throws Exception // NOSONAR propagates checked exceptions across the reflective boundary by design
+    @SuppressWarnings({"java:S112", "java:S3011"})
+    public static Object getFieldValue(Object target, String fieldName) throws Exception
     {
         Class<?> type = target.getClass();
         while (type != null)
@@ -49,7 +51,7 @@ public final class ReflectionUtils
             try
             {
                 Field field = type.getDeclaredField(fieldName);
-                field.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+                field.setAccessible(true);
                 return field.get(target);
             }
             catch (NoSuchFieldException ex)
@@ -94,17 +96,18 @@ public final class ReflectionUtils
      * @param value the value to set
      * @return {@code true} if successful
      */
+    @SuppressWarnings("java:S3011")
     public static boolean forceStaticFinalBoolean(Class<?> targetClass, String fieldName, boolean value)
     {
         try
         {
             Class<?> unsafeClass = Class.forName("sun.misc.Unsafe"); //$NON-NLS-1$
             Field theUnsafeField = unsafeClass.getDeclaredField("theUnsafe"); //$NON-NLS-1$
-            theUnsafeField.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            theUnsafeField.setAccessible(true);
             Object unsafe = theUnsafeField.get(null);
 
             Field targetField = targetClass.getDeclaredField(fieldName);
-            targetField.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            targetField.setAccessible(true);
 
             Method staticFieldBase = unsafeClass.getMethod("staticFieldBase", Field.class); //$NON-NLS-1$
             Method staticFieldOffset = unsafeClass.getMethod("staticFieldOffset", Field.class); //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/StyleValueBuilder.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/StyleValueBuilder.java
@@ -344,16 +344,17 @@ public final class StyleValueBuilder
         return (el != null && el.isJsonPrimitive()) ? el.getAsString() : null;
     }
 
+    @SuppressWarnings("java:S2447")
     private static Boolean boolMember(JsonObject obj, String name)
     {
         if (obj == null || !obj.has(name))
         {
-            return null; // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
+            return null;
         }
         JsonElement el = obj.get(name);
         if (el == null || !el.isJsonPrimitive())
         {
-            return null; // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
+            return null;
         }
         JsonPrimitive p = el.getAsJsonPrimitive();
         if (p.isBoolean())
@@ -369,7 +370,7 @@ public final class StyleValueBuilder
         {
             return Boolean.FALSE;
         }
-        return null; // NOSONAR intentional tri-state Boolean; null is distinct from false for callers
+        return null;
     }
 
     private static String summarizeFont(String faceName, Integer height, boolean bold, boolean italic,

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/SubsystemUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/SubsystemUtils.java
@@ -93,21 +93,22 @@ public final class SubsystemUtils
      *   <li>"Subsystem" → null (missing name)</li>
      * </ul>
      */
+    @SuppressWarnings("java:S1168")
     public static String[] parseSubsystemPath(String fqn)
     {
         if (fqn == null)
         {
-            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+            return null;
         }
         String trimmed = fqn.trim();
         if (trimmed.isEmpty())
         {
-            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+            return null;
         }
         String[] parts = trimmed.split("\\."); //$NON-NLS-1$
         if (parts.length < 2 || (parts.length % 2) != 0)
         {
-            return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+            return null;
         }
 
         String[] names = new String[parts.length / 2];
@@ -115,12 +116,12 @@ public final class SubsystemUtils
         {
             if (!isSubsystemTypeToken(parts[i]))
             {
-                return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+                return null;
             }
             String name = parts[i + 1] != null ? parts[i + 1].trim() : ""; //$NON-NLS-1$
             if (name.isEmpty())
             {
-                return null; // NOSONAR null is a deliberate signal (omit/sentinel), not an empty collection
+                return null;
             }
             names[i / 2] = name;
         }


### PR DESCRIPTION
**Why:** SonarCloud does **not** honour the `// NOSONAR` comments from #184 — a fresh main analysis re-reported all ~139 of them as OPEN even though the comments sit on the exact flagged lines (the issue `updateDate` is *after* #184 merged). That's why the smell count jumped back up. So #184's mechanism is ineffective for this project.\n\n**What:** replace every ineffective `// NOSONAR <reason>` with a `@SuppressWarnings("java:Sxxxx")` annotation on the **enclosing declaration** (method/field/class), which the SonarJava analyzer honours via the AST. Many collapse: the 11 NLS fields of `Messages.java` → one class-level `@SuppressWarnings({"java:S1444","java:S3008"})`; 3 `setAccessible` in one method → one `@SuppressWarnings("java:S3011")`; rule keys merged per declaration (and into existing `@SuppressWarnings` like `"unchecked"`). **Annotations + comment removal only — zero behaviour change; `mvn clean verify` green (2698 tests).** Supersedes #184.\n\nRules: S3011, S1168, S125, S112, S1444+S3008, S2447, S1181, S2696, S1135/S1134.\n\n⚠️ Note: since NOSONAR was already ignored here, please confirm on the next analysis that `@SuppressWarnings("java:…")` *is* honoured. If SonarCloud ignores in-code suppression entirely, the fallback is `sonar.issue.ignore.multicriteria` in `mcp/pom.xml` (scanner-level, always works) or UI Won't Fix — say the word and I'll switch.