### PR TITLE
get_metadata_details: обогащённая структура формы по FQN (#198)

### DIFF
--- a/docs/tools/get_metadata_details.md
+++ b/docs/tools/get_metadata_details.md
@@ -19,7 +19,7 @@ Return the detailed properties of one or more 1C metadata objects. By default yo
 - Batch several objects in one call by passing multiple FQNs in `objectFqns`.
 - Prefer the default (basic) view first; reach for `full: true` only when you need the exhaustive reflection.
 - Pass `assignable: true` to get the SETTABLE-property schema instead of the details view: per property its value kind, current value, and ALLOWED values (enum literals) - exactly what modify_metadata can set. In this mode an FQN may address a member (e.g. `Catalog.Products.Attribute.Weight`), not just a top object.
-- Pass a FORM FQN (`Catalog.Products.Form.ItemForm` or `CommonForm.MyForm`) to render that form's STRUCTURE - its items (the nested visual tree), attributes and commands. (For a CommonForm this renders the form structure, not the CommonForm's mdclass properties.) Form members are created/edited/removed by their own FQNs via create_metadata / modify_metadata / delete_metadata.
+- Pass a FORM FQN (`Catalog.Products.Form.ItemForm` or `CommonForm.MyForm`) to render that form's enriched STRUCTURE: its items (the nested visual tree, with each item's visibility, bound `dataPath` and per-kind extras), an attributes table (with the `Main`/`SavedData` flags), a commands table and an Event handlers section. (For a CommonForm this renders the form structure, not the CommonForm's mdclass properties.) Form members are created/edited/removed by their own FQNs via create_metadata / modify_metadata / delete_metadata.
 
 ## Parameter details
 - `projectName` (required) - EDT project name.
@@ -29,6 +29,7 @@ Return the detailed properties of one or more 1C metadata objects. By default yo
 
 ## Output
 - Markdown, one section per resolved object, separated by `---`.
+- A form FQN renders the enriched form structure instead of an mdclass object section: an Items outline (each item with its visibility, bound `dataPath` and per-kind extras), an Attributes table (with the `Main`/`SavedData` columns), a Commands table and an Event handlers section.
 - Per-object failures (malformed FQN or object not found) do NOT fail the whole call. They are collected into a dedicated `## Errors` table at the end with an `ERROR` status row carrying the FQN and reason, so a client can tell a failed object from data.
 
 ## Examples

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/get_metadata_details.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/get_metadata_details.md
@@ -5,7 +5,7 @@ Return the detailed properties of one or more 1C metadata objects. By default yo
 - Batch several objects in one call by passing multiple FQNs in `objectFqns`.
 - Prefer the default (basic) view first; reach for `full: true` only when you need the exhaustive reflection.
 - Pass `assignable: true` to get the SETTABLE-property schema instead of the details view: per property its value kind, current value, and ALLOWED values (enum literals) - exactly what modify_metadata can set. In this mode an FQN may address a member (e.g. `Catalog.Products.Attribute.Weight`), not just a top object.
-- Pass a FORM FQN (`Catalog.Products.Form.ItemForm` or `CommonForm.MyForm`) to render that form's STRUCTURE - its items (the nested visual tree), attributes and commands. (For a CommonForm this renders the form structure, not the CommonForm's mdclass properties.) Form members are created/edited/removed by their own FQNs via create_metadata / modify_metadata / delete_metadata.
+- Pass a FORM FQN (`Catalog.Products.Form.ItemForm` or `CommonForm.MyForm`) to render that form's enriched STRUCTURE: its items (the nested visual tree, with each item's visibility, bound `dataPath` and per-kind extras), an attributes table (with the `Main`/`SavedData` flags), a commands table and an Event handlers section. (For a CommonForm this renders the form structure, not the CommonForm's mdclass properties.) Form members are created/edited/removed by their own FQNs via create_metadata / modify_metadata / delete_metadata.
 
 ## Parameter details
 - `projectName` (required) - EDT project name.
@@ -15,6 +15,7 @@ Return the detailed properties of one or more 1C metadata objects. By default yo
 
 ## Output
 - Markdown, one section per resolved object, separated by `---`.
+- A form FQN renders the enriched form structure instead of an mdclass object section: an Items outline (each item with its visibility, bound `dataPath` and per-kind extras), an Attributes table (with the `Main`/`SavedData` columns), a Commands table and an Event handlers section.
 - Per-object failures (malformed FQN or object not found) do NOT fail the whole call. They are collected into a dedicated `## Errors` table at the end with an `ERROR` status row carrying the FQN and reason, so a client can tell a failed object from data.
 
 ## Examples

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormStructureReader.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormStructureReader.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.EMap;
+import org.eclipse.emf.common.util.Enumerator;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 
@@ -20,10 +21,12 @@ import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
 
 /**
  * Shared READER for a 1C managed form's structure: it resolves the {@code BasicForm} mdo from a form
- * FQN path and renders the editable form content model ({@code com._1c.g5.v8.dt.form.model.Form}) - the
- * nested items tree, the form attributes and the form commands - to Markdown. The form model is read
- * entirely through EMF reflection ({@code EObject} / {@code eGet}), so this bundle needs no compile-time
- * dependency on the form-model package (mirroring {@link FormElementWriter}, the form WRITER).
+ * FQN path and renders the editable form content model ({@code com._1c.g5.v8.dt.form.model.Form}) to a
+ * full enriched Markdown document - the nested items tree (with per-element synonym/visibility/dataPath
+ * and per-kind extras), an Attributes table (Name/Synonym/Type/Main/SavedData), a Commands table and an
+ * Event handlers section. The form model is read entirely through EMF reflection ({@code EObject} /
+ * {@code eGet}), so this bundle needs no compile-time dependency on the form-model package (mirroring
+ * {@link FormElementWriter}, the form WRITER).
  *
  * <p>This is the single home for the form-read logic that {@code get_metadata_details} (a form FQN
  * renders its structure) and {@code delete_metadata} (the form-member delete preview lists item
@@ -57,6 +60,53 @@ public final class FormStructureReader
     /** Singular item-bearing containments outside {@code items} (bar / context menu / tooltip). */
     private static final String[] SINGULAR_ITEM_CONTAINMENTS =
         {FEATURE_AUTO_COMMAND_BAR, "contextMenu", "extendedTooltip"}; //$NON-NLS-1$ //$NON-NLS-2$
+
+    /** EAttribute name (Boolean) carrying an item's visibility on a {@code FormVisualEntity}. */
+    private static final String FEATURE_VISIBLE = "visible"; //$NON-NLS-1$
+    /** EReference name holding the contained {@code DataPath} on a bound {@code FormItem}. */
+    private static final String FEATURE_DATA_PATH = "dataPath"; //$NON-NLS-1$
+    /** EAttribute name (EList of String) carrying the dot-joined path parts on a {@code DataPath}. */
+    private static final String FEATURE_SEGMENTS = "segments"; //$NON-NLS-1$
+    /** EReference name holding a visual item's type-specific {@code extInfo} sub-object. */
+    private static final String FEATURE_EXT_INFO = "extInfo"; //$NON-NLS-1$
+    /** EAttribute name (EEnum) carrying the layout {@code group} mode on a group's extInfo. */
+    private static final String FEATURE_GROUP = "group"; //$NON-NLS-1$
+    /** EAttribute name (EEnum) carrying the optional {@code behavior} on a group's extInfo. */
+    private static final String FEATURE_BEHAVIOR = "behavior"; //$NON-NLS-1$
+    /** EAttribute name (EEnum) carrying the platform {@code type} on a {@code FormField}/group. */
+    private static final String FEATURE_TYPE = "type"; //$NON-NLS-1$
+    /** EAttribute name (EEnum) carrying the {@code editMode} on a {@code FormField}. */
+    private static final String FEATURE_EDIT_MODE = "editMode"; //$NON-NLS-1$
+    /** EAttribute name carrying the bound metadata-command name on a {@code FormButton}. */
+    private static final String FEATURE_COMMAND_NAME = "commandName"; //$NON-NLS-1$
+    /** EAttribute name (Boolean) flagging the MAIN form attribute on a {@code FormAttribute}. */
+    private static final String FEATURE_MAIN = "main"; //$NON-NLS-1$
+    /** EAttribute name (Boolean) flagging the saved-data form attribute on a {@code FormAttribute}. */
+    private static final String FEATURE_SAVED_DATA = "savedData"; //$NON-NLS-1$
+    /** EReference name carrying the single {@code event} on an {@code EventHandler}. */
+    private static final String FEATURE_EVENT = "event"; //$NON-NLS-1$
+    /** EAttribute name carrying the Russian event name on an {@code Event}. */
+    private static final String FEATURE_NAME_RU = "nameRu"; //$NON-NLS-1$
+
+    /** EClass simple-name token identifying a group item. */
+    private static final String ECLASS_FORM_GROUP = "FormGroup"; //$NON-NLS-1$
+    /** EClass simple-name token identifying a field item. */
+    private static final String ECLASS_FORM_FIELD = "FormField"; //$NON-NLS-1$
+    /**
+     * EClass simple-name token identifying a button item. The concrete form-model button EClass is
+     * {@code Button} (NOT {@code FormButton}, which is its platform-type presentation name); this mirrors
+     * {@code FormElementWriter.ELEM_BUTTON} and is matched against {@code item.eClass().getName()}.
+     */
+    private static final String ECLASS_BUTTON = "Button"; //$NON-NLS-1$
+
+    /** The Russian language CODE; selects the {@code nameRu} event name over the English {@code name}. */
+    private static final String LANG_RU = "ru"; //$NON-NLS-1$
+
+    /** Upper bound on total visited item nodes for {@link #render}, guarding a pathological form. */
+    private static final int MAX_NODES = 5000;
+
+    /** The root-owner label used in the Event handlers table for a form-level handler. */
+    private static final String FORM_OWNER_LABEL = "(form)"; //$NON-NLS-1$
 
     private FormStructureReader()
     {
@@ -137,14 +187,19 @@ public final class FormStructureReader
     // ==================== Rendering (pure, transaction-bound EObjects only) ====================
 
     /**
-     * Renders the whole form structure (items tree + attributes + commands) to a Markdown document.
-     * Pure aside from reading the supplied EObjects, which must still be inside the read transaction
-     * when this runs.
+     * Renders the FULL enriched form structure to a Markdown document: the nested items tree (each line
+     * carries name / type / id / title plus per-item visibility and dataPath and kind-specific extras -
+     * group layout / field type+editMode / button command), an Attributes table (Name / Synonym / Type /
+     * Main / SavedData) and a Commands table, followed by an Event handlers section listing the BSL
+     * handler bound to each event of the form root and every element. Read entirely through EMF
+     * reflection - any absent feature simply degrades to nothing, so this never throws on a model that
+     * lacks a feature. Pure aside from reading the supplied EObjects, which must still be inside the read
+     * transaction when this runs.
      *
      * @param formPath the (normalized) form FQN path, for the heading
-     * @param formModel the editable form model EObject
-     * @param language the resolved title language CODE (may be {@code null})
-     * @return the Markdown document
+     * @param formModel the editable form model EObject (must still be inside the read transaction)
+     * @param language the resolved title/event language CODE (may be {@code null})
+     * @return the enriched Markdown document
      */
     public static String render(String formPath, EObject formModel, String language)
     {
@@ -160,15 +215,23 @@ public final class FormStructureReader
         }
         else
         {
-            // The form's auto command bar is a separate containment, not part of 'items'; render it
-            // first (the way the designer shows it). Address it as parent 'AutoCommandBar'.
+            int[] budget = {MAX_NODES};
+            boolean[] truncated = {false};
             if (autoCommandBar != null)
             {
-                appendItem(sb, autoCommandBar, 0, language);
+                appendItem(sb, autoCommandBar, 0, language, budget, truncated);
             }
             for (EObject item : items)
             {
-                appendItem(sb, item, 0, language);
+                appendItem(sb, item, 0, language, budget, truncated);
+            }
+            // Gate the note on the explicit flag (set only when a node was actually dropped), NOT on an
+            // exhausted budget: a form with EXACTLY MAX_NODES nodes drains the budget to 0 yet renders
+            // every node, so inferring truncation from budget[0] <= 0 would falsely flag it.
+            if (truncated[0])
+            {
+                sb.append("- _(item outline truncated: more than ") //$NON-NLS-1$
+                    .append(MAX_NODES).append(" nodes)_\n"); //$NON-NLS-1$
             }
             sb.append('\n');
         }
@@ -181,10 +244,13 @@ public final class FormStructureReader
         }
         else
         {
-            sb.append(MarkdownUtils.tableHeader("Name", "Type")); //$NON-NLS-1$ //$NON-NLS-2$
+            sb.append(MarkdownUtils.tableHeader(
+                "Name", "Synonym", "Type", "Main", "SavedData")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
             for (EObject attribute : attributes)
             {
-                sb.append(MarkdownUtils.tableRow(nameOf(attribute), valueTypeOf(attribute)));
+                sb.append(MarkdownUtils.tableRow(nameOf(attribute), titleOf(attribute, language),
+                    valueTypeOf(attribute), Boolean.toString(booleanFeature(attribute, FEATURE_MAIN)),
+                    Boolean.toString(booleanFeature(attribute, FEATURE_SAVED_DATA))));
             }
             sb.append('\n');
         }
@@ -206,22 +272,53 @@ public final class FormStructureReader
             sb.append('\n');
         }
 
+        sb.append("## Event handlers\n\n"); //$NON-NLS-1$
+        List<String[]> handlers = new ArrayList<>();
+        // collectHandlers recurses the form root's 'items' AND its singular containments (the form-wide
+        // auto command bar, context menus, tooltips), so the whole element tree is covered from here. It
+        // shares the same MAX_NODES bound as the item-outline pass (its own fresh budget, since it is an
+        // independent walk) so the Event-handlers section honours the same cap on a pathological form.
+        collectHandlers(formModel, FORM_OWNER_LABEL, language, handlers, new int[] {MAX_NODES});
+        if (handlers.isEmpty())
+        {
+            sb.append("_(no event handlers)_\n\n"); //$NON-NLS-1$
+        }
+        else
+        {
+            sb.append(MarkdownUtils.tableHeader("Element", "Event", "Handler")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            for (String[] row : handlers)
+            {
+                sb.append(MarkdownUtils.tableRow(row[0], row[1], row[2]));
+            }
+            sb.append('\n');
+        }
+
         return sb.toString();
     }
 
     /**
-     * Appends one item (and recursively its child items) as a nested outline line. The item NAME is
-     * the stable programmatic id; the integer id and item type are shown alongside, and the title (by
-     * language code) is appended when present.
+     * Appends one item (and recursively its child items) as a nested outline line: beyond name / type /
+     * id / title it appends visibility (only when {@code false}), the bound dataPath, and per-kind
+     * extras (group layout, field type+editMode, button command). The item NAME is the stable
+     * programmatic id; the integer id and item type are shown alongside, and the title (by language
+     * code) is appended when present. A shared {@code budget} caps the total node count for a
+     * pathological form; when it is hit the shared {@code truncated} flag is raised so the caller can
+     * record that nodes were actually dropped.
      */
-    private static void appendItem(StringBuilder sb, EObject item, int depth, String language)
+    private static void appendItem(StringBuilder sb, EObject item, int depth, String language,
+        int[] budget, boolean[] truncated)
     {
+        if (budget[0] <= 0)
+        {
+            truncated[0] = true;
+            return;
+        }
+        budget[0]--;
         for (int i = 0; i < depth; i++)
         {
             sb.append("  "); //$NON-NLS-1$
         }
-        String name = nameOf(item);
-        sb.append("- ").append(escapeOutline(name)); //$NON-NLS-1$
+        sb.append("- ").append(escapeOutline(nameOf(item))); //$NON-NLS-1$
         sb.append(" (type: ").append(escapeOutline(typeOf(item))); //$NON-NLS-1$
         Integer id = idOf(item);
         if (id != null)
@@ -233,12 +330,26 @@ public final class FormStructureReader
         {
             sb.append(", title: ").append(escapeOutline(title)); //$NON-NLS-1$
         }
+        if (!visibilityOf(item))
+        {
+            sb.append(", visible: false"); //$NON-NLS-1$
+        }
+        String dataPath = dataPathOf(item);
+        if (!dataPath.isEmpty())
+        {
+            sb.append(", dataPath: ").append(escapeOutline(dataPath)); //$NON-NLS-1$
+        }
+        String extras = kindExtrasOf(item);
+        if (!extras.isEmpty())
+        {
+            sb.append(", ").append(escapeOutline(extras)); //$NON-NLS-1$
+        }
         sb.append(")\n"); //$NON-NLS-1$
 
         // Recurse into containers (groups / tables expose the same 'items' feature).
         for (EObject child : getReferenceList(item, FEATURE_ITEMS))
         {
-            appendItem(sb, child, depth + 1, language);
+            appendItem(sb, child, depth + 1, language, budget, truncated);
         }
         // Singular item-bearing containments OUTSIDE 'items' (a table's command bar, an item's
         // context menu / extended tooltip). Their names occupy the form-wide namespace, so they must
@@ -251,7 +362,7 @@ public final class FormStructureReader
                 && (!getReferenceList(child, FEATURE_ITEMS).isEmpty()
                     || !titleOf(child, language).isEmpty()))
             {
-                appendItem(sb, child, depth + 1, language);
+                appendItem(sb, child, depth + 1, language, budget, truncated);
             }
         }
     }
@@ -443,6 +554,225 @@ public final class FormStructureReader
     private static String stringValue(Object value)
     {
         return value instanceof String ? (String)value : ""; //$NON-NLS-1$
+    }
+
+    // ==================== Enrichment reflection helpers ====================
+
+    /**
+     * @return the item's {@code visible} flag; an absent feature or a non-Boolean value is treated as
+     *         visible ({@code true}), so the render only ever calls out a HIDDEN item
+     */
+    private static boolean visibilityOf(EObject item)
+    {
+        Object value = getValue(item, FEATURE_VISIBLE);
+        return !(value instanceof Boolean) || ((Boolean)value).booleanValue();
+    }
+
+    /**
+     * @return the item's bound data path, the contained {@code DataPath}'s {@code segments} joined by
+     *         {@code "."} (e.g. {@code Object.Description}), or {@code ""} when the item carries no
+     *         data path or it has no segments
+     */
+    @SuppressWarnings("unchecked")
+    private static String dataPathOf(EObject item)
+    {
+        EObject dataPath = getSingleReference(item, FEATURE_DATA_PATH);
+        if (dataPath == null)
+        {
+            return ""; //$NON-NLS-1$
+        }
+        EStructuralFeature segments = dataPath.eClass().getEStructuralFeature(FEATURE_SEGMENTS);
+        if (segments == null || !segments.isMany())
+        {
+            return ""; //$NON-NLS-1$
+        }
+        Object value = dataPath.eGet(segments);
+        if (!(value instanceof List<?>))
+        {
+            return ""; //$NON-NLS-1$
+        }
+        List<String> parts = new ArrayList<>();
+        for (Object part : (List<Object>)value)
+        {
+            if (part != null)
+            {
+                parts.add(part.toString());
+            }
+        }
+        return String.join(".", parts); //$NON-NLS-1$
+    }
+
+    /**
+     * @return kind-specific extras for the outline line, or {@code ""} for a kind with none:
+     *         <ul>
+     *         <li>group ({@code FormGroup}): {@code "group: <extInfoSimpleName> <group> [behavior]"};</li>
+     *         <li>field ({@code FormField}): {@code "field: type=<type> editMode=<editMode>"};</li>
+     *         <li>button ({@code Button}): {@code "command: <commandName>"}.</li>
+     *         </ul>
+     *         Every enum is read as its literal via {@link Enumerator}; an absent feature is omitted.
+     */
+    private static String kindExtrasOf(EObject item)
+    {
+        if (item == null)
+        {
+            return ""; //$NON-NLS-1$
+        }
+        String eClassName = item.eClass().getName();
+        if (ECLASS_FORM_GROUP.equals(eClassName))
+        {
+            return groupExtras(item);
+        }
+        if (ECLASS_FORM_FIELD.equals(eClassName))
+        {
+            return fieldExtras(item);
+        }
+        if (ECLASS_BUTTON.equals(eClassName))
+        {
+            String command = stringValue(getValue(item, FEATURE_COMMAND_NAME));
+            return command.isEmpty() ? "" : "command: " + command; //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return ""; //$NON-NLS-1$
+    }
+
+    /** Builds the {@code group: ...} extras from a group's {@code extInfo} (EClass + group + behavior). */
+    private static String groupExtras(EObject group)
+    {
+        EObject extInfo = getSingleReference(group, FEATURE_EXT_INFO);
+        if (extInfo == null)
+        {
+            return ""; //$NON-NLS-1$
+        }
+        StringBuilder sb = new StringBuilder("group: ").append(extInfo.eClass().getName()); //$NON-NLS-1$
+        String groupMode = enumLiteralOf(extInfo, FEATURE_GROUP);
+        if (!groupMode.isEmpty())
+        {
+            sb.append(' ').append(groupMode);
+        }
+        String behavior = enumLiteralOf(extInfo, FEATURE_BEHAVIOR);
+        if (!behavior.isEmpty())
+        {
+            sb.append(' ').append(behavior);
+        }
+        return sb.toString();
+    }
+
+    /** Builds the {@code field: type=... editMode=...} extras from a field's own enum features. */
+    private static String fieldExtras(EObject field)
+    {
+        String type = enumLiteralOf(field, FEATURE_TYPE);
+        String editMode = enumLiteralOf(field, FEATURE_EDIT_MODE);
+        if (type.isEmpty() && editMode.isEmpty())
+        {
+            return ""; //$NON-NLS-1$
+        }
+        StringBuilder sb = new StringBuilder("field:"); //$NON-NLS-1$
+        if (!type.isEmpty())
+        {
+            sb.append(" type=").append(type); //$NON-NLS-1$
+        }
+        if (!editMode.isEmpty())
+        {
+            sb.append(" editMode=").append(editMode); //$NON-NLS-1$
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Reads an EEnum feature as its literal, NEVER importing the enum type: the value is cast to
+     * {@link Enumerator} and its {@code getName()} returned (falling back to {@code toString()}).
+     *
+     * @return the enum literal, or {@code ""} when the feature is absent / unset / not an enum value
+     */
+    private static String enumLiteralOf(EObject object, String featureName)
+    {
+        if (object == null)
+        {
+            return ""; //$NON-NLS-1$
+        }
+        EStructuralFeature feature = object.eClass().getEStructuralFeature(featureName);
+        // Only an EXPLICITLY-SET enum is reported: an unset enum feature reads back as the metamodel's
+        // default literal (e.g. a field's default view type), which is noise rather than authored
+        // structure, so an absent/unset feature contributes no extra.
+        if (feature == null || !object.eIsSet(feature))
+        {
+            return ""; //$NON-NLS-1$
+        }
+        Object value = object.eGet(feature);
+        if (value instanceof Enumerator)
+        {
+            String name = ((Enumerator)value).getName();
+            return name != null ? name : value.toString();
+        }
+        return value != null ? value.toString() : ""; //$NON-NLS-1$
+    }
+
+    /**
+     * @return the value of a Boolean feature; an absent feature or a non-Boolean value yields
+     *         {@code false}, so a missing flag never throws and never reports as set
+     */
+    private static boolean booleanFeature(EObject object, String featureName)
+    {
+        Object value = getValue(object, featureName);
+        return value instanceof Boolean && ((Boolean)value).booleanValue();
+    }
+
+    /**
+     * Appends one {@code [owner, event, handler]} row per bound event handler of {@code element} to
+     * {@code rows}, then recurses into the element's child items (and singular item containments) so the
+     * whole subtree is covered. Each handler exposes its own {@code name} (the BSL procedure) and a
+     * single {@code event} reference whose {@code name} (en) / {@code nameRu} (ru) is the event name.
+     *
+     * @param element the form root or a form item whose {@code handlers} list is read
+     * @param ownerLabel the Element-column label for handlers directly on {@code element}
+     * @param language the event-name language CODE
+     * @param rows the accumulator receiving {@code {owner, event, handler}} rows
+     * @param budget the shared per-visited-element node budget, capping the walk on a pathological form
+     */
+    private static void collectHandlers(EObject element, String ownerLabel, String language,
+        List<String[]> rows, int[] budget)
+    {
+        if (element == null || budget[0] <= 0)
+        {
+            return;
+        }
+        budget[0]--;
+        for (EObject handler : getReferenceList(element, FEATURE_HANDLERS))
+        {
+            String procName = stringValue(getValue(handler, FEATURE_NAME));
+            String eventName = eventNameOf(getSingleReference(handler, FEATURE_EVENT), language);
+            rows.add(new String[] {ownerLabel, eventName, procName});
+        }
+        for (EObject child : getReferenceList(element, FEATURE_ITEMS))
+        {
+            collectHandlers(child, nameOf(child), language, rows, budget);
+        }
+        for (String featureName : SINGULAR_ITEM_CONTAINMENTS)
+        {
+            EObject child = getSingleReference(element, featureName);
+            if (child != null)
+            {
+                collectHandlers(child, nameOf(child), language, rows, budget);
+            }
+        }
+    }
+
+    /**
+     * @return the event's name for the given language CODE - {@code nameRu} for {@code "ru"}, otherwise
+     *         the English {@code name}, falling back to the other when the preferred one is blank
+     */
+    private static String eventNameOf(EObject event, String language)
+    {
+        if (event == null)
+        {
+            return ""; //$NON-NLS-1$
+        }
+        boolean ru = LANG_RU.equalsIgnoreCase(language);
+        String preferred = stringValue(getValue(event, ru ? FEATURE_NAME_RU : FEATURE_NAME));
+        if (!preferred.isEmpty())
+        {
+            return preferred;
+        }
+        return stringValue(getValue(event, ru ? FEATURE_NAME : FEATURE_NAME_RU));
     }
 
     /**

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormStructureReaderTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormStructureReaderTest.java
@@ -14,9 +14,12 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.EMap;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EEnum;
+import org.eclipse.emf.ecore.EEnumLiteral;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
@@ -249,6 +252,206 @@ public class FormStructureReaderTest
         assertFalse(md.contains("| Cmd|Name |")); //$NON-NLS-1$
     }
 
+    // ==================== render: enriched outline + tables + event handlers =====================
+
+    /**
+     * The detailed render of a representative form: a group (extInfo + group + child field), a field
+     * (type + editMode + dataPath + hidden), a button (commandName), an attribute (main + savedData +
+     * synonym) and a form-root event handler. Asserts every enrichment the slice adds.
+     */
+    @Test
+    public void testRenderDetailedEnrichments()
+    {
+        EObject form = buildRichForm();
+
+        String md = FormStructureReader.render(
+            "Catalog.Products.Forms.ItemForm", form, "en"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        // Items: per-kind extras + visibility + dataPath on the field. NON-default enum literals are
+        // used (Horizontal/LabelField/Directly) so the values are genuinely authored — only explicitly
+        // set enums are reported (an unset enum reads back as the metamodel default, which is noise).
+        assertTrue(md.contains("- MainGroup (type: FormGroup, id: 1, " //$NON-NLS-1$
+            + "group: UsualGroupExtInfo Horizontal Collapsible)")); //$NON-NLS-1$
+        assertTrue(md.contains("field: type=LabelField editMode=Directly")); //$NON-NLS-1$
+        assertTrue(md.contains("visible: false")); //$NON-NLS-1$
+        assertTrue(md.contains("dataPath: Object.Description")); //$NON-NLS-1$
+        assertTrue(md.contains("command: Post")); //$NON-NLS-1$
+
+        // Attributes: the new Synonym / Main / SavedData columns.
+        assertTrue(md.contains("| Name | Synonym | Type | Main | SavedData |")); //$NON-NLS-1$
+        assertTrue(md.contains("| Goods | Goods item | ")); //$NON-NLS-1$
+        assertTrue(md.contains("| true | true |")); //$NON-NLS-1$
+
+        // Event handlers: a NEW section with the form-root handler row.
+        assertTrue(md.contains("## Event handlers")); //$NON-NLS-1$
+        assertTrue(md.contains("| Element | Event | Handler |")); //$NON-NLS-1$
+        assertTrue(md.contains("| (form) | OnOpen | FormOnOpen |")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRenderDetailedVisibleTrueOmitted()
+    {
+        // A visible (default) field must NOT carry the 'visible: false' note.
+        EObject form = newForm();
+        EObject field = newItem(MODEL.formField, "Price", 2); //$NON-NLS-1$
+        setBoolean(field, "visible", true); //$NON-NLS-1$
+        addItem(form, field);
+
+        String md = FormStructureReader.render("CommonForm.F", form, "en"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse(md.contains("visible: false")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRenderDetailedElementHandlerOwner()
+    {
+        // A handler on an ELEMENT (not the form root) is attributed to that element's name.
+        EObject form = newForm();
+        EObject field = newItem(MODEL.formField, "Quantity", 3); //$NON-NLS-1$
+        addHandler(field, "OnChange", null, "QuantityOnChange"); //$NON-NLS-1$ //$NON-NLS-2$
+        addItem(form, field);
+
+        String md = FormStructureReader.render("CommonForm.F", form, "en"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(md.contains("| Quantity | OnChange | QuantityOnChange |")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRenderDetailedNoHandlers()
+    {
+        // With no handlers anywhere the section shows the empty placeholder.
+        EObject form = newForm();
+        addItem(form, newItem(MODEL.formField, "Plain", 1)); //$NON-NLS-1$
+
+        String md = FormStructureReader.render("CommonForm.F", form, "en"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(md.contains("## Event handlers")); //$NON-NLS-1$
+        assertTrue(md.contains("_(no event handlers)_")); //$NON-NLS-1$
+    }
+
+    /** Mirrors {@code FormStructureReader.MAX_NODES} (private): the detailed-render item-outline cap. */
+    private static final int MAX_NODES = 5000;
+
+    @Test
+    public void testRenderDetailedExactlyMaxNodesNotTruncated()
+    {
+        // BOUNDARY (off-by-one guard): a form with EXACTLY MAX_NODES item nodes drains the budget to 0
+        // while every node is still rendered, so the truncation note must NOT appear. The note is gated
+        // on an explicit 'a node was dropped' flag, not on the exhausted budget.
+        EObject form = newForm();
+        for (int i = 0; i < MAX_NODES; i++)
+        {
+            addItem(form, newItem(MODEL.formField, "F" + i, i)); //$NON-NLS-1$
+        }
+
+        String md = FormStructureReader.render("CommonForm.F", form, "en"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse(md.contains("item outline truncated")); //$NON-NLS-1$
+        // The last node IS present in the outline (nothing was dropped).
+        assertTrue(md.contains("- F" + (MAX_NODES - 1) + " (")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testRenderDetailedBeyondMaxNodesTruncated()
+    {
+        // A form with MAX_NODES + 1 item nodes genuinely exceeds the cap: the outline is capped and the
+        // truncation note is emitted, naming the cap.
+        EObject form = newForm();
+        for (int i = 0; i <= MAX_NODES; i++)
+        {
+            addItem(form, newItem(MODEL.formField, "F" + i, i)); //$NON-NLS-1$
+        }
+
+        String md = FormStructureReader.render("CommonForm.F", form, "en"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(md.contains(
+            "- _(item outline truncated: more than " + MAX_NODES + " nodes)_")); //$NON-NLS-1$ //$NON-NLS-2$
+        // The node past the cap is dropped from the outline.
+        assertFalse(md.contains("- F" + MAX_NODES + " (")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testRenderDetailedEnumReadsLiteralNotName()
+    {
+        // Pin the accessor: enumLiteralOf reads Enumerator.getName(), NOT getLiteral(). The shared
+        // enums set name==literal (true of the real 1C metamodel) so they can't tell the two apart;
+        // here the field's 'type' literal carries a DISTINCT name ('Vertical') vs literal ('vertical'),
+        // so a future swap of getName() for getLiteral() flips the rendered token and fails this test.
+        // The distinct literal is added to the SHARED 'type' enum only for this test, then removed in a
+        // finally so the singleton MODEL is not mutated for any other test.
+        EEnum fieldTypeEnum = (EEnum)((EAttribute)MODEL.formField.getEStructuralFeature("type")) //$NON-NLS-1$
+            .getEAttributeType();
+        EEnumLiteral distinct = EcoreFactory.eINSTANCE.createEEnumLiteral();
+        distinct.setName("Vertical"); //$NON-NLS-1$
+        distinct.setLiteral("vertical"); //$NON-NLS-1$
+        distinct.setValue(fieldTypeEnum.getELiterals().size());
+        fieldTypeEnum.getELiterals().add(distinct);
+        try
+        {
+            EObject form = newForm();
+            EObject field = newItem(MODEL.formField, "Mode", 1); //$NON-NLS-1$
+            field.eSet(field.eClass().getEStructuralFeature("type"), distinct.getInstance()); //$NON-NLS-1$
+            addItem(form, field);
+
+            String md = FormStructureReader.render("CommonForm.F", form, "en"); //$NON-NLS-1$ //$NON-NLS-2$
+            // The rendered token is the literal's NAME, never its (lower-case) literal.
+            assertTrue(md.contains("field: type=Vertical")); //$NON-NLS-1$
+            assertFalse(md.contains("vertical")); //$NON-NLS-1$
+        }
+        finally
+        {
+            fieldTypeEnum.getELiterals().remove(distinct);
+        }
+    }
+
+    @Test
+    public void testRenderDetailedEventNameByLanguageRu()
+    {
+        // The event name is selected by language CODE: 'ru' picks nameRu, never the English name.
+        EObject form = newForm();
+        addHandler(form, "OnOpen", "ПриОткрытии", "ФормаПриОткрытии"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+        String mdRu = FormStructureReader.render("CommonForm.F", form, "ru"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(mdRu.contains("ПриОткрытии")); //$NON-NLS-1$
+        String mdEn = FormStructureReader.render("CommonForm.F", form, "en"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(mdEn.contains("| (form) | OnOpen | ")); //$NON-NLS-1$
+    }
+
+    /**
+     * Builds a representative form exercising every enrichment: a {@code MainGroup}
+     * (extInfo Horizontal/Collapsible) containing a hidden {@code Description} field (LabelField /
+     * Directly, dataPath {@code Object.Description}); a {@code Post} button bound to a metadata command; a
+     * {@code Goods} attribute (main + savedData, synonym "Goods item"); and a form-root {@code OnOpen}
+     * handler ({@code FormOnOpen}).
+     */
+    @SuppressWarnings("unchecked")
+    private static EObject buildRichForm()
+    {
+        EObject form = newForm();
+
+        EObject group = newItem(MODEL.formGroup, "MainGroup", 1); //$NON-NLS-1$
+        setGroupExtInfo(group, "Horizontal", "Collapsible"); //$NON-NLS-1$ //$NON-NLS-2$
+        EObject field = newItem(MODEL.formField, "Description", 2); //$NON-NLS-1$
+        setEnum(field, "type", "LabelField"); //$NON-NLS-1$ //$NON-NLS-2$
+        setEnum(field, "editMode", "Directly"); //$NON-NLS-1$ //$NON-NLS-2$
+        setBoolean(field, "visible", false); //$NON-NLS-1$
+        setDataPath(field, "Object", "Description"); //$NON-NLS-1$ //$NON-NLS-2$
+        addItem(group, field);
+        addItem(form, group);
+
+        EObject button = newItem(MODEL.formButton, "PostButton", 4); //$NON-NLS-1$
+        button.eSet(button.eClass().getEStructuralFeature("commandName"), "Post"); //$NON-NLS-1$ //$NON-NLS-2$
+        addItem(form, button);
+
+        EObject attribute = newAttribute("Goods"); //$NON-NLS-1$
+        setBoolean(attribute, "main", true); //$NON-NLS-1$
+        setBoolean(attribute, "savedData", true); //$NON-NLS-1$
+        EMap<String, String> title =
+            (EMap<String, String>)attribute.eGet(attribute.eClass().getEStructuralFeature("title")); //$NON-NLS-1$
+        title.put("en", "Goods item"); //$NON-NLS-1$ //$NON-NLS-2$
+        addAttribute(form, attribute);
+
+        addHandler(form, "OnOpen", "ПриОткрытии", //$NON-NLS-1$
+            "FormOnOpen"); //$NON-NLS-1$
+
+        return form;
+    }
+
     // ==================== Dynamic EMF model shaped like a managed form ====================
 
     private static final FormLikeModel MODEL = new FormLikeModel();
@@ -314,6 +517,66 @@ public class FormStructureReaderTest
         ((List<EObject>)owner.eGet(owner.eClass().getEStructuralFeature(featureName))).add(child);
     }
 
+    // ---- detailed-render test scaffolding ------------------------------------------------------
+
+    /** Sets a Boolean feature by name on an item (e.g. {@code visible}, {@code main}). */
+    private static void setBoolean(EObject object, String featureName, boolean value)
+    {
+        object.eSet(object.eClass().getEStructuralFeature(featureName), Boolean.valueOf(value));
+    }
+
+    /** Sets an EEnum feature to a named literal, read back by the reader as that literal. */
+    private static void setEnum(EObject object, String featureName, String literal)
+    {
+        EAttribute feature = (EAttribute)object.eClass().getEStructuralFeature(featureName);
+        EEnumLiteral lit = ((EEnum)feature.getEAttributeType()).getEEnumLiteral(literal);
+        object.eSet(feature, lit.getInstance());
+    }
+
+    /** Attaches a contained {@code DataPath} whose {@code segments} are the given parts. */
+    @SuppressWarnings("unchecked")
+    private static void setDataPath(EObject item, String... parts)
+    {
+        EObject dataPath = new DynamicEObjectImpl(MODEL.dataPath);
+        EList<String> segments =
+            (EList<String>)dataPath.eGet(MODEL.dataPath.getEStructuralFeature("segments")); //$NON-NLS-1$
+        for (String part : parts)
+        {
+            segments.add(part);
+        }
+        item.eSet(item.eClass().getEStructuralFeature("dataPath"), dataPath); //$NON-NLS-1$
+    }
+
+    /** Attaches a contained {@code UsualGroupExtInfo} carrying the layout {@code group} + {@code behavior}. */
+    private static void setGroupExtInfo(EObject group, String groupMode, String behavior)
+    {
+        EObject extInfo = new DynamicEObjectImpl(MODEL.usualGroupExtInfo);
+        setEnum(extInfo, "group", groupMode); //$NON-NLS-1$
+        if (behavior != null)
+        {
+            setEnum(extInfo, "behavior", behavior); //$NON-NLS-1$
+        }
+        group.eSet(group.eClass().getEStructuralFeature("extInfo"), extInfo); //$NON-NLS-1$
+    }
+
+    /** Appends an {@code EventHandler} (its BSL proc name + a contained {@code Event}) to the element. */
+    private static void addHandler(EObject element, String eventName, String eventNameRu, String procName)
+    {
+        EObject handler = new DynamicEObjectImpl(MODEL.eventHandler);
+        handler.eSet(MODEL.eventHandler.getEStructuralFeature("name"), procName); //$NON-NLS-1$
+        EObject event = new DynamicEObjectImpl(MODEL.event);
+        if (eventName != null)
+        {
+            event.eSet(MODEL.event.getEStructuralFeature("name"), eventName); //$NON-NLS-1$
+        }
+        if (eventNameRu != null)
+        {
+            event.eSet(MODEL.event.getEStructuralFeature("nameRu"), eventNameRu); //$NON-NLS-1$
+        }
+        handler.eSet(MODEL.eventHandler.getEStructuralFeature("event"), event); //$NON-NLS-1$
+        addTo(element, "handlers", handler); //$NON-NLS-1$
+    }
+
     /**
      * A tiny dynamic EMF metamodel reproducing the feature names the reader reads via reflection:
      * {@code items} / {@code attributes} / {@code formCommands} on the form, {@code name} / {@code id}
@@ -326,12 +589,17 @@ public class FormStructureReaderTest
         final EClass form;
         final EClass formGroup;
         final EClass formField;
+        final EClass formButton;
         final EClass formAttribute;
         final EClass formCommand;
         final EClass commandHandler;
         final EClass handlerContainer;
         final EClass autoCommandBar;
         final EClass table;
+        final EClass usualGroupExtInfo;
+        final EClass dataPath;
+        final EClass eventHandler;
+        final EClass event;
 
         final EAttribute itemName;
         final EAttribute itemId;
@@ -347,8 +615,61 @@ public class FormStructureReaderTest
             pkg.setNsPrefix("formlike"); //$NON-NLS-1$
             pkg.setNsURI("http://ditrix.com/test/formlike"); //$NON-NLS-1$
 
-            // FormItem-like base: name + id. Both groups and fields extend it, so the many-valued
-            // 'items' references can be typed to this common supertype.
+            // ---- enums the detailed render reads as their literal (via Enumerator) -------------------
+            EEnum groupTypeEnum = enumOf(factory, "FormGroupExtInfoType", "Vertical", "Horizontal"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            EEnum behaviorEnum = enumOf(factory, "UsualGroupBehavior", "Usual", "Collapsible"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            EEnum fieldTypeEnum = enumOf(factory, "FormFieldType", "InputField", "LabelField"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            EEnum editModeEnum = enumOf(factory, "FormFieldEditMode", "Enter", "Directly"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+            // ---- supporting contained objects --------------------------------------------------------
+            // DataPath-like: a 'segments' string list joined by '.' to form an item's bound path.
+            dataPath = factory.createEClass();
+            dataPath.setName("DataPath"); //$NON-NLS-1$
+            EAttribute segments = factory.createEAttribute();
+            segments.setName("segments"); //$NON-NLS-1$
+            segments.setEType(EcorePackage.Literals.ESTRING);
+            segments.setUpperBound(-1);
+            dataPath.getEStructuralFeatures().add(segments);
+
+            // UsualGroupExtInfo-like: a group's extInfo carrying the layout 'group' + 'behavior' enums.
+            usualGroupExtInfo = factory.createEClass();
+            usualGroupExtInfo.setName("UsualGroupExtInfo"); //$NON-NLS-1$
+            EAttribute groupMode = factory.createEAttribute();
+            groupMode.setName("group"); //$NON-NLS-1$
+            groupMode.setEType(groupTypeEnum);
+            usualGroupExtInfo.getEStructuralFeatures().add(groupMode);
+            EAttribute behavior = factory.createEAttribute();
+            behavior.setName("behavior"); //$NON-NLS-1$
+            behavior.setEType(behaviorEnum);
+            usualGroupExtInfo.getEStructuralFeatures().add(behavior);
+
+            // Event-like + EventHandler-like: a handler's own 'name' (BSL proc) + single 'event' ref
+            // whose 'name' (en) / 'nameRu' (ru) is the platform event name.
+            event = factory.createEClass();
+            event.setName("Event"); //$NON-NLS-1$
+            EAttribute eventName = factory.createEAttribute();
+            eventName.setName("name"); //$NON-NLS-1$
+            eventName.setEType(EcorePackage.Literals.ESTRING);
+            event.getEStructuralFeatures().add(eventName);
+            EAttribute eventNameRu = factory.createEAttribute();
+            eventNameRu.setName("nameRu"); //$NON-NLS-1$
+            eventNameRu.setEType(EcorePackage.Literals.ESTRING);
+            event.getEStructuralFeatures().add(eventNameRu);
+            eventHandler = factory.createEClass();
+            eventHandler.setName("EventHandler"); //$NON-NLS-1$
+            EAttribute ehName = factory.createEAttribute();
+            ehName.setName("name"); //$NON-NLS-1$
+            ehName.setEType(EcorePackage.Literals.ESTRING);
+            eventHandler.getEStructuralFeatures().add(ehName);
+            EReference ehEvent = factory.createEReference();
+            ehEvent.setName("event"); //$NON-NLS-1$
+            ehEvent.setEType(event);
+            ehEvent.setContainment(true);
+            eventHandler.getEStructuralFeatures().add(ehEvent);
+
+            // FormItem-like base: name + id + visible + dataPath + extInfo + handlers. Groups, fields and
+            // buttons extend it, so the many-valued 'items' references can be typed to this supertype and
+            // every item carries the detailed-render features (read reflectively, only when present).
             formItem = factory.createEClass();
             formItem.setName("FormItem"); //$NON-NLS-1$
             formItem.setAbstract(true);
@@ -360,6 +681,22 @@ public class FormStructureReaderTest
             itemId.setName("id"); //$NON-NLS-1$
             itemId.setEType(EcorePackage.Literals.EINT);
             formItem.getEStructuralFeatures().add(itemId);
+            EAttribute itemVisible = factory.createEAttribute();
+            itemVisible.setName("visible"); //$NON-NLS-1$
+            itemVisible.setEType(EcorePackage.Literals.EBOOLEAN);
+            itemVisible.setDefaultValueLiteral("true"); //$NON-NLS-1$
+            formItem.getEStructuralFeatures().add(itemVisible);
+            EReference itemDataPath = factory.createEReference();
+            itemDataPath.setName("dataPath"); //$NON-NLS-1$
+            itemDataPath.setEType(dataPath);
+            itemDataPath.setContainment(true);
+            formItem.getEStructuralFeatures().add(itemDataPath);
+            EReference itemExtInfo = factory.createEReference();
+            itemExtInfo.setName("extInfo"); //$NON-NLS-1$
+            itemExtInfo.setEType(usualGroupExtInfo);
+            itemExtInfo.setContainment(true);
+            formItem.getEStructuralFeatures().add(itemExtInfo);
+            formItem.getEStructuralFeatures().add(handlersReference(factory, eventHandler));
 
             // FormGroup-like container: a FormItem that also exposes an 'items' list.
             formGroup = factory.createEClass();
@@ -367,18 +704,51 @@ public class FormStructureReaderTest
             formGroup.getESuperTypes().add(formItem);
             formGroup.getEStructuralFeatures().add(itemsReference(factory, formItem));
 
-            // FormField-like leaf: a FormItem with no 'items' feature.
+            // FormField-like leaf: a FormItem with 'type' + 'editMode' enums, no 'items' feature.
             formField = factory.createEClass();
             formField.setName("FormField"); //$NON-NLS-1$
             formField.getESuperTypes().add(formItem);
+            EAttribute fieldType = factory.createEAttribute();
+            fieldType.setName("type"); //$NON-NLS-1$
+            fieldType.setEType(fieldTypeEnum);
+            formField.getEStructuralFeatures().add(fieldType);
+            EAttribute fieldEditMode = factory.createEAttribute();
+            fieldEditMode.setName("editMode"); //$NON-NLS-1$
+            fieldEditMode.setEType(editModeEnum);
+            formField.getEStructuralFeatures().add(fieldEditMode);
 
-            // FormAttribute-like: name only.
+            // Button-like leaf: a FormItem carrying the bound metadata 'commandName'. The concrete
+            // form-model button EClass is named "Button" (NOT "FormButton", its platform-type name), so
+            // the dynamic EClass must use that name for kindExtrasOf's eClass()-name match to fire.
+            formButton = factory.createEClass();
+            formButton.setName("Button"); //$NON-NLS-1$
+            formButton.getESuperTypes().add(formItem);
+            EAttribute buttonCommand = factory.createEAttribute();
+            buttonCommand.setName("commandName"); //$NON-NLS-1$
+            buttonCommand.setEType(EcorePackage.Literals.ESTRING);
+            formButton.getEStructuralFeatures().add(buttonCommand);
+
+            // FormAttribute-like: name + title (EMap by language code) + main + savedData flags.
             formAttribute = factory.createEClass();
             formAttribute.setName("FormAttribute"); //$NON-NLS-1$
             attributeName = factory.createEAttribute();
             attributeName.setName("name"); //$NON-NLS-1$
             attributeName.setEType(EcorePackage.Literals.ESTRING);
             formAttribute.getEStructuralFeatures().add(attributeName);
+            EReference attributeTitle = factory.createEReference();
+            attributeTitle.setName("title"); //$NON-NLS-1$
+            attributeTitle.setEType(EcorePackage.Literals.ESTRING_TO_STRING_MAP_ENTRY);
+            attributeTitle.setContainment(true);
+            attributeTitle.setUpperBound(-1);
+            formAttribute.getEStructuralFeatures().add(attributeTitle);
+            EAttribute attributeMain = factory.createEAttribute();
+            attributeMain.setName("main"); //$NON-NLS-1$
+            attributeMain.setEType(EcorePackage.Literals.EBOOLEAN);
+            formAttribute.getEStructuralFeatures().add(attributeMain);
+            EAttribute attributeSavedData = factory.createEAttribute();
+            attributeSavedData.setName("savedData"); //$NON-NLS-1$
+            attributeSavedData.setEType(EcorePackage.Literals.EBOOLEAN);
+            formAttribute.getEStructuralFeatures().add(attributeSavedData);
 
             // CommandHandler-like pair: the command's contained action holding the handler name.
             commandHandler = factory.createEClass();
@@ -444,11 +814,22 @@ public class FormStructureReaderTest
             barRef.setEType(autoCommandBar);
             barRef.setContainment(true);
             form.getEStructuralFeatures().add(barRef);
+            // The form ROOT carries its own event handlers (e.g. OnOpen / BeforeClose).
+            form.getEStructuralFeatures().add(handlersReference(factory, eventHandler));
 
+            pkg.getEClassifiers().add(groupTypeEnum);
+            pkg.getEClassifiers().add(behaviorEnum);
+            pkg.getEClassifiers().add(fieldTypeEnum);
+            pkg.getEClassifiers().add(editModeEnum);
+            pkg.getEClassifiers().add(dataPath);
+            pkg.getEClassifiers().add(usualGroupExtInfo);
+            pkg.getEClassifiers().add(event);
+            pkg.getEClassifiers().add(eventHandler);
             pkg.getEClassifiers().add(formItem);
             pkg.getEClassifiers().add(form);
             pkg.getEClassifiers().add(formGroup);
             pkg.getEClassifiers().add(formField);
+            pkg.getEClassifiers().add(formButton);
             pkg.getEClassifiers().add(formAttribute);
             pkg.getEClassifiers().add(formCommand);
             pkg.getEClassifiers().add(commandHandler);
@@ -460,6 +841,27 @@ public class FormStructureReaderTest
         private static EReference itemsReference(EcoreFactory factory, EClass itemType)
         {
             return containment(factory, "items", itemType); //$NON-NLS-1$
+        }
+
+        private static EReference handlersReference(EcoreFactory factory, EClass handlerType)
+        {
+            return containment(factory, "handlers", handlerType); //$NON-NLS-1$
+        }
+
+        private static EEnum enumOf(EcoreFactory factory, String name, String... literals)
+        {
+            EEnum eEnum = factory.createEEnum();
+            eEnum.setName(name);
+            int value = 0;
+            for (String literal : literals)
+            {
+                EEnumLiteral lit = factory.createEEnumLiteral();
+                lit.setName(literal);
+                lit.setLiteral(literal);
+                lit.setValue(value++);
+                eEnum.getELiterals().add(lit);
+            }
+            return eEnum;
         }
 
         private static EReference containment(EcoreFactory factory, String name, EClass type)

--- a/tests/e2e/tools/test_get_metadata_details.py
+++ b/tests/e2e/tools/test_get_metadata_details.py
@@ -220,13 +220,19 @@ def test_nonexistent_project_is_error():
 
 
 # ──────────────────────────────────────────────────────────────────────────────
-# FORM structure — a form FQN renders the form's structure (folds get_form_structure)
+# FORM structure — a form FQN renders the form's ENRICHED structure
+# (folds get_form_structure; FormStructureReader.render adds visibility / dataPath /
+# per-kind extras to the items outline, Main / SavedData flags to the Attributes table,
+# and a new Event handlers section)
 # ──────────────────────────────────────────────────────────────────────────────
 
 @e2e_test(tool="get_metadata_details", kind="write-metadata")
 def test_form_fqn_renders_structure():
-    # A managed-form FQN (Type.Object.Form.FormName) renders its STRUCTURE: items / attributes /
-    # commands. Seed an attribute + command, then read the whole form back by its FQN.
+    # A managed-form FQN (Type.Object.Form.FormName) renders its ENRICHED STRUCTURE: items
+    # outline (now with visibility / dataPath / per-kind extras), an Attributes table (now
+    # carrying Main / SavedData flags) and a NEW Event handlers section -- the enrichment folded
+    # into get_metadata_details by FormStructureReader.render. Seed an attribute + command,
+    # then read the whole form back by its FQN.
     r1 = call("create_metadata", {
         "projectName": PROJECT, "fqn": "Catalog.Catalog.Form.ItemForm.Attribute.GMDFAttr"})
     assert_ok(r1, "seed form attribute")
@@ -242,6 +248,18 @@ def test_form_fqn_renders_structure():
     assert_contains(r.text, "## Attributes", "must render the Attributes section")
     assert_contains(r.text, "GMDFAttr", "must list the seeded form attribute")
     assert_contains(r.text, "GMDFCmd", "must list the seeded form command")
+    # Enriched markers (render). The auto-generated ItemForm binds its fields to the
+    # object (e.g. Object.Code / Object.Description), so the items outline now exposes their
+    # dataPath. A no-op enrichment (the former plain render) would lack all three. Because the
+    # dataPath marker depends on the auto-generated form actually binding a field, also assert a
+    # marker the enriched render ALWAYS emits for any form (the enriched Attributes header row).
+    assert_contains(r.text, "dataPath", "the enriched items outline must expose item dataPath")
+    # The Attributes table gained the Main / SavedData flag columns: assert the enriched header row
+    # rather than bare "Main" / "SavedData" substrings (which could match anywhere in the body).
+    assert_contains(r.text, "| Main | SavedData |", "the enriched Attributes header must carry Main / SavedData columns")
+    # A new, always-rendered Event handlers section (empty-section convention emits the header
+    # even when the form has no handlers).
+    assert_contains(r.text, "Event handlers", "the enriched structure must add an Event handlers section")
 
 
 @e2e_test(tool="get_metadata_details", kind="read")
@@ -251,3 +269,6 @@ def test_common_form_fqn_renders_structure():
     assert_ok(r, "get_metadata_details on a CommonForm FQN")
     assert_contains(r.text, "Form Structure", "a CommonForm FQN must render the form structure")
     assert_contains(r.text, "## Items", "must render the Items section")
+    # The enriched renderer (FormStructureReader.render) always emits the Event handlers section
+    # header, even for a form that declares no handlers (empty-section convention).
+    assert_contains(r.text, "Event handlers", "the enriched structure must add an Event handlers section")


### PR DESCRIPTION
## Задача (#198)
Сейчас ИИ не может получить структуру формы (реквизиты, дерево элементов, команды, подписки) и вынужден читать сырой `.form`-XML «глазами» — мутно и часто неинформативно. Нужно отдавать структуру с ключевыми полями в виде MD-таблицы с иерархией вложенности.

## Решение
`get_metadata_details` по FQN формы **уже** рендерил её структуру (дерево элементов + реквизиты + команды). Обогатил этот рендер, чтобы форму можно было читать без разбора XML:
- по каждому элементу: **синоним** (эффективный язык), **видимость** (когда скрыт), **dataPath**, и **тип-специфичные доп.поля** — для группы её вид (`extInfo` + ориентация + поведение), для поля вид + режим редактирования, для кнопки команда;
- таблица **Реквизиты** получила колонки `Synonym`, `Main`, `SavedData`;
- новая секция **Event handlers** — обработчики формы и элементов (событие → процедура BSL).

Доступ к форме **полностью рефлективный** (без импорта `com._1c.g5.v8.dt.form.model`). Показываются только **явно заданные** enum-значения (unset читается как дефолт метамодели — это шум). **Нового инструмента нет**, golden `tools_list` не меняется.

## Архитектура
Общий `FormStructureReader.render` теперь даёт единый обогащённый вид; прежний «простой» рендер не имел больше вызывающих в проде (delete-preview/adopt используют `resolveMdForm`/`getReferenceList`/`nameOf`) и свёрнут в один метод.

## Проверка
- **Юнит-тесты**: каждое новое поле — headless через in-memory EMF (`DynamicEObjectImpl`/`EcoreFactory`); сборка зелёная (2756 тестов).
- **Live на реальных ERP-формах** (ERP-Демо). Рендер `Document.АвансовыйПлатежИностранцаПоНДФЛ.Forms.ФормаДокумента` и `Catalog.АктыОтбораПробЗЕРНО.Forms.ФормаЭлемента` показал:
  - dataPath: `Объект.Организация`, `РеквизитыУведомления.НомерУведомления`;
  - вид поля: `field: type=InputField editMode=EnterOnInput`, `type=CheckBoxField`;
  - вид группы: `group: UsualGroupExtInfo Vertical`, `AlwaysHorizontal Auto`, `ButtonGroupExtInfo`;
  - видимость: `visible: false`;
  - реквизиты с `Main`/`SavedData` = `true`/`true`;
  - секцию Event handlers.

  Рефлективные имена фич совпали с реальной моделью формы.

🤖 Generated with [Claude Code](https://claude.com/claude-code)