### PR TITLE
Скилл edt-mcp-autopilot: автономный SDD-конвейер ведения задачи на мультиагентах

### DIFF
--- a/.claude/skills/edt-mcp-autopilot/SKILL.md
+++ b/.claude/skills/edt-mcp-autopilot/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: edt-mcp-autopilot
+description: Autonomous, spec-driven, multi-agent pipeline that takes an EDT-MCP task or issue end-to-end — research → critics → architect → parallel development → review loop → tests → live-stand check → Russian issue comment + PR. Use when asked to take a whole task/issue to completion autonomously (not for a single quick edit or a pure question).
+---
+
+# EDT-MCP Autopilot
+
+A repeatable pipeline for delivering a whole EDT-MCP task with minimal human input. You are
+the **conductor** running in the main loop: you prepare the stand, drive each fan-out phase
+with the `Workflow` tool, hold the gates a workflow cannot (waiting/polling, human confirm,
+irreversible ship), and finish by commenting the issue and opening a PR.
+
+It runs **unattended**. The only mandatory human touchpoint is the **operator confirming the
+live stand result** (Phase 8). Principal design questions are posted to the issue and polled
+until answered (Phase 4 gate). Everything else proceeds on its own.
+
+## Operating rules (always)
+
+- **Spec-Driven (SDD).** Write the spec before the code; keep the spec as the contract every
+  agent works against. Persist artifacts to `.claude/work/<task-slug>/` (this path is
+  git-ignored — safe for internal notes, issue numbers, stand details).
+- **Language.** Code, comments, commits → **English**. Issue comments + PR title + PR body →
+  **Russian**.
+- **Safety.** Never touch the live EDT — stand work runs only on a throwaway copy. The concrete
+  stand path/port are environment-specific (the build/test sibling skills know how to reach
+  them); never hardcode them in this skill.
+- **Delegate machine specifics.** For build, stand, redeploy and test mechanics, use the
+  sibling skills (`edt-mcp-build-test`, `edt-mcp-e2e-testing`, `edt-mcp-ready-to-deploy`) and
+  the project context — do not re-derive commands here.
+- **Scale to the task.** Small tasks get the minimum fan-out; large tasks get more. Pass
+  `size` and a token `budget` directive to the workflows so they size themselves.
+- **Skip-bias.** Every agent brief ends with: *"no behaviour change unless the spec says so;
+  if the cited code is actually meaningful or risky, SKIP and report instead of forcing a
+  change."*
+
+## Checklist (create one todo per phase)
+
+1. Phase 0 — Intake & stand prep
+2. Phase 1–4 — Discover (run `discover.workflow.js`)
+3. Phase 4 gate — escalate principal questions to the issue, poll until answered
+4. Phase 5–6 — Build (run `build.workflow.js`)
+5. Phase 7 — Build + unit tests (the real safety net)
+6. Phase 8 — Live stand scenarios + operator confirmation
+7. Phase 9 — Ship (issue comment + PR, Russian)
+
+## Phase 0 — Intake & stand prep
+
+- Read and **study the task** (the issue / tracker item / user prompt). Restate it in your own
+  words and capture the acceptance criteria.
+- **Sync the fork and branch from fresh master** (per the project git flow): sync upstream →
+  `master` → `git pull` → `git checkout -b feature/<slug>` (or `fix/<slug>`). Use a worktree
+  to keep the main clone clean.
+- **Prepare the test stand now**, at the very start, so it is healthy by verification time
+  (delegate to `edt-mcp-build-test`). If a fresh build is needed for the stand, kick it off.
+- Create `.claude/work/<slug>/` and write `spec.md` from `references/sdd-templates.md`.
+
+## Phases 1–4 — Discover
+
+Run the discover workflow (it implements: 2 doc researchers → ≥3 code-research agents in waves
+with loop-until-dry → adversarial critics that drop refuted findings and bounce "rework" back
+into another wave → an architect that synthesises the surviving findings into a concrete spec
+and a **file-disjoint developer partition**):
+
+```
+Workflow({
+  scriptPath: ".claude/skills/edt-mcp-autopilot/references/discover.workflow.js",
+  args: { task: "<the task statement>", size: "small|medium|large" }
+})
+```
+
+It returns `{ spec, devPartition, escalations }`. Save `spec` + `devPartition` into
+`.claude/work/<slug>/architecture.md` (template in `references/sdd-templates.md`).
+
+## Phase 4 gate — escalate principal questions
+
+If `escalations` is non-empty, do **not** guess. For each, post the question to the issue **in
+Russian** (with the 2–3 options), then enter the poll loop in `references/autonomy.md`
+(`ScheduleWakeup` ≈ every 10 min) until the maintainer answers. Fold the answer into
+`architecture.md`, then continue. What counts as "principal" (wire contract, architecture
+choice, bilingual semantics, breaking change, destructive op, ambiguous requirement) is listed
+in `references/review-checklist.md`.
+
+## Phases 5–6 — Build
+
+Run the build workflow (parallel developers over the file-disjoint slices → a 3–4 reviewer loop
+that re-runs until clean, sending problems back to fixers each round, with a max-round
+safeguard that escalates instead of spinning):
+
+```
+Workflow({
+  scriptPath: ".claude/skills/edt-mcp-autopilot/references/build.workflow.js",
+  args: {
+    task: "<the task statement>",
+    spec: <spec from discover>,
+    devPartition: <devPartition from discover>,
+    reviewChecklist: "<contents of references/review-checklist.md>",
+    maxRounds: 4
+  }
+})
+```
+
+It returns `{ changedFiles, reviewLog, openProblems, rounds, clean }`. If `clean` is false after
+`maxRounds`, treat the remaining `openProblems` as an escalation (Phase 4 gate). Record the
+review outcome in `.claude/work/<slug>/review-log.md`.
+
+> The developers edit disjoint files in the shared working tree and do **not** touch git — you
+> commit at the end. If two slices must touch the same file, re-partition or run that slice with
+> `isolation:'worktree'` and merge.
+
+## Phase 7 — Build + unit tests
+
+Run the project build + unit tests (delegate to `edt-mcp-build-test`). This is the real safety
+net — it catches missing `throws`, ratchet failures (unit `XxxToolTest`, schema/execute parity)
+and golden drift that reviewers miss. **Red → back to Phase 5/6** with the failures as the brief.
+Green → continue. If a tool's wire surface changed, regenerate the golden and review the diff.
+
+## Phase 8 — Live stand scenarios + operator gate
+
+If the task is live-verifiable (a tool behaviour, a form/metadata effect, a runtime contract):
+- Redeploy the fresh build to the **throwaway** stand and run the real scenarios (the e2e
+  matrix or targeted MCP calls) — delegate to `edt-mcp-e2e-testing` / `edt-mcp-ready-to-deploy`.
+- **Operator gate (the one human touchpoint):** use `AskUserQuestion` to show the live result
+  and ask the operator to confirm it before shipping (see `references/autonomy.md`). Do not open
+  the PR until the operator confirms.
+
+If the task is not live-verifiable (pure refactor, hygiene, docs), skip the stand run and the
+operator gate — the green build + e2e already prove it.
+
+## Phase 9 — Ship
+
+On all-green and operator OK:
+- Record the key facts and lessons for future work.
+- Commit (English message; include the standard AI `Co-Authored-By` trailer), push the branch.
+- Comment the issue **in Russian** (what was done, how it was verified).
+- Open the PR to upstream **in Russian** (title + body), body ending with
+  `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+
+## Files in this skill
+
+- `references/discover.workflow.js` — Phases 1–4 (research → critics → architect).
+- `references/build.workflow.js` — Phases 5–6 (parallel dev → review loop).
+- `references/review-checklist.md` — the MUST-ENFORCE criteria reviewers and the architect apply.
+- `references/sdd-templates.md` — `spec.md` / `architecture.md` / `review-log.md` templates.
+- `references/autonomy.md` — the issue-poll gate and the operator-confirm gate recipes.
+
+## Notes
+
+- This skill orchestrates the existing recipes; it does not redefine build/stand mechanics.
+- Keep this skill and its references **release-clean**: English only, no machine paths, ports,
+  stand names, or internal issue numbers (those belong in the project context and in the
+  git-ignored `.claude/work/`).

--- a/.claude/skills/edt-mcp-autopilot/references/autonomy.md
+++ b/.claude/skills/edt-mcp-autopilot/references/autonomy.md
@@ -1,0 +1,54 @@
+# Autonomy gates
+
+The pipeline runs unattended. There are exactly two places it pauses for input, and only one of
+them needs a human. Both are driven by the conductor (the main loop), not by a workflow — a
+`Workflow` cannot sleep/poll or take irreversible outward actions.
+
+## Gate A — principal design question -> issue + poll (no human required to keep going)
+
+When the discover workflow returns a non-empty `escalations` (or the build review loop cannot
+converge), do NOT guess. Instead:
+
+1. **Post the question to the issue in Russian.** State the question and the 2-3 options with
+   their trade-offs, and say you will wait for the maintainer's choice. Use `gh issue comment`
+   (or the GitHub MCP) on the task's issue.
+2. **Enter the poll loop.** Schedule a re-check roughly every 10 minutes and, on each wake,
+   read the issue comments for a new maintainer reply:
+
+   ```
+   ScheduleWakeup({
+     delaySeconds: 600,
+     reason: "polling <issue> for the maintainer's answer to the escalated design question",
+     prompt: "<the /edt-mcp-autopilot invocation, verbatim>"
+   })
+   ```
+
+   On each wake: fetch the latest comments; if the maintainer answered, fold the decision into
+   `architecture.md` and continue the pipeline; if not, schedule another `ScheduleWakeup(600)`.
+   Stop scheduling once answered (omit the call). Keep `delaySeconds` at ~600 — short enough to
+   feel responsive, long enough not to burn the cache every minute.
+3. While waiting, you may continue any **independent** work that does not depend on the answer.
+
+This is the "fundamental questions go to the issue and are polled until answered" rule.
+
+## Gate B — operator confirms the live stand result (the one human touchpoint)
+
+After the live stand scenarios pass (Phase 8), before shipping, ask the operator to confirm the
+real result with `AskUserQuestion`:
+
+- Summarise what was run on the throwaway stand and the observed result (paste the key
+  evidence — a value read back, a screenshot path, a health/response snippet).
+- Offer: **Confirm — ship it** / **Not right — describe what is wrong** (the operator can add
+  notes). Do not open the PR until the operator confirms.
+- If the operator reports a problem, route it back into the build/review loop (Phase 5/6) as the
+  brief, then re-verify on the stand and ask again.
+
+Skip Gate B only when the task is not live-verifiable (pure refactor, hygiene, docs) — the green
+build + e2e already prove it; ship directly.
+
+## What never pauses
+
+- Research, critique, development, review, build, unit + e2e tests — fully autonomous.
+- The ship step (commit/push/issue comment/PR) runs automatically once Gate B is confirmed (or
+  skipped for non-live tasks). It is the conductor that performs it, so the outward action stays
+  under explicit, logged control.

--- a/.claude/skills/edt-mcp-autopilot/references/build.workflow.js
+++ b/.claude/skills/edt-mcp-autopilot/references/build.workflow.js
@@ -7,18 +7,22 @@ export const meta = {
   ],
 }
 
-// args:
+// args arrives as a JSON STRING in this harness - parse defensively (object/undefined handled too).
 //   task            - the task statement (string, required)
 //   spec            - the architect spec object (optional, for context)
 //   devPartition    - array of slices { slice, files, change, invariant, tests } (required)
 //   reviewChecklist - the MUST-ENFORCE checklist text reviewers apply (string)
 //   maxRounds       - review-loop cap before escalating (default 4)
-const task = (args && args.task) || ''
-const spec = (args && args.spec) || {}
-const partition = (args && args.devPartition) || (spec && spec.devPartition) || []
-const checklist = (args && args.reviewChecklist) ||
+const A = (() => {
+  if (typeof args === 'string') { try { return JSON.parse(args) } catch (e) { return {} } }
+  return args || {}
+})()
+const task = A.task || ''
+const spec = A.spec || {}
+const partition = A.devPartition || (spec && spec.devPartition) || []
+const checklist = A.reviewChecklist ||
   'Apply the project review checklist (review-checklist.md) and the project code rules.'
-const MAX_ROUNDS = (args && args.maxRounds) || 4
+const MAX_ROUNDS = A.maxRounds || 4
 const REVIEWERS = partition.length > 4 ? 4 : 3
 
 const CHANGE_SCHEMA = {

--- a/.claude/skills/edt-mcp-autopilot/references/build.workflow.js
+++ b/.claude/skills/edt-mcp-autopilot/references/build.workflow.js
@@ -1,0 +1,110 @@
+export const meta = {
+  name: 'edt-mcp-autopilot-build',
+  description: 'Implements an approved EDT-MCP spec with parallel developers over file-disjoint slices, then runs a 3-4 reviewer loop that re-runs until clean (problems -> fixers -> re-review), with a max-round safeguard.',
+  phases: [
+    { title: 'Develop', detail: 'one developer per file-disjoint slice' },
+    { title: 'Review', detail: 'cyclic reviewers until clean' },
+  ],
+}
+
+// args:
+//   task            - the task statement (string, required)
+//   spec            - the architect spec object (optional, for context)
+//   devPartition    - array of slices { slice, files, change, invariant, tests } (required)
+//   reviewChecklist - the MUST-ENFORCE checklist text reviewers apply (string)
+//   maxRounds       - review-loop cap before escalating (default 4)
+const task = (args && args.task) || ''
+const spec = (args && args.spec) || {}
+const partition = (args && args.devPartition) || (spec && spec.devPartition) || []
+const checklist = (args && args.reviewChecklist) ||
+  'Apply the project review checklist (review-checklist.md) and the project code rules.'
+const MAX_ROUNDS = (args && args.maxRounds) || 4
+const REVIEWERS = partition.length > 4 ? 4 : 3
+
+const CHANGE_SCHEMA = {
+  type: 'object',
+  properties: {
+    slice: { type: 'string' },
+    changedFiles: { type: 'array', items: { type: 'string' } },
+    summary: { type: 'string' },
+    notes: { type: 'string' },
+  },
+  required: ['summary'],
+}
+
+const REVIEW_SCHEMA = {
+  type: 'object',
+  properties: {
+    problems: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          severity: { type: 'string', enum: ['blocker', 'major', 'minor'] },
+          file: { type: 'string' },
+          detail: { type: 'string' },
+          fix: { type: 'string' },
+        },
+        required: ['severity', 'detail'],
+      },
+    },
+  },
+  required: ['problems'],
+}
+
+if (!partition.length) {
+  return { changedFiles: [], reviewLog: [], openProblems: [], rounds: 0, clean: false, error: 'empty devPartition' }
+}
+
+// ---- Phase 5: parallel development over file-disjoint slices ---------------------------------
+phase('Develop')
+const dev = (await parallel(partition.map((s, i) => () =>
+  agent(
+    `You are DEVELOPER #${i + 1} implementing ONE slice of an approved EDT-MCP spec.\n\nTask: ${task}\n\nYour slice (implement EXACTLY this, nothing outside it):\n${JSON.stringify(s)}\n\nEdit only the files in your slice - they are disjoint from the other developers. Follow the project conventions and code rules: English-only code, reuse the shared helpers/resolvers, preserve the cited invariant, and add/adjust the slice's tests. Do NOT commit, push, or run git - only edit the files. Return what you changed.`,
+    { phase: 'Develop', label: `dev#${i + 1}`, schema: CHANGE_SCHEMA }))))
+  .filter(Boolean)
+const changedFiles = dev.flatMap((d) => d.changedFiles || [])
+log(`Developed ${dev.length}/${partition.length} slices, ${changedFiles.length} files touched`)
+
+// ---- Phase 6: review loop (problems -> fixers -> re-review) until clean ----------------------
+phase('Review')
+const reviewLog = []
+let openProblems = []
+let round = 0
+let clean = false
+
+for (round = 1; round <= MAX_ROUNDS; round++) {
+  const problems = (await parallel(Array.from({ length: REVIEWERS }, (_, r) => () =>
+    agent(
+      `You are REVIEWER #${r + 1} (round ${round}) of an EDT-MCP change. Read the working-tree diff (run: git diff) and the changed files.\n\n${checklist}\n\nTask under review: ${task}\n\nHunt for REAL defects and rule violations (correctness, unattended-safety, bilingual language-CODE keys, schema/execute parity, reflective-form rules, transaction/state-flag timing, error-shape sentinels, English-only / no internal traces, missing ratchet tests). Report only problems you can substantiate, each with a concrete fix. If the change is clean, return an empty problems list.`,
+      { phase: 'Review', label: `review:r${round}#${r + 1}`, schema: REVIEW_SCHEMA }))))
+    .filter(Boolean)
+    .flatMap((rv) => rv.problems)
+
+  reviewLog.push({ round, problems })
+  // Blockers/majors always loop; minors are acted on only in round 1, then recorded.
+  const actionable = problems.filter((p) => p.severity !== 'minor' || round === 1)
+  log(`Round ${round}: ${problems.length} problems (${actionable.length} actionable)`)
+
+  if (!actionable.length) { openProblems = []; clean = true; break }
+  openProblems = problems
+
+  // Dispatch fixers grouped by file (file-disjoint -> safe in parallel).
+  const byFile = {}
+  for (const p of actionable) {
+    const f = p.file || 'general'
+    ;(byFile[f] = byFile[f] || []).push(p)
+  }
+  await parallel(Object.keys(byFile).map((f) => () =>
+    agent(
+      `You are a DEVELOPER fixing review problems in an EDT-MCP change.\n\nTask: ${task}\n\nFile: ${f}\nProblems to fix:\n${JSON.stringify(byFile[f])}\n\nApply minimal, correct fixes that satisfy the reviewers WITHOUT changing behaviour beyond the spec. Edit only the affected file(s); do NOT commit or run git. Return when done.`,
+      { phase: 'Review', label: `fix:r${round}:${f.split(/[\\/]/).pop()}` })))
+}
+
+return {
+  changedFiles,
+  reviewLog,
+  openProblems,
+  rounds: round > MAX_ROUNDS ? MAX_ROUNDS : round,
+  clean,
+}

--- a/.claude/skills/edt-mcp-autopilot/references/build.workflow.js
+++ b/.claude/skills/edt-mcp-autopilot/references/build.workflow.js
@@ -12,6 +12,7 @@ export const meta = {
 //   spec            - the architect spec object (optional, for context)
 //   devPartition    - array of slices { slice, files, change, invariant, tests } (required)
 //   reviewChecklist - the MUST-ENFORCE checklist text reviewers apply (string)
+//   workdir         - ABSOLUTE path of the git worktree the devs must edit (keeps other branches safe)
 //   maxRounds       - review-loop cap before escalating (default 4)
 const A = (() => {
   if (typeof args === 'string') { try { return JSON.parse(args) } catch (e) { return {} } }
@@ -22,8 +23,24 @@ const spec = A.spec || {}
 const partition = A.devPartition || (spec && spec.devPartition) || []
 const checklist = A.reviewChecklist ||
   'Apply the project review checklist (review-checklist.md) and the project code rules.'
+const workdir = A.workdir || ''
 const MAX_ROUNDS = A.maxRounds || 4
 const REVIEWERS = partition.length > 4 ? 4 : 3
+
+const WD = workdir
+  ? `\n\nWORK ONLY in the git worktree at: ${workdir}\nTreat every file path as relative to that directory (use absolute paths under it). Do NOT edit, create, or git-touch anything outside it.`
+  : ''
+const GITDIFF = workdir ? `git -C "${workdir}" diff` : 'git diff'
+
+// Resilient agent call: re-spawn a few times if the subagent dies (e.g. a transient API 529).
+async function retryAgent(prompt, opts, attempts = 3) {
+  for (let i = 1; i <= attempts; i++) {
+    const r = await agent(prompt, opts)
+    if (r !== null && r !== undefined) return r
+    log(`retry ${(opts && opts.label) || (opts && opts.phase) || 'agent'} (attempt ${i}/${attempts})`)
+  }
+  return null
+}
 
 const CHANGE_SCHEMA = {
   type: 'object',
@@ -63,8 +80,8 @@ if (!partition.length) {
 // ---- Phase 5: parallel development over file-disjoint slices ---------------------------------
 phase('Develop')
 const dev = (await parallel(partition.map((s, i) => () =>
-  agent(
-    `You are DEVELOPER #${i + 1} implementing ONE slice of an approved EDT-MCP spec.\n\nTask: ${task}\n\nYour slice (implement EXACTLY this, nothing outside it):\n${JSON.stringify(s)}\n\nEdit only the files in your slice - they are disjoint from the other developers. Follow the project conventions and code rules: English-only code, reuse the shared helpers/resolvers, preserve the cited invariant, and add/adjust the slice's tests. Do NOT commit, push, or run git - only edit the files. Return what you changed.`,
+  retryAgent(
+    `You are DEVELOPER #${i + 1} implementing ONE slice of an approved EDT-MCP spec.\n\nTask: ${task}\n\nYour slice (implement EXACTLY this, nothing outside it):\n${JSON.stringify(s)}${WD}\n\nEdit only the files in your slice - they are disjoint from the other developers. Follow the project conventions and code rules: English-only code, reuse the shared helpers/resolvers, preserve the cited invariant, and add/adjust the slice's tests. Do NOT commit, push, or run git - only edit the files. Return what you changed.`,
     { phase: 'Develop', label: `dev#${i + 1}`, schema: CHANGE_SCHEMA }))))
   .filter(Boolean)
 const changedFiles = dev.flatMap((d) => d.changedFiles || [])
@@ -79,11 +96,11 @@ let clean = false
 
 for (round = 1; round <= MAX_ROUNDS; round++) {
   const problems = (await parallel(Array.from({ length: REVIEWERS }, (_, r) => () =>
-    agent(
-      `You are REVIEWER #${r + 1} (round ${round}) of an EDT-MCP change. Read the working-tree diff (run: git diff) and the changed files.\n\n${checklist}\n\nTask under review: ${task}\n\nHunt for REAL defects and rule violations (correctness, unattended-safety, bilingual language-CODE keys, schema/execute parity, reflective-form rules, transaction/state-flag timing, error-shape sentinels, English-only / no internal traces, missing ratchet tests). Report only problems you can substantiate, each with a concrete fix. If the change is clean, return an empty problems list.`,
+    retryAgent(
+      `You are REVIEWER #${r + 1} (round ${round}) of an EDT-MCP change. Read the working-tree diff (run: ${GITDIFF}) and the changed files.\n\n${checklist}\n\nTask under review: ${task}${WD}\n\nHunt for REAL defects and rule violations (correctness, unattended-safety, bilingual language-CODE keys, schema/execute parity, reflective-form rules, transaction/state-flag timing, error-shape sentinels, English-only / no internal traces, missing ratchet tests). Report only problems you can substantiate, each with a concrete fix. If the change is clean, return an empty problems list.`,
       { phase: 'Review', label: `review:r${round}#${r + 1}`, schema: REVIEW_SCHEMA }))))
     .filter(Boolean)
-    .flatMap((rv) => rv.problems)
+    .flatMap((rv) => rv.problems || [])
 
   reviewLog.push({ round, problems })
   // Blockers/majors always loop; minors are acted on only in round 1, then recorded.
@@ -100,8 +117,8 @@ for (round = 1; round <= MAX_ROUNDS; round++) {
     ;(byFile[f] = byFile[f] || []).push(p)
   }
   await parallel(Object.keys(byFile).map((f) => () =>
-    agent(
-      `You are a DEVELOPER fixing review problems in an EDT-MCP change.\n\nTask: ${task}\n\nFile: ${f}\nProblems to fix:\n${JSON.stringify(byFile[f])}\n\nApply minimal, correct fixes that satisfy the reviewers WITHOUT changing behaviour beyond the spec. Edit only the affected file(s); do NOT commit or run git. Return when done.`,
+    retryAgent(
+      `You are a DEVELOPER fixing review problems in an EDT-MCP change.\n\nTask: ${task}\n\nFile: ${f}\nProblems to fix:\n${JSON.stringify(byFile[f])}${WD}\n\nApply minimal, correct fixes that satisfy the reviewers WITHOUT changing behaviour beyond the spec. Edit only the affected file(s); do NOT commit or run git. Return when done.`,
       { phase: 'Review', label: `fix:r${round}:${f.split(/[\\/]/).pop()}` })))
 }
 

--- a/.claude/skills/edt-mcp-autopilot/references/discover.workflow.js
+++ b/.claude/skills/edt-mcp-autopilot/references/discover.workflow.js
@@ -4,34 +4,51 @@ export const meta = {
   phases: [
     { title: 'Docs', detail: '2 documentation researchers' },
     { title: 'Code research', detail: 'size-scaled waves, loop-until-dry' },
-    { title: 'Critique', detail: 'adversarial verify; refuted dropped, rework bounced back' },
+    { title: 'Critique', detail: 'a small fixed critic panel batch-reviews each wave' },
     { title: 'Architect', detail: 'synthesise surviving findings into a spec + dev partition' },
   ],
 }
 
-// args:
+// args arrives as a JSON STRING in this harness - parse defensively (object/undefined also handled).
 //   task   - the task statement / issue text (string, required)
 //   size   - 'small' | 'medium' | 'large' (scales fan-out; default 'medium')
 //   dryRun - when true, agents only outline what they WOULD do (no deep work)
-const task = (args && args.task) || 'No task provided.'
-const size = (args && args.size) || 'medium'
-const dryRun = !!(args && args.dryRun)
+const A = (() => {
+  if (typeof args === 'string') { try { return JSON.parse(args) } catch (e) { return { task: args } } }
+  return args || {}
+})()
+const task = (A.task && String(A.task).trim()) || ''
+const size = A.size || 'medium'
+const dryRun = !!A.dryRun
 
-// Fan-out sizing by task size. budget.total (if the user set a "+Nk" directive) tightens caps.
-const WAVE = { small: 3, medium: 5, large: 8 }[size] || 5
-const MAX_WAVES = { small: 2, medium: 3, large: 4 }[size] || 3
-const CRITICS = size === 'large' ? 3 : 2
+// SAFETY: never fan out on an empty task (this is what caused a 210-agent no-op run).
+if (!task || task === 'No task provided.') {
+  log('ABORT: no task provided to discover.workflow - nothing to research.')
+  return {
+    spec: null,
+    devPartition: [],
+    escalations: [{ question: 'No task was provided to the discover workflow. Re-run with args.task set.', options: 'Pass {task: "<the task/issue text>"} as args.', why: 'The workflow refuses to fan out agents on an empty task.' }],
+  }
+}
+
+// Fan-out sizing by task size, kept deliberately small. budget tightens it further.
+const WAVE = { small: 3, medium: 4, large: 6 }[size] || 4
+const MAX_WAVES = { small: 2, medium: 2, large: 3 }[size] || 2
+const PANEL = size === 'large' ? 3 : 2          // critics per wave (fixed panel, NOT per-finding)
+const MAX_FINDINGS_PER_AGENT = 6
+const MAX_FRESH_PER_WAVE = 24                    // bound the critique batch + its JSON size
 const tight = budget && budget.total && budget.remaining() < 120000
 
 const SKIP_BIAS =
-  ' Report only what you verified against the real code/docs; be skeptical. ' +
-  'No behaviour change is implied here - if something looks meaningful or risky, flag it, do not paper over it.'
+  ' Report only what you verified against the real code/docs; be skeptical. Keep each finding tight' +
+  ' (a sentence or two). No behaviour change is implied here - if something looks meaningful or risky, flag it.'
 
 const FINDINGS_SCHEMA = {
   type: 'object',
   properties: {
     findings: {
       type: 'array',
+      maxItems: MAX_FINDINGS_PER_AGENT,
       items: {
         type: 'object',
         properties: {
@@ -48,14 +65,24 @@ const FINDINGS_SCHEMA = {
   required: ['findings'],
 }
 
-const VERDICT_SCHEMA = {
+// One critic call returns a verdict for EVERY finding in the batch (by index).
+const BATCH_VERDICT_SCHEMA = {
   type: 'object',
   properties: {
-    verdict: { type: 'string', enum: ['CONFIRMED', 'REFUTED', 'REWORK'] },
-    reason: { type: 'string' },
-    correction: { type: 'string' },
+    verdicts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          index: { type: 'integer' },
+          verdict: { type: 'string', enum: ['CONFIRMED', 'REFUTED', 'REWORK'] },
+          reason: { type: 'string' },
+        },
+        required: ['index', 'verdict'],
+      },
+    },
   },
-  required: ['verdict', 'reason'],
+  required: ['verdicts'],
 }
 
 const SPEC_SCHEMA = {
@@ -99,16 +126,16 @@ const SPEC_SCHEMA = {
 // ---- Phase 1: documentation research (2 agents) ----------------------------------------------
 phase('Docs')
 const docPrompts = [
-  `You are a DOCUMENTATION researcher for this EDT-MCP task:\n\n${task}\n\nStudy ONLY authoritative documentation (the local apidocs Javadoc index, the official EDT apidocs site, the project docs/ knowledge base, plugin docs). Report concrete API facts that bear on the task: exact class/method/enum names and signatures, constraints, version differences. Cite where each fact comes from.${dryRun ? ' DRY RUN: only outline what you would look up.' : ''}${SKIP_BIAS}`,
-  `You are a PRECEDENT researcher for this EDT-MCP task:\n\n${task}\n\nFind how the project ALREADY does similar things: existing tools, shared helpers/resolvers, conventions, prior PRs/issues, and the relevant project skills. Report the reusable building blocks with their file paths so we reuse instead of reinventing.${dryRun ? ' DRY RUN: only outline.' : ''}${SKIP_BIAS}`,
+  `You are a DOCUMENTATION researcher for this EDT-MCP task:\n\n${task}\n\nStudy ONLY authoritative documentation (the local apidocs Javadoc index, the official EDT apidocs site, the project docs/ knowledge base, plugin docs). Report at most ${MAX_FINDINGS_PER_AGENT} concrete API facts that bear on the task: exact class/method/enum names and signatures, constraints, version differences. Cite where each fact comes from.${dryRun ? ' DRY RUN: only outline what you would look up.' : ''}${SKIP_BIAS}`,
+  `You are a PRECEDENT researcher for this EDT-MCP task:\n\n${task}\n\nFind how the project ALREADY does similar things: existing tools, shared helpers/resolvers, conventions, prior PRs/issues, relevant project skills. Report at most ${MAX_FINDINGS_PER_AGENT} reusable building blocks with their file paths so we reuse instead of reinventing.${dryRun ? ' DRY RUN: only outline.' : ''}${SKIP_BIAS}`,
 ]
 const docFindings = (await parallel(docPrompts.map((p) => () =>
   agent(p, { phase: 'Docs', schema: FINDINGS_SCHEMA }))))
   .filter(Boolean)
-  .flatMap((r) => r.findings)
+  .flatMap((r) => r.findings || [])
 log(`Docs: ${docFindings.length} findings`)
 
-// ---- Phases 2-3: code-research waves + critics (loop-until-dry, critics can bounce back) -----
+// ---- Phases 2-3: code-research waves + a fixed critic panel (loop-until-dry, bounce-back) -----
 const ANGLES = [
   'data flow and exactly where the change must land',
   'existing patterns / shared helpers to reuse',
@@ -116,8 +143,6 @@ const ANGLES = [
   'tests and build ratchets that will gate the change',
   'cross-file callers and wire/contract impact',
   'bilingual (RU/EN) resolution paths',
-  'transaction boundaries and state-flag timing',
-  'forms / reflective model access (if relevant)',
 ]
 
 const seen = new Set()
@@ -132,44 +157,53 @@ for (let wave = 1; wave <= MAX_WAVES; wave++) {
   const lenses = Array.from({ length: WAVE }, (_, i) => ANGLES[(i + (wave - 1) * WAVE) % ANGLES.length])
   const found = (await parallel(lenses.map((lens, i) => () =>
     agent(
-      `You are CODE researcher #${i + 1} (wave ${wave}) for this EDT-MCP task:\n\n${task}\n\nInvestigate the PRODUCT CODE through this lens: ${lens}. Use ripgrep and read the real files. Report concrete, file-anchored findings (what is true, where, why it matters for the task).${reworkNotes ? ' Critics asked to re-examine: ' + reworkNotes : ''}${dryRun ? ' DRY RUN: only outline what you would inspect.' : ''}${SKIP_BIAS}`,
+      `You are CODE researcher #${i + 1} (wave ${wave}) for this EDT-MCP task:\n\n${task}\n\nInvestigate the PRODUCT CODE through this lens: ${lens}. Use ripgrep and read the real files. Report at most ${MAX_FINDINGS_PER_AGENT} concrete, file-anchored findings (what is true, where, why it matters).${reworkNotes ? ' Critics asked to re-examine: ' + reworkNotes : ''}${dryRun ? ' DRY RUN: only outline.' : ''}${SKIP_BIAS}`,
       { phase: 'Code research', label: `research:w${wave}#${i + 1}`, schema: FINDINGS_SCHEMA }))))
     .filter(Boolean)
-    .flatMap((r) => r.findings)
+    .flatMap((r) => r.findings || [])
 
-  const fresh = found.filter((f) => !seen.has(keyOf(f)))
+  let fresh = found.filter((f) => !seen.has(keyOf(f)))
   fresh.forEach((f) => seen.add(keyOf(f)))
-  log(`Wave ${wave}: ${found.length} found, ${fresh.length} new`)
+  if (fresh.length > MAX_FRESH_PER_WAVE) {
+    log(`Wave ${wave}: ${fresh.length} new findings -> capping critique to ${MAX_FRESH_PER_WAVE}`)
+    fresh = fresh.slice(0, MAX_FRESH_PER_WAVE)
+  }
+  log(`Wave ${wave}: ${found.length} found, ${fresh.length} new (critique batch)`)
   if (!fresh.length) break
 
-  // Critique each fresh finding with independent skeptics.
+  // FIXED critic panel: each critic reviews the WHOLE fresh batch and returns a verdict per index.
   reworkNotes = ''
-  const judged = (await parallel(fresh.map((f) => () =>
-    parallel(Array.from({ length: CRITICS }, (_, c) => () =>
-      agent(
-        `You are an adversarial CRITIC #${c + 1} of a research finding on this EDT-MCP task:\n\n${task}\n\nFinding:\n- title: ${f.title}\n- file: ${f.file || '(none)'}\n- detail: ${f.detail}\n- evidence: ${f.evidence || '(none)'}\n\nVerify it against the REAL code/docs. Return CONFIRMED only if you can point at the proof; REFUTED if it is wrong or unfounded (quote what disproves it); REWORK if the direction is right but the specifics need re-investigation (say what to re-check). Default to REFUTED when uncertain.`,
-        { phase: 'Critique', label: `critic:${(f.title || '').slice(0, 24)}`, schema: VERDICT_SCHEMA })))
-      .then((vs) => ({ f, vs: vs.filter(Boolean) })))))
+  const numbered = fresh.map((f, i) => `#${i}: ${f.title}${f.file ? ' [' + f.file + ']' : ''} - ${f.detail}`).join('\n')
+  const panels = (await parallel(Array.from({ length: PANEL }, (_, c) => () =>
+    agent(
+      `You are adversarial CRITIC #${c + 1} for this EDT-MCP task:\n\n${task}\n\nHere are ${fresh.length} research findings (indexed):\n${numbered}\n\nVerify EACH against the real code/docs and return a verdict per index: CONFIRMED (you can point at the proof), REFUTED (wrong/unfounded), or REWORK (right direction, specifics need re-checking - say what). Default to REFUTED when uncertain. Return one verdict object per finding index.`,
+      { phase: 'Critique', label: `critic:w${wave}#${c + 1}`, schema: BATCH_VERDICT_SCHEMA }))))
     .filter(Boolean)
+    .map((r) => r.verdicts || [])
 
-  for (const { f, vs } of judged) {
-    const confirms = vs.filter((v) => v.verdict === 'CONFIRMED').length
-    const reworks = vs.filter((v) => v.verdict === 'REWORK')
-    if (confirms >= Math.ceil(CRITICS / 2)) {
-      confirmed.push(f)
-    } else if (reworks.length) {
-      reworkNotes += ` [${f.title}: ${reworks.map((r) => r.reason).join('; ')}]`
+  // Aggregate: a finding is kept when a majority of the panel CONFIRMS it.
+  const need = Math.ceil(PANEL / 2)
+  fresh.forEach((f, i) => {
+    let confirms = 0
+    const reworks = []
+    for (const verdicts of panels) {
+      const v = verdicts.find((x) => x.index === i)
+      if (!v) continue
+      if (v.verdict === 'CONFIRMED') confirms++
+      else if (v.verdict === 'REWORK') reworks.push(v.reason || 'recheck')
     }
-  }
+    if (confirms >= need) confirmed.push(f)
+    else if (reworks.length) reworkNotes += ` [${f.title}: ${reworks.join('; ')}]`
+  })
   log(`Confirmed so far: ${confirmed.length}${reworkNotes ? ' (rework queued)' : ''}`)
-  if (!reworkNotes) break // nothing bounced back -> research has converged
+  if (!reworkNotes) break // converged - nothing bounced back
 }
 
 // ---- Phase 4: architect synthesis -----------------------------------------------------------
 phase('Architect')
 const corpus = JSON.stringify({ docFindings, confirmed }, null, 0)
 const spec = await agent(
-  `You are the ARCHITECT for this EDT-MCP task:\n\n${task}\n\nConfirmed research findings and documentation facts (JSON):\n${corpus}\n\nProduce a concrete, Spec-Driven implementation plan:\n- a short summary and TESTABLE acceptance criteria;\n- the chosen approach;\n- a DEVELOPER PARTITION that splits the work into INDEPENDENT, FILE-DISJOINT slices so multiple developers can work in parallel without conflict - each slice with its files, the exact change, the invariant to preserve, and its tests;\n- recommendedDevs (how many of those slices can run in parallel).\n\nRespect the project MUST-ENFORCE rules (English-only code, unattended-safety, bilingual language-CODE keys, schema/execute parity + lowerCamelCase, reflective forms with no form-model import, transaction boundaries with state-flags only after commit, the unit + e2e + golden ratchets).\n\nIf a PRINCIPAL design question must be answered by a human BEFORE implementation (a wire-contract change, an architecture choice, bilingual semantics, a breaking change, a destructive operation, or an ambiguous requirement), list it under escalations with 2-3 options - do NOT guess.`,
+  `You are the ARCHITECT for this EDT-MCP task:\n\n${task}\n\nConfirmed research findings and documentation facts (JSON):\n${corpus}\n\nProduce a concrete, Spec-Driven implementation plan:\n- a short summary and TESTABLE acceptance criteria;\n- the chosen approach;\n- a DEVELOPER PARTITION that splits the work into INDEPENDENT, FILE-DISJOINT slices so multiple developers can work in parallel without conflict - each slice with its files, the exact change, the invariant to preserve, and its tests;\n- recommendedDevs (how many of those slices can run in parallel).\n\nRespect the project MUST-ENFORCE rules (English-only code, unattended-safety, bilingual language-CODE keys, schema/execute parity + lowerCamelCase, reflective forms with no form-model import, transaction boundaries with state-flags only after commit, the unit + e2e + golden ratchets).\n\nIf a PRINCIPAL design question must be answered by a human BEFORE implementation (a wire-contract change, an architecture choice, bilingual semantics, a breaking change, a destructive operation, or an ambiguous/infeasible requirement), list it under escalations with 2-3 options - do NOT guess.`,
   { phase: 'Architect', schema: SPEC_SCHEMA, effort: 'high' })
 
 return { spec, devPartition: spec.devPartition, escalations: spec.escalations || [] }

--- a/.claude/skills/edt-mcp-autopilot/references/discover.workflow.js
+++ b/.claude/skills/edt-mcp-autopilot/references/discover.workflow.js
@@ -123,6 +123,16 @@ const SPEC_SCHEMA = {
   required: ['summary', 'acceptanceCriteria', 'approach', 'devPartition'],
 }
 
+// Resilient agent call: re-spawn a few times if the subagent dies (e.g. a transient API 529).
+async function retryAgent(prompt, opts, attempts = 3) {
+  for (let i = 1; i <= attempts; i++) {
+    const r = await agent(prompt, opts)
+    if (r !== null && r !== undefined) return r
+    log(`retry ${(opts && opts.label) || (opts && opts.phase) || 'agent'} (attempt ${i}/${attempts})`)
+  }
+  return null
+}
+
 // ---- Phase 1: documentation research (2 agents) ----------------------------------------------
 phase('Docs')
 const docPrompts = [
@@ -175,7 +185,7 @@ for (let wave = 1; wave <= MAX_WAVES; wave++) {
   reworkNotes = ''
   const numbered = fresh.map((f, i) => `#${i}: ${f.title}${f.file ? ' [' + f.file + ']' : ''} - ${f.detail}`).join('\n')
   const panels = (await parallel(Array.from({ length: PANEL }, (_, c) => () =>
-    agent(
+    retryAgent(
       `You are adversarial CRITIC #${c + 1} for this EDT-MCP task:\n\n${task}\n\nHere are ${fresh.length} research findings (indexed):\n${numbered}\n\nVerify EACH against the real code/docs and return a verdict per index: CONFIRMED (you can point at the proof), REFUTED (wrong/unfounded), or REWORK (right direction, specifics need re-checking - say what). Default to REFUTED when uncertain. Return one verdict object per finding index.`,
       { phase: 'Critique', label: `critic:w${wave}#${c + 1}`, schema: BATCH_VERDICT_SCHEMA }))))
     .filter(Boolean)
@@ -202,8 +212,16 @@ for (let wave = 1; wave <= MAX_WAVES; wave++) {
 // ---- Phase 4: architect synthesis -----------------------------------------------------------
 phase('Architect')
 const corpus = JSON.stringify({ docFindings, confirmed }, null, 0)
-const spec = await agent(
+const spec = await retryAgent(
   `You are the ARCHITECT for this EDT-MCP task:\n\n${task}\n\nConfirmed research findings and documentation facts (JSON):\n${corpus}\n\nProduce a concrete, Spec-Driven implementation plan:\n- a short summary and TESTABLE acceptance criteria;\n- the chosen approach;\n- a DEVELOPER PARTITION that splits the work into INDEPENDENT, FILE-DISJOINT slices so multiple developers can work in parallel without conflict - each slice with its files, the exact change, the invariant to preserve, and its tests;\n- recommendedDevs (how many of those slices can run in parallel).\n\nRespect the project MUST-ENFORCE rules (English-only code, unattended-safety, bilingual language-CODE keys, schema/execute parity + lowerCamelCase, reflective forms with no form-model import, transaction boundaries with state-flags only after commit, the unit + e2e + golden ratchets).\n\nIf a PRINCIPAL design question must be answered by a human BEFORE implementation (a wire-contract change, an architecture choice, bilingual semantics, a breaking change, a destructive operation, or an ambiguous/infeasible requirement), list it under escalations with 2-3 options - do NOT guess.`,
   { phase: 'Architect', schema: SPEC_SCHEMA, effort: 'high' })
 
+if (!spec) {
+  log('architect step failed (likely transient API error) - returning a resumable escalation')
+  return {
+    spec: null,
+    devPartition: [],
+    escalations: [{ question: 'The architect step failed after retries (transient API error). Resume the discover workflow once the API is healthy.', options: 'Resume from this run id (cached research is reused).', why: 'No spec could be synthesised.' }],
+  }
+}
 return { spec, devPartition: spec.devPartition, escalations: spec.escalations || [] }

--- a/.claude/skills/edt-mcp-autopilot/references/discover.workflow.js
+++ b/.claude/skills/edt-mcp-autopilot/references/discover.workflow.js
@@ -1,0 +1,175 @@
+export const meta = {
+  name: 'edt-mcp-autopilot-discover',
+  description: 'Research -> critics -> architect for an EDT-MCP task: produces an implementation spec, a file-disjoint developer partition, and any escalation questions for the human.',
+  phases: [
+    { title: 'Docs', detail: '2 documentation researchers' },
+    { title: 'Code research', detail: 'size-scaled waves, loop-until-dry' },
+    { title: 'Critique', detail: 'adversarial verify; refuted dropped, rework bounced back' },
+    { title: 'Architect', detail: 'synthesise surviving findings into a spec + dev partition' },
+  ],
+}
+
+// args:
+//   task   - the task statement / issue text (string, required)
+//   size   - 'small' | 'medium' | 'large' (scales fan-out; default 'medium')
+//   dryRun - when true, agents only outline what they WOULD do (no deep work)
+const task = (args && args.task) || 'No task provided.'
+const size = (args && args.size) || 'medium'
+const dryRun = !!(args && args.dryRun)
+
+// Fan-out sizing by task size. budget.total (if the user set a "+Nk" directive) tightens caps.
+const WAVE = { small: 3, medium: 5, large: 8 }[size] || 5
+const MAX_WAVES = { small: 2, medium: 3, large: 4 }[size] || 3
+const CRITICS = size === 'large' ? 3 : 2
+const tight = budget && budget.total && budget.remaining() < 120000
+
+const SKIP_BIAS =
+  ' Report only what you verified against the real code/docs; be skeptical. ' +
+  'No behaviour change is implied here - if something looks meaningful or risky, flag it, do not paper over it.'
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          file: { type: 'string' },
+          detail: { type: 'string' },
+          evidence: { type: 'string' },
+          relevance: { type: 'string' },
+        },
+        required: ['title', 'detail'],
+      },
+    },
+  },
+  required: ['findings'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  properties: {
+    verdict: { type: 'string', enum: ['CONFIRMED', 'REFUTED', 'REWORK'] },
+    reason: { type: 'string' },
+    correction: { type: 'string' },
+  },
+  required: ['verdict', 'reason'],
+}
+
+const SPEC_SCHEMA = {
+  type: 'object',
+  properties: {
+    summary: { type: 'string' },
+    acceptanceCriteria: { type: 'array', items: { type: 'string' } },
+    approach: { type: 'string' },
+    devPartition: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          slice: { type: 'string' },
+          files: { type: 'array', items: { type: 'string' } },
+          change: { type: 'string' },
+          invariant: { type: 'string' },
+          tests: { type: 'string' },
+        },
+        required: ['slice', 'change'],
+      },
+    },
+    recommendedDevs: { type: 'integer' },
+    testPlan: { type: 'string' },
+    escalations: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          question: { type: 'string' },
+          options: { type: 'string' },
+          why: { type: 'string' },
+        },
+        required: ['question'],
+      },
+    },
+  },
+  required: ['summary', 'acceptanceCriteria', 'approach', 'devPartition'],
+}
+
+// ---- Phase 1: documentation research (2 agents) ----------------------------------------------
+phase('Docs')
+const docPrompts = [
+  `You are a DOCUMENTATION researcher for this EDT-MCP task:\n\n${task}\n\nStudy ONLY authoritative documentation (the local apidocs Javadoc index, the official EDT apidocs site, the project docs/ knowledge base, plugin docs). Report concrete API facts that bear on the task: exact class/method/enum names and signatures, constraints, version differences. Cite where each fact comes from.${dryRun ? ' DRY RUN: only outline what you would look up.' : ''}${SKIP_BIAS}`,
+  `You are a PRECEDENT researcher for this EDT-MCP task:\n\n${task}\n\nFind how the project ALREADY does similar things: existing tools, shared helpers/resolvers, conventions, prior PRs/issues, and the relevant project skills. Report the reusable building blocks with their file paths so we reuse instead of reinventing.${dryRun ? ' DRY RUN: only outline.' : ''}${SKIP_BIAS}`,
+]
+const docFindings = (await parallel(docPrompts.map((p) => () =>
+  agent(p, { phase: 'Docs', schema: FINDINGS_SCHEMA }))))
+  .filter(Boolean)
+  .flatMap((r) => r.findings)
+log(`Docs: ${docFindings.length} findings`)
+
+// ---- Phases 2-3: code-research waves + critics (loop-until-dry, critics can bounce back) -----
+const ANGLES = [
+  'data flow and exactly where the change must land',
+  'existing patterns / shared helpers to reuse',
+  'edge cases, error paths and unattended-safety',
+  'tests and build ratchets that will gate the change',
+  'cross-file callers and wire/contract impact',
+  'bilingual (RU/EN) resolution paths',
+  'transaction boundaries and state-flag timing',
+  'forms / reflective model access (if relevant)',
+]
+
+const seen = new Set()
+const confirmed = []
+const keyOf = (f) =>
+  `${(f.file || '').toLowerCase().trim()}::${(f.title || '').toLowerCase().trim().slice(0, 80)}`
+let reworkNotes = ''
+
+for (let wave = 1; wave <= MAX_WAVES; wave++) {
+  if (tight) { log('budget tight - stopping research waves'); break }
+  phase('Code research')
+  const lenses = Array.from({ length: WAVE }, (_, i) => ANGLES[(i + (wave - 1) * WAVE) % ANGLES.length])
+  const found = (await parallel(lenses.map((lens, i) => () =>
+    agent(
+      `You are CODE researcher #${i + 1} (wave ${wave}) for this EDT-MCP task:\n\n${task}\n\nInvestigate the PRODUCT CODE through this lens: ${lens}. Use ripgrep and read the real files. Report concrete, file-anchored findings (what is true, where, why it matters for the task).${reworkNotes ? ' Critics asked to re-examine: ' + reworkNotes : ''}${dryRun ? ' DRY RUN: only outline what you would inspect.' : ''}${SKIP_BIAS}`,
+      { phase: 'Code research', label: `research:w${wave}#${i + 1}`, schema: FINDINGS_SCHEMA }))))
+    .filter(Boolean)
+    .flatMap((r) => r.findings)
+
+  const fresh = found.filter((f) => !seen.has(keyOf(f)))
+  fresh.forEach((f) => seen.add(keyOf(f)))
+  log(`Wave ${wave}: ${found.length} found, ${fresh.length} new`)
+  if (!fresh.length) break
+
+  // Critique each fresh finding with independent skeptics.
+  reworkNotes = ''
+  const judged = (await parallel(fresh.map((f) => () =>
+    parallel(Array.from({ length: CRITICS }, (_, c) => () =>
+      agent(
+        `You are an adversarial CRITIC #${c + 1} of a research finding on this EDT-MCP task:\n\n${task}\n\nFinding:\n- title: ${f.title}\n- file: ${f.file || '(none)'}\n- detail: ${f.detail}\n- evidence: ${f.evidence || '(none)'}\n\nVerify it against the REAL code/docs. Return CONFIRMED only if you can point at the proof; REFUTED if it is wrong or unfounded (quote what disproves it); REWORK if the direction is right but the specifics need re-investigation (say what to re-check). Default to REFUTED when uncertain.`,
+        { phase: 'Critique', label: `critic:${(f.title || '').slice(0, 24)}`, schema: VERDICT_SCHEMA })))
+      .then((vs) => ({ f, vs: vs.filter(Boolean) })))))
+    .filter(Boolean)
+
+  for (const { f, vs } of judged) {
+    const confirms = vs.filter((v) => v.verdict === 'CONFIRMED').length
+    const reworks = vs.filter((v) => v.verdict === 'REWORK')
+    if (confirms >= Math.ceil(CRITICS / 2)) {
+      confirmed.push(f)
+    } else if (reworks.length) {
+      reworkNotes += ` [${f.title}: ${reworks.map((r) => r.reason).join('; ')}]`
+    }
+  }
+  log(`Confirmed so far: ${confirmed.length}${reworkNotes ? ' (rework queued)' : ''}`)
+  if (!reworkNotes) break // nothing bounced back -> research has converged
+}
+
+// ---- Phase 4: architect synthesis -----------------------------------------------------------
+phase('Architect')
+const corpus = JSON.stringify({ docFindings, confirmed }, null, 0)
+const spec = await agent(
+  `You are the ARCHITECT for this EDT-MCP task:\n\n${task}\n\nConfirmed research findings and documentation facts (JSON):\n${corpus}\n\nProduce a concrete, Spec-Driven implementation plan:\n- a short summary and TESTABLE acceptance criteria;\n- the chosen approach;\n- a DEVELOPER PARTITION that splits the work into INDEPENDENT, FILE-DISJOINT slices so multiple developers can work in parallel without conflict - each slice with its files, the exact change, the invariant to preserve, and its tests;\n- recommendedDevs (how many of those slices can run in parallel).\n\nRespect the project MUST-ENFORCE rules (English-only code, unattended-safety, bilingual language-CODE keys, schema/execute parity + lowerCamelCase, reflective forms with no form-model import, transaction boundaries with state-flags only after commit, the unit + e2e + golden ratchets).\n\nIf a PRINCIPAL design question must be answered by a human BEFORE implementation (a wire-contract change, an architecture choice, bilingual semantics, a breaking change, a destructive operation, or an ambiguous requirement), list it under escalations with 2-3 options - do NOT guess.`,
+  { phase: 'Architect', schema: SPEC_SCHEMA, effort: 'high' })
+
+return { spec, devPartition: spec.devPartition, escalations: spec.escalations || [] }

--- a/.claude/skills/edt-mcp-autopilot/references/review-checklist.md
+++ b/.claude/skills/edt-mcp-autopilot/references/review-checklist.md
@@ -1,0 +1,78 @@
+# EDT-MCP review checklist (MUST-ENFORCE)
+
+Reviewers (Phase 6) and the architect (Phase 4) apply this. Each line is a hard rule for this
+plugin; a violation is a review problem. Pass the whole file to the build workflow as
+`reviewChecklist`.
+
+## Architecture & reuse
+- Express metadata/form operations through the unified `create` / `modify` / `delete_metadata`
+  tools with FQN addressing; do not add a new per-op tool for something that is an FQN.
+- A genuinely new tool needs the full contract: `IMcpTool` impl + registration + toolset group +
+  guide + golden entry + `docs/tools/` README + e2e `test_<tool>.py` + unit `<Tool>Test`.
+- Reuse the canonical helpers (project/metadata/code/transaction/JSON/form/launch resolvers)
+  instead of hand-rolling resolution or duplicating logic.
+- `IMcpTool` classes live only in `tools/impl/`; shared logic in `utils/` or `tools/base/`.
+
+## Model mutation & transactions
+- Touch the model only inside transaction boundaries (reads in a read tx, writes in a write tx).
+- Set state flags (`removed`, `persisted`, ...) only AFTER a successful commit/export, never before.
+- Export changed metadata to disk after exiting the transaction; export the correct owning FQN.
+
+## Bilingual safety (RU/EN) — top bug source
+- Key synonyms by **language code** (`"ru"` / `"en"`), never by language name.
+- Never hardcode `"ru"` as a fallback; use the first configured language's code.
+- Resolve objects by programmatic `Name`; type tokens are bilingual; reuse the bilingual resolvers.
+- Any metadata/code read/write/resolve/search change must be proven on BOTH the EN and RU paths.
+
+## Unattended-safety
+- No modal dialog that waits for a click; run long platform ops in a background `Job`.
+- Auto-confirm known dialogs via the shared display filter; never pick a destructive default.
+- Respect the user opt-out flags on launch tools (skip auto-confirm / session sweep when off).
+- Never block the UI thread; bound every wait with a timeout that returns an actionable error.
+- Report-only / preview by default; write-mode tools never claim read-safety.
+
+## Wire contract & error shape
+- Schema⇄execute parity: every parameter read in `execute()` is in `inputSchema` and vice versa.
+- Parameter names are lowerCamelCase (a ratchet enforces this).
+- Emit the same output fields across all branches (hit / timeout / error).
+- A wire-field rename keeps a dual-emit deprecated alias for one release — never a hard rename.
+- Error sentinel phrases are continuous substrings (e2e regex-matches them); route every error
+  through the shared error result, actionable (name the bad value + the fix / sibling tool).
+- Escape markdown table cells with the shared builder.
+
+## Forms — strictly reflective
+- No compile dependency on the form model package; resolve the `EPackage` from the global registry.
+- Resolve enums by literal (not name) via the shared enum helpers.
+- No bare `Class.forName()` for non-imported packages; get types from already-resolved `Method`s.
+- Fill only unset features; mirror the designer defaults by platform `Version`.
+- Form auto-element names come from the project's script variant, never hardcoded.
+- Screenshot/snapshot: open + wait for the specific form editor + verify FQN; never the global
+  active editor.
+
+## Hygiene & release-readiness
+- English-only code/comments/docs/error messages. Cyrillic only where it is real 1C/BSL DATA the
+  code matches (type tokens, BSL keywords, example FQNs); use `\uXXXX` escapes in regexes.
+- No internal traces in code/guides/docs: no internal issue/task numbers, spike codes, stand or
+  host names, machine paths, or "live-verify" jargon.
+- EOL = LF in `docs/tools/**` and golden files.
+- Never claim "done" by review/grep alone; never present an undone refactor as fact.
+
+## Ratchets (the build/e2e will fail otherwise)
+- Every advertised tool has a unit `XxxToolTest` and an e2e `test_<tool>.py`.
+- The `tools_list` golden matches; regenerate + review the diff when a tool's wire surface changes.
+
+---
+
+## Escalate to the human (do NOT decide autonomously)
+
+These are "principal design questions" — surface them in `escalations` / post to the issue:
+- Wire-contract change (new parameter shape, output structure, field/tool rename).
+- Architecture choice (a new tool vs extending a unified one; a new shared abstraction).
+- Bilingual semantics (how synonyms are keyed; cross-language token handling).
+- Any breaking change (golden change a consumer depends on, formatter output order).
+- Destructive operation (rename / delete metadata, update database, delete project) — only on
+  explicit request.
+- Ambiguous or under-specified requirement where two readings lead to different implementations.
+
+Autonomy zone (no escalation): clear bug fixes that keep the external contract, added tests,
+internal refactors with a stable public API, docs/comments.

--- a/.claude/skills/edt-mcp-autopilot/references/sdd-templates.md
+++ b/.claude/skills/edt-mcp-autopilot/references/sdd-templates.md
@@ -1,0 +1,93 @@
+# SDD artifact templates
+
+The pipeline is spec-driven. Persist these to `.claude/work/<task-slug>/` (git-ignored — safe
+for internal notes and issue numbers). They are the contract every agent works against.
+
+---
+
+## `spec.md` (written in Phase 0, before any research)
+
+```markdown
+# Spec — <task title>
+
+## Source
+<issue / tracker item / user prompt — link or quote>
+
+## Problem
+<what is wrong / missing, in one short paragraph>
+
+## Goal
+<the intended outcome in one sentence>
+
+## Scope
+- In: <what this task covers>
+- Out: <explicitly excluded>
+
+## Acceptance criteria
+- [ ] <testable criterion 1>
+- [ ] <testable criterion 2>
+
+## Constraints
+<known rules that bind this task — link review-checklist.md; note any version/contract limits>
+
+## Verification
+<how we will prove it: unit, e2e, live stand scenario(s)>
+```
+
+---
+
+## `architecture.md` (written in Phase 4, from the discover workflow output)
+
+```markdown
+# Architecture — <task title>
+
+## Approach
+<2-4 sentences on the chosen solution and why>
+
+## Confirmed findings (post-critique)
+<the surviving research findings the solution rests on, each file-anchored>
+
+## Developer partition (file-disjoint slices)
+### Slice 1 — <name>
+- Files: <exact paths>
+- Change: <exact change>
+- Invariant: <what must stay true / not change>
+- Tests: <unit + e2e to add/adjust>
+### Slice 2 — ...
+
+## Recommended developers: <N>
+
+## Test plan
+<build + unit; e2e tests; live stand scenarios if applicable; golden regen if wire changed>
+
+## Escalations (if any)
+<principal questions posted to the issue + the answers once received>
+```
+
+---
+
+## `review-log.md` (appended during Phase 6)
+
+```markdown
+# Review log — <task title>
+
+## Round 1
+- <severity> <file>: <problem> -> <fix applied>
+## Round 2
+- ...
+
+## Outcome
+- Rounds: <n>
+- Clean: <yes/no>
+- Remaining (if escalated): <...>
+```
+
+---
+
+## Agent brief shape (SDD-style, used in every dispatched agent)
+
+Every research / dev / review / fix brief is built as:
+- **exact target** — the file(s) / area + the precise change or question;
+- **the invariant** — what must remain true (behaviour, contract, ratchets);
+- **the skip-bias** — "no behaviour change unless the spec says so; if the cited code is actually
+  meaningful or risky, SKIP and report instead of forcing a change."

--- a/README.md
+++ b/README.md
@@ -896,6 +896,33 @@ bash source/compile.sh
 - The output zip uses forward-slash entries (produced by `jar` when `zip` is unavailable) so it installs cleanly on both Windows and Linux EDT instances.
 - `source/dist/` is gitignored; only the script itself is tracked.
 
+## AI-assisted development: the `edt-mcp-autopilot` skill
+
+This repository ships a Claude Code project skill at `.claude/skills/edt-mcp-autopilot/` that takes a whole task or issue end-to-end with minimal human input, using a multi-agent, Spec-Driven (SDD) pipeline. The code-conduct it follows lives in [CLAUDE.md](CLAUDE.md) and the sibling skills under `.claude/skills/`.
+
+**Pipeline (phases):** study the task → documentation researchers → several waves of code researchers (loop-until-dry) → adversarial critics (refuted findings dropped, "rework" bounced back) → an architect that synthesises a spec and a file-disjoint developer partition → N parallel developers → a 3–4 reviewer loop until clean → build + unit tests → live-stand scenarios → a Russian issue comment and a pull request.
+
+**How to run (Claude Code):** the skill is auto-discovered from `.claude/skills/`. Invoke it with
+
+```
+/edt-mcp-autopilot <issue number or task description>
+```
+
+It runs unattended: the only mandatory human touchpoint is confirming the live-stand result before shipping; principal design questions are posted to the issue and polled until answered. The heavy fan-out runs through the Claude Code `Workflow` tool (the two scripts under `references/`), orchestrated by the main session as a "conductor". Scale the fan-out with the `size` argument (`small` / `medium` / `large`).
+
+### ⚠️ This skill consumes a LOT of tokens
+
+It deliberately spawns many subagents — documentation and code researchers in waves, a critic panel, parallel developers, and a cyclic reviewer pool. Measured cost per real task in this repository (subagent tokens only — the conductor, the Maven build and the live-stand verification add more on top):
+
+| Phase | Subagents | Subagent tokens | Wall time |
+|---|---|---|---|
+| Discover (research → critics → architect) | ~8–9 | ~0.6–0.9 M | ~15 min |
+| Build (parallel developers → reviewer loop) | ~11–15 | ~0.7–0.8 M | ~15 min |
+
+So a single task's discover + build phases alone are roughly **20–25 subagents and ~1.3–1.8 M subagent tokens**; a full end-to-end task (with the conductor, the builds, golden regeneration and live-stand checks) typically runs **several million tokens and 30–60+ minutes**. A misconfigured run can be far worse — an early, pre-hardened version once burned ~9.8 M tokens / ~210 agents on a no-op before the guard rails were added.
+
+Use it for substantial whole-task work — a feature, a non-trivial bug, or a new tool — **not** for small edits or quick questions, where working directly is far cheaper.
+
 ## Requirements
 
 - 1C:EDT 2025.2 (Ruby) or later


### PR DESCRIPTION
## Что это

Новый проектный скилл **`edt-mcp-autopilot`** в `.claude/skills/` (рядом с существующими) — переиспользуемый «конвейер» для сквозного ведения задачи по плагину с минимумом ручного вмешательства. Никакого кода плагина не трогает: это **только документация процесса** (1 `SKILL.md` + 5 reference-файлов).

## Зачем

Чтобы не описывать один и тот же процесс под каждую задачу. Скилл задаёт Spec-Driven (SDD) мультиагентный пайплайн: изучить задачу → 2 исследователя документации → волны код-исследователей (loop-until-dry) → состязательные критики (отклонённое отбрасывают, «доработать» возвращают в новую волну) → архитектор склеивает выжившие находки в спеку и **разбиение работы по непересекающимся файлам** → параллельная разработка → цикл из 3–4 ревьюеров до «чисто» → сборка + unit-тесты → реальные сценарии на тестовом стенде → коммент в issue + PR.

## Как устроено (ключевые решения)

- **Дирижёр + воркфлоу.** Тяжёлый веер агентов запускается через инструмент `Workflow` (`references/discover.workflow.js` — фазы 1–4; `references/build.workflow.js` — фазы 5–6). Сам скилл (главный цикл) держит то, что воркфлоу не умеет: ожидание/поллинг, подтверждение человека, необратимый ship.
- **Автономность.** Единственная обязательная точка участия человека — оператор подтверждает результат на стенде. Принципиальные вопросы проектирования уходят в issue и опрашиваются (~раз в 10 мин), пока не придёт ответ.
- **Адаптивный размер.** Число агентов масштабируется под размер задачи (`args.size` + token-budget).
- **Чистота.** В скилле нет машинных путей/портов/имён стендов — они среды-зависимы (как и просит корневой `CLAUDE.md`); внутренние артефакты задачи пишутся в git-ignored `.claude/work/<slug>/`.

## Состав

| Файл | Роль |
|---|---|
| `SKILL.md` | Фазы пайплайна, ворота, SDD-дисциплина, когда запускать воркфлоу |
| `references/discover.workflow.js` | Research → критики → архитектор |
| `references/build.workflow.js` | Параллельная разработка → цикл ревью |
| `references/review-checklist.md` | MUST-ENFORCE правила (из кодекса проекта) + список «принципиальных вопросов» для эскалации |
| `references/sdd-templates.md` | Шаблоны spec/architecture/review-log |
| `references/autonomy.md` | Два ворота: эскалация в issue + поллинг; подтверждение оператора |

## Проверка

- Сборку плагина не затрагивает (изменения только в `.claude/skills/`).
- Оба воркфлоу-скрипта синтаксически валидны (проверены как async-тело — так их оборачивает рантайм `Workflow`).
- Пройдена самопроверка на «чистоту»: ни путей, ни портов, ни личных идентификаторов.

> Это предложение процесса; если он не вписывается в репозиторий — можно смержить выборочно или закрыть, скилл легко держать локально.

🤖 Generated with [Claude Code](https://claude.com/claude-code)