### PR TITLE
Чистка хвоста замечаний SonarCloud после слитых PR (#194/#197/#199)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
@@ -270,6 +270,7 @@ public class CreateInfobaseTool implements IMcpTool
         String credUser = JsonUtils.extractStringArgument(params, KEY_USER);
         String credPassword = JsonUtils.extractStringArgument(params, "password"); //$NON-NLS-1$
         String credAccess = JsonUtils.extractStringArgument(params, KEY_ACCESS);
+        Credentials credentials = new Credentials(credUser, credPassword, credAccess);
 
         // Reject an out-of-enum access value before doing any work (the schema enum is advisory).
         String credAccessError = InfobaseAccessSupport.accessError(credAccess);
@@ -280,26 +281,17 @@ public class CreateInfobaseTool implements IMcpTool
 
         // Validate applicationKind (default 'infobase'). When absent or 'infobase' the behaviour is
         // byte-identical to the original file-infobase tool.
-        boolean standaloneServer;
-        if (applicationKind == null || applicationKind.isEmpty() || KIND_INFOBASE.equals(applicationKind))
+        FlagResult kind = parseApplicationKind(applicationKind);
+        if (kind.error != null)
         {
-            standaloneServer = false;
+            return kind.error;
         }
-        else if (KIND_STANDALONE_SERVER.equals(applicationKind))
-        {
-            standaloneServer = true;
-        }
-        else
-        {
-            return ToolResult.error("Invalid applicationKind: '" + applicationKind //$NON-NLS-1$
-                + "'. Allowed values: '" + KIND_INFOBASE + "', '" + KIND_STANDALONE_SERVER //$NON-NLS-1$ //$NON-NLS-2$
-                + "'.").toJson(); //$NON-NLS-1$
-        }
+        boolean standaloneServer = kind.value;
 
         // Credentials (#194) target a FILE infobase's access settings; the standalone-server path
         // manages its own infobase/auth and would silently drop them. Reject up front (before any
         // workspace/service access) rather than no-op so the caller is not misled.
-        if (standaloneServer && hasCredentialArgs(credUser, credPassword, credAccess))
+        if (standaloneServer && credentials.any())
         {
             return ToolResult.error("user/password/access are supported only with " //$NON-NLS-1$
                 + "applicationKind='infobase' (a file infobase). A standalone server manages its " //$NON-NLS-1$
@@ -307,20 +299,12 @@ public class CreateInfobaseTool implements IMcpTool
         }
 
         // Validate mode (default 'create').
-        boolean register;
-        if (modeStr == null || modeStr.isEmpty() || "create".equals(modeStr)) //$NON-NLS-1$
+        FlagResult mode = parseMode(modeStr);
+        if (mode.error != null)
         {
-            register = false;
+            return mode.error;
         }
-        else if ("register".equals(modeStr)) //$NON-NLS-1$
-        {
-            register = true;
-        }
-        else
-        {
-            return ToolResult.error("Invalid mode: '" + modeStr //$NON-NLS-1$
-                + "'. Allowed values: 'create', 'register'.").toJson(); //$NON-NLS-1$
-        }
+        boolean register = mode.value;
 
         // Validate and normalize the infobase path early (before acquiring services)
         Path infobaseDir;
@@ -356,12 +340,101 @@ public class CreateInfobaseTool implements IMcpTool
         }
 
         return createInfobase(projectName, infobaseDir, infobaseName, platform, setDefault, register,
-            credUser, credPassword, credAccess);
+            credentials);
+    }
+
+    /**
+     * Validates {@code applicationKind} (default {@code 'infobase'}): {@link FlagResult#value} is
+     * {@code true} for {@code 'standaloneServer'}, {@code false} for {@code 'infobase'} / absent, and
+     * {@link FlagResult#error} carries a ready JSON error for any other value.
+     */
+    private static FlagResult parseApplicationKind(String applicationKind)
+    {
+        if (applicationKind == null || applicationKind.isEmpty() || KIND_INFOBASE.equals(applicationKind))
+        {
+            return FlagResult.of(false);
+        }
+        if (KIND_STANDALONE_SERVER.equals(applicationKind))
+        {
+            return FlagResult.of(true);
+        }
+        return FlagResult.failed(ToolResult.error("Invalid applicationKind: '" + applicationKind //$NON-NLS-1$
+            + "'. Allowed values: '" + KIND_INFOBASE + "', '" + KIND_STANDALONE_SERVER //$NON-NLS-1$ //$NON-NLS-2$
+            + "'.").toJson()); //$NON-NLS-1$
+    }
+
+    /**
+     * Validates {@code mode} (default {@code 'create'}): {@link FlagResult#value} is {@code true} for
+     * {@code 'register'}, {@code false} for {@code 'create'} / absent, and {@link FlagResult#error} carries
+     * a ready JSON error for any other value.
+     */
+    private static FlagResult parseMode(String modeStr)
+    {
+        if (modeStr == null || modeStr.isEmpty() || "create".equals(modeStr)) //$NON-NLS-1$
+        {
+            return FlagResult.of(false);
+        }
+        if ("register".equals(modeStr)) //$NON-NLS-1$
+        {
+            return FlagResult.of(true);
+        }
+        return FlagResult.failed(ToolResult.error("Invalid mode: '" + modeStr //$NON-NLS-1$
+            + "'. Allowed values: 'create', 'register'.").toJson()); //$NON-NLS-1$
+    }
+
+    /**
+     * A parsed boolean flag, or a ready JSON {@code error} when the input value was out of range. Lets the
+     * mode / applicationKind validations early-return out of {@link #execute} without inflating its
+     * cognitive complexity.
+     */
+    private static final class FlagResult
+    {
+        final boolean value;
+        final String error;
+
+        private FlagResult(boolean value, String error)
+        {
+            this.value = value;
+            this.error = error;
+        }
+
+        static FlagResult of(boolean value)
+        {
+            return new FlagResult(value, null);
+        }
+
+        static FlagResult failed(String error)
+        {
+            return new FlagResult(false, error);
+        }
+    }
+
+    /** The infobase connection credentials (#194); any field may be {@code null}/empty when not supplied. */
+    private static final class Credentials
+    {
+        final String user;
+        final String password;
+        final String access;
+
+        Credentials(String user, String password, String access)
+        {
+            this.user = user;
+            this.password = password;
+            this.access = access;
+        }
+
+        /** Whether the caller supplied any connection-credential argument (user / password / access). */
+        boolean any()
+        {
+            return (user != null && !user.isEmpty())
+                || (password != null && !password.isEmpty())
+                || (access != null && !access.isEmpty());
+        }
     }
 
     private String createInfobase(String projectName, Path infobaseDir,
             String infobaseName, String platform, boolean setDefault, boolean register,
-            String credUser, String credPassword, String credAccess)
+            Credentials credentials)
     {
         // --- 1-2. Resolve project + services ---
         CreateContext context = resolveCreateContext(projectName);
@@ -410,7 +483,7 @@ public class CreateInfobaseTool implements IMcpTool
         String setDefaultNote = setDefault ? applySetDefault(appManager, project, ibRef) : null;
 
         // --- 8.5 Optionally store infobase connection credentials (#194) ---
-        String credNote = storeCredentialsIfRequested(ibRef, credUser, credPassword, credAccess, register);
+        String credNote = storeCredentialsIfRequested(ibRef, credentials, register);
 
         // --- 9. Read back and return ---
         ResultContext rc = new ResultContext(projectName, infobaseDir, infobaseName, appManager, project);
@@ -427,30 +500,20 @@ public class CreateInfobaseTool implements IMcpTool
      * infobase creation itself (the base is already created and bound).
      *
      * @param ibRef the new infobase reference (the access-settings key)
-     * @param user the requested connection user (may be {@code null}/empty)
-     * @param password the requested password (may be {@code null}/empty)
-     * @param access the requested access kind (may be {@code null})
+     * @param credentials the requested connection credentials (any field may be {@code null}/empty)
      * @param register {@code true} for mode='register' (an existing base that already has users),
      *            {@code false} for mode='create' (a brand-new empty base with no users yet)
      * @return a message note, or {@code null} when no credentials were requested
      */
-    /** Whether the caller supplied any connection-credential argument (user / password / access). */
-    private static boolean hasCredentialArgs(String user, String password, String access)
+    private static String storeCredentialsIfRequested(InfobaseReference ibRef, Credentials credentials,
+            boolean register)
     {
-        return (user != null && !user.isEmpty())
-            || (password != null && !password.isEmpty())
-            || (access != null && !access.isEmpty());
-    }
-
-    private static String storeCredentialsIfRequested(InfobaseReference ibRef, String user,
-            String password, String access, boolean register)
-    {
-        if (!hasCredentialArgs(user, password, access))
+        if (!credentials.any())
         {
             return null;
         }
-        String error = InfobaseAccessSupport.storeCredentials(ibRef, user, password,
-            InfobaseAccessSupport.parseAccess(access));
+        String error = InfobaseAccessSupport.storeCredentials(ibRef, credentials.user, credentials.password,
+            InfobaseAccessSupport.parseAccess(credentials.access));
         if (error != null)
         {
             return " WARNING: connection credentials were NOT stored: " + error; //$NON-NLS-1$
@@ -463,7 +526,7 @@ public class CreateInfobaseTool implements IMcpTool
             ? "" //$NON-NLS-1$
             : " NOTE: a newly created infobase has no users yet — these credentials authenticate " //$NON-NLS-1$
                 + "only after a matching infobase user is added."; //$NON-NLS-1$
-        return " Stored connection credentials for user '" + (user == null ? "" : user) //$NON-NLS-1$ //$NON-NLS-2$
+        return " Stored connection credentials for user '" + (credentials.user == null ? "" : credentials.user) //$NON-NLS-1$ //$NON-NLS-2$
             + "' (change them later with set_infobase_credentials)." + userNote; //$NON-NLS-1$
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -642,51 +642,14 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         FormElementWriter.FormMemberRef ref, List<JsonObject> properties,
         MdNameNormalizer.Report normReport)
     {
-        String queryText = null;
-        Boolean customQuery = null;
-        String mainTable = null;
-        boolean queryTextGiven = false;
-        for (JsonObject prop : properties)
+        DynListQueryRequest req = parseDynListQueryProps(properties);
+        if (req.error != null)
         {
-            String name = asString(prop.get("name")); //$NON-NLS-1$
-            if (isQueryTextProp(name))
-            {
-                queryText = asString(prop.get(KEY_VALUE));
-                queryTextGiven = true;
-            }
-            else if (isCustomQueryProp(name))
-            {
-                Boolean parsed = parseBooleanFlag(prop.get(KEY_VALUE));
-                if (parsed == null)
-                {
-                    return ToolResult.error("'customQuery' must be a boolean (true / false).").toJson(); //$NON-NLS-1$
-                }
-                customQuery = parsed;
-            }
-            else if (isMainTableProp(name))
-            {
-                mainTable = asString(prop.get(KEY_VALUE));
-                if (mainTable == null || mainTable.trim().isEmpty())
-                {
-                    return ToolResult.error("'mainTable' must be an object FQN, e.g. " //$NON-NLS-1$
-                        + "'Catalog.Products' or 'Document.Order'.").toJson(); //$NON-NLS-1$
-                }
-            }
-            else
-            {
-                return ToolResult.error("Setting a dynamic-list query ('queryText' / 'customQuery' / " //$NON-NLS-1$
-                    + "'mainTable') cannot be combined with other property changes ('" + name //$NON-NLS-1$
-                    + "') in one call. Configure the query first, then make the other changes " //$NON-NLS-1$
-                    + "separately.").toJson(); //$NON-NLS-1$
-            }
+            return req.error;
         }
-        if (queryTextGiven && (queryText == null || queryText.trim().isEmpty()))
-        {
-            return ToolResult.error("'queryText' must be a non-empty 1C query, e.g. " //$NON-NLS-1$
-                + "\"SELECT Ref, Description AS Description FROM Catalog.Products\". To switch the " //$NON-NLS-1$
-                + "dynamic list back to its automatic query, pass 'customQuery' = false instead.") //$NON-NLS-1$
-                .toJson();
-        }
+        final String queryText = req.queryText;
+        final Boolean customQuery = req.customQuery;
+        final String mainTable = req.mainTable;
 
         IV8ProjectManager v8ProjectManager = Activator.getDefault().getV8ProjectManager();
         IV8Project v8Project = v8ProjectManager != null ? v8ProjectManager.getProject(ctx.project) : null;
@@ -742,6 +705,95 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
     }
 
     /**
+     * The parsed dynamic-list query properties, or a ready JSON {@code error} when a value was malformed
+     * or a query prop was mixed with another property change. Lets {@link #configureDynamicListQuery} stay
+     * a thin orchestrator while the property loop and its early-return validations live in
+     * {@link #parseDynListQueryProps}.
+     */
+    private static final class DynListQueryRequest
+    {
+        final String queryText;
+        final Boolean customQuery;
+        final String mainTable;
+        final String error;
+
+        private DynListQueryRequest(String queryText, Boolean customQuery, String mainTable, String error)
+        {
+            this.queryText = queryText;
+            this.customQuery = customQuery;
+            this.mainTable = mainTable;
+            this.error = error;
+        }
+
+        static DynListQueryRequest of(String queryText, Boolean customQuery, String mainTable)
+        {
+            return new DynListQueryRequest(queryText, customQuery, mainTable, null);
+        }
+
+        static DynListQueryRequest failed(String error)
+        {
+            return new DynListQueryRequest(null, null, null, error);
+        }
+    }
+
+    /**
+     * Reads the dynamic-list query properties ({@code queryText} / {@code customQuery} / {@code mainTable})
+     * from the property list into a {@link DynListQueryRequest}. Returns one carrying a ready JSON error
+     * when a value is malformed or a query prop is mixed with another property change. Pure (reads only the
+     * supplied list).
+     */
+    private DynListQueryRequest parseDynListQueryProps(List<JsonObject> properties)
+    {
+        String queryText = null;
+        Boolean customQuery = null;
+        String mainTable = null;
+        boolean queryTextGiven = false;
+        for (JsonObject prop : properties)
+        {
+            String name = asString(prop.get("name")); //$NON-NLS-1$
+            if (isQueryTextProp(name))
+            {
+                queryText = asString(prop.get(KEY_VALUE));
+                queryTextGiven = true;
+            }
+            else if (isCustomQueryProp(name))
+            {
+                Boolean parsed = parseBooleanFlag(prop.get(KEY_VALUE));
+                if (parsed == null)
+                {
+                    return DynListQueryRequest.failed(
+                        ToolResult.error("'customQuery' must be a boolean (true / false).").toJson()); //$NON-NLS-1$
+                }
+                customQuery = parsed;
+            }
+            else if (isMainTableProp(name))
+            {
+                mainTable = asString(prop.get(KEY_VALUE));
+                if (mainTable == null || mainTable.trim().isEmpty())
+                {
+                    return DynListQueryRequest.failed(ToolResult.error("'mainTable' must be an object FQN, e.g. " //$NON-NLS-1$
+                        + "'Catalog.Products' or 'Document.Order'.").toJson()); //$NON-NLS-1$
+                }
+            }
+            else
+            {
+                return DynListQueryRequest.failed(
+                    ToolResult.error("Setting a dynamic-list query ('queryText' / 'customQuery' / " //$NON-NLS-1$
+                        + "'mainTable') cannot be combined with other property changes ('" + name //$NON-NLS-1$
+                        + "') in one call. Configure the query first, then make the other changes " //$NON-NLS-1$
+                        + "separately.").toJson()); //$NON-NLS-1$
+            }
+        }
+        if (queryTextGiven && (queryText == null || queryText.trim().isEmpty()))
+        {
+            return DynListQueryRequest.failed(ToolResult.error("'queryText' must be a non-empty 1C query, e.g. " //$NON-NLS-1$
+                + "\"SELECT Ref, Description AS Description FROM Catalog.Products\". To switch the " //$NON-NLS-1$
+                + "dynamic list back to its automatic query, pass 'customQuery' = false instead.").toJson()); //$NON-NLS-1$
+        }
+        return DynListQueryRequest.of(queryText, customQuery, mainTable);
+    }
+
+    /**
      * Parses a flag property value (a JSON boolean, or the string {@code "true"} / {@code "false"}),
      * or {@code null} when the value is not a recognizable boolean.
      */
@@ -749,7 +801,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
     {
         if (value == null || !value.isJsonPrimitive())
         {
-            return null;
+            return null; // NOSONAR tri-state: null means "not a recognizable boolean"; callers check it explicitly
         }
         JsonPrimitive prim = value.getAsJsonPrimitive();
         if (prim.isBoolean())
@@ -765,7 +817,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         {
             return Boolean.FALSE;
         }
-        return null;
+        return null; // NOSONAR tri-state: null means "not a recognizable boolean"; callers check it explicitly
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
@@ -57,7 +57,7 @@ public final class BslModuleUtils
 
     /** Regex for BSL method start (Процедура/Функция / Procedure/Function). Group 1 = method name, group 2 = params text after '(' */
     public static final Pattern METHOD_START_PATTERN = Pattern.compile(
-        "^\\s*(?:\u041F\u0440\u043E\u0446\u0435\u0434\u0443\u0440\u0430|\u0424\u0443\u043D\u043A\u0446\u0438\u044F|Procedure|Function)\\s+(\\S+?)\\s*\\((.*)$", //$NON-NLS-1$
+        "^\\s*(?:\u041F\u0440\u043E\u0446\u0435\u0434\u0443\u0440\u0430|\u0424\u0443\u043D\u043A\u0446\u0438\u044F|Procedure|Function)\\s+([^\\s(]+)\\s*\\((.*)$", //$NON-NLS-1$
         Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
 
     /** Regex for BSL method end (КонецПроцедуры/КонецФункции / EndProcedure/EndFunction) */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -79,6 +79,10 @@ public final class FormElementWriter
     private static final String FEATURE_EXT_INFO = "extInfo"; //$NON-NLS-1$
     private static final String FEATURE_ID = "id"; //$NON-NLS-1$
     private static final String FEATURE_NAME = "name"; //$NON-NLS-1$
+    /** The command-bar / menu "auto-fill from the form commands" flag. */
+    private static final String FEATURE_AUTO_FILL = "autoFill"; //$NON-NLS-1$
+    /** The default field ext-info EClass (a plain input field, before the value type is known). */
+    private static final String ECLASS_INPUT_FIELD_EXT_INFO = "InputFieldExtInfo"; //$NON-NLS-1$
     /** The form attribute's "is the form's main data source" flag. */
     private static final String FEATURE_MAIN = "main"; //$NON-NLS-1$
     /** The dynamic-list ext-info EClass and its query-carrying features. */
@@ -1072,7 +1076,7 @@ public final class FormElementWriter
         {
             return null;
         }
-        setBooleanFeature(bar, "autoFill", true); //$NON-NLS-1$
+        setBooleanFeature(bar, FEATURE_AUTO_FILL, true);
         setEnumFeature(bar, KEY_HORIZONTAL_ALIGN, "Left"); //$NON-NLS-1$
         setIntFeature(bar, FEATURE_ID, -1);
         setStringFeature(bar, FEATURE_NAME,
@@ -1222,31 +1226,7 @@ public final class FormElementWriter
         }
         if (!alreadyDynamicList)
         {
-            // Turn a plain form attribute into a dynamic list: create the ext-info, set the DynamicList
-            // value type, auto-fill available fields, and make it the form's main attribute if none yet.
-            setExtInfoClassifier(formModel, attribute, ECLASS_DYNAMIC_LIST_EXT_INFO);
-            extInfo = singleReference(attribute, FEATURE_EXT_INFO);
-            if (extInfo == null)
-            {
-                throw new IllegalStateException(
-                    "The form model does not expose a DynamicListExtInfo classifier."); //$NON-NLS-1$
-            }
-            EObject dynamicListType = MetadataTypeBuilder.dynamicListType(version);
-            EStructuralFeature valueTypeFeature =
-                attribute.eClass().getEStructuralFeature(FEATURE_VALUE_TYPE);
-            if (dynamicListType != null && valueTypeFeature instanceof EReference)
-            {
-                attribute.eSet(valueTypeFeature, dynamicListType);
-            }
-            setBooleanFeature(extInfo, FEATURE_AUTO_FILL_AVAILABLE_FIELDS, true);
-            // The designer turns on "dynamic data reading" for a new dynamic list (the model default is
-            // false); mirror it so an MCP-created list matches a designer-created one.
-            setBooleanFeature(extInfo, FEATURE_DYNAMIC_DATA_READ, true);
-            if (!hasMainAttribute(formModel))
-            {
-                setBooleanFeature(attribute, FEATURE_MAIN, true);
-            }
-            applied.add("dynamicList"); //$NON-NLS-1$
+            extInfo = convertPlainAttributeToDynamicList(formModel, attribute, version, applied);
         }
 
         boolean effectiveCustomQuery = customQuery != null ? customQuery.booleanValue() : queryText != null;
@@ -1268,21 +1248,66 @@ public final class FormElementWriter
         }
         if (mainTableFqn != null)
         {
-            EObject mainTable = resolveMainTableDbView(config, mainTableFqn);
-            if (mainTable == null)
-            {
-                throw new FormValidationException(ToolResult.error(
-                    "Cannot resolve the main table '" + mainTableFqn + "'. Pass the FQN of the object " //$NON-NLS-1$ //$NON-NLS-2$
-                    + "the list reads from, e.g. 'Catalog.Products' or 'Document.Order'.").toJson()); //$NON-NLS-1$
-            }
-            EStructuralFeature mainTableFeature = extInfo.eClass().getEStructuralFeature(FEATURE_MAIN_TABLE);
-            if (mainTableFeature instanceof EReference)
-            {
-                extInfo.eSet(mainTableFeature, mainTable);
-                applied.add(FEATURE_MAIN_TABLE);
-            }
+            applyMainTable(extInfo, config, mainTableFqn, applied);
         }
         return applied;
+    }
+
+    /**
+     * Turns a plain form attribute into a dynamic list: creates the {@code DynamicListExtInfo}, sets the
+     * {@code DynamicList} value type, turns on {@code autoFillAvailableFields} and {@code dynamicDataRead}
+     * (mirroring the designer's new-list defaults), and marks the attribute as the form's main one when the
+     * form has none yet. Appends {@code "dynamicList"} to {@code applied} and returns the new ext-info.
+     */
+    private static EObject convertPlainAttributeToDynamicList(EObject formModel, EObject attribute,
+        Version version, List<String> applied)
+    {
+        setExtInfoClassifier(formModel, attribute, ECLASS_DYNAMIC_LIST_EXT_INFO);
+        EObject extInfo = singleReference(attribute, FEATURE_EXT_INFO);
+        if (extInfo == null)
+        {
+            throw new IllegalStateException(
+                "The form model does not expose a DynamicListExtInfo classifier."); //$NON-NLS-1$
+        }
+        EObject dynamicListType = MetadataTypeBuilder.dynamicListType(version);
+        EStructuralFeature valueTypeFeature = attribute.eClass().getEStructuralFeature(FEATURE_VALUE_TYPE);
+        if (dynamicListType != null && valueTypeFeature instanceof EReference)
+        {
+            attribute.eSet(valueTypeFeature, dynamicListType);
+        }
+        setBooleanFeature(extInfo, FEATURE_AUTO_FILL_AVAILABLE_FIELDS, true);
+        // The designer turns on "dynamic data reading" for a new dynamic list (the model default is
+        // false); mirror it so an MCP-created list matches a designer-created one.
+        setBooleanFeature(extInfo, FEATURE_DYNAMIC_DATA_READ, true);
+        if (!hasMainAttribute(formModel))
+        {
+            setBooleanFeature(attribute, FEATURE_MAIN, true);
+        }
+        applied.add("dynamicList"); //$NON-NLS-1$
+        return extInfo;
+    }
+
+    /**
+     * Resolves {@code mainTableFqn} to its {@code DbViewDef} and sets it as the dynamic list's
+     * {@code mainTable} reference, appending {@code "mainTable"} to {@code applied}. Throws a
+     * {@link FormValidationException} when the FQN cannot be resolved.
+     */
+    private static void applyMainTable(EObject extInfo, Configuration config, String mainTableFqn,
+        List<String> applied)
+    {
+        EObject mainTable = resolveMainTableDbView(config, mainTableFqn);
+        if (mainTable == null)
+        {
+            throw new FormValidationException(ToolResult.error(
+                "Cannot resolve the main table '" + mainTableFqn + "'. Pass the FQN of the object " //$NON-NLS-1$ //$NON-NLS-2$
+                + "the list reads from, e.g. 'Catalog.Products' or 'Document.Order'.").toJson()); //$NON-NLS-1$
+        }
+        EStructuralFeature mainTableFeature = extInfo.eClass().getEStructuralFeature(FEATURE_MAIN_TABLE);
+        if (mainTableFeature instanceof EReference)
+        {
+            extInfo.eSet(mainTableFeature, mainTable);
+            applied.add(FEATURE_MAIN_TABLE);
+        }
     }
 
     /** Whether a form attribute carries a {@code DynamicListExtInfo} (i.e. it is a dynamic list). */
@@ -1846,7 +1871,7 @@ public final class FormElementWriter
         // Pure-model default field type (InputField + a fresh InputFieldExtInfo), as the platform's
         // own factory does before the value type is known.
         setEnumFeature(item, FEATURE_TYPE, "InputField"); //$NON-NLS-1$
-        setExtInfoClassifier(formModel, item, "InputFieldExtInfo"); //$NON-NLS-1$
+        setExtInfoClassifier(formModel, item, ECLASS_INPUT_FIELD_EXT_INFO);
         // The designer's new-field defaults (FormObjectFactory.newFormField / newInputFieldExtInfo); // NOSONAR explanatory comment, not commented-out code
         // the booleans default to false in the model, so without them a created field renders with
         // no table header/footer, no wrap and a read-only text box. 'Auto'-valued enums are the
@@ -2010,7 +2035,7 @@ public final class FormElementWriter
         setBooleanFeature(column, "showInFooter", true); //$NON-NLS-1$
         setEnumFeature(column, "headerHorizontalAlign", "Left"); //$NON-NLS-1$ //$NON-NLS-2$
         setEnumFeature(column, "editMode", "EnterOnInput"); //$NON-NLS-1$ //$NON-NLS-2$
-        setExtInfoClassifier(formModel, column, "InputFieldExtInfo"); //$NON-NLS-1$
+        setExtInfoClassifier(formModel, column, ECLASS_INPUT_FIELD_EXT_INFO);
         EObject extInfo = singleReference(column, FEATURE_EXT_INFO);
         if (extInfo != null)
         {
@@ -2036,7 +2061,7 @@ public final class FormElementWriter
         }
         setStringFeature(bar, FEATURE_NAME, uniqueChildName(formModel, stringFeature(table, FEATURE_NAME),
             russianAutoNames ? RU_SUFFIX_COMMAND_BAR : SUFFIX_COMMAND_BAR));
-        setBooleanFeature(bar, "autoFill", true); //$NON-NLS-1$
+        setBooleanFeature(bar, FEATURE_AUTO_FILL, true);
         setEnumFeature(bar, KEY_HORIZONTAL_ALIGN, "Left"); //$NON-NLS-1$
         table.eSet(barFeat, bar);
         setIntFeature(bar, FEATURE_ID, nextItemId(formModel));
@@ -2275,7 +2300,7 @@ public final class FormElementWriter
             {
                 setStringFeature(menu, FEATURE_NAME, uniqueChildName(formModel, base,
                     russianAutoNames ? RU_SUFFIX_CONTEXT_MENU : SUFFIX_CONTEXT_MENU));
-                setBooleanFeature(menu, "autoFill", true); //$NON-NLS-1$
+                setBooleanFeature(menu, FEATURE_AUTO_FILL, true);
                 item.eSet(menuFeat, menu);
                 setIntFeature(menu, FEATURE_ID, nextItemId(formModel));
             }
@@ -2872,7 +2897,7 @@ public final class FormElementWriter
         m.put("PictureDecorationExtInfo", "FormDecorationExtensionForAPicture"); //$NON-NLS-1$ //$NON-NLS-2$
         // Field ext-infos.
         m.put("LabelFieldExtInfo", "FormFieldExtensionForALabelField"); //$NON-NLS-1$ //$NON-NLS-2$
-        m.put("InputFieldExtInfo", "FormFieldExtensionForATextBox"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.put(ECLASS_INPUT_FIELD_EXT_INFO, "FormFieldExtensionForATextBox"); //$NON-NLS-1$
         m.put("CheckBoxFieldExtInfo", "FormFieldExtensionForACheckBoxField"); //$NON-NLS-1$ //$NON-NLS-2$
         m.put("ImageFieldExtInfo", "FormFieldExtensionForAPictureField"); //$NON-NLS-1$ //$NON-NLS-2$
         m.put("RadioButtonsFieldExtInfo", "FormFieldExtensionForARadioButtonField"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -3304,23 +3329,35 @@ public final class FormElementWriter
 
         for (EObject item : items)
         {
-            if (item == rootAutoCommandBar)
-            {
-                continue;
-            }
-            int id = intFeature(item, FEATURE_ID);
-            if (id > 0 && seen.add(Integer.valueOf(id)))
-            {
-                continue;
-            }
-            do
-            {
-                max++;
-            }
-            while (max <= 0 || seen.contains(Integer.valueOf(max)));
-            setIntFeature(item, FEATURE_ID, max);
-            seen.add(Integer.valueOf(max));
+            max = assignItemId(item, rootAutoCommandBar, seen, max);
         }
+    }
+
+    /**
+     * Assigns {@code item} a positive id unique within {@code seen} - skipping the form root's
+     * {@code autoCommandBar} (which keeps the platform sentinel {@code -1}) and keeping an already-unique
+     * positive id - then advances and returns the running {@code max}. Early-returns keep the per-item
+     * logic free of loop {@code continue}s.
+     */
+    private static int assignItemId(EObject item, EObject rootAutoCommandBar, Set<Integer> seen, int max)
+    {
+        if (item == rootAutoCommandBar)
+        {
+            return max;
+        }
+        int id = intFeature(item, FEATURE_ID);
+        if (id > 0 && seen.add(Integer.valueOf(id)))
+        {
+            return max;
+        }
+        do
+        {
+            max++;
+        }
+        while (max <= 0 || seen.contains(Integer.valueOf(max)));
+        setIntFeature(item, FEATURE_ID, max);
+        seen.add(Integer.valueOf(max));
+        return max;
     }
 
     // ---- reflective helpers ---------------------------------------------------------------------

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/JUnitMarkdownFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/JUnitMarkdownFormatter.java
@@ -57,7 +57,7 @@ public final class JUnitMarkdownFormatter
      * kind/part words are localized, so they are matched but not interpreted.
      */
     private static final Pattern FRAME_LOCATION = Pattern.compile(
-        "\\{\\s*(?:([^.{}()\\s]+)\\s+)?[^.{}()]+\\.([^.{}()]+)\\.([^.{}()]+)\\((\\d+)\\)"); //$NON-NLS-1$
+        "\\{\\s*+(?:([^.{}()\\s]++)\\s++)?[^.{}()]++\\.([^.{}()]++)\\.([^.{}()]++)\\((\\d++)\\)"); //$NON-NLS-1$
 
     /** Minimum length before a head/message overlap is treated as a real duplicate. */
     private static final int MIN_DUPLICATE_LENGTH = 16;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/TemplateScreenshotHelper.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/TemplateScreenshotHelper.java
@@ -224,7 +224,7 @@ public final class TemplateScreenshotHelper
                 }
                 if (!(content instanceof SpreadsheetDocument))
                 {
-                    return RenderOutcome.notSpreadsheet(content.eClass().getName());
+                    return RenderOutcome.nonSpreadsheet(content.eClass().getName());
                 }
                 return renderSpreadsheet((SpreadsheetDocument)content, presentation);
             });
@@ -374,7 +374,7 @@ public final class TemplateScreenshotHelper
             return new RenderOutcome(null, true, false, null);
         }
 
-        static RenderOutcome notSpreadsheet(String detail)
+        static RenderOutcome nonSpreadsheet(String detail)
         {
             return new RenderOutcome(null, false, true, detail);
         }


### PR DESCRIPTION
## Что это

После слияния #194/#197/#199 в master SonarCloud показывает **13 открытых замечаний** (0 BUG, 13 CODE_SMELL), почти все — в добавленном этими PR коде. Эта ветка закрывает их: **12 реальных фиксов + 1 осознанный won't-fix** с обоснованием. Поведение не меняется.

## Разбор по правилам

| Правило | Где | Что сделано |
|---|---|---|
| **S1845** (BLOCKER) | `TemplateScreenshotHelper` | factory `RenderOutcome.notSpreadsheet(...)` переименован в `nonSpreadsheet(...)` — больше не совпадает с одноимённым полем |
| **S1192** ×2 | `FormElementWriter` | вынесены константы `FEATURE_AUTO_FILL` (`"autoFill"`) и `ECLASS_INPUT_FIELD_EXT_INFO` (`"InputFieldExtInfo"`) вместо повторов литералов (с пересчётом `$NON-NLS$`) |
| **S8786** ×2 | `BslModuleUtils`, `JUnitMarkdownFormatter` | убран суперлинейный backtracking: для имени метода BSL — непересекающийся класс `([^\s(]+)` вместо ленивого `(\S+?)`; для frame-регэкспа — possessive-квантификаторы. Множество совпадений не меняется |
| **S3776** ×4 | `ModifyMetadataTool`, `FormElementWriter` ×2, `CreateInfobaseTool` | методы разбиты на тонкие оркестраторы + хелперы/holder'ы: `DynListQueryRequest`+`parseDynListQueryProps`; `convertPlainAttributeToDynamicList`+`applyMainTable`; `assignItemId`; `FlagResult`+`parseApplicationKind`+`parseMode` |
| **S135** | `FormElementWriter.normalizeFormItemIds` | два `continue` в цикле заменены на хелпер `assignItemId` с early-return (тот же extract, что и для S3776) |
| **S107** | `CreateInfobaseTool.createInfobase` | три cred-параметра свёрнуты в holder `Credentials` (9 → 7 параметров) |
| **S2447** ×2 | `ModifyMetadataTool.parseBooleanFlag` | оставлено как есть (`// NOSONAR`): `null` = «не распознан булев», вызывающий код это явно проверяет, поведение зафиксировано юнит-тестом. Это тот же осознанный tri-state-кластер, что и раньше |

## Проверка

`mvn clean verify -T 1C` — **BUILD SUCCESS, 2748 тестов зелёные**, рефакторинги поведенчески идентичны (extract-method без изменения control-flow/исключений; регэкспы дают те же совпадения).

🤖 Generated with [Claude Code](https://claude.com/claude-code)