### PR TITLE
Issue #189 (дефект 1): autoCommandBar формы сохраняет id=-1 → уходит form-invalid-item-id

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -819,6 +819,13 @@ public final class FormElementWriter
         // (6) Fill default references / usePurposes as the wizard does.
         mdFactory.fillDefaultReferences(mdForm);
 
+        // (6a) Re-assert the autoCommandBar's id=-1 sentinel as the LAST writer. createContentForm
+        // already set it, but the BM integration above (attachTopObject + fillDefaultReferences)
+        // resets the bar's id back to the model default (0). A 0-id predefined command bar serializes
+        // WITHOUT an <id> element and EDT flags the form with form-invalid-item-id; re-applying it here
+        // makes the bar match a designer-built form (<id>-1</id>). See issue #189.
+        enforceAutoCommandBarIdSentinel(content);
+
         // (7) Optionally set as the owner's default object form.
         if (setAsDefault)
         {
@@ -864,12 +871,29 @@ public final class FormElementWriter
         // The FormObjectFactory-built bar does NOT carry the id=-1 sentinel a form's own predefined
         // command bar requires, so EDT validation flags it (form-invalid-item-id). Enforce id=-1 on
         // the bar regardless of who created it (the fallback bar already set it; this is idempotent).
-        if (autoCommandBar != null)
-        {
-            setIntFeature(autoCommandBar, FEATURE_ID, -1);
-        }
+        // NOTE: when this runs as part of createForm, the later BM integration (attachTopObject +
+        // fillDefaultReferences) RESETS this id back to 0, so createForm re-applies it as its last
+        // step (6a). This set here still matters for the direct (headless / no-BM) callers. Issue #189.
+        enforceAutoCommandBarIdSentinel(content);
         applyFormDefaults(content, version);
         return content;
+    }
+
+    /**
+     * Forces the form's predefined {@code autoCommandBar} to carry the {@code id == -1} sentinel - the
+     * value a designer-built form persists for its own command bar, keeping it out of the regular
+     * element id space. A {@code 0}-id bar serializes WITHOUT an {@code <id>} element and EDT then
+     * flags the form with {@code form-invalid-item-id}. Called by {@link #createContentForm} and again
+     * by {@link #createForm} after the BM integration (which resets the id to the model default). A
+     * no-op when the form has no command bar. Package-visible for the headless test. Issue #189.
+     */
+    static void enforceAutoCommandBarIdSentinel(EObject content)
+    {
+        EObject bar = singleReference(content, FEATURE_AUTO_COMMAND_BAR);
+        if (bar != null)
+        {
+            setIntFeature(bar, FEATURE_ID, -1);
+        }
     }
 
     /** The form model EPackage nsURI ({@code com._1c.g5.v8.dt.form.model.FormPackage.eNS_URI}). */

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -457,6 +457,29 @@ public class FormElementWriterTest
     }
 
     @Test
+    public void testEnforceAutoCommandBarIdSentinelRestoresMinusOne()
+    {
+        EObject form = newForm();
+        EObject bar = (EObject)form.eGet(feature(form, "autoCommandBar")); //$NON-NLS-1$
+        // Simulate the BM integration (attachTopObject + fillDefaultReferences) resetting the
+        // predefined bar's id back to the model default (0) - the regression behind issue #189.
+        bar.eSet(feature(bar, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        FormElementWriter.enforceAutoCommandBarIdSentinel(form);
+        // The bar carries the -1 sentinel again, matching a designer-built form (<id>-1</id>), which
+        // serializes as <id>-1</id> instead of being dropped (a dropped id resolves to 0 -> invalid).
+        assertEquals(Integer.valueOf(-1), bar.eGet(feature(bar, "id"))); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testEnforceAutoCommandBarIdSentinelToleratesMissingBar()
+    {
+        // A form with no command bar (an ordinary/legacy form) must not fail.
+        EObject form = newObject(MODEL.form);
+        FormElementWriter.enforceAutoCommandBarIdSentinel(form);
+        assertNull(form.eGet(feature(form, "autoCommandBar"))); //$NON-NLS-1$
+    }
+
+    @Test
     public void testCreateButtonParentToleratesDottedPathAndChildItems()
     {
         EObject form = newForm();


### PR DESCRIPTION
## Проблема (дефект 1 из #189)

Форма, целиком созданная через `create_metadata`, сериализовала предопределённую `autoCommandBar` **без элемента `<id>`** → при загрузке id резолвится в `0` → EDT помечает форму `form-invalid-item-id` (воспроизводится на 2025.2).

## Корень

`createForm` (в `FormElementWriter`) выставляет у панели `id=-1` внутри `createContentForm`, но сразу после идёт интеграция в BM — `attachTopObject` + `mdFactory.fillDefaultReferences(...)`, — которая **сбрасывает id панели обратно в дефолт (`0`)**. То есть фикс #165 записывал значение слишком рано в жизненном цикле и на рантайме не срабатывал (его юнит-тест покрывал только fallback-путь `factory=null`, без BM-интеграции).

Подтверждено на живой модели: после старого кода `AutoCommandBar, id: 0`, на диске — без `<id>`. Эталон формы из дизайнера: `<id>-1</id>`.

## Решение

Переустанавливаю sentinel `id=-1` **последним шагом** `createForm` (новый шаг 6a), уже после `attachTopObject` / `fillDefaultReferences`. Логика вынесена в `enforceAutoCommandBarIdSentinel(content)` и переиспользуется в `createContentForm`.

## Проверка

- Сборка `mvn clean verify` — зелёная, **2700 тестов** (+2).
- Новые headless-тесты: восстановление `-1` после симуляции BM-сброса + терпимость к форме без панели. (Сам BM-путь headless не покрыть — нужен рантайм EDT, как и отмечалось при попытке #165.)
- **Рантайм на EDT 2025.2.6.4:** свежесозданная форма теперь пишет `<autoCommandBar><id>-1</id>`, маркер `form-invalid-item-id` исчез.

| | До | После |
|---|---|---|
| `autoCommandBar` на диске | нет `<id>` (id=0) | `<id>-1</id>` |
| `form-invalid-item-id` | есть | нет |

## Важно: PR закрывает только дефект 1

Второй дефект из #189 — `form-legacy-emf-check` «Duplicate id '0'» на дочерних `contextMenu` полей — **этим PR не затрагивается** и на 2025.2 по-прежнему воспроизводится. На диске id у `contextMenu` / `extendedTooltip` **уникальны и корректны** (1/2/3, 4/5/6, …); дубликаты «0» приходят из производной «legacy-EMF» модели валидатора EDT, а не из файла. Подробности — в комментарии к #189.

Частично по #189 (дефект 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
