### PR TITLE
Fix #189: MCP-built forms get form-attribute ids (clears form-legacy-emf-check "Duplicate id 0")

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -10,8 +10,10 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import org.eclipse.core.resources.IProject;
@@ -92,6 +94,9 @@ public final class FormElementWriter
     private static final String FEATURE_COMMAND_INTERFACE = "commandInterface"; //$NON-NLS-1$
     private static final String FEATURE_NAVIGATION_PANEL = "navigationPanel"; //$NON-NLS-1$
     private static final String FEATURE_COMMAND_BAR = "commandBar"; //$NON-NLS-1$
+    private static final String FEATURE_BASE_FORM = "baseForm"; //$NON-NLS-1$
+    private static final String FEATURE_EXTENSION_FORM = "extensionForm"; //$NON-NLS-1$
+    private static final int DEFAULT_EXT_FORM_OBJECT_ID = 1_000_000;
     /** {@code FormChildrenGroup.VERTICAL} - the designer default children grouping before 8.5.1. */
     private static final String LITERAL_VERTICAL = "Vertical"; //$NON-NLS-1$
     /** The {@code Auto} enum literal/name ({@code FormChildrenGroup.AUTO}, {@code ShowTitle851.AUTO}). */
@@ -100,6 +105,7 @@ public final class FormElementWriter
     // Concrete form-model classifier names (resolved on the form EPackage).
     private static final String ECLASS_FORM_GROUP = "FormGroup"; //$NON-NLS-1$
     private static final String ECLASS_DECORATION = "Decoration"; //$NON-NLS-1$
+    private static final String ECLASS_ABSTRACT_FORM_ATTRIBUTE = "AbstractFormAttribute"; //$NON-NLS-1$
     private static final String ECLASS_FORM_ITEM = "FormItem"; //$NON-NLS-1$
     private static final String ECLASS_FORM_FIELD = "FormField"; //$NON-NLS-1$
     private static final String ECLASS_USUAL_GROUP_EXT_INFO = "UsualGroupExtInfo"; //$NON-NLS-1$
@@ -616,6 +622,8 @@ public final class FormElementWriter
         {
             EObject formModel = editableFormInTx(ctx, tx);
             work.run(formModel, tx);
+            normalizeFormAttributeIds(formModel);
+            normalizeFormItemIds(formModel);
             // The content Form is a separate top object serialized to Form.form - export ITS fqn.
             return (formModel instanceof IBmObject) ? ((IBmObject)formModel).bmGetFqn() : null;
         });
@@ -869,6 +877,8 @@ public final class FormElementWriter
             setIntFeature(autoCommandBar, FEATURE_ID, -1);
         }
         applyFormDefaults(content, version);
+        normalizeFormAttributeIds(content);
+        normalizeFormItemIds(content);
         return content;
     }
 
@@ -1076,6 +1086,7 @@ public final class FormElementWriter
             return "Cannot create a form attribute for this form model."; //$NON-NLS-1$
         }
         setStringFeature(attr, FEATURE_NAME, name);
+        setIntFeature(attr, FEATURE_ID, nextAttributeId(formModel));
         setDefaultValueType(attr);
         applyTitle(attr, titleLanguage, title);
         addToList(formModel, FEATURE_ATTRIBUTES, attr);
@@ -2512,6 +2523,62 @@ public final class FormElementWriter
 
     // ---- the form-wide id allocation ------------------------------------------------------------
 
+    /**
+     * The next free form-attribute id = max existing {@code AbstractFormAttribute} id across the whole
+     * form + 1. This is a separate EDT id space from {@code FormItem.id}.
+     */
+    private static int nextAttributeId(EObject formModel)
+    {
+        EClass attributeClass = formEClass(formModel, ECLASS_ABSTRACT_FORM_ATTRIBUTE);
+        if (attributeClass == null)
+        {
+            return 1;
+        }
+        int max = maxAttributeIdForAllocation(formModel, attributeClass);
+        EObject extensionForm = liveReference(formModel, FEATURE_EXTENSION_FORM);
+        if (extensionForm != null)
+        {
+            max = Math.max(max, maxAttributeIdForAllocation(extensionForm, attributeClass));
+        }
+        return max + 1;
+    }
+
+    private static int maxAttributeIdForAllocation(EObject formModel, EClass attributeClass)
+    {
+        int max = maxAttributeId(formModel, attributeClass);
+        if (hasExtensionPeer(formModel) && max < DEFAULT_EXT_FORM_OBJECT_ID)
+        {
+            return DEFAULT_EXT_FORM_OBJECT_ID;
+        }
+        return max;
+    }
+
+    private static int maxAttributeId(EObject formModel, EClass attributeClass)
+    {
+        int max = 0;
+        for (TreeIterator<EObject> it = formModel.eAllContents(); it.hasNext();)
+        {
+            EObject obj = it.next();
+            if (attributeClass.isInstance(obj))
+            {
+                max = Math.max(max, intFeature(obj, FEATURE_ID));
+            }
+        }
+        return max;
+    }
+
+    private static boolean hasExtensionPeer(EObject formModel)
+    {
+        return liveReference(formModel, FEATURE_BASE_FORM) != null
+            || liveReference(formModel, FEATURE_EXTENSION_FORM) != null;
+    }
+
+    private static EObject liveReference(EObject owner, String featureName)
+    {
+        EObject reference = singleReference(owner, featureName);
+        return reference != null && !reference.eIsProxy() ? reference : null;
+    }
+
     /** The next free form-item id = max existing {@code FormItem} id across the whole form + 1. */
     private static int nextItemId(EObject formModel)
     {
@@ -2532,6 +2599,118 @@ public final class FormElementWriter
             }
         }
         return max + 1;
+    }
+
+    /**
+     * Repairs the form-wide {@code AbstractFormAttribute.id} invariant before validation/export sees
+     * the model. The designer allocates these ids through {@code getNextAttributeId}; attributes and
+     * attribute columns share this attribute id space, but it is intentionally independent from
+     * {@code FormItem.id}.
+     * Package-visible for the headless unit test.
+     */
+    static void normalizeFormAttributeIds(EObject formModel)
+    {
+        EClass attributeClass = formEClass(formModel, ECLASS_ABSTRACT_FORM_ATTRIBUTE);
+        if (attributeClass == null)
+        {
+            return;
+        }
+
+        List<EObject> attributes = new ArrayList<>();
+        int max = maxAttributeIdForAllocation(formModel, attributeClass);
+        EObject extensionForm = liveReference(formModel, FEATURE_EXTENSION_FORM);
+        if (extensionForm != null)
+        {
+            max = Math.max(max, maxAttributeIdForAllocation(extensionForm, attributeClass));
+        }
+        for (TreeIterator<EObject> it = formModel.eAllContents(); it.hasNext();)
+        {
+            EObject obj = it.next();
+            if (!attributeClass.isInstance(obj))
+            {
+                continue;
+            }
+            attributes.add(obj);
+        }
+
+        Set<Integer> seen = new HashSet<>();
+        for (EObject attribute : attributes)
+        {
+            int id = intFeature(attribute, FEATURE_ID);
+            if (id > 0 && seen.add(Integer.valueOf(id)))
+            {
+                continue;
+            }
+            do
+            {
+                max++;
+            }
+            while (max <= 0 || seen.contains(Integer.valueOf(max)));
+            setIntFeature(attribute, FEATURE_ID, max);
+            seen.add(Integer.valueOf(max));
+        }
+    }
+
+    /**
+     * Repairs the form-wide {@code FormItem.id} invariant before validation/export sees the model.
+     * The form root's predefined {@code autoCommandBar} has the platform sentinel {@code -1}; every
+     * other form item, including designer auto-children such as {@code contextMenu} and
+     * {@code extendedTooltip}, gets a positive id unique in the same form-wide space.
+     * Package-visible for the headless unit test.
+     */
+    static void normalizeFormItemIds(EObject formModel)
+    {
+        EPackage pkg = formModel.eClass().getEPackage();
+        EClassifier formItem = pkg != null ? pkg.getEClassifier(ECLASS_FORM_ITEM) : null;
+        if (!(formItem instanceof EClass))
+        {
+            return;
+        }
+
+        EClass formItemClass = (EClass)formItem;
+        EObject rootAutoCommandBar = singleReference(formModel, FEATURE_AUTO_COMMAND_BAR);
+        List<EObject> items = new ArrayList<>();
+        int max = 0;
+        for (TreeIterator<EObject> it = formModel.eAllContents(); it.hasNext();)
+        {
+            EObject obj = it.next();
+            if (!formItemClass.isInstance(obj))
+            {
+                continue;
+            }
+            items.add(obj);
+            if (obj != rootAutoCommandBar)
+            {
+                max = Math.max(max, intFeature(obj, FEATURE_ID));
+            }
+        }
+
+        Set<Integer> seen = new HashSet<>();
+        if (rootAutoCommandBar != null && formItemClass.isInstance(rootAutoCommandBar))
+        {
+            setIntFeature(rootAutoCommandBar, FEATURE_ID, -1);
+            seen.add(Integer.valueOf(-1));
+        }
+
+        for (EObject item : items)
+        {
+            if (item == rootAutoCommandBar)
+            {
+                continue;
+            }
+            int id = intFeature(item, FEATURE_ID);
+            if (id > 0 && seen.add(Integer.valueOf(id)))
+            {
+                continue;
+            }
+            do
+            {
+                max++;
+            }
+            while (max <= 0 || seen.contains(Integer.valueOf(max)));
+            setIntFeature(item, FEATURE_ID, max);
+            seen.add(Integer.valueOf(max));
+        }
     }
 
     // ---- reflective helpers ---------------------------------------------------------------------
@@ -2901,6 +3080,13 @@ public final class FormElementWriter
         EStructuralFeature feature = object.eClass().getEStructuralFeature(featureName);
         Object value = feature != null ? object.eGet(feature) : null;
         return value instanceof String ? (String)value : null;
+    }
+
+    private static int intFeature(EObject object, String featureName)
+    {
+        EStructuralFeature feature = object.eClass().getEStructuralFeature(featureName);
+        Object value = feature != null ? object.eGet(feature) : null;
+        return value instanceof Integer ? ((Integer)value).intValue() : 0;
     }
 
     private static void setStringFeature(EObject object, String featureName, String value)

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -16,9 +16,12 @@ import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EEnum;
@@ -890,6 +893,97 @@ public class FormElementWriterTest
     }
 
     @Test
+    public void testNormalizeFormItemIdsRepairsAutoChildrenAndRootBar()
+    {
+        EObject form = newForm();
+        EObject bar = (EObject)form.eGet(feature(form, "autoCommandBar")); //$NON-NLS-1$
+        bar.eSet(feature(bar, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+
+        for (int i = 0; i < 7; i++)
+        {
+            String attrName = "Attr" + i; //$NON-NLS-1$
+            EObject attribute = newObject(MODEL.formAttribute);
+            attribute.eSet(feature(attribute, "name"), attrName); //$NON-NLS-1$
+            addTo(form, "attributes", attribute); //$NON-NLS-1$
+
+            String fieldName = "Field" + i; //$NON-NLS-1$
+            assertNull(FormElementWriter.createMember(form, Kind.FIELD, fieldName, null, attrName,
+                null, null, false, null));
+            EObject field = FormElementWriter.findFormItem(form, fieldName);
+            EObject menu = (EObject)field.eGet(feature(field, "contextMenu")); //$NON-NLS-1$
+            EObject tooltip = (EObject)field.eGet(feature(field, "extendedTooltip")); //$NON-NLS-1$
+            menu.eSet(feature(menu, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+            tooltip.eSet(feature(tooltip, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        }
+
+        assertNull(FormElementWriter.createMember(form, Kind.COMMAND, "Print", null, null, //$NON-NLS-1$
+            null, null, false, null));
+        assertNull(FormElementWriter.createMember(form, Kind.BUTTON, "PrintButton", //$NON-NLS-1$
+            "AutoCommandBar", "Print", null, null, false, null)); //$NON-NLS-1$ //$NON-NLS-2$
+        EObject button = FormElementWriter.findFormItem(form, "PrintButton"); //$NON-NLS-1$
+        EObject buttonTooltip = (EObject)button.eGet(feature(button, "extendedTooltip")); //$NON-NLS-1$
+        buttonTooltip.eSet(feature(buttonTooltip, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+
+        FormElementWriter.normalizeFormItemIds(form);
+
+        assertEquals(Integer.valueOf(-1), bar.eGet(feature(bar, "id"))); //$NON-NLS-1$
+        assertUniqueNonZeroFormItemIds(form);
+    }
+
+    @Test
+    public void testCreateAttributeAssignsUniqueIdsInAttributeNamespace()
+    {
+        EObject form = newForm();
+
+        assertNull(FormElementWriter.createMember(form, Kind.ATTRIBUTE, "Customer", null, null, //$NON-NLS-1$
+            null, null, false, null));
+        assertNull(FormElementWriter.createMember(form, Kind.ATTRIBUTE, "Total", null, null, //$NON-NLS-1$
+            null, null, false, null));
+
+        EObject customer = FormElementWriter.findFormAttribute(form, "Customer"); //$NON-NLS-1$
+        EObject total = FormElementWriter.findFormAttribute(form, "Total"); //$NON-NLS-1$
+        assertNotNull(customer);
+        assertNotNull(total);
+        assertEquals(Integer.valueOf(1), customer.eGet(feature(customer, "id"))); //$NON-NLS-1$
+        assertEquals(Integer.valueOf(2), total.eGet(feature(total, "id"))); //$NON-NLS-1$
+
+        assertNull(FormElementWriter.createMember(form, Kind.GROUP, "Main", null, null, //$NON-NLS-1$
+            null, null, false, null));
+        EObject group = FormElementWriter.findFormItem(form, "Main"); //$NON-NLS-1$
+        assertNotNull(group);
+        assertEquals("attribute ids must not advance the form-item namespace", Integer.valueOf(1), //$NON-NLS-1$
+            group.eGet(feature(group, "id"))); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNormalizeFormAttributeIdsRepairsDuplicatesWithoutChangingItemIds()
+    {
+        EObject form = newForm();
+        EObject first = newObject(MODEL.formAttribute);
+        first.eSet(feature(first, "name"), "First"); //$NON-NLS-1$ //$NON-NLS-2$
+        first.eSet(feature(first, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        addTo(form, "attributes", first); //$NON-NLS-1$
+        EObject second = newObject(MODEL.formAttribute);
+        second.eSet(feature(second, "name"), "Second"); //$NON-NLS-1$ //$NON-NLS-2$
+        second.eSet(feature(second, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        addTo(form, "attributes", second); //$NON-NLS-1$
+
+        EObject group = newObject(MODEL.formGroup);
+        group.eSet(feature(group, "name"), "Main"); //$NON-NLS-1$ //$NON-NLS-2$
+        group.eSet(feature(group, "id"), Integer.valueOf(9)); //$NON-NLS-1$
+        addTo(form, "items", group); //$NON-NLS-1$
+
+        FormElementWriter.normalizeFormAttributeIds(form);
+
+        Set<Integer> ids = new HashSet<>();
+        assertTrue(((Integer)first.eGet(feature(first, "id"))).intValue() > 0); //$NON-NLS-1$
+        assertTrue(ids.add((Integer)first.eGet(feature(first, "id")))); //$NON-NLS-1$
+        assertTrue(((Integer)second.eGet(feature(second, "id"))).intValue() > 0); //$NON-NLS-1$
+        assertTrue(ids.add((Integer)second.eGet(feature(second, "id")))); //$NON-NLS-1$
+        assertEquals(Integer.valueOf(9), group.eGet(feature(group, "id"))); //$NON-NLS-1$
+    }
+
+    @Test
     public void testAutoChildrenRussianSuffixes()
     {
         EObject form = newForm();
@@ -1384,6 +1478,31 @@ public class FormElementWriterTest
         ((List<EObject>)owner.eGet(feature(owner, featureName))).add(child);
     }
 
+    private static void assertUniqueNonZeroFormItemIds(EObject form)
+    {
+        Set<Integer> ids = new HashSet<>();
+        int count = 0;
+        for (TreeIterator<EObject> it = form.eAllContents(); it.hasNext();)
+        {
+            EObject object = it.next();
+            if (!MODEL.formItem.isInstance(object))
+            {
+                continue;
+            }
+            EStructuralFeature idFeature = object.eClass().getEStructuralFeature("id"); //$NON-NLS-1$
+            if (idFeature == null)
+            {
+                continue;
+            }
+            int id = ((Integer)object.eGet(idFeature)).intValue();
+            assertTrue("form-item id must not be 0 on " + object.eClass().getName(), id != 0); //$NON-NLS-1$
+            assertTrue("duplicate form-item id " + id, ids.add(Integer.valueOf(id))); //$NON-NLS-1$
+            count++;
+        }
+        assertEquals("root bar + 7 fields + 14 field auto-children + button + button tooltip", //$NON-NLS-1$
+            24, count);
+    }
+
     /**
      * A dynamic EMF metamodel reproducing the form-model features the writer touches reflectively:
      * the Form (items / attributes / formCommands / autoCommandBar), FormItem subtypes (Button with
@@ -1395,6 +1514,7 @@ public class FormElementWriterTest
     private static final class FormLikeModel
     {
         final EClass form;
+        final EClass formItem;
         final EClass formGroup;
         final EClass autoCommandBar;
         final EClass table;
@@ -1448,7 +1568,7 @@ public class FormElementWriterTest
             addBoolean(f, inputFieldExtInfo, "typeDomainEnabled"); //$NON-NLS-1$
             addBoolean(f, inputFieldExtInfo, "textEdit"); //$NON-NLS-1$
 
-            EClass formItem = f.createEClass();
+            formItem = f.createEClass();
             formItem.setName("FormItem"); //$NON-NLS-1$
             formItem.setAbstract(true);
             addString(f, formItem, "name"); //$NON-NLS-1$
@@ -1564,9 +1684,15 @@ public class FormElementWriterTest
             formField.getEStructuralFeatures().add(
                 containment(f, "extendedTooltip", extendedTooltip, false)); //$NON-NLS-1$
 
+            EClass abstractFormAttribute = f.createEClass();
+            abstractFormAttribute.setName("AbstractFormAttribute"); //$NON-NLS-1$
+            abstractFormAttribute.setAbstract(true);
+            addInt(f, abstractFormAttribute, "id"); //$NON-NLS-1$
+            addString(f, abstractFormAttribute, "name"); //$NON-NLS-1$
+
             formAttribute = f.createEClass();
             formAttribute.setName("FormAttribute"); //$NON-NLS-1$
-            addString(f, formAttribute, "name"); //$NON-NLS-1$
+            formAttribute.getESuperTypes().add(abstractFormAttribute);
 
             autoCommandBar = f.createEClass();
             autoCommandBar.setName("AutoCommandBar"); //$NON-NLS-1$
@@ -1622,6 +1748,7 @@ public class FormElementWriterTest
             pkg.getEClassifiers().add(decoration);
             pkg.getEClassifiers().add(dataPath);
             pkg.getEClassifiers().add(formField);
+            pkg.getEClassifiers().add(abstractFormAttribute);
             pkg.getEClassifiers().add(formAttribute);
             pkg.getEClassifiers().add(autoCommandBar);
         }

--- a/tests/e2e/tools/test_create_metadata.py
+++ b/tests/e2e/tools/test_create_metadata.py
@@ -31,6 +31,8 @@ Fixture inventory (TestConfiguration, English Names):
   need one create it first.)
 """
 
+import xml.etree.ElementTree as ET
+
 from harness import (
     call,
     assert_ok,
@@ -40,11 +42,15 @@ from harness import (
     assert_not_contains,
     assert_diff_contains,
     assert_no_diff,
+    assert_tree_unchanged,
     diff,
     poll_diff_contains,
+    read_disk,
+    tree_snapshot,
     wait_for_project_ready,
     e2e_test,
     PROJECT,
+    _fail,
 )
 
 
@@ -53,6 +59,38 @@ def _objects_text(metadata_type):
     r = call("get_metadata_objects", {"projectName": PROJECT, "metadataType": metadata_type})
     assert_ok(r, "get_metadata_objects read-back (%s)" % metadata_type)
     return r.text
+
+
+def _xml_local(tag):
+    return tag.rsplit("}", 1)[-1]
+
+
+def _direct_child_text(node, child_name):
+    for child in list(node):
+        if _xml_local(child.tag) == child_name:
+            return child.text or ""
+    return None
+
+
+def _direct_child_int(node, child_name):
+    text = _direct_child_text(node, child_name)
+    if text is None or not text.strip():
+        return 0
+    try:
+        return int(text.strip())
+    except ValueError:
+        _fail("expected <%s> to be an integer, got %r" % (child_name, text))
+
+
+def _assert_unique_nonzero(ids_by_name, ctx):
+    seen = {}
+    for name, value in ids_by_name.items():
+        if value == 0:
+            _fail("%s %s must have a nonzero id: %r" % (ctx, name, ids_by_name))
+        if value in seen:
+            _fail("%s ids must be unique, but %s and %s both use %s: %r"
+                  % (ctx, seen[value], name, value, ids_by_name))
+        seen[value] = name
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -449,6 +487,135 @@ def test_create_form_object_then_add_member():
     assert_ok(r2, "add an attribute to the just-created form")
     assert r2.structured.get("action") == "created", "must report created: %r" % (r2.structured,)
     poll_diff_contains(attr, ctx="the member added to the new form must land in its Form.form on disk")
+
+
+@e2e_test(tool="create_metadata", kind="write-metadata")
+def test_create_data_processor_form_members_allocate_form_ids_issue_189():
+    # Issue #189 end-to-end repro: a managed form and ALL its attributes/items are created by
+    # MCP writes. The validator used to see duplicate id=0 for field context menus, the command
+    # bar serialized without <id>, and form attributes had no ids at all.
+    obj, form = "E2EIdCheck", "Form"
+    base = "DataProcessor.%s" % obj
+    form_fqn = "%s.Form.%s" % (base, form)
+    form_rel = "src/DataProcessors/%s/Forms/%s/Form.form" % (obj, form)
+
+    def create_ok(fqn, properties=None, ctx=None):
+        payload = {"projectName": PROJECT, "fqn": fqn}
+        if properties is not None:
+            payload["properties"] = properties
+        r = call("create_metadata", payload)
+        assert_ok(r, ctx or ("create " + fqn))
+        wait_for_project_ready()
+        return r
+
+    create_ok(base, ctx="create the DataProcessor owner")
+    # DataProcessor managed forms reject setAsDefault=true, so the repro creates the form without it.
+    create_ok(form_fqn, ctx="create the DataProcessor managed form")
+
+    attrs = ["FAttr%d" % i for i in range(1, 8)]
+    for i, attr in enumerate(attrs, start=1):
+        create_ok("%s.Attribute.%s" % (form_fqn, attr), ctx="create form attribute " + attr)
+        r = call("modify_metadata", {
+            "projectName": PROJECT,
+            "fqn": "%s.Attribute.%s" % (form_fqn, attr),
+            "properties": [{"name": "type",
+                            "value": {"types": [{"kind": "Number", "precision": 8 + i, "scale": 0}]}}],
+        })
+        assert_ok(r, "set form attribute type " + attr)
+        assert "valueType" in (r.structured.get("applied") or []), \
+            "type alias must apply to valueType for %s: %r" % (attr, r.structured)
+        wait_for_project_ready()
+
+    fields = ["FField%d" % i for i in range(1, 8)]
+    for attr, field in zip(attrs, fields):
+        create_ok("%s.Field.%s" % (form_fqn, field),
+                  [{"name": "dataPath", "value": attr}],
+                  ctx="create field %s bound to %s" % (field, attr))
+
+    cmd, proc, btn = "RunCheck", "RunCheckAction", "RunCheckBtn"
+    create_ok("%s.Command.%s" % (form_fqn, cmd), ctx="create form command")
+    create_ok("%s.Command.%s.Handler.Action" % (form_fqn, cmd),
+              [{"name": "procedure", "value": proc}],
+              ctx="bind the command Action handler")
+    create_ok("%s.Button.%s" % (form_fqn, btn),
+              [{"name": "command", "value": cmd}, {"name": "parent", "value": "AutoCommandBar"}],
+              ctx="create command-bar button bound to the command")
+
+    poll_diff_contains("<name>%s</name>" % btn,
+                       ctx="the fully MCP-created DataProcessor form must be exported to disk")
+
+    details = call("get_metadata_details", {"projectName": PROJECT, "objectFqns": [form_fqn]})
+    assert_ok(details, "read the fully MCP-created form structure")
+    for name in attrs + fields + [cmd, proc, btn, "AutoCommandBar"]:
+        assert_contains(details.text, name, "get_metadata_details must surface " + name)
+
+    reval = call("revalidate_objects", {"projectName": PROJECT, "objects": [form_fqn]})
+    assert_ok(reval, "revalidate the MCP-created form")
+    assert_contains(reval.text, "status: success", "revalidation must report success")
+    assert_contains(reval.text, form_fqn, "revalidation must name the requested form")
+
+    problems = call("get_project_errors", {
+        "projectName": PROJECT,
+        "objects": [form_fqn],
+        "responseFormat": "detailed",
+    })
+    assert_ok(problems, "read form validation markers")
+    assert_not_contains(problems.text, "form-legacy-emf-check",
+                        "legacy EMF twin must not report duplicate id=0")
+    assert_not_contains(problems.text, "form-invalid-item-id",
+                        "autoCommandBar must not report an invalid form item id")
+    assert_not_contains(problems.text, "Duplicate id '0'",
+                        "duplicate zero-id diagnostics must be gone")
+
+    root = ET.fromstring(read_disk(form_rel))
+    attr_ids = {}
+    for node in root.iter():
+        if _xml_local(node.tag) == "attributes":
+            name = _direct_child_text(node, "name") or "<unnamed>"
+            attr_ids[name] = _direct_child_int(node, "id")
+    for attr in attrs:
+        if attr not in attr_ids:
+            _fail("created form attribute %s was not serialized: %r" % (attr, sorted(attr_ids)))
+    _assert_unique_nonzero(attr_ids, "form attribute")
+
+    item_tags = ("items", "childItems", "extendedTooltip", "contextMenu", "autoCommandBar")
+    item_ids = {}
+    for node in root.iter():
+        if _xml_local(node.tag) in item_tags:
+            name = _direct_child_text(node, "name") or _xml_local(node.tag)
+            item_ids[name] = _direct_child_int(node, "id")
+
+    bar_id = item_ids.get("FormCommandBar")
+    if bar_id != -1:
+        _fail("autoCommandBar must serialize the designer sentinel id -1, got %r in %r"
+              % (bar_id, item_ids))
+
+    positive_item_ids = {name: value for name, value in item_ids.items()
+                         if name != "FormCommandBar"}
+    expected_items = set(fields)
+    expected_items.update(field + "ExtendedTooltip" for field in fields)
+    expected_items.update(field + "ContextMenu" for field in fields)
+    expected_items.add(btn)
+    expected_items.add(btn + "ExtendedTooltip")
+    missing = expected_items - set(positive_item_ids)
+    if missing:
+        _fail("expected item/auto-child ids for %r, got %r"
+              % (sorted(missing), sorted(positive_item_ids)))
+    _assert_unique_nonzero(positive_item_ids, "form item")
+
+    # Namespace guard: attributes and FormItems are independent id spaces. The test fails
+    # on zero/duplicates inside either namespace, but it intentionally does not compare
+    # attribute ids against item ids.
+
+    before = tree_snapshot()
+    dup = call("create_metadata", {
+        "projectName": PROJECT,
+        "fqn": "%s.Command.%s.Handler.Action" % (form_fqn, cmd),
+    })
+    err = assert_error(dup, "duplicate command Action handler")
+    assert_error_quality(err, suggests=["already exists"],
+                         ctx="duplicate Action handler must be a clean rejected call")
+    assert_tree_unchanged(before, "duplicate Action handler rejection must not mutate the dirty setup")
 
 
 @e2e_test(tool="create_metadata", kind="write-metadata")


### PR DESCRIPTION
Fixes #189.

## Symptom (reproduced live on EDT 2026.1.1)

A managed form built entirely through `create_metadata` (form → attributes / fields / command / handler / button) reports **N × `Duplicate id '0'`** (`form-legacy-emf-check`) after `revalidate_objects`, where **N = the number of form attributes**.

## Root cause

MCP never assigned an id to **form attributes**. EDT does not assign element ids as a model invariant — the designer stamps them in `FormAttributeManagementService` / `FormItemManagementService` (via `FormIdentifierService`) when the UI command runs. MCP writes straight into the `attributes` / `items` EList inside a BM write transaction and never invokes that service, so form attributes serialized **without an `<id>`** (EMF default `0`). Every attribute then resolved to id `0` → N duplicates of id `'0'`. `FormAttribute` is a hierarchy **separate** from `FormItem` with its **own** id space, so the existing form-item allocator never covered it.

> The "context menu" attribution in the issue thread was a miscount: on 2026.1.1 the field context menus / tooltips already serialize with unique ids; the markers anchor on the form object with no precise location, and N attributes = N fields = N menus. The `autoCommandBar` / `form-invalid-item-id` defect does **not** reproduce on 2026.1.1 (the bar is already `-1` there) — that one is 2025.2-only and is handled by #190.

## Fix (`FormElementWriter`)

- `createAttribute` now allocates an id from the **attribute** id space.
- `normalizeFormAttributeIds` — repairs `0` / duplicate attribute ids (attributes + columns) in their own space before export, with the extension/base high-id band.
- `normalizeFormItemIds` — defensive: pins the root `autoCommandBar` to the `-1` sentinel and repairs `0`/duplicate item ids incl. `extendedTooltip` / `contextMenu`. A no-op on 2026.1.1 (items were already fine) — cheap insurance / robustness.
- Both run after content-form creation and before export in the `writeEditableForm` scaffold.

## Verification — live before/after, same repro, EDT 2026.1.1

| | baseline (pre-fix) | this PR |
| --- | --- | --- |
| `Duplicate id '0'` (`form-legacy-emf-check`) | **7** | **0** |
| disk attribute ids | all missing (→ 0) | **1…7 unique** |
| item / menu / tooltip ids | unique 1…23 | unique 1…23 |
| `autoCommandBar` id | -1 | -1 |

## Tests

- **Unit** (`FormElementWriterTest`): `testCreateAttributeAssignsUniqueIdsInAttributeNamespace`, `testNormalizeFormAttributeIdsRepairsDuplicatesWithoutChangingItemIds`, `testNormalizeFormItemIdsRepairsAutoChildrenAndRootBar`.
- **e2e** (`test_create_metadata::test_create_data_processor_form_members_allocate_form_ids_issue_189`): full repro on a DataProcessor form; asserts no `form-legacy-emf-check` / `form-invalid-item-id` / `Duplicate id '0'` via `get_project_errors`, **and parses the exported `Form.form` XML** for unique nonzero ids per namespace + the `-1` bar sentinel. Empirically confirmed to fail on pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
