### PR TITLE
Чистка 11 new-code замечаний SonarCloud из недавних релизных PR

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/BuildExternalObjectsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/BuildExternalObjectsTool.java
@@ -177,7 +177,7 @@ public class BuildExternalObjectsTool implements IMcpTool
     public String getOutputSchema()
     {
         return JsonSchemaBuilder.object()
-            .booleanProperty("success", //$NON-NLS-1$
+            .booleanProperty(RES_SUCCESS,
                 "true only when every requested object was built; false when any object failed.", true) //$NON-NLS-1$
             .stringProperty(McpKeys.PROJECT, "Target EDT external-object project name.") //$NON-NLS-1$
             .stringProperty(KEY_OUTPUT_DIR, "Absolute output directory the files were written to.") //$NON-NLS-1$
@@ -257,7 +257,9 @@ public class BuildExternalObjectsTool implements IMcpTool
         }
 
         // 7. Run the dump loop off the calling thread, with dialog suppressors armed and a timeout.
-        return runBuild(new BuildContext(projectName, resolved.project, enumeration.bmModel, dumper,
+        //    projectName is derived from resolved.project.getName() in BuildContext: for a resolved
+        //    workspace project handle IWorkspaceRoot.getProject(name).getName() equals the passed name.
+        return runBuild(new BuildContext(resolved.project, enumeration.bmModel, dumper,
             enumeration.targets, outputDir, outsideWorkspace, recordBuildTime));
     }
 
@@ -402,43 +404,75 @@ public class BuildExternalObjectsTool implements IMcpTool
             Collection<MdObject> all = resolved.externalObjectProject.getExternalObjects();
             if (all == null || all.isEmpty())
             {
-                if (objectName == null)
-                {
-                    // Build ALL of an empty project: not an error — an empty target list yields a
-                    // clear "nothing to build" success (built=0/failed=0) in runBuild.
-                    return EnumerationResult.ok(new ArrayList<>(), bmModel);
-                }
-                // A SPECIFIC object was requested but the project has none: a value-naming not-found.
-                return EnumerationResult.failure(ToolResult.error("External object not found: '" //$NON-NLS-1$
-                    + objectName + "'. The external-object project has no external data " //$NON-NLS-1$
-                    + "processors/reports.").toJson()); //$NON-NLS-1$
+                return enumerateEmpty(objectName, bmModel);
             }
-            List<Target> matched = new ArrayList<>();
-            List<String> available = new ArrayList<>();
-            for (MdObject object : all)
-            {
-                String name = object.getName();
-                available.add(name);
-                if (objectName == null || objectName.equals(name))
-                {
-                    // Resolve name + extension (.epf for a data processor, .erf for a report) here, in
-                    // the read boundary, so the file name is fully decided before the Job runs. Capture
-                    // the BM id so the Job can re-resolve the object inside its own read transaction.
-                    String fileName = ExternalObjectDumpSupport.outputFileName(name,
-                        ExternalObjectDumpSupport.extensionForObject(object));
-                    matched.add(new Target(((IBmObject)object).bmGetId(),
-                        ((IBmObject)object).bmGetFqn(), name, fileName));
-                }
-            }
-            if (matched.isEmpty())
-            {
-                // Reachable only with a specific objectName that matched nothing (build-all over a
-                // non-empty project always matches >=1).
-                return EnumerationResult.failure(ToolResult.error("External object not found: '" //$NON-NLS-1$
-                    + objectName + "'. Available external objects: " + available + ".").toJson()); //$NON-NLS-1$ //$NON-NLS-2$
-            }
-            return EnumerationResult.ok(matched, bmModel);
+            return matchTargets(all, objectName, bmModel);
         });
+    }
+
+    /**
+     * Handles the empty-project branch of {@link #enumerateTargets}: build-all over a project with no
+     * external objects is not an error (an empty target list yields a clear "nothing to build" success),
+     * but a SPECIFIC requested object that the empty project cannot contain is a value-naming not-found.
+     *
+     * @param objectName the single object name requested, or {@code null} for build-all
+     * @param bmModel the resolved BM model (carried on the success result)
+     * @return an empty-targets success for build-all, or a ready-to-return not-found error
+     */
+    private static EnumerationResult enumerateEmpty(String objectName, IBmModel bmModel)
+    {
+        if (objectName == null)
+        {
+            // Build ALL of an empty project: not an error — an empty target list yields a
+            // clear "nothing to build" success (built=0/failed=0) in runBuild.
+            return EnumerationResult.ok(new ArrayList<>(), bmModel);
+        }
+        // A SPECIFIC object was requested but the project has none: a value-naming not-found.
+        return EnumerationResult.failure(ToolResult.error("External object not found: '" //$NON-NLS-1$
+            + objectName + "'. The external-object project has no external data " //$NON-NLS-1$
+            + "processors/reports.").toJson()); //$NON-NLS-1$
+    }
+
+    /**
+     * Walks the project's external objects (inside the BM read boundary opened by
+     * {@link #enumerateTargets}) and selects the build targets: when {@code objectName} is {@code null}
+     * every object is selected, otherwise only the one whose name matches. Each selected object's name,
+     * BM id, FQN and {@code .epf}/{@code .erf} file name are captured on a detached {@link Target}. When a
+     * specific {@code objectName} matched nothing, a value-naming not-found error (listing the available
+     * names) is returned instead.
+     *
+     * @param all the project's external objects (non-empty)
+     * @param objectName the single object name to match, or {@code null} for all
+     * @param bmModel the resolved BM model (carried on the success result)
+     * @return the matched targets, or a ready-to-return not-found error
+     */
+    private static EnumerationResult matchTargets(Collection<MdObject> all, String objectName, IBmModel bmModel)
+    {
+        List<Target> matched = new ArrayList<>();
+        List<String> available = new ArrayList<>();
+        for (MdObject object : all)
+        {
+            String name = object.getName();
+            available.add(name);
+            if (objectName == null || objectName.equals(name))
+            {
+                // Resolve name + extension (.epf for a data processor, .erf for a report) here, in
+                // the read boundary, so the file name is fully decided before the Job runs. Capture
+                // the BM id so the Job can re-resolve the object inside its own read transaction.
+                String fileName = ExternalObjectDumpSupport.outputFileName(name,
+                    ExternalObjectDumpSupport.extensionForObject(object));
+                matched.add(new Target(((IBmObject)object).bmGetId(),
+                    ((IBmObject)object).bmGetFqn(), name, fileName));
+            }
+        }
+        if (matched.isEmpty())
+        {
+            // Reachable only with a specific objectName that matched nothing (build-all over a
+            // non-empty project always matches >=1).
+            return EnumerationResult.failure(ToolResult.error("External object not found: '" //$NON-NLS-1$
+                + objectName + "'. Available external objects: " + available + ".").toJson()); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return EnumerationResult.ok(matched, bmModel);
     }
 
     /**
@@ -471,7 +505,7 @@ public class BuildExternalObjectsTool implements IMcpTool
         // One timestamp per build run: every object stamped in this call shares the same build time.
         final String buildStamp = STAMP_PREFIX + LocalDateTime.now().format(STAMP_FMT);
 
-        Job buildJob = new Job(NAME + ": " + bc.projectName) //$NON-NLS-1$
+        Job buildJob = new Job(NAME + ": " + bc.project.getName()) //$NON-NLS-1$
         {
             @Override
             protected IStatus run(IProgressMonitor monitor)
@@ -526,7 +560,7 @@ public class BuildExternalObjectsTool implements IMcpTool
         }
         if (fatalHolder[0] != null)
         {
-            Activator.logError(NAME + " failed for project " + bc.projectName, fatalHolder[0]); //$NON-NLS-1$
+            Activator.logError(NAME + " failed for project " + bc.project.getName(), fatalHolder[0]); //$NON-NLS-1$
             return ToolResult.error("External object build failed: " + fatalHolder[0].getMessage() //$NON-NLS-1$
                 + authHint(fatalHolder[0])).toJson();
         }
@@ -650,7 +684,7 @@ public class BuildExternalObjectsTool implements IMcpTool
         ToolResult tr = allOk ? ToolResult.success() : ToolResult.error("Built " + built //$NON-NLS-1$
             + " of " + (built + failed) + " external object(s) in " + elapsedMs + " ms; " //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             + failed + " failed."); //$NON-NLS-1$
-        tr.put(McpKeys.PROJECT, bc.projectName)
+        tr.put(McpKeys.PROJECT, bc.project.getName())
             .put(KEY_OUTPUT_DIR, bc.outputDir.toString())
             .put(KEY_BUILT, built)
             .put(KEY_FAILED, failed)
@@ -814,10 +848,15 @@ public class BuildExternalObjectsTool implements IMcpTool
         }
     }
 
-    /** Immutable bundle of the resolved inputs threaded through the build loop. */
+    /**
+     * Immutable bundle of the resolved inputs threaded through the build loop. The project name is
+     * derived from {@link #project} via {@code project.getName()} at its read sites rather than carried
+     * as a separate field: for a resolved workspace project handle
+     * {@code IWorkspaceRoot.getProject(name).getName()} equals the passed name, so this is identical to
+     * the original {@code projectName} argument.
+     */
     private static final class BuildContext
     {
-        final String projectName;
         final IProject project;
         final IBmModel bmModel;
         final IExternalObjectDumper dumper;
@@ -826,11 +865,10 @@ public class BuildExternalObjectsTool implements IMcpTool
         final boolean outsideWorkspace;
         final boolean recordBuildTime;
 
-        private BuildContext(String projectName, IProject project, IBmModel bmModel,
+        private BuildContext(IProject project, IBmModel bmModel,
                 IExternalObjectDumper dumper, List<Target> targets, Path outputDir, boolean outsideWorkspace,
                 boolean recordBuildTime)
         {
-            this.projectName = projectName;
             this.project = project;
             this.bmModel = bmModel;
             this.dumper = dumper;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetApplicationsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetApplicationsTool.java
@@ -126,30 +126,10 @@ public class GetApplicationsTool implements IMcpTool
             IProject project = mr.project();
             IApplicationManager appManager = mr.manager();
 
-            // Get applications for the named project
-            List<IApplication> applications = appManager.getApplications(project);
-
-            // The project whose applications and default application are reported. For a
-            // configuration project this is always the named project. For a dependent
-            // project (external-objects / extension) whose own application list is empty,
-            // fall back to the BASE configuration project the applications are inherited from.
-            IProject applicationsProject = project;
-            String baseProjectName = null;
-
-            if (applications == null || applications.isEmpty())
-            {
-                IProject base = ExtensionOriginUtils.resolveBaseProject(project);
-                if (base != null && base.exists() && base.isOpen())
-                {
-                    List<IApplication> baseApplications = appManager.getApplications(base);
-                    if (baseApplications != null && !baseApplications.isEmpty())
-                    {
-                        applications = baseApplications;
-                        applicationsProject = base;
-                        baseProjectName = base.getName();
-                    }
-                }
-            }
+            // Get applications for the named project, falling back to the base
+            // configuration project for dependent projects with an empty list.
+            ResolvedApplications resolved = resolveApplications(appManager, project);
+            List<IApplication> applications = resolved.applications;
 
             if (applications == null || applications.isEmpty())
             {
@@ -162,31 +142,10 @@ public class GetApplicationsTool implements IMcpTool
             }
 
             // Build applications array
-            JsonArray appsArray = new JsonArray();
-            for (IApplication app : applications)
-            {
-                JsonObject appObj = new JsonObject();
-                appObj.addProperty("id", app.getId()); //$NON-NLS-1$
-                appObj.addProperty("name", app.getName()); //$NON-NLS-1$
-                
-                // Add type info
-                if (app.getType() != null)
-                {
-                    appObj.addProperty("type", app.getType().getId()); //$NON-NLS-1$
-                }
-                
-                // Add update state
-                addUpdateState(appManager, app, appObj);
-                
-                // Add required version if present
-                app.getRequiredVersion().ifPresent(version -> 
-                    appObj.addProperty("requiredVersion", version)); //$NON-NLS-1$
-                
-                appsArray.add(appObj);
-            }
-            
+            JsonArray appsArray = buildApplicationsArray(appManager, applications);
+
             // Get default application from whichever project supplied the applications
-            String defaultAppId = resolveDefaultApplicationId(appManager, applicationsProject);
+            String defaultAppId = resolveDefaultApplicationId(appManager, resolved.applicationsProject);
 
             ToolResult result = ToolResult.success()
                 .put(McpKeys.PROJECT, projectName)
@@ -200,9 +159,9 @@ public class GetApplicationsTool implements IMcpTool
 
             // Present only on the inherited branch (dependent project whose applications
             // come from its base configuration project).
-            if (baseProjectName != null)
+            if (resolved.baseProjectName != null)
             {
-                result.put("inheritedFromProject", baseProjectName); //$NON-NLS-1$
+                result.put("inheritedFromProject", resolved.baseProjectName); //$NON-NLS-1$
             }
 
             return result.toJson();
@@ -213,7 +172,94 @@ public class GetApplicationsTool implements IMcpTool
             return ToolResult.error("Error getting applications: " + e.getMessage()).toJson(); //$NON-NLS-1$
         }
     }
-    
+
+    /**
+     * Resolves the applications for the named project. For a configuration project this is always
+     * the named project's own list. For a dependent project (external-objects / extension) whose
+     * own application list is empty, falls back to the BASE configuration project the applications
+     * are inherited from.
+     *
+     * @param appManager the application manager
+     * @param project the named project
+     * @return the resolved applications together with the supplying project and (for the inherited
+     *         branch only) the base project name
+     * @throws ApplicationException if the application list cannot be read
+     */
+    private ResolvedApplications resolveApplications(IApplicationManager appManager, IProject project)
+        throws ApplicationException
+    {
+        List<IApplication> applications = appManager.getApplications(project);
+        if (applications != null && !applications.isEmpty())
+        {
+            return new ResolvedApplications(applications, project, null);
+        }
+
+        IProject base = ExtensionOriginUtils.resolveBaseProject(project);
+        if (base != null && base.exists() && base.isOpen())
+        {
+            List<IApplication> baseApplications = appManager.getApplications(base);
+            if (baseApplications != null && !baseApplications.isEmpty())
+            {
+                return new ResolvedApplications(baseApplications, base, base.getName());
+            }
+        }
+
+        return new ResolvedApplications(applications, project, null);
+    }
+
+    /**
+     * Builds the JSON array describing the given applications, preserving the original
+     * per-application property order (id, name, type, update state, required version).
+     *
+     * @param appManager the application manager
+     * @param applications the applications to render
+     * @return the JSON array of applications
+     */
+    private JsonArray buildApplicationsArray(IApplicationManager appManager, List<IApplication> applications)
+    {
+        JsonArray appsArray = new JsonArray();
+        for (IApplication app : applications)
+        {
+            JsonObject appObj = new JsonObject();
+            appObj.addProperty("id", app.getId()); //$NON-NLS-1$
+            appObj.addProperty("name", app.getName()); //$NON-NLS-1$
+
+            // Add type info
+            if (app.getType() != null)
+            {
+                appObj.addProperty("type", app.getType().getId()); //$NON-NLS-1$
+            }
+
+            // Add update state
+            addUpdateState(appManager, app, appObj);
+
+            // Add required version if present
+            app.getRequiredVersion().ifPresent(version ->
+                appObj.addProperty("requiredVersion", version)); //$NON-NLS-1$
+
+            appsArray.add(appObj);
+        }
+        return appsArray;
+    }
+
+    /**
+     * Holds the applications resolved for a project together with the project that supplied them
+     * and, only when inherited from a base configuration project, that base project's name.
+     */
+    private static final class ResolvedApplications
+    {
+        final List<IApplication> applications;
+        final IProject applicationsProject;
+        final String baseProjectName;
+
+        ResolvedApplications(List<IApplication> applications, IProject applicationsProject, String baseProjectName)
+        {
+            this.applications = applications;
+            this.applicationsProject = applicationsProject;
+            this.baseProjectName = baseProjectName;
+        }
+    }
+
     /**
      * Adds the update-state properties for a single application to its JSON object.
      * On error the state is reported as {@code "ERROR"} together with the error message,

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -744,53 +744,71 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
      */
     private DynListQueryRequest parseDynListQueryProps(List<JsonObject> properties)
     {
-        String queryText = null;
-        Boolean customQuery = null;
-        String mainTable = null;
-        boolean queryTextGiven = false;
+        DynListQueryProps acc = new DynListQueryProps();
         for (JsonObject prop : properties)
         {
-            String name = asString(prop.get("name")); //$NON-NLS-1$
-            if (isQueryTextProp(name))
+            String error = readDynListQueryProp(prop, acc);
+            if (error != null)
             {
-                queryText = asString(prop.get(KEY_VALUE));
-                queryTextGiven = true;
-            }
-            else if (isCustomQueryProp(name))
-            {
-                Boolean parsed = parseBooleanFlag(prop.get(KEY_VALUE));
-                if (parsed == null)
-                {
-                    return DynListQueryRequest.failed(
-                        ToolResult.error("'customQuery' must be a boolean (true / false).").toJson()); //$NON-NLS-1$
-                }
-                customQuery = parsed;
-            }
-            else if (isMainTableProp(name))
-            {
-                mainTable = asString(prop.get(KEY_VALUE));
-                if (mainTable == null || mainTable.trim().isEmpty())
-                {
-                    return DynListQueryRequest.failed(ToolResult.error("'mainTable' must be an object FQN, e.g. " //$NON-NLS-1$
-                        + "'Catalog.Products' or 'Document.Order'.").toJson()); //$NON-NLS-1$
-                }
-            }
-            else
-            {
-                return DynListQueryRequest.failed(
-                    ToolResult.error("Setting a dynamic-list query ('queryText' / 'customQuery' / " //$NON-NLS-1$
-                        + "'mainTable') cannot be combined with other property changes ('" + name //$NON-NLS-1$
-                        + "') in one call. Configure the query first, then make the other changes " //$NON-NLS-1$
-                        + "separately.").toJson()); //$NON-NLS-1$
+                return DynListQueryRequest.failed(error);
             }
         }
-        if (queryTextGiven && (queryText == null || queryText.trim().isEmpty()))
+        if (acc.queryTextGiven && (acc.queryText == null || acc.queryText.trim().isEmpty()))
         {
             return DynListQueryRequest.failed(ToolResult.error("'queryText' must be a non-empty 1C query, e.g. " //$NON-NLS-1$
                 + "\"SELECT Ref, Description AS Description FROM Catalog.Products\". To switch the " //$NON-NLS-1$
                 + "dynamic list back to its automatic query, pass 'customQuery' = false instead.").toJson()); //$NON-NLS-1$
         }
-        return DynListQueryRequest.of(queryText, customQuery, mainTable);
+        return DynListQueryRequest.of(acc.queryText, acc.customQuery, acc.mainTable);
+    }
+
+    /** Mutable accumulator for the dynamic-list query properties read by {@link #readDynListQueryProp}. */
+    private static final class DynListQueryProps
+    {
+        String queryText;
+        Boolean customQuery;
+        String mainTable;
+        boolean queryTextGiven;
+    }
+
+    /**
+     * Reads a single property into {@code acc}, returning a ready JSON error string when the value is
+     * malformed or a query prop is mixed with another property change, or {@code null} to continue.
+     * Pure apart from updating {@code acc}.
+     */
+    private String readDynListQueryProp(JsonObject prop, DynListQueryProps acc)
+    {
+        String name = asString(prop.get("name")); //$NON-NLS-1$
+        if (isQueryTextProp(name))
+        {
+            acc.queryText = asString(prop.get(KEY_VALUE));
+            acc.queryTextGiven = true;
+            return null;
+        }
+        if (isCustomQueryProp(name))
+        {
+            Boolean parsed = parseBooleanFlag(prop.get(KEY_VALUE));
+            if (parsed == null)
+            {
+                return ToolResult.error("'customQuery' must be a boolean (true / false).").toJson(); //$NON-NLS-1$
+            }
+            acc.customQuery = parsed;
+            return null;
+        }
+        if (isMainTableProp(name))
+        {
+            acc.mainTable = asString(prop.get(KEY_VALUE));
+            if (acc.mainTable == null || acc.mainTable.trim().isEmpty())
+            {
+                return ToolResult.error("'mainTable' must be an object FQN, e.g. " //$NON-NLS-1$
+                    + "'Catalog.Products' or 'Document.Order'.").toJson(); //$NON-NLS-1$
+            }
+            return null;
+        }
+        return ToolResult.error("Setting a dynamic-list query ('queryText' / 'customQuery' / " //$NON-NLS-1$
+            + "'mainTable') cannot be combined with other property changes ('" + name //$NON-NLS-1$
+            + "') in one call. Configure the query first, then make the other changes " //$NON-NLS-1$
+            + "separately.").toJson(); //$NON-NLS-1$
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetInfobaseCredentialsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetInfobaseCredentialsTool.java
@@ -152,55 +152,24 @@ public class SetInfobaseCredentialsTool implements IMcpTool
         }
 
         boolean hasName = configName != null && !configName.isEmpty();
-        if (!hasName)
-        {
-            if (projectName == null || projectName.isEmpty())
-            {
-                return ToolResult.error("projectName is required (or pass launchConfigurationName).").toJson(); //$NON-NLS-1$
-            }
-            if (applicationId == null || applicationId.isEmpty())
-            {
-                return ToolResult.error("applicationId is required (or pass launchConfigurationName). " //$NON-NLS-1$
-                    + "Use get_applications or list_configurations.").toJson(); //$NON-NLS-1$
-            }
-        }
-
-        // Resolve the project + applicationId from the launch configuration when a name was given.
         if (hasName)
         {
-            String resolveError = null;
-            ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
-            if (launchManager == null)
+            // Resolve the project + applicationId from the launch configuration when a name was given.
+            TargetResolution resolved = resolveFromLaunchConfig(configName);
+            if (resolved.error() != null)
             {
-                return ToolResult.error("Launch manager is not available").toJson(); //$NON-NLS-1$
+                return resolved.error();
             }
-            ILaunchConfiguration cfg = LaunchConfigUtils.findLaunchConfigByName(launchManager, configName);
-            if (cfg == null)
+            projectName = resolved.projectName();
+            applicationId = resolved.applicationId();
+        }
+        else
+        {
+            String targetError = validateExplicitTarget(projectName, applicationId);
+            if (targetError != null)
             {
-                return ToolResult.error("Launch configuration not found: '" + configName //$NON-NLS-1$
-                    + "'. Use list_configurations to see what's available.").toJson(); //$NON-NLS-1$
+                return targetError;
             }
-            // findLaunchConfigByName also matches Attach/debug configs (ALL_DEBUG_CONFIG_TYPE_IDS);
-            // credentials target a runtime-client config (same guard as update_database) — an attach
-            // config has no project/applicationId to derive from.
-            if (!LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID.equals(LaunchConfigUtils.getConfigTypeId(cfg)))
-            {
-                return ToolResult.error("Launch configuration '" + cfg.getName() //$NON-NLS-1$
-                    + "' is not a runtime-client config — set_infobase_credentials requires one.").toJson(); //$NON-NLS-1$
-            }
-            String cfgProject = LaunchConfigUtils.readAttribute(cfg, LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
-            String cfgAppId = LaunchConfigUtils.readAttribute(cfg, LaunchConfigUtils.ATTR_APPLICATION_ID, ""); //$NON-NLS-1$
-            if (cfgProject.isEmpty() || cfgAppId.isEmpty())
-            {
-                resolveError = "Launch configuration '" + cfg.getName() //$NON-NLS-1$
-                    + "' has no project or applicationId attribute — cannot derive the target."; //$NON-NLS-1$
-            }
-            if (resolveError != null)
-            {
-                return ToolResult.error(resolveError).toJson();
-            }
-            projectName = cfgProject;
-            applicationId = cfgAppId;
         }
 
         String building = ProjectStateChecker.buildingErrorOrNull(projectName);
@@ -210,6 +179,106 @@ public class SetInfobaseCredentialsTool implements IMcpTool
         }
 
         return store(projectName, applicationId, user, password, access);
+    }
+
+    /**
+     * Validates that an explicit (project + applicationId) target was supplied when no launch
+     * configuration name was given.
+     *
+     * @return an error tool-result JSON, or {@code null} when both values are present
+     */
+    private static String validateExplicitTarget(String projectName, String applicationId)
+    {
+        if (projectName == null || projectName.isEmpty())
+        {
+            return ToolResult.error("projectName is required (or pass launchConfigurationName).").toJson(); //$NON-NLS-1$
+        }
+        if (applicationId == null || applicationId.isEmpty())
+        {
+            return ToolResult.error("applicationId is required (or pass launchConfigurationName). " //$NON-NLS-1$
+                + "Use get_applications or list_configurations.").toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the target project + applicationId from a runtime-client launch configuration name.
+     *
+     * @return a {@link TargetResolution} carrying either the resolved project/applicationId or an
+     *         error tool-result JSON
+     */
+    private static TargetResolution resolveFromLaunchConfig(String configName)
+    {
+        ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
+        if (launchManager == null)
+        {
+            return TargetResolution.error(ToolResult.error("Launch manager is not available").toJson()); //$NON-NLS-1$
+        }
+        ILaunchConfiguration cfg = LaunchConfigUtils.findLaunchConfigByName(launchManager, configName);
+        if (cfg == null)
+        {
+            return TargetResolution.error(ToolResult.error("Launch configuration not found: '" + configName //$NON-NLS-1$
+                + "'. Use list_configurations to see what's available.").toJson()); //$NON-NLS-1$
+        }
+        // findLaunchConfigByName also matches Attach/debug configs, not just runtime-client ones.
+        // Credentials target a runtime-client config — the same guard update_database applies — and
+        // an attach config has no project or applicationId to derive from.
+        if (!LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID.equals(LaunchConfigUtils.getConfigTypeId(cfg)))
+        {
+            return TargetResolution.error(ToolResult.error("Launch configuration '" + cfg.getName() //$NON-NLS-1$
+                + "' is not a runtime-client config — set_infobase_credentials requires one.").toJson()); //$NON-NLS-1$
+        }
+        String cfgProject = LaunchConfigUtils.readAttribute(cfg, LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+        String cfgAppId = LaunchConfigUtils.readAttribute(cfg, LaunchConfigUtils.ATTR_APPLICATION_ID, ""); //$NON-NLS-1$
+        if (cfgProject.isEmpty() || cfgAppId.isEmpty())
+        {
+            return TargetResolution.error(ToolResult.error("Launch configuration '" + cfg.getName() //$NON-NLS-1$
+                + "' has no project or applicationId attribute — cannot derive the target.").toJson()); //$NON-NLS-1$
+        }
+        return TargetResolution.resolved(cfgProject, cfgAppId);
+    }
+
+    /**
+     * Outcome of resolving a launch-configuration name: either the resolved project + applicationId,
+     * or an error tool-result JSON.
+     */
+    private static final class TargetResolution
+    {
+        private final String projectName;
+        private final String applicationId;
+        private final String error;
+
+        private TargetResolution(String projectName, String applicationId, String error)
+        {
+            this.projectName = projectName;
+            this.applicationId = applicationId;
+            this.error = error;
+        }
+
+        static TargetResolution resolved(String projectName, String applicationId)
+        {
+            return new TargetResolution(projectName, applicationId, null);
+        }
+
+        static TargetResolution error(String error)
+        {
+            return new TargetResolution(null, null, error);
+        }
+
+        String projectName()
+        {
+            return projectName;
+        }
+
+        String applicationId()
+        {
+            return applicationId;
+        }
+
+        String error()
+        {
+            return error;
+        }
     }
 
     private String store(String projectName, String applicationId, String user, String password,

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ExternalObjectDumpSupport.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ExternalObjectDumpSupport.java
@@ -55,9 +55,6 @@ public final class ExternalObjectDumpSupport
     /** File extension of a dumped external report. */
     public static final String EXTENSION_ERF = "erf"; //$NON-NLS-1$
 
-    /** EClass name of an external data processor (used as a class-loader-independent fallback check). */
-    private static final String ECLASS_EXTERNAL_DATA_PROCESSOR = "ExternalDataProcessor"; //$NON-NLS-1$
-
     /** EClass name of an external report (used as a class-loader-independent fallback check). */
     private static final String ECLASS_EXTERNAL_REPORT = "ExternalReport"; //$NON-NLS-1$
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormStructureReader.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormStructureReader.java
@@ -205,73 +205,101 @@ public final class FormStructureReader
     {
         StringBuilder sb = new StringBuilder();
         sb.append("# Form Structure: ").append(formPath).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        renderItems(sb, formModel, language);
+        renderAttributes(sb, formModel, language);
+        renderCommands(sb, formModel, language);
+        renderEventHandlers(sb, formModel, language);
+        return sb.toString();
+    }
 
+    /**
+     * Renders the {@code ## Items} section: the nested item outline (auto command bar first, then the
+     * form root's items), capped at {@link #MAX_NODES} nodes with a truncation note. Falls back to
+     * {@code _(no items)_} when the form carries neither items nor an auto command bar.
+     */
+    private static void renderItems(StringBuilder sb, EObject formModel, String language)
+    {
         sb.append("## Items\n\n"); //$NON-NLS-1$
         List<EObject> items = getReferenceList(formModel, FEATURE_ITEMS);
         EObject autoCommandBar = getSingleReference(formModel, FEATURE_AUTO_COMMAND_BAR);
         if (items.isEmpty() && autoCommandBar == null)
         {
             sb.append("_(no items)_\n\n"); //$NON-NLS-1$
+            return;
         }
-        else
+        int[] budget = {MAX_NODES};
+        boolean[] truncated = {false};
+        if (autoCommandBar != null)
         {
-            int[] budget = {MAX_NODES};
-            boolean[] truncated = {false};
-            if (autoCommandBar != null)
-            {
-                appendItem(sb, autoCommandBar, 0, language, budget, truncated);
-            }
-            for (EObject item : items)
-            {
-                appendItem(sb, item, 0, language, budget, truncated);
-            }
-            // Gate the note on the explicit flag (set only when a node was actually dropped), NOT on an
-            // exhausted budget: a form with EXACTLY MAX_NODES nodes drains the budget to 0 yet renders
-            // every node, so inferring truncation from budget[0] <= 0 would falsely flag it.
-            if (truncated[0])
-            {
-                sb.append("- _(item outline truncated: more than ") //$NON-NLS-1$
-                    .append(MAX_NODES).append(" nodes)_\n"); //$NON-NLS-1$
-            }
-            sb.append('\n');
+            appendItem(sb, autoCommandBar, 0, language, budget, truncated);
         }
+        for (EObject item : items)
+        {
+            appendItem(sb, item, 0, language, budget, truncated);
+        }
+        // Gate the note on the explicit flag (set only when a node was actually dropped), NOT on an
+        // exhausted budget: a form with EXACTLY MAX_NODES nodes drains the budget to 0 yet renders
+        // every node, so inferring truncation from budget[0] <= 0 would falsely flag it.
+        if (truncated[0])
+        {
+            sb.append("- _(item outline truncated: more than ") //$NON-NLS-1$
+                .append(MAX_NODES).append(" nodes)_\n"); //$NON-NLS-1$
+        }
+        sb.append('\n');
+    }
 
+    /**
+     * Renders the {@code ## Attributes} table (Name / Synonym / Type / Main / SavedData), or
+     * {@code _(no attributes)_} when the form has no attributes.
+     */
+    private static void renderAttributes(StringBuilder sb, EObject formModel, String language)
+    {
         sb.append("## Attributes\n\n"); //$NON-NLS-1$
         List<EObject> attributes = getReferenceList(formModel, FEATURE_ATTRIBUTES);
         if (attributes.isEmpty())
         {
             sb.append("_(no attributes)_\n\n"); //$NON-NLS-1$
+            return;
         }
-        else
+        sb.append(MarkdownUtils.tableHeader(
+            "Name", "Synonym", "Type", "Main", "SavedData")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+        for (EObject attribute : attributes)
         {
-            sb.append(MarkdownUtils.tableHeader(
-                "Name", "Synonym", "Type", "Main", "SavedData")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
-            for (EObject attribute : attributes)
-            {
-                sb.append(MarkdownUtils.tableRow(nameOf(attribute), titleOf(attribute, language),
-                    valueTypeOf(attribute), Boolean.toString(booleanFeature(attribute, FEATURE_MAIN)),
-                    Boolean.toString(booleanFeature(attribute, FEATURE_SAVED_DATA))));
-            }
-            sb.append('\n');
+            sb.append(MarkdownUtils.tableRow(nameOf(attribute), titleOf(attribute, language),
+                valueTypeOf(attribute), Boolean.toString(booleanFeature(attribute, FEATURE_MAIN)),
+                Boolean.toString(booleanFeature(attribute, FEATURE_SAVED_DATA))));
         }
+        sb.append('\n');
+    }
 
+    /**
+     * Renders the {@code ## Commands} table (Name / Title / Action handler), or {@code _(no commands)_}
+     * when the form has no commands.
+     */
+    private static void renderCommands(StringBuilder sb, EObject formModel, String language)
+    {
         sb.append("## Commands\n\n"); //$NON-NLS-1$
         List<EObject> commands = getReferenceList(formModel, FEATURE_FORM_COMMANDS);
         if (commands.isEmpty())
         {
             sb.append("_(no commands)_\n\n"); //$NON-NLS-1$
+            return;
         }
-        else
+        sb.append(MarkdownUtils.tableHeader("Name", "Title", "Action handler")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        for (EObject command : commands)
         {
-            sb.append(MarkdownUtils.tableHeader("Name", "Title", "Action handler")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-            for (EObject command : commands)
-            {
-                sb.append(MarkdownUtils.tableRow(nameOf(command), titleOf(command, language),
-                    actionHandlerOf(command)));
-            }
-            sb.append('\n');
+            sb.append(MarkdownUtils.tableRow(nameOf(command), titleOf(command, language),
+                actionHandlerOf(command)));
         }
+        sb.append('\n');
+    }
 
+    /**
+     * Renders the {@code ## Event handlers} table (Element / Event / Handler) for the BSL handler bound
+     * to each event of the form root and every element, or {@code _(no event handlers)_} when none.
+     */
+    private static void renderEventHandlers(StringBuilder sb, EObject formModel, String language)
+    {
         sb.append("## Event handlers\n\n"); //$NON-NLS-1$
         List<String[]> handlers = new ArrayList<>();
         // collectHandlers recurses the form root's 'items' AND its singular containments (the form-wide
@@ -282,18 +310,14 @@ public final class FormStructureReader
         if (handlers.isEmpty())
         {
             sb.append("_(no event handlers)_\n\n"); //$NON-NLS-1$
+            return;
         }
-        else
+        sb.append(MarkdownUtils.tableHeader("Element", "Event", "Handler")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        for (String[] row : handlers)
         {
-            sb.append(MarkdownUtils.tableHeader("Element", "Event", "Handler")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-            for (String[] row : handlers)
-            {
-                sb.append(MarkdownUtils.tableRow(row[0], row[1], row[2]));
-            }
-            sb.append('\n');
+            sb.append(MarkdownUtils.tableRow(row[0], row[1], row[2]));
         }
-
-        return sb.toString();
+        sb.append('\n');
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/McpSecureStorageProvider.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/McpSecureStorageProvider.java
@@ -6,23 +6,24 @@
 
 package com.ditrix.edt.mcp.server.utils;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
-
 import javax.crypto.spec.PBEKeySpec;
 
 import org.eclipse.equinox.security.storage.provider.IPreferencesContainer;
 import org.eclipse.equinox.security.storage.provider.PasswordProvider;
 
 /**
- * Supplies a stable master password for the Eclipse default secure storage so that EDT's
+ * Supplies an <b>empty</b> master password for the Eclipse default secure storage so that EDT's
  * {@code IInfobaseAccessManager.updateSettings} (used by {@code set_infobase_credentials} and
  * {@code create_infobase}) never raises the blocking <b>"Secure Storage — please enter a new master
  * password"</b> dialog on a fresh / headless stand (issue #194). On such a stand writing the infobase
  * connection credentials initializes the Eclipse keyring, which otherwise prompts for a master password
  * and hangs the unattended call.
+ *
+ * <p><b>No master password by design.</b> On a trusted-caller server the local keyring only protects
+ * infobase connection settings, which are re-settable; there is nothing to defend against a local
+ * attacker that filesystem access would not already expose. So instead of inventing a secret we supply
+ * an empty passphrase — there is no credential literal in source (an empty value is not a secret, so
+ * S6437 does not apply).
  *
  * <p>Registered via the {@code org.eclipse.equinox.security.secureStorage} extension at a priority just
  * above the platform's interactive {@code DefaultPasswordProvider} (priority 2) — so on a headless stand
@@ -36,63 +37,17 @@ import org.eclipse.equinox.security.storage.provider.PasswordProvider;
  */
 public final class McpSecureStorageProvider extends PasswordProvider
 {
-    /**
-     * Non-secret application salt mixed into the derived master password. A salt is a fixed,
-     * publishable application constant (NOT a credential), so it carries no secret value on its own.
-     */
-    private static final String SALT = "com.ditrix.edt.mcp.server.secureStorage.v1"; //$NON-NLS-1$
-
-    /** NUL field separator between the identity components of the hashed material. */
-    private static final char SEP = (char)0;
-
-    /**
-     * Master password for the LOCAL Eclipse keyring — NOT an infobase user password. It is now
-     * <b>derived per machine + user</b> (from the OS user name and home directory mixed with a fixed
-     * application {@link #SALT}) rather than stored as a hardcoded secret, so no credential literal
-     * remains in source. The derivation is deterministic, so the keyring re-opens every session
-     * without a prompt; on a trusted-caller server the keyring only protects infobase connection
-     * settings. Because the value is derived, a keyring created under a different OS user / home will
-     * not decrypt — acceptable here, as it only caches re-settable infobase connection settings.
-     */
-    private static final String MASTER = deriveMaster();
-
     @Override
     public PBEKeySpec getPassword(IPreferencesContainer container, int passwordType)
     {
-        // Always supply the stable derived password: the moduleID design (above) means we only ever own
-        // the values we encrypt, so this cannot affect a user's existing secure-storage entries, and on a
-        // desktop the higher-priority OS keyring providers are chosen ahead of us anyway.
-        return new PBEKeySpec(MASTER.toCharArray());
-    }
-
-    /**
-     * Derives the stable master password from machine/installation-local identity so that no secret
-     * literal lives in source. Computes {@code Base64url(SHA-256(user.name SEP user.home SEP SALT))},
-     * where {@code SEP} is a NUL separator.
-     *
-     * @return the derived, deterministic master password for the current OS user / home
-     */
-    private static String deriveMaster()
-    {
-        String material = System.getProperty("user.name", "") //$NON-NLS-1$ //$NON-NLS-2$
-            + SEP + System.getProperty("user.home", "") //$NON-NLS-1$ //$NON-NLS-2$
-            + SEP + SALT;
-        try
-        {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256"); //$NON-NLS-1$
-            byte[] hash = digest.digest(material.getBytes(StandardCharsets.UTF_8));
-            return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
-        }
-        catch (NoSuchAlgorithmException e)
-        {
-            // SHA-256 is mandated by every JRE; absence is a broken platform, not a recoverable state.
-            throw new IllegalStateException("SHA-256 algorithm is not available", e); //$NON-NLS-1$
-        }
+        // No master password: supply an empty passphrase so the keyring opens unattended without a
+        // prompt and no secret literal lives in source.
+        return new PBEKeySpec(new char[0]);
     }
 
     @Override
     public boolean retryOnError(Exception e, IPreferencesContainer container)
     {
-        return false; // a wrong stable password must not loop
+        return false; // the empty password is fixed; retrying cannot help
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/McpSecureStorageProvider.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/McpSecureStorageProvider.java
@@ -6,6 +6,11 @@
 
 package com.ditrix.edt.mcp.server.utils;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
 import javax.crypto.spec.PBEKeySpec;
 
 import org.eclipse.equinox.security.storage.provider.IPreferencesContainer;
@@ -32,19 +37,57 @@ import org.eclipse.equinox.security.storage.provider.PasswordProvider;
 public final class McpSecureStorageProvider extends PasswordProvider
 {
     /**
-     * Master password for the LOCAL Eclipse keyring — NOT an infobase user password. A fixed constant so
-     * the keyring re-opens every session without a prompt; on a trusted-caller server the keyring only
-     * protects infobase connection settings.
+     * Non-secret application salt mixed into the derived master password. A salt is a fixed,
+     * publishable application constant (NOT a credential), so it carries no secret value on its own.
      */
-    private static final String MASTER = "edt-mcp-unattended-secure-storage-v1"; //$NON-NLS-1$
+    private static final String SALT = "com.ditrix.edt.mcp.server.secureStorage.v1"; //$NON-NLS-1$
+
+    /** NUL field separator between the identity components of the hashed material. */
+    private static final char SEP = (char)0;
+
+    /**
+     * Master password for the LOCAL Eclipse keyring — NOT an infobase user password. It is now
+     * <b>derived per machine + user</b> (from the OS user name and home directory mixed with a fixed
+     * application {@link #SALT}) rather than stored as a hardcoded secret, so no credential literal
+     * remains in source. The derivation is deterministic, so the keyring re-opens every session
+     * without a prompt; on a trusted-caller server the keyring only protects infobase connection
+     * settings. Because the value is derived, a keyring created under a different OS user / home will
+     * not decrypt — acceptable here, as it only caches re-settable infobase connection settings.
+     */
+    private static final String MASTER = deriveMaster();
 
     @Override
     public PBEKeySpec getPassword(IPreferencesContainer container, int passwordType)
     {
-        // Always supply the stable password: the moduleID design (above) means we only ever own the
-        // values we encrypt, so this cannot affect a user's existing secure-storage entries, and on a
+        // Always supply the stable derived password: the moduleID design (above) means we only ever own
+        // the values we encrypt, so this cannot affect a user's existing secure-storage entries, and on a
         // desktop the higher-priority OS keyring providers are chosen ahead of us anyway.
         return new PBEKeySpec(MASTER.toCharArray());
+    }
+
+    /**
+     * Derives the stable master password from machine/installation-local identity so that no secret
+     * literal lives in source. Computes {@code Base64url(SHA-256(user.name SEP user.home SEP SALT))},
+     * where {@code SEP} is a NUL separator.
+     *
+     * @return the derived, deterministic master password for the current OS user / home
+     */
+    private static String deriveMaster()
+    {
+        String material = System.getProperty("user.name", "") //$NON-NLS-1$ //$NON-NLS-2$
+            + SEP + System.getProperty("user.home", "") //$NON-NLS-1$ //$NON-NLS-2$
+            + SEP + SALT;
+        try
+        {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256"); //$NON-NLS-1$
+            byte[] hash = digest.digest(material.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+        }
+        catch (NoSuchAlgorithmException e)
+        {
+            // SHA-256 is mandated by every JRE; absence is a broken platform, not a recoverable state.
+            throw new IllegalStateException("SHA-256 algorithm is not available", e); //$NON-NLS-1$
+        }
     }
 
     @Override


### PR DESCRIPTION
## Что это

После релиза v2.5.1 SonarCloud завёл **11 new-code замечаний** (PR #197/#199/#202/#204/#205/#206). Этот PR закрывает все 11. Изменения поведения нет нигде, **кроме намеренного** — мастер-пароль локального secure-storage (см. ⚠️ ниже).

## Замечания и как закрыты

| Правило | Severity | Файл | Решение |
|---|---|---|---|
| **S6437** | 🔴 **BLOCKER** | `McpSecureStorageProvider` | **убран мастер-пароль вовсе** — провайдер отдаёт пустой пароль (`new char[0]`), литерала-секрета в исходниках нет |
| S3776 ×5 | CRITICAL | `BuildExternalObjectsTool.enumerateTargets`, `GetApplicationsTool.getApplications`, `ModifyMetadataTool.parseDynListQueryProps`, `SetInfobaseCredentialsTool.execute`, `FormStructureReader.render` | сложность снижена извлечением связных private-хелперов; поведение байт-в-байт |
| S6541 | INFO | `GetApplicationsTool` | «Brain Method» уходит со снижением сложности |
| S107 | MAJOR | `BuildExternalObjectsTool.BuildContext` | убран избыточный `projectName`, 8 → 7 параметров |
| S1192 | CRITICAL | `BuildExternalObjectsTool` | литерал `"success"` → константа `RES_SUCCESS` |
| S125 | MAJOR | `SetInfobaseCredentialsTool` | пояснительный комментарий переформулирован (ложное срабатывание) |
| S1068 | MAJOR | `ExternalObjectDumpSupport` | удалено неиспользуемое поле |

## ⚠️ BLOCKER S6437 — без мастер-пароля + результаты live-проверки

`McpSecureStorageProvider` (из #205) хранил мастер-пароль локального keyring строковым литералом. Здесь подход проще: **мастер-пароля нет вовсе** — провайдер отдаёт пустой пароль (`new char[0]`). Литерала-секрета в исходниках не остаётся → S6437 закрыт без NOSONAR.

Это сознательный выбор для trusted-caller модели: на доверенном локальном сервере keyring защищает только **пере-задаваемые** настройки подключения к ИБ, и общий мастер-пароль (как в #205) реальной защиты от того, у кого уже есть доступ к ФС, не давал. Так что вместо выдуманного «секрета» — пустой пароль: без диалога, без литерала, без привязки к машине.

**Live-проверено на стенде EDT 2025.2.6 (dev-ai), unattended:**
- ✅ **Свежий keyring:** `set_infobase_credentials` (Admin) — успех за 0.1с, **без диалога мастер-пароля**, keyring создан.
- ✅ **Рестарт JVM:** повторный вызов — успех за 0.1с, пустой пароль **переоткрыл** существующий keyring.

(Для справки также проверял вариант с деривацией SHA-256 — тоже работает, но привязывает keyring к машине/пользователю и сложнее; пустой пароль чище.)

### 🔁 Единственное следствие — одноразовая миграция при апгрейде
Любая смена значения мастер-пароля = **ротация ключа**: keyring, созданный билдом #205 (старая константа), новым пустым паролем не расшифровывается → первая credential-операция после апгрейда упадёт с «Secure storage loading error», пока старый keyring не удалить один раз (`<eclipse-config>/org.eclipse.equinox.security/secure_storage` — он кэширует только пере-задаваемые настройки ИБ). На свежих установках проблемы нет (проверено).

## Проверка
- ✅ `mvn clean verify -T 1C` — **BUILD SUCCESS, все юнит-тесты зелёные**.
- ✅ Каждый файл — отдельная состязательная верификация (finding снят, поведение сохранено, импорты/`throws`/модификаторы корректны).
- ✅ Live round-trip keyring на стенде 2025.2.6 (свежий + рестарт) — зелёный, без диалога.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
