### PR TITLE
Fix #189 (follow-up): allocate form-COMMAND ids on MCP form creation

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -624,6 +624,7 @@ public final class FormElementWriter
             work.run(formModel, tx);
             normalizeFormAttributeIds(formModel);
             normalizeFormItemIds(formModel);
+            normalizeFormCommandIds(formModel);
             // The content Form is a separate top object serialized to Form.form - export ITS fqn.
             return (formModel instanceof IBmObject) ? ((IBmObject)formModel).bmGetFqn() : null;
         });
@@ -886,6 +887,7 @@ public final class FormElementWriter
         applyFormDefaults(content, version);
         normalizeFormAttributeIds(content);
         normalizeFormItemIds(content);
+        normalizeFormCommandIds(content);
         return content;
     }
 
@@ -1131,6 +1133,7 @@ public final class FormElementWriter
             return "Cannot create a form command for this form model."; //$NON-NLS-1$
         }
         setStringFeature(cmd, FEATURE_NAME, name);
+        setIntFeature(cmd, FEATURE_ID, nextCommandId(formModel));
         // The platform factory's defaults: use=AdjustableBoolean(common) and currentRowUse=Auto -
         // without them the exported command is unusable.
         setAdjustableBooleanFeature(cmd, FEATURE_USE);
@@ -2577,6 +2580,51 @@ public final class FormElementWriter
         return max;
     }
 
+    /**
+     * The next free form-command id = max existing {@code FormCommand} id across the whole form + 1.
+     * This is a separate EDT id space from both {@code FormItem.id} and
+     * {@code AbstractFormAttribute.id}.
+     */
+    private static int nextCommandId(EObject formModel)
+    {
+        EClass commandClass = formEClass(formModel, ECLASS_FORM_COMMAND);
+        if (commandClass == null)
+        {
+            return 1;
+        }
+        int max = maxCommandIdForAllocation(formModel, commandClass);
+        EObject extensionForm = liveReference(formModel, FEATURE_EXTENSION_FORM);
+        if (extensionForm != null)
+        {
+            max = Math.max(max, maxCommandIdForAllocation(extensionForm, commandClass));
+        }
+        return max + 1;
+    }
+
+    private static int maxCommandIdForAllocation(EObject formModel, EClass commandClass)
+    {
+        int max = maxCommandId(formModel, commandClass);
+        if (hasExtensionPeer(formModel) && max < DEFAULT_EXT_FORM_OBJECT_ID)
+        {
+            return DEFAULT_EXT_FORM_OBJECT_ID;
+        }
+        return max;
+    }
+
+    private static int maxCommandId(EObject formModel, EClass commandClass)
+    {
+        int max = 0;
+        for (TreeIterator<EObject> it = formModel.eAllContents(); it.hasNext();)
+        {
+            EObject obj = it.next();
+            if (commandClass.isInstance(obj))
+            {
+                max = Math.max(max, intFeature(obj, FEATURE_ID));
+            }
+        }
+        return max;
+    }
+
     private static int maxAttributeId(EObject formModel, EClass attributeClass)
     {
         int max = 0;
@@ -2671,6 +2719,55 @@ public final class FormElementWriter
             }
             while (max <= 0 || seen.contains(Integer.valueOf(max)));
             setIntFeature(attribute, FEATURE_ID, max);
+            seen.add(Integer.valueOf(max));
+        }
+    }
+
+    /**
+     * Repairs the form-wide {@code FormCommand.id} invariant before validation/export sees the model.
+     * The designer allocates these ids through {@code getNextCommandId}; commands have their own id
+     * space, independent from form items and form attributes.
+     * Package-visible for the headless unit test.
+     */
+    static void normalizeFormCommandIds(EObject formModel)
+    {
+        EClass commandClass = formEClass(formModel, ECLASS_FORM_COMMAND);
+        if (commandClass == null)
+        {
+            return;
+        }
+
+        List<EObject> commands = new ArrayList<>();
+        int max = maxCommandIdForAllocation(formModel, commandClass);
+        EObject extensionForm = liveReference(formModel, FEATURE_EXTENSION_FORM);
+        if (extensionForm != null)
+        {
+            max = Math.max(max, maxCommandIdForAllocation(extensionForm, commandClass));
+        }
+        for (TreeIterator<EObject> it = formModel.eAllContents(); it.hasNext();)
+        {
+            EObject obj = it.next();
+            if (!commandClass.isInstance(obj))
+            {
+                continue;
+            }
+            commands.add(obj);
+        }
+
+        Set<Integer> seen = new HashSet<>();
+        for (EObject command : commands)
+        {
+            int id = intFeature(command, FEATURE_ID);
+            if (id > 0 && seen.add(Integer.valueOf(id)))
+            {
+                continue;
+            }
+            do
+            {
+                max++;
+            }
+            while (max <= 0 || seen.contains(Integer.valueOf(max)));
+            setIntFeature(command, FEATURE_ID, max);
             seen.add(Integer.valueOf(max));
         }
     }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -1007,6 +1007,71 @@ public class FormElementWriterTest
     }
 
     @Test
+    public void testCreateCommandAssignsUniqueIdsInCommandNamespace()
+    {
+        EObject form = newForm();
+
+        assertNull(FormElementWriter.createMember(form, Kind.COMMAND, "Run", null, null, //$NON-NLS-1$
+            null, null, false, null));
+        assertNull(FormElementWriter.createMember(form, Kind.COMMAND, "Stop", null, null, //$NON-NLS-1$
+            null, null, false, null));
+
+        EObject run = FormElementWriter.findFormCommand(form, "Run"); //$NON-NLS-1$
+        EObject stop = FormElementWriter.findFormCommand(form, "Stop"); //$NON-NLS-1$
+        assertNotNull(run);
+        assertNotNull(stop);
+        assertEquals(Integer.valueOf(1), run.eGet(feature(run, "id"))); //$NON-NLS-1$
+        assertEquals(Integer.valueOf(2), stop.eGet(feature(stop, "id"))); //$NON-NLS-1$
+
+        assertNull(FormElementWriter.createMember(form, Kind.ATTRIBUTE, "Customer", null, null, //$NON-NLS-1$
+            null, null, false, null));
+        assertNull(FormElementWriter.createMember(form, Kind.GROUP, "Main", null, null, //$NON-NLS-1$
+            null, null, false, null));
+        EObject customer = FormElementWriter.findFormAttribute(form, "Customer"); //$NON-NLS-1$
+        EObject group = FormElementWriter.findFormItem(form, "Main"); //$NON-NLS-1$
+        assertNotNull(customer);
+        assertNotNull(group);
+        assertEquals("command ids must not advance the form-attribute namespace", Integer.valueOf(1), //$NON-NLS-1$
+            customer.eGet(feature(customer, "id"))); //$NON-NLS-1$
+        assertEquals("command ids must not advance the form-item namespace", Integer.valueOf(1), //$NON-NLS-1$
+            group.eGet(feature(group, "id"))); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNormalizeFormCommandIdsRepairsDuplicatesWithoutChangingOtherIds()
+    {
+        EObject form = newForm();
+        EObject first = newObject(MODEL.formCommand);
+        first.eSet(feature(first, "name"), "First"); //$NON-NLS-1$ //$NON-NLS-2$
+        first.eSet(feature(first, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        addTo(form, "formCommands", first); //$NON-NLS-1$
+        EObject second = newObject(MODEL.formCommand);
+        second.eSet(feature(second, "name"), "Second"); //$NON-NLS-1$ //$NON-NLS-2$
+        second.eSet(feature(second, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        addTo(form, "formCommands", second); //$NON-NLS-1$
+
+        EObject attribute = newObject(MODEL.formAttribute);
+        attribute.eSet(feature(attribute, "name"), "Customer"); //$NON-NLS-1$ //$NON-NLS-2$
+        attribute.eSet(feature(attribute, "id"), Integer.valueOf(7)); //$NON-NLS-1$
+        addTo(form, "attributes", attribute); //$NON-NLS-1$
+
+        EObject group = newObject(MODEL.formGroup);
+        group.eSet(feature(group, "name"), "Main"); //$NON-NLS-1$ //$NON-NLS-2$
+        group.eSet(feature(group, "id"), Integer.valueOf(9)); //$NON-NLS-1$
+        addTo(form, "items", group); //$NON-NLS-1$
+
+        FormElementWriter.normalizeFormCommandIds(form);
+
+        Set<Integer> ids = new HashSet<>();
+        assertTrue(((Integer)first.eGet(feature(first, "id"))).intValue() > 0); //$NON-NLS-1$
+        assertTrue(ids.add((Integer)first.eGet(feature(first, "id")))); //$NON-NLS-1$
+        assertTrue(((Integer)second.eGet(feature(second, "id"))).intValue() > 0); //$NON-NLS-1$
+        assertTrue(ids.add((Integer)second.eGet(feature(second, "id")))); //$NON-NLS-1$
+        assertEquals(Integer.valueOf(7), attribute.eGet(feature(attribute, "id"))); //$NON-NLS-1$
+        assertEquals(Integer.valueOf(9), group.eGet(feature(group, "id"))); //$NON-NLS-1$
+    }
+
+    @Test
     public void testAutoChildrenRussianSuffixes()
     {
         EObject form = newForm();
@@ -1543,6 +1608,7 @@ public class FormElementWriterTest
         final EClass table;
         final EClass decoration;
         final EClass formAttribute;
+        final EClass formCommand;
 
         FormLikeModel()
         {
@@ -1625,9 +1691,10 @@ public class FormElementWriterTest
             formCommandHandlerContainer.getEStructuralFeatures().add(
                 containment(f, "handler", commandHandler, false)); //$NON-NLS-1$
 
-            EClass formCommand = f.createEClass();
+            formCommand = f.createEClass();
             formCommand.setName("FormCommand"); //$NON-NLS-1$
             addString(f, formCommand, "name"); //$NON-NLS-1$
+            addInt(f, formCommand, "id"); //$NON-NLS-1$
             formCommand.getEStructuralFeatures().add(
                 containment(f, "action", handlerContainer, false)); //$NON-NLS-1$
             formCommand.getEStructuralFeatures().add(

--- a/tests/e2e/tools/test_create_metadata.py
+++ b/tests/e2e/tools/test_create_metadata.py
@@ -491,9 +491,9 @@ def test_create_form_object_then_add_member():
 
 @e2e_test(tool="create_metadata", kind="write-metadata")
 def test_create_data_processor_form_members_allocate_form_ids_issue_189():
-    # Issue #189 end-to-end repro: a managed form and ALL its attributes/items are created by
+    # Issue #189 end-to-end repro: a managed form and ALL its attributes/items/commands are created by
     # MCP writes. The validator used to see duplicate id=0 for field context menus, the command
-    # bar serialized without <id>, and form attributes had no ids at all.
+    # bar serialized without <id>, and form attributes/commands had no ids at all.
     obj, form = "E2EIdCheck", "Form"
     base = "DataProcessor.%s" % obj
     form_fqn = "%s.Form.%s" % (base, form)
@@ -532,8 +532,9 @@ def test_create_data_processor_form_members_allocate_form_ids_issue_189():
                   [{"name": "dataPath", "value": attr}],
                   ctx="create field %s bound to %s" % (field, attr))
 
-    cmd, proc, btn = "RunCheck", "RunCheckAction", "RunCheckBtn"
+    cmd, second_cmd, proc, btn = "RunCheck", "ResetCheck", "RunCheckAction", "RunCheckBtn"
     create_ok("%s.Command.%s" % (form_fqn, cmd), ctx="create form command")
+    create_ok("%s.Command.%s" % (form_fqn, second_cmd), ctx="create second form command")
     create_ok("%s.Command.%s.Handler.Action" % (form_fqn, cmd),
               [{"name": "procedure", "value": proc}],
               ctx="bind the command Action handler")
@@ -546,7 +547,7 @@ def test_create_data_processor_form_members_allocate_form_ids_issue_189():
 
     details = call("get_metadata_details", {"projectName": PROJECT, "objectFqns": [form_fqn]})
     assert_ok(details, "read the fully MCP-created form structure")
-    for name in attrs + fields + [cmd, proc, btn, "AutoCommandBar"]:
+    for name in attrs + fields + [cmd, second_cmd, proc, btn, "AutoCommandBar"]:
         assert_contains(details.text, name, "get_metadata_details must surface " + name)
 
     reval = call("revalidate_objects", {"projectName": PROJECT, "objects": [form_fqn]})
@@ -577,6 +578,19 @@ def test_create_data_processor_form_members_allocate_form_ids_issue_189():
         if attr not in attr_ids:
             _fail("created form attribute %s was not serialized: %r" % (attr, sorted(attr_ids)))
     _assert_unique_nonzero(attr_ids, "form attribute")
+
+    command_ids = {}
+    for node in root.iter():
+        if _xml_local(node.tag) == "formCommands":
+            name = _direct_child_text(node, "name") or "<unnamed>"
+            command_ids[name] = _direct_child_int(node, "id")
+    created_command_ids = {}
+    for command in (cmd, second_cmd):
+        if command not in command_ids:
+            _fail("created form command %s was not serialized: %r"
+                  % (command, sorted(command_ids)))
+        created_command_ids[command] = command_ids[command]
+    _assert_unique_nonzero(created_command_ids, "form command")
 
     item_tags = ("items", "childItems", "extendedTooltip", "contextMenu", "autoCommandBar")
     item_ids = {}


### PR DESCRIPTION
Follow-up to #189 (after #190 + #191): the **third** form id space — **form commands**.

## Symptom (reproduced live on EDT 2026.1.1)

Every `FormCommand` created through `create_metadata` serializes to `Form.form` **without an `<id>`** (resolves to `0`).

```
-- formCommands --   (pre-fix)
   command Cmd1  id=None
   command Cmd2  id=None
   command Cmd3  id=None
```

Unlike attributes, the legacy check does **not** flag command id `0`, so `get_project_errors` stays clean — this is a **fidelity gap vs a designer-built form**, not an active marker.

## Root cause

`FormCommand extends Command` with its **own** `id` — a third id space, distinct from `FormItem` and `AbstractFormAttribute`. The designer assigns it in `FormCommandManagementService.addCommand(...)` → `FormIdentifierService.getNextCommandId(...)`. MCP's `createCommand` wrote the command straight into the `formCommands` EList and never invoked that service, so the id stayed at the EMF default `0`. Neither `normalizeFormItemIds` nor `normalizeFormAttributeIds` covered commands.

## Why three separate id spaces (not form-global)

EDT's `FormIdentifierService` keeps **three independent counters**, each allocating `max(id of that type) + 1`:

| counter | predicate | allocator |
| --- | --- | --- |
| `FORM_ITEM_CURRENT_ID` | `FormItem` | `getNextItemId` |
| `FORM_ATTR_CURRENT_ID` | `AbstractFormAttribute` | `getNextAttributeId` |
| `FORM_CMD_CURRENT_ID` | `FormCommand` | `getNextCommandId` |

So ids are unique **per kind**, not across the whole form — a designer-built form likewise has an attribute, an item and a command all at id `1`. The legacy validators are type-scoped too (`isFormAttributeIdAndNamesUnique` over attributes, `form-invalid-item-id` over items), and the live repro confirms **zero markers** with cross-kind id overlap. This PR mirrors `getNextCommandId` exactly: same predicate, `max+1`, and the same extension/base high-id band (`1_000_000`) the attribute path uses.

## Fix (`FormElementWriter`)

- `createCommand` now allocates an id from the **command** id space.
- `nextCommandId` / `normalizeFormCommandIds` repair `0`/duplicate command ids in their own space, run after the attribute + item normalization in `writeEditableForm` and `createContentForm`. The three id spaces stay independent.

## Verification — live, EDT 2026.1.1, same repro

| | pre-fix | this PR |
| --- | --- | --- |
| `formCommands` ids | all missing (→ 0) | **1 / 2 / 3 (own space)** |
| attribute ids | 1 / 2 | 1 / 2 (unchanged) |
| item / menu / tooltip ids | 1 … 23 | 1 … 23 (unchanged) |
| markers | none | none |

## Tests

- **Unit** (`FormElementWriterTest`): `testCreateCommandAssignsUniqueIdsInCommandNamespace`, `testNormalizeFormCommandIdsRepairsDuplicatesWithoutChangingOtherIds`.
- **e2e** (`test_create_metadata::...issue_189`): now creates two commands and **parses the exported `Form.form` `<formCommands>`** for unique nonzero ids. Since command id `0` produces no marker, this disk-XML assertion is the anti-cheat — it fails on pre-fix code. Re-ran live: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
