### PR TITLE
get_method_call_hierarchy: режим direction='outgoing' — агрегированные исходящие вызовы (#212)

### DIFF
--- a/docs/tools/get_method_call_hierarchy.md
+++ b/docs/tools/get_method_call_hierarchy.md
@@ -7,8 +7,9 @@ Find a BSL method's call hierarchy: who calls it (callers, default) or what it c
 | --- | --- | --- | --- |
 | projectName | yes | string | EDT project name (required) |
 | modulePath | yes | string | Path from src/ folder, e.g. 'CommonModules/MyModule/Module.bsl' (required) |
-| methodName | yes | string | Name of the procedure/function (case-insensitive, required) |
-| direction | — | string (one of: callers, callees) | 'callers' (default) or 'callees' |
+| methodName | — | string | Name of the procedure/function (case-insensitive). Required for direction 'callers'/'callees'; optional for 'outgoing' (omit to aggregate the whole module). |
+| direction | — | string (one of: callers, callees, outgoing) | 'callers' (default) = who calls this method; 'callees' = what this method calls; 'outgoing' = aggregated distinct call targets (module-wide when methodName omitted) |
+| extApiPrefix | — | string | For direction 'outgoing': literal call-qualifier prefix (case-insensitive) that flags a target as an external service API. Default: the 1C region name 'ПрограммныйИнтерфейсСервиса'. |
 | limit | — | integer | Max results. Default: 100, max: 500 |
 
 ## Guide
@@ -17,29 +18,47 @@ Resolves a BSL method's call graph in one direction at a time using the semantic
 ## When to use
 - `callers`: find every place that invokes a given procedure/function before renaming, changing its signature, or assessing impact.
 - `callees`: list what a method itself calls, to understand its dependencies.
+- `outgoing`: get an aggregated overview of the distinct call targets of a method (or of the whole module) - one row per `qualifier.method` with a call-site count, useful for spotting which external/service APIs a module depends on and how heavily.
 - Prefer this over `search_in_code` for identifier lookup: text search is literal and not dialect-aware, so it misses the other-language spelling.
 
 ## Parameter details
 - `projectName` (required) - EDT project name.
 - `modulePath` (required) - path from the project's `src/` folder to the module that DEFINES the method, e.g. `CommonModules/MyModule/Module.bsl` or `Documents/SalesOrder/ManagerModule.bsl`.
-- `methodName` (required) - the procedure/function name; case-insensitive, matched by programmatic Name (not by synonym).
-- `direction` - `callers` (default) = who calls this method; `callees` = what this method calls. An unknown value returns an error.
-- `limit` - max rows returned; default 100, max 500 (clamped). The reported total count is exact even when rows are truncated.
+- `methodName` - the procedure/function name; case-insensitive, matched by programmatic Name (not by synonym). Required for `callers` and `callees`. Optional for `outgoing`: omit it to aggregate the whole module; supply it to aggregate a single method's body.
+- `direction` - `callers` (default) = who calls this method; `callees` = what this method calls; `outgoing` = aggregated distinct call targets. An unknown value returns an error.
+- `extApiPrefix` - only used by `outgoing`. A literal call-qualifier prefix, compared case-insensitively against each target's qualifier token; a match flags the row as an external service API (`ExtAPI = yes`). This is a plain text match on the call qualifier (`Module` part), NOT a resolved-module lookup. Default: the conventional 1C region name `ПрограммныйИнтерфейсСервиса`.
+- `limit` - max rows returned; default 100, max 500 (clamped). For `outgoing` the limit clamps DISTINCT target rows. The reported total count is exact even when rows are truncated.
 
 ## How callers are found
 BSL invocations are linked by name through scoping and are NOT stored as ordinary cross-references in the index, so the generic Xtext reference finder cannot see them. This tool mirrors EDT's own strategy: text-prefilter the `.bsl` modules whose source mentions the method name, parse only those, and match each invocation to this exact method by its resolved feature entry. When the resolver left entries empty it falls back to the call qualifier (`Module.Method`) or an unqualified call inside the defining module itself.
 
+## How outgoing calls are aggregated
+`outgoing` walks the AST of the chosen scope (a single method's body when `methodName` is given, otherwise the whole module) and groups every invocation by its `qualifier.method` pair. The qualifier token is derived from the call shape:
+- an unqualified local call (`DoWork(...)`) -> `(local)`;
+- a qualified module call (`MyModule.DoWork(...)`) -> the module name (`MyModule`);
+- a chained or expression call (`Foo().Bar()`, `a.b.Method()`) -> `(expr)`.
+
+Each distinct pair reports the number of call sites (`Count`) and the smallest source line where it first appears (`First line`). The `ExtAPI` column is `yes` when the qualifier literally starts with `extApiPrefix` (case-insensitive); the synthetic `(local)` and `(expr)` tokens are always `-`.
+
 ## Output
-Markdown table. Callers: # / Module / Method / Line / Call Code. Callees: # / Called Method / Line / Call Code. Long or multi-line call expressions are compacted (comment lines stripped, body collapsed to `Name(...)`).
+Markdown table.
+- Callers: # / Module / Method / Line / Call Code.
+- Callees: # / Called Method / Line / Call Code. Long or multi-line call expressions are compacted (comment lines stripped, body collapsed to `Name(...)`).
+- Outgoing: Qualifier / Method / Count / First line / ExtAPI (one row per distinct target, first-seen order).
 
 ## Examples
 - Callers (default): `{projectName, modulePath: "CommonModules/MyModule/Module.bsl", methodName: "DoWork"}`.
 - Callees: `{projectName, modulePath: "CommonModules/MyModule/Module.bsl", methodName: "DoWork", direction: "callees"}`.
+- Outgoing, single method: `{projectName, modulePath: "CommonModules/MyModule/Module.bsl", methodName: "DoWork", direction: "outgoing"}`.
+- Outgoing, whole module (methodName omitted): `{projectName, modulePath: "CommonModules/MyModule/Module.bsl", direction: "outgoing"}`.
+- Outgoing with a custom ext-API prefix: `{projectName, modulePath: "CommonModules/MyModule/Module.bsl", direction: "outgoing", extApiPrefix: "PublicApi"}`.
 
 ## Notes & gotchas
-- `modulePath` must point at the module that DEFINES the method; if the method is not found there the tool returns a not-found response listing the module's methods.
-- `callees` lists raw invocation names from the target method's body and does not resolve each callee to its defining module.
+- For `callers`/`callees`, `modulePath` must point at the module that DEFINES the method; if the method is not found there the tool returns a not-found response listing the module's methods. The same applies to a scoped `outgoing` call (with `methodName`).
+- `callees` and `outgoing` list raw invocation names from the scanned body and do not resolve each target to its defining module.
+- `extApiPrefix` matching is literal on the call qualifier text (e.g. `ПрограммныйИнтерфейсСервисаТовары` starts with the default prefix); it does not resolve or open the qualifying module.
 - Requires a loadable BSL AST (EMF); a module that fails to parse returns an error pointing at the EDT Error Log.
+- The `outgoing` mode is a clean-room implementation inspired by the idea behind edt-bridge's `edt_outgoing_calls` tool (Apache-2.0); no source was copied.
 
 ---
 *Generated from the live MCP server (`get_tool_guide`) by `docs/generate_tool_docs.py`. Do not edit this file. Edit the tool's description/schema in its Java source and its guide body in `mcp/bundles/com.ditrix.edt.mcp.server/guides/<tool>.md`.*

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/get_method_call_hierarchy.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/get_method_call_hierarchy.md
@@ -3,26 +3,44 @@ Resolves a BSL method's call graph in one direction at a time using the semantic
 ## When to use
 - `callers`: find every place that invokes a given procedure/function before renaming, changing its signature, or assessing impact.
 - `callees`: list what a method itself calls, to understand its dependencies.
+- `outgoing`: get an aggregated overview of the distinct call targets of a method (or of the whole module) - one row per `qualifier.method` with a call-site count, useful for spotting which external/service APIs a module depends on and how heavily.
 - Prefer this over `search_in_code` for identifier lookup: text search is literal and not dialect-aware, so it misses the other-language spelling.
 
 ## Parameter details
 - `projectName` (required) - EDT project name.
 - `modulePath` (required) - path from the project's `src/` folder to the module that DEFINES the method, e.g. `CommonModules/MyModule/Module.bsl` or `Documents/SalesOrder/ManagerModule.bsl`.
-- `methodName` (required) - the procedure/function name; case-insensitive, matched by programmatic Name (not by synonym).
-- `direction` - `callers` (default) = who calls this method; `callees` = what this method calls. An unknown value returns an error.
-- `limit` - max rows returned; default 100, max 500 (clamped). The reported total count is exact even when rows are truncated.
+- `methodName` - the procedure/function name; case-insensitive, matched by programmatic Name (not by synonym). Required for `callers` and `callees`. Optional for `outgoing`: omit it to aggregate the whole module; supply it to aggregate a single method's body.
+- `direction` - `callers` (default) = who calls this method; `callees` = what this method calls; `outgoing` = aggregated distinct call targets. An unknown value returns an error.
+- `extApiPrefix` - only used by `outgoing`. A literal call-qualifier prefix, compared case-insensitively against each target's qualifier token; a match flags the row as an external service API (`ExtAPI = yes`). This is a plain text match on the call qualifier (`Module` part), NOT a resolved-module lookup. Default: the conventional 1C region name `ПрограммныйИнтерфейсСервиса`.
+- `limit` - max rows returned; default 100, max 500 (clamped). For `outgoing` the limit clamps DISTINCT target rows. The reported total count is exact even when rows are truncated.
 
 ## How callers are found
 BSL invocations are linked by name through scoping and are NOT stored as ordinary cross-references in the index, so the generic Xtext reference finder cannot see them. This tool mirrors EDT's own strategy: text-prefilter the `.bsl` modules whose source mentions the method name, parse only those, and match each invocation to this exact method by its resolved feature entry. When the resolver left entries empty it falls back to the call qualifier (`Module.Method`) or an unqualified call inside the defining module itself.
 
+## How outgoing calls are aggregated
+`outgoing` walks the AST of the chosen scope (a single method's body when `methodName` is given, otherwise the whole module) and groups every invocation by its `qualifier.method` pair. The qualifier token is derived from the call shape:
+- an unqualified local call (`DoWork(...)`) -> `(local)`;
+- a qualified module call (`MyModule.DoWork(...)`) -> the module name (`MyModule`);
+- a chained or expression call (`Foo().Bar()`, `a.b.Method()`) -> `(expr)`.
+
+Each distinct pair reports the number of call sites (`Count`) and the smallest source line where it first appears (`First line`). The `ExtAPI` column is `yes` when the qualifier literally starts with `extApiPrefix` (case-insensitive); the synthetic `(local)` and `(expr)` tokens are always `-`.
+
 ## Output
-Markdown table. Callers: # / Module / Method / Line / Call Code. Callees: # / Called Method / Line / Call Code. Long or multi-line call expressions are compacted (comment lines stripped, body collapsed to `Name(...)`).
+Markdown table.
+- Callers: # / Module / Method / Line / Call Code.
+- Callees: # / Called Method / Line / Call Code. Long or multi-line call expressions are compacted (comment lines stripped, body collapsed to `Name(...)`).
+- Outgoing: Qualifier / Method / Count / First line / ExtAPI (one row per distinct target, first-seen order).
 
 ## Examples
 - Callers (default): `{projectName, modulePath: "CommonModules/MyModule/Module.bsl", methodName: "DoWork"}`.
 - Callees: `{projectName, modulePath: "CommonModules/MyModule/Module.bsl", methodName: "DoWork", direction: "callees"}`.
+- Outgoing, single method: `{projectName, modulePath: "CommonModules/MyModule/Module.bsl", methodName: "DoWork", direction: "outgoing"}`.
+- Outgoing, whole module (methodName omitted): `{projectName, modulePath: "CommonModules/MyModule/Module.bsl", direction: "outgoing"}`.
+- Outgoing with a custom ext-API prefix: `{projectName, modulePath: "CommonModules/MyModule/Module.bsl", direction: "outgoing", extApiPrefix: "PublicApi"}`.
 
 ## Notes & gotchas
-- `modulePath` must point at the module that DEFINES the method; if the method is not found there the tool returns a not-found response listing the module's methods.
-- `callees` lists raw invocation names from the target method's body and does not resolve each callee to its defining module.
+- For `callers`/`callees`, `modulePath` must point at the module that DEFINES the method; if the method is not found there the tool returns a not-found response listing the module's methods. The same applies to a scoped `outgoing` call (with `methodName`).
+- `callees` and `outgoing` list raw invocation names from the scanned body and do not resolve each target to its defining module.
+- `extApiPrefix` matching is literal on the call qualifier text (e.g. `ПрограммныйИнтерфейсСервисаТовары` starts with the default prefix); it does not resolve or open the qualifying module.
 - Requires a loadable BSL AST (EMF); a module that fails to parse returns an error pointing at the EDT Error Log.
+- The `outgoing` mode is a clean-room implementation inspired by the idea behind edt-bridge's `edt_outgoing_calls` tool (Apache-2.0); no source was copied.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
@@ -146,8 +146,10 @@ public class GetMethodCallHierarchyTool implements IMcpTool
     @Override
     public String getResultFileName(Map<String, String> params)
     {
-        String methodName = JsonUtils.extractStringArgument(params, KEY_METHOD_NAME);
-        String direction = JsonUtils.extractStringArgument(params, KEY_DIRECTION);
+        // Normalize the same way execute() does so a padded value like " outgoing " yields the
+        // outgoing file name (not the generic fallback) and no whitespace leaks into the name.
+        String methodName = normalizeArg(JsonUtils.extractStringArgument(params, KEY_METHOD_NAME));
+        String direction = normalizeArg(JsonUtils.extractStringArgument(params, KEY_DIRECTION));
         if (methodName != null && !methodName.isEmpty())
         {
             return "call-hierarchy-" + methodName.toLowerCase() + //$NON-NLS-1$
@@ -161,14 +163,35 @@ public class GetMethodCallHierarchyTool implements IMcpTool
         return "call-hierarchy.md"; //$NON-NLS-1$
     }
 
+    /**
+     * Trims a raw input argument and folds a blank result to {@code null} so a whitespace-only value
+     * is treated as absent. Shared by {@link #execute(Map)} and {@link #getResultFileName(Map)} so
+     * both see the same normalized {@code direction}/{@code methodName}. No-op for already-clean,
+     * non-null values.
+     *
+     * @param s the raw argument (may be {@code null})
+     * @return the trimmed value, or {@code null} when {@code s} is {@code null} or blank
+     */
+    private static String normalizeArg(String s)
+    {
+        if (s == null)
+        {
+            return null;
+        }
+        String t = s.trim();
+        return t.isEmpty() ? null : t;
+    }
+
     @Override
     public String execute(Map<String, String> params)
     {
         String projectName = JsonUtils.extractStringArgument(params, McpKeys.PROJECT_NAME);
         String modulePath = JsonUtils.extractStringArgument(params, McpKeys.MODULE_PATH);
-        String methodName = JsonUtils.extractStringArgument(params, KEY_METHOD_NAME);
-        String direction = JsonUtils.extractStringArgument(params, KEY_DIRECTION);
-        String extApiPrefix = JsonUtils.extractStringArgument(params, KEY_EXT_API_PREFIX);
+        // Trim these three so a whitespace-only value is treated as absent (defaults to callers /
+        // whole-module scope / default prefix) and a padded value like " outgoing " still routes.
+        String methodName = normalizeArg(JsonUtils.extractStringArgument(params, KEY_METHOD_NAME));
+        String direction = normalizeArg(JsonUtils.extractStringArgument(params, KEY_DIRECTION));
+        String extApiPrefix = normalizeArg(JsonUtils.extractStringArgument(params, KEY_EXT_API_PREFIX));
         int limit = JsonUtils.extractIntArgument(params, McpKeys.LIMIT, 100);
 
         // methodName is optional (only required for callers/callees); require it manually below
@@ -616,7 +639,9 @@ public class GetMethodCallHierarchyTool implements IMcpTool
         {
             return false;
         }
-        return qualifier.toLowerCase().startsWith(prefix.toLowerCase());
+        // Allocation-free, locale-independent case-insensitive prefix test. regionMatches returns
+        // false when qualifier is shorter than prefix, matching the old startsWith semantics.
+        return qualifier.regionMatches(true, 0, prefix, 0, prefix.length());
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
@@ -8,6 +8,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -54,6 +55,9 @@ import com.ditrix.edt.mcp.server.utils.ProjectContext;
  * those and match each invocation to this exact method via its resolved AST feature entries
  * (with a call-qualifier fallback when the resolver has not populated them). Callees are
  * collected by walking the target method's own AST.
+ * <p>
+ * The aggregated {@code direction='outgoing'} mode is a clean-room implementation inspired by the
+ * idea behind edt-bridge's {@code edt_outgoing_calls} tool (Apache-2.0); no source was copied.
  */
 public class GetMethodCallHierarchyTool implements IMcpTool
 {
@@ -62,11 +66,34 @@ public class GetMethodCallHierarchyTool implements IMcpTool
     /** Input param: name of the procedure/function to analyze. */
     private static final String KEY_METHOD_NAME = "methodName"; //$NON-NLS-1$
 
-    /** Input param: hierarchy direction ('callers' or 'callees'). */
+    /** Input param: hierarchy direction ('callers', 'callees' or 'outgoing'). */
     private static final String KEY_DIRECTION = "direction"; //$NON-NLS-1$
 
     /** Direction value: callers (who calls this method). */
     private static final String KEY_CALLERS = "callers"; //$NON-NLS-1$
+
+    /** Direction value: aggregated outgoing calls (distinct call targets). */
+    private static final String KEY_OUTGOING = "outgoing"; //$NON-NLS-1$
+
+    /** Input param: literal call-qualifier prefix that flags a call as an external service API. */
+    private static final String KEY_EXT_API_PREFIX = "extApiPrefix"; //$NON-NLS-1$
+
+    /**
+     * Default {@link #KEY_EXT_API_PREFIX} value: the Cyrillic 1C region name that conventionally
+     * marks a module's service programming interface ("ProgrammnyyInterfeysServisa"). Encoded via
+     * {@code \\uXXXX} escapes per project rule #7 (never a raw UTF-8 literal in source).
+     * Package-visible so the headless unit tests can assert the default without a UTF-8 literal.
+     */
+    static final String DEFAULT_EXT_API_PREFIX =
+        "\u041f\u0440\u043e\u0433\u0440\u0430\u043c\u043c\u043d\u044b\u0439" //$NON-NLS-1$
+        + "\u0418\u043d\u0442\u0435\u0440\u0444\u0435\u0439\u0441" //$NON-NLS-1$
+        + "\u0421\u0435\u0440\u0432\u0438\u0441\u0430"; //$NON-NLS-1$
+
+    /** Qualifier token for an unqualified local call (methodAccess is a StaticFeatureAccess). */
+    private static final String QUALIFIER_LOCAL = "(local)"; //$NON-NLS-1$
+
+    /** Qualifier token for a chained/expression call whose source is not a StaticFeatureAccess. */
+    private static final String QUALIFIER_EXPR = "(expr)"; //$NON-NLS-1$
 
     @Override
     public String getName()
@@ -92,10 +119,19 @@ public class GetMethodCallHierarchyTool implements IMcpTool
             .stringProperty(McpKeys.MODULE_PATH,
                 "Path from src/ folder, e.g. 'CommonModules/MyModule/Module.bsl' (required)", true) //$NON-NLS-1$
             .stringProperty(KEY_METHOD_NAME,
-                "Name of the procedure/function (case-insensitive, required)", true) //$NON-NLS-1$
+                "Name of the procedure/function (case-insensitive). " //$NON-NLS-1$
+                + "Required for direction 'callers'/'callees'; optional for 'outgoing' " //$NON-NLS-1$
+                + "(omit to aggregate the whole module).", false) //$NON-NLS-1$
             .enumProperty(KEY_DIRECTION,
-                "'callers' (default) or 'callees'", //$NON-NLS-1$
-                KEY_CALLERS, "callees") //$NON-NLS-1$
+                "'callers' (default) = who calls this method; 'callees' = what this method calls; " //$NON-NLS-1$
+                + "'outgoing' = aggregated distinct call targets (module-wide when methodName omitted)", //$NON-NLS-1$
+                KEY_CALLERS, "callees", KEY_OUTGOING) //$NON-NLS-1$
+            .stringProperty(KEY_EXT_API_PREFIX,
+                "For direction 'outgoing': literal call-qualifier prefix (case-insensitive) that " //$NON-NLS-1$
+                + "flags a target as an external service API. Default: the 1C region name " //$NON-NLS-1$
+                + "'\u041f\u0440\u043e\u0433\u0440\u0430\u043c\u043c\u043d\u044b\u0439" //$NON-NLS-1$
+                + "\u0418\u043d\u0442\u0435\u0440\u0444\u0435\u0439\u0441" //$NON-NLS-1$
+                + "\u0421\u0435\u0440\u0432\u0438\u0441\u0430'.") //$NON-NLS-1$
             .integerProperty(McpKeys.LIMIT,
                 "Max results. Default: 100, max: 500") //$NON-NLS-1$
             .build();
@@ -117,6 +153,11 @@ public class GetMethodCallHierarchyTool implements IMcpTool
             return "call-hierarchy-" + methodName.toLowerCase() + //$NON-NLS-1$
                    "-" + (direction != null ? direction : KEY_CALLERS) + ".md"; //$NON-NLS-1$ //$NON-NLS-2$
         }
+        // Module-wide outgoing scope has no method name; keep a distinct, descriptive file name.
+        if (direction != null && KEY_OUTGOING.equalsIgnoreCase(direction))
+        {
+            return "call-hierarchy-outgoing.md"; //$NON-NLS-1$
+        }
         return "call-hierarchy.md"; //$NON-NLS-1$
     }
 
@@ -127,9 +168,12 @@ public class GetMethodCallHierarchyTool implements IMcpTool
         String modulePath = JsonUtils.extractStringArgument(params, McpKeys.MODULE_PATH);
         String methodName = JsonUtils.extractStringArgument(params, KEY_METHOD_NAME);
         String direction = JsonUtils.extractStringArgument(params, KEY_DIRECTION);
+        String extApiPrefix = JsonUtils.extractStringArgument(params, KEY_EXT_API_PREFIX);
         int limit = JsonUtils.extractIntArgument(params, McpKeys.LIMIT, 100);
 
-        String err = JsonUtils.requireArguments(params, McpKeys.PROJECT_NAME, McpKeys.MODULE_PATH, KEY_METHOD_NAME);
+        // methodName is optional (only required for callers/callees); require it manually below
+        // after we have parsed and validated direction, so the guard can honour 'outgoing'.
+        String err = JsonUtils.requireArguments(params, McpKeys.PROJECT_NAME, McpKeys.MODULE_PATH);
         if (err != null)
         {
             return err;
@@ -141,9 +185,21 @@ public class GetMethodCallHierarchyTool implements IMcpTool
         }
         direction = direction.toLowerCase();
 
-        if (!KEY_CALLERS.equals(direction) && !"callees".equals(direction)) //$NON-NLS-1$
+        if (!KEY_CALLERS.equals(direction) && !"callees".equals(direction) //$NON-NLS-1$
+            && !KEY_OUTGOING.equals(direction))
         {
-            return ToolResult.error("direction must be 'callers' or 'callees'").toJson(); //$NON-NLS-1$
+            return ToolResult.error("direction must be 'callers', 'callees' or 'outgoing'").toJson(); //$NON-NLS-1$
+        }
+
+        if ((methodName == null || methodName.trim().isEmpty()) && !KEY_OUTGOING.equals(direction))
+        {
+            return ToolResult.error("methodName is required for callers/callees" //$NON-NLS-1$
+                + ". Use get_module_structure to list the module's procedures and functions.").toJson(); //$NON-NLS-1$
+        }
+
+        if (extApiPrefix == null || extApiPrefix.isEmpty())
+        {
+            extApiPrefix = DEFAULT_EXT_API_PREFIX;
         }
 
         limit = Pagination.clampLimit(limit, 500);
@@ -151,13 +207,18 @@ public class GetMethodCallHierarchyTool implements IMcpTool
         AtomicReference<String> resultRef = new AtomicReference<>();
         final String dir = direction;
         final int maxResults = limit;
+        final String prefix = extApiPrefix;
 
         Display display = PlatformUI.getWorkbench().getDisplay();
         display.syncExec(() -> {
             try
             {
                 String result;
-                if (KEY_CALLERS.equals(dir))
+                if (KEY_OUTGOING.equals(dir))
+                {
+                    result = findOutgoing(projectName, modulePath, methodName, prefix, maxResults);
+                }
+                else if (KEY_CALLERS.equals(dir))
                 {
                     result = findCallers(projectName, modulePath, methodName, maxResults);
                 }
@@ -501,6 +562,64 @@ public class GetMethodCallHierarchyTool implements IMcpTool
     }
 
     /**
+     * Classifies an invocation's method access into the qualifier token used to aggregate outgoing
+     * calls. Pinned semantics (guarded against NPE / ClassCastException):
+     * <ul>
+     * <li>an unqualified local call ({@code methodAccess} is a {@link StaticFeatureAccess}) →
+     * {@code "(local)"};</li>
+     * <li>a {@link DynamicFeatureAccess} whose {@code getSource()} is a {@link StaticFeatureAccess}
+     * → that source's name (the qualifying object, e.g. {@code CommonModule});</li>
+     * <li>a {@link DynamicFeatureAccess} whose source is a chained/other expression → {@code "(expr)"}.
+     * </li>
+     * </ul>
+     * A {@code null} or unrecognized access yields {@code "(expr)"}.
+     *
+     * @param methodAccess the invocation's method access node (may be {@code null})
+     * @return the qualifier token, never {@code null}
+     */
+    static String qualifierKey(EObject methodAccess)
+    {
+        if (methodAccess instanceof StaticFeatureAccess)
+        {
+            return QUALIFIER_LOCAL;
+        }
+        if (methodAccess instanceof DynamicFeatureAccess)
+        {
+            Expression source = ((DynamicFeatureAccess)methodAccess).getSource();
+            if (source instanceof StaticFeatureAccess)
+            {
+                String name = ((StaticFeatureAccess)source).getName();
+                return name != null ? name : QUALIFIER_EXPR;
+            }
+            return QUALIFIER_EXPR;
+        }
+        return QUALIFIER_EXPR;
+    }
+
+    /**
+     * True when a call qualifier flags an external service API, i.e. the resolved qualifier token
+     * starts (case-insensitively) with {@code prefix}. This is a literal text match on the call
+     * qualifier itself, not a resolved-module lookup. The synthetic tokens {@code "(local)"} and
+     * {@code "(expr)"} never match (they cannot start with a real region name).
+     *
+     * @param qualifier the resolved qualifier token (from {@link #qualifierKey(EObject)})
+     * @param prefix the external-API prefix to test against
+     * @return true when the qualifier begins with the prefix (case-insensitive)
+     */
+    static boolean isExtApi(String qualifier, String prefix)
+    {
+        if (qualifier == null || prefix == null || prefix.isEmpty())
+        {
+            return false;
+        }
+        if (QUALIFIER_LOCAL.equals(qualifier) || QUALIFIER_EXPR.equals(qualifier))
+        {
+            return false;
+        }
+        return qualifier.toLowerCase().startsWith(prefix.toLowerCase());
+    }
+
+    /**
      * Finds all callees from the specified method by traversing its AST.
      */
     private String findCallees(String projectName, String modulePath, String methodName, int limit)
@@ -724,6 +843,167 @@ public class GetMethodCallHierarchyTool implements IMcpTool
         return sb.toString();
     }
 
+    // ========== Outgoing (aggregated targets) ==========
+
+    /**
+     * Aggregates the distinct outgoing call targets of a scope. When {@code methodName} is given the
+     * scope is that method's AST (mirroring {@link #findCallees}); when it is omitted the scope is
+     * the whole module's AST (mirroring the invocation walk of {@link #findCallers} /
+     * {@link #scanCandidateInvocations}). Each {@link Invocation} is classified via
+     * {@link #qualifierKey(EObject)} and aggregated by {@code qualifier + "." + method} into a
+     * first-seen-ordered map: {@code count} is the number of call sites and {@code firstLine} is the
+     * smallest start line across those sites.
+     *
+     * @param projectName the EDT project
+     * @param modulePath the source-relative module path
+     * @param methodName the scoping method name, or {@code null}/blank for the whole module
+     * @param extApiPrefix the literal external-API qualifier prefix (case-insensitive)
+     * @param limit the maximum number of distinct rows to render
+     * @return the rendered Markdown, or a {@link ToolResult#error} JSON string on failure
+     */
+    private String findOutgoing(String projectName, String modulePath, String methodName,
+        String extApiPrefix, int limit)
+    {
+        ProjectContext ctx = ProjectContext.of(projectName);
+        if (!ctx.exists())
+        {
+            return ToolResult.error(ProjectContext.notFoundMessage(projectName)).toJson();
+        }
+        IProject project = ctx.project();
+
+        Module module = BslModuleUtils.loadModule(project, modulePath);
+        if (module == null)
+        {
+            return ToolResult.error("Could not load EMF model for " + modulePath + //$NON-NLS-1$
+                   ". Call hierarchy requires BSL AST (EMF). Check EDT Error Log for details.").toJson(); //$NON-NLS-1$
+        }
+
+        boolean scoped = methodName != null && !methodName.trim().isEmpty();
+        EObject scope;
+        if (scoped)
+        {
+            Method method = BslModuleUtils.findMethod(module, methodName);
+            if (method == null)
+            {
+                return BslModuleUtils.buildMethodNotFoundResponse(module, modulePath, methodName);
+            }
+            scope = method;
+        }
+        else
+        {
+            scope = module;
+        }
+
+        // First-seen-ordered aggregation keyed by qualifier + "." + method.
+        Map<String, OutgoingTarget> targets = new LinkedHashMap<>();
+
+        try
+        {
+            for (Iterator<EObject> iter = scope.eAllContents(); iter.hasNext();)
+            {
+                EObject obj = iter.next();
+                if (!(obj instanceof Invocation))
+                {
+                    continue;
+                }
+                Invocation inv = (Invocation)obj;
+                // Reuse the frozen resolveInvocationName (it re-derives the method access from the
+                // Invocation) rather than a duplicate name-resolver; classify the qualifier separately.
+                String method = resolveInvocationName(inv);
+                if (method == null || method.isEmpty())
+                {
+                    continue;
+                }
+                String qualifier = qualifierKey(inv.getMethodAccess());
+                int line = BslModuleUtils.getStartLine(inv);
+
+                String key = qualifier + "." + method; //$NON-NLS-1$
+                OutgoingTarget target = targets.get(key);
+                if (target == null)
+                {
+                    target = new OutgoingTarget();
+                    target.qualifier = qualifier;
+                    target.method = method;
+                    target.count = 0;
+                    target.firstLine = line;
+                    target.extApi = isExtApi(qualifier, extApiPrefix);
+                    targets.put(key, target);
+                }
+                target.count++;
+                // firstLine = min getStartLine across the call sites of this target.
+                target.firstLine = Math.min(target.firstLine, line);
+            }
+        }
+        catch (Exception e)
+        {
+            // Per-file parse failure must never abort the aggregation; log and continue with what
+            // was collected so far (mirrors the candidate-scan resilience of findCallers).
+            Activator.logWarning("Failed to walk module for outgoing calls " + modulePath //$NON-NLS-1$
+                + ": " + e.getMessage()); //$NON-NLS-1$
+        }
+
+        return formatOutgoingOutput(modulePath, scoped ? methodName : null,
+            new ArrayList<>(targets.values()), limit);
+    }
+
+    /**
+     * Renders the aggregated outgoing-call targets as Markdown. The heading names the module and,
+     * only when the scope is a single method, appends {@code " :: <method>"}. Distinct rows are
+     * clamped to {@code limit}; the total-distinct count and truncation notice are computed against
+     * the full set before clamping.
+     *
+     * @param modulePath the analyzed module path
+     * @param methodName the scoping method name, or {@code null} for a module-wide scope
+     * @param targets the aggregated distinct targets in first-seen order
+     * @param limit the maximum number of rows to render
+     * @return the rendered Markdown
+     */
+    private String formatOutgoingOutput(String modulePath, String methodName,
+        List<OutgoingTarget> targets, int limit)
+    {
+        int totalDistinct = targets.size();
+        int shown = Math.min(totalDistinct, limit);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("## Outgoing Calls: ").append(modulePath); //$NON-NLS-1$
+        if (methodName != null && !methodName.isEmpty())
+        {
+            sb.append(" :: ").append(methodName); //$NON-NLS-1$
+        }
+        sb.append("\n\n"); //$NON-NLS-1$
+        sb.append("**Direction:** Outgoing calls (aggregated targets)\n"); //$NON-NLS-1$
+        sb.append("**Total distinct targets:** ").append(totalDistinct); //$NON-NLS-1$
+        sb.append(Pagination.truncationNotice(shown, totalDistinct));
+        sb.append("\n\n"); //$NON-NLS-1$
+
+        if (targets.isEmpty())
+        {
+            sb.append("No outgoing calls found.\n"); //$NON-NLS-1$
+            return sb.toString();
+        }
+
+        sb.append("| Qualifier | Method | Count | First line | ExtAPI |\n"); //$NON-NLS-1$
+        sb.append("|-----------|--------|-------|------------|--------|\n"); //$NON-NLS-1$
+
+        int rendered = 0;
+        for (OutgoingTarget target : targets)
+        {
+            if (rendered >= shown)
+            {
+                break;
+            }
+            rendered++;
+            sb.append("| ").append(MarkdownUtils.escapeForTable(target.qualifier)); //$NON-NLS-1$
+            sb.append(" | ").append(MarkdownUtils.escapeForTable(target.method)); //$NON-NLS-1$
+            sb.append(" | ").append(MarkdownUtils.escapeForTable(String.valueOf(target.count))); //$NON-NLS-1$
+            sb.append(" | ").append(MarkdownUtils.escapeForTable(String.valueOf(target.firstLine))); //$NON-NLS-1$
+            sb.append(" | ").append(MarkdownUtils.escapeForTable(target.extApi ? "yes" : "-")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            sb.append(" |\n"); //$NON-NLS-1$
+        }
+
+        return sb.toString();
+    }
+
     // ========== Data structures ==========
 
     private static class CallerInfo
@@ -739,5 +1019,18 @@ public class GetMethodCallHierarchyTool implements IMcpTool
         String calledMethodName;
         int line;
         String callCode;
+    }
+
+    /**
+     * One aggregated outgoing-call target: a distinct {@code qualifier.method} pair with the number
+     * of call sites and the smallest start line across them.
+     */
+    private static class OutgoingTarget
+    {
+        String qualifier;
+        String method;
+        int count;
+        int firstLine;
+        boolean extApi;
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
@@ -620,6 +620,20 @@ public class GetMethodCallHierarchyTool implements IMcpTool
     }
 
     /**
+     * The case-insensitive aggregation key for an outgoing target. BSL identifiers are
+     * case-insensitive, so {@code Module.Method} and {@code module.method} fold to the same target
+     * (the first-seen spelling is kept for display). Package-visible for headless unit tests.
+     *
+     * @param qualifier the qualifier token
+     * @param method the called method name
+     * @return the lower-cased {@code qualifier.method} key (Locale.ROOT)
+     */
+    static String aggregationKey(String qualifier, String method)
+    {
+        return (qualifier + "." + method).toLowerCase(java.util.Locale.ROOT); //$NON-NLS-1$
+    }
+
+    /**
      * Finds all callees from the specified method by traversing its AST.
      */
     private String findCallees(String projectName, String modulePath, String methodName, int limit)
@@ -917,7 +931,7 @@ public class GetMethodCallHierarchyTool implements IMcpTool
                 String qualifier = qualifierKey(inv.getMethodAccess());
                 int line = BslModuleUtils.getStartLine(inv);
 
-                String key = qualifier + "." + method; //$NON-NLS-1$
+                String key = aggregationKey(qualifier, method);
                 OutgoingTarget target = targets.get(key);
                 if (target == null)
                 {
@@ -930,8 +944,13 @@ public class GetMethodCallHierarchyTool implements IMcpTool
                     targets.put(key, target);
                 }
                 target.count++;
-                // firstLine = min getStartLine across the call sites of this target.
-                target.firstLine = Math.min(target.firstLine, line);
+                // firstLine = smallest POSITIVE start line across the call sites. getStartLine() returns
+                // 0 when a node has no line info; 0 must not win the min (it renders as '-', like
+                // callers/callees), so only positive lines lower firstLine.
+                if (line > 0 && (target.firstLine <= 0 || line < target.firstLine))
+                {
+                    target.firstLine = line;
+                }
             }
         }
         catch (Exception e)
@@ -996,7 +1015,7 @@ public class GetMethodCallHierarchyTool implements IMcpTool
             sb.append("| ").append(MarkdownUtils.escapeForTable(target.qualifier)); //$NON-NLS-1$
             sb.append(" | ").append(MarkdownUtils.escapeForTable(target.method)); //$NON-NLS-1$
             sb.append(" | ").append(MarkdownUtils.escapeForTable(String.valueOf(target.count))); //$NON-NLS-1$
-            sb.append(" | ").append(MarkdownUtils.escapeForTable(String.valueOf(target.firstLine))); //$NON-NLS-1$
+            sb.append(" | ").append(target.firstLine > 0 ? String.valueOf(target.firstLine) : "-"); //$NON-NLS-1$ //$NON-NLS-2$
             sb.append(" | ").append(MarkdownUtils.escapeForTable(target.extApi ? "yes" : "-")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             sb.append(" |\n"); //$NON-NLS-1$
         }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyToolTest.java
@@ -384,15 +384,15 @@ public class GetMethodCallHierarchyToolTest
     }
 
     @Test
-    public void testResultFileNameEmptyDirectionIsAppendedVerbatim()
+    public void testResultFileNameBlankDirectionDefaultsToCallers()
     {
-        // The direction segment guards on null, NOT on emptiness: an explicitly empty
-        // direction is appended as-is (it does not fall back to "callers"). Pins the
-        // exact (direction != null ? direction : KEY_CALLERS) semantics.
+        // A blank (empty or whitespace-only) direction is normalized to null the same way
+        // execute() does, so the direction segment falls back to "callers" instead of
+        // leaking whitespace into the file name. Mirrors execute()'s defaulting.
         Map<String, String> params = new HashMap<>();
         params.put("methodName", "DoWork"); //$NON-NLS-1$ //$NON-NLS-2$
-        params.put("direction", ""); //$NON-NLS-1$ //$NON-NLS-2$
-        assertEquals("call-hierarchy-dowork-.md", //$NON-NLS-1$
+        params.put("direction", "   "); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("call-hierarchy-dowork-callers.md", //$NON-NLS-1$
             new GetMethodCallHierarchyTool().getResultFileName(params));
     }
 

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyToolTest.java
@@ -54,6 +54,19 @@ public class GetMethodCallHierarchyToolTest
     }
 
     @Test
+    public void testAggregationKeyIsCaseInsensitive()
+    {
+        // BSL identifiers are case-insensitive: Module.Method and module.method aggregate as one target.
+        assertEquals(GetMethodCallHierarchyTool.aggregationKey("MyModule", "DoWork"), //$NON-NLS-1$ //$NON-NLS-2$
+            GetMethodCallHierarchyTool.aggregationKey("mymodule", "dowork")); //$NON-NLS-1$ //$NON-NLS-2$
+        // Distinct qualifiers or methods still map to distinct keys.
+        assertFalse(GetMethodCallHierarchyTool.aggregationKey("A", "X") //$NON-NLS-1$ //$NON-NLS-2$
+            .equals(GetMethodCallHierarchyTool.aggregationKey("B", "X"))); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse(GetMethodCallHierarchyTool.aggregationKey("A", "X") //$NON-NLS-1$ //$NON-NLS-2$
+            .equals(GetMethodCallHierarchyTool.aggregationKey("A", "Y"))); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
     public void testResponseTypeMarkdown()
     {
         assertEquals(ResponseType.MARKDOWN, new GetMethodCallHierarchyTool().getResponseType());

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyToolTest.java
@@ -7,6 +7,7 @@
 package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -16,6 +17,9 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import com._1c.g5.v8.dt.bsl.model.BslFactory;
+import com._1c.g5.v8.dt.bsl.model.DynamicFeatureAccess;
+import com._1c.g5.v8.dt.bsl.model.StaticFeatureAccess;
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 
 /**
@@ -23,10 +27,17 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
  * <p>
  * Covers tool metadata, the input schema, and the argument-validation branches
  * that return before any live EDT access. {@code execute()} validates
- * projectName, modulePath, methodName and the direction value before the first
- * {@code PlatformUI.getWorkbench()} call, so those returns are reachable
- * headlessly. Project/module resolution and the reference-finder walk need a
- * live workbench and are covered by the E2E suite.
+ * projectName, modulePath, the direction value and (for callers/callees) methodName
+ * before the first {@code PlatformUI.getWorkbench()} call, so those returns are
+ * reachable headlessly. Project/module resolution and the reference-finder walk need
+ * a live workbench and are covered by the E2E suite.
+ * <p>
+ * The {@code outgoing} direction adds an aggregated outgoing-calls mode: methodName
+ * is optional there, and the pure qualifier-classification / ext-API helpers
+ * ({@link GetMethodCallHierarchyTool#qualifierKey} /
+ * {@link GetMethodCallHierarchyTool#isExtApi}) are exercised here with in-memory
+ * {@code BslFactory}-built model objects (no live workbench, editor or injector) —
+ * matching the seam convention used by {@code SymbolInfoServiceTest}.
  */
 public class GetMethodCallHierarchyToolTest
 {
@@ -82,6 +93,31 @@ public class GetMethodCallHierarchyToolTest
         assertTrue(schema.contains("\"direction\"")); //$NON-NLS-1$
     }
 
+    @Test
+    public void testSchemaDeclaresOutgoingDirectionAndExtApiPrefix()
+    {
+        // The aggregated outgoing mode adds a third direction enum value and the
+        // optional extApiPrefix knob; both must be visible to schema-driven clients.
+        String schema = new GetMethodCallHierarchyTool().getInputSchema();
+        assertTrue("direction enum includes 'outgoing'", schema.contains("outgoing")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("extApiPrefix property declared", schema.contains("\"extApiPrefix\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testSchemaNoLongerRequiresMethodName()
+    {
+        // methodName was dropped from required[] (it is optional in outgoing mode).
+        // The required[] list still holds projectName + modulePath, so assert methodName
+        // is absent from that JSON array specifically (not from the whole schema, where
+        // it still appears as a declared-but-optional property).
+        String schema = new GetMethodCallHierarchyTool().getInputSchema();
+        String required = extractRequiredArray(schema);
+        assertNotNull("schema has a required[] array", required); //$NON-NLS-1$
+        assertTrue("projectName still required", required.contains("projectName")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("modulePath still required", required.contains("modulePath")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("methodName is no longer required", required.contains("methodName")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
     // ==================== Argument validation (no live workbench needed) ====================
 
     @Test
@@ -104,11 +140,45 @@ public class GetMethodCallHierarchyToolTest
     @Test
     public void testMissingMethodName()
     {
+        // With the default direction (callers) a missing methodName is still an error.
         Map<String, String> params = new HashMap<>();
         params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
         params.put("modulePath", "CommonModules/Foo/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
         String result = new GetMethodCallHierarchyTool().execute(params);
         assertTrue(result.contains("methodName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingMethodNameCalleesStillErrors()
+    {
+        // direction=callees + blank methodName -> the callers/callees methodName guard.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("modulePath", "CommonModules/Foo/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("methodName", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("direction", "callees"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new GetMethodCallHierarchyTool().execute(params);
+        assertTrue(result.contains("methodName is required for callers/callees")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testOutgoingWithoutMethodNameSkipsMethodNameGuard()
+    {
+        // direction=outgoing makes methodName OPTIONAL: execute() must NOT return the
+        // methodName-required error. It may still fail later on the live model (no
+        // workbench here) - that is fine; we only assert it is not the methodName guard.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("modulePath", "CommonModules/Foo/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("direction", "outgoing"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = runWithoutLiveModel(() -> new GetMethodCallHierarchyTool().execute(params));
+        // Whatever comes back (an error from the live-model path, or null), it must not
+        // be the methodName-required message that guards callers/callees.
+        if (result != null)
+        {
+            assertFalse("outgoing must not trip the methodName guard", //$NON-NLS-1$
+                result.contains("methodName is required")); //$NON-NLS-1$
+        }
     }
 
     @Test
@@ -118,11 +188,13 @@ public class GetMethodCallHierarchyToolTest
         params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
         params.put("modulePath", "CommonModules/Foo/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
         params.put("methodName", "DoWork"); //$NON-NLS-1$ //$NON-NLS-2$
-        // A non-empty direction that is neither "callers" nor "callees" is rejected
-        // before any workbench access (an empty/missing direction defaults to callers).
+        // A non-empty direction that is none of the accepted values is rejected before any
+        // workbench access (an empty/missing direction defaults to callers).
         params.put("direction", "sideways"); //$NON-NLS-1$ //$NON-NLS-2$
         String result = new GetMethodCallHierarchyTool().execute(params);
         assertTrue(result.contains("direction must be")); //$NON-NLS-1$
+        // The error now enumerates all three accepted values.
+        assertTrue(result.contains("outgoing")); //$NON-NLS-1$
     }
 
     // ==================== Call-qualifier derivation (pure logic) ====================
@@ -148,6 +220,106 @@ public class GetMethodCallHierarchyToolTest
     {
         assertNull(GetMethodCallHierarchyTool.extractModuleName(null));
         assertNull(GetMethodCallHierarchyTool.extractModuleName("Module.bsl")); //$NON-NLS-1$
+    }
+
+    // ==================== isExtApi — the bilingual ext-API prefix guard (pure) ====================
+
+    @Test
+    public void testIsExtApiDefaultPrefixMatchesCyrillicMember()
+    {
+        // A qualifier that starts with the default Cyrillic service-API prefix is ext-API.
+        assertTrue(GetMethodCallHierarchyTool.isExtApi(
+            "ПрограммныйИнтерфейсСервисаТовары", //$NON-NLS-1$ ПрограммныйИнтерфейсСервисаТовары
+            GetMethodCallHierarchyTool.DEFAULT_EXT_API_PREFIX));
+    }
+
+    @Test
+    public void testIsExtApiOrdinaryModuleIsNotExtApi()
+    {
+        // An ordinary common-module qualifier does not start with the prefix.
+        assertFalse(GetMethodCallHierarchyTool.isExtApi(
+            "AccountingClientServer", //$NON-NLS-1$
+            GetMethodCallHierarchyTool.DEFAULT_EXT_API_PREFIX));
+    }
+
+    @Test
+    public void testIsExtApiIsCaseInsensitive()
+    {
+        // The startsWith comparison is case-insensitive: a lower-cased spelling of the
+        // default prefix is still recognized as ext-API.
+        assertTrue(GetMethodCallHierarchyTool.isExtApi(
+            "программныйинтерфейссервиса", //$NON-NLS-1$ программныйинтерфейссервиса (lower)
+            GetMethodCallHierarchyTool.DEFAULT_EXT_API_PREFIX));
+    }
+
+    @Test
+    public void testIsExtApiWithCustomPrefix()
+    {
+        // A caller-supplied prefix wins over the default (still literal + case-insensitive).
+        assertTrue(GetMethodCallHierarchyTool.isExtApi("PublicApiOrders", "publicapi")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse(GetMethodCallHierarchyTool.isExtApi("AccountingClientServer", "publicapi")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testIsExtApiLocalAndExprTokensAreNeverExtApi()
+    {
+        // The synthetic '(local)' / '(expr)' qualifier tokens are always non-ext-API,
+        // regardless of prefix (they cannot literally start with a real prefix word).
+        assertFalse(GetMethodCallHierarchyTool.isExtApi("(local)", //$NON-NLS-1$
+            GetMethodCallHierarchyTool.DEFAULT_EXT_API_PREFIX));
+        assertFalse(GetMethodCallHierarchyTool.isExtApi("(expr)", //$NON-NLS-1$
+            GetMethodCallHierarchyTool.DEFAULT_EXT_API_PREFIX));
+    }
+
+    // ==================== qualifierKey — call-shape classification (pure, in-memory model) ====================
+
+    @Test
+    public void testQualifierKeyUnqualifiedLocalCall()
+    {
+        // An unqualified local call: the method access is a StaticFeatureAccess -> '(local)'.
+        StaticFeatureAccess sfa = BslFactory.eINSTANCE.createStaticFeatureAccess();
+        sfa.setName("DoWork"); //$NON-NLS-1$
+        assertEquals("(local)", GetMethodCallHierarchyTool.qualifierKey(sfa)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testQualifierKeyQualifiedModuleCall()
+    {
+        // "MyModule.DoWork(...)": a DynamicFeatureAccess whose source is a StaticFeatureAccess
+        // (the module reference) -> the qualifier is that module name.
+        StaticFeatureAccess moduleRef = BslFactory.eINSTANCE.createStaticFeatureAccess();
+        moduleRef.setName("MyModule"); //$NON-NLS-1$
+
+        DynamicFeatureAccess dfa = BslFactory.eINSTANCE.createDynamicFeatureAccess();
+        dfa.setName("DoWork"); //$NON-NLS-1$
+        dfa.setSource(moduleRef);
+
+        assertEquals("MyModule", GetMethodCallHierarchyTool.qualifierKey(dfa)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testQualifierKeyChainedExpressionCall()
+    {
+        // A chained/expression call ("Foo().Bar()" or "a.b.Method()"): the source of the
+        // DynamicFeatureAccess is NOT a StaticFeatureAccess -> '(expr)'.
+        DynamicFeatureAccess chainedSource = BslFactory.eINSTANCE.createDynamicFeatureAccess();
+        chainedSource.setName("Intermediate"); //$NON-NLS-1$
+
+        DynamicFeatureAccess dfa = BslFactory.eINSTANCE.createDynamicFeatureAccess();
+        dfa.setName("Method"); //$NON-NLS-1$
+        dfa.setSource(chainedSource);
+
+        assertEquals("(expr)", GetMethodCallHierarchyTool.qualifierKey(dfa)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testQualifierKeyDynamicWithNoSourceIsExpr()
+    {
+        // Defensive: a DynamicFeatureAccess with no source (null) must not NPE - it falls
+        // through to the '(expr)' token like any non-StaticFeatureAccess source.
+        DynamicFeatureAccess dfa = BslFactory.eINSTANCE.createDynamicFeatureAccess();
+        dfa.setName("Method"); //$NON-NLS-1$
+        assertEquals("(expr)", GetMethodCallHierarchyTool.qualifierKey(dfa)); //$NON-NLS-1$
     }
 
     // ==================== getResultFileName (pure, no live workbench) ====================
@@ -181,9 +353,20 @@ public class GetMethodCallHierarchyToolTest
         // The method-name segment is always lower-cased, so a mixed-case ru/en spelling
         // produces a stable, case-insensitive file name.
         Map<String, String> params = new HashMap<>();
-        params.put("methodName", "ПолучитьДанные"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("methodName", "ПолучитьДанные"); //$NON-NLS-1$ ПолучитьДанные
         params.put("direction", "callers"); //$NON-NLS-1$ //$NON-NLS-2$
-        assertEquals("call-hierarchy-получитьданные-callers.md", //$NON-NLS-1$
+        assertEquals("call-hierarchy-получитьданные-callers.md", //$NON-NLS-1$ получитьданные
+            new GetMethodCallHierarchyTool().getResultFileName(params));
+    }
+
+    @Test
+    public void testResultFileNameOutgoingWithMethod()
+    {
+        // methodName + direction=outgoing → the direction segment is appended verbatim.
+        Map<String, String> params = new HashMap<>();
+        params.put("methodName", "DoWork"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("direction", "outgoing"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("call-hierarchy-dowork-outgoing.md", //$NON-NLS-1$
             new GetMethodCallHierarchyTool().getResultFileName(params));
     }
 
@@ -201,13 +384,14 @@ public class GetMethodCallHierarchyToolTest
     }
 
     @Test
-    public void testResultFileNameDefaultWhenMethodNameMissing()
+    public void testResultFileNameOutgoingWhenMethodNameMissing()
     {
-        // No methodName argument → the generic fallback file name (the direction is
-        // irrelevant when there is no method to name).
+        // No methodName argument but direction=outgoing → the module-wide outgoing scope
+        // has a distinct, descriptive file name (there is no method to name, so the
+        // generic per-method pattern does not apply). Pins the dedicated outgoing branch.
         Map<String, String> params = new HashMap<>();
-        params.put("direction", "callees"); //$NON-NLS-1$ //$NON-NLS-2$
-        assertEquals("call-hierarchy.md", //$NON-NLS-1$
+        params.put("direction", "outgoing"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("call-hierarchy-outgoing.md", //$NON-NLS-1$
             new GetMethodCallHierarchyTool().getResultFileName(params));
     }
 
@@ -228,5 +412,55 @@ public class GetMethodCallHierarchyToolTest
         // The no-arguments case (neither methodName nor direction) returns the constant fallback.
         assertEquals("call-hierarchy.md", //$NON-NLS-1$
             new GetMethodCallHierarchyTool().getResultFileName(new HashMap<>()));
+    }
+
+    // ==================== helpers ====================
+
+    /**
+     * Extracts the {@code "required":[...]} array literal from a built JSON schema so a
+     * test can assert membership of that specific array (not the whole schema, where an
+     * optional-but-declared property name also appears under {@code "properties"}).
+     *
+     * @param schema the JSON schema string
+     * @return the text between the {@code required} array's brackets, or {@code null} when absent
+     */
+    private static String extractRequiredArray(String schema)
+    {
+        int key = schema.indexOf("\"required\""); //$NON-NLS-1$
+        if (key < 0)
+        {
+            return null;
+        }
+        int open = schema.indexOf('[', key);
+        int close = schema.indexOf(']', open);
+        if (open < 0 || close < 0)
+        {
+            return null;
+        }
+        return schema.substring(open, close + 1);
+    }
+
+    /**
+     * Runs a supplier that may touch the live workbench, swallowing the class of failures
+     * that only happen headlessly (no {@code PlatformUI} workbench / no injector). The
+     * outgoing-mode test only cares that argument validation ran to completion without the
+     * methodName guard firing; any downstream live-model failure is not this test's concern.
+     *
+     * @param call the tool invocation to run
+     * @return the tool result, or {@code null} when a headless-only failure was thrown
+     */
+    private static String runWithoutLiveModel(java.util.function.Supplier<String> call)
+    {
+        try
+        {
+            return call.get();
+        }
+        catch (Exception | LinkageError e)
+        {
+            // No live workbench in this headless test - the argument-validation branch we
+            // care about already ran (and returned an error string if it fired) before any
+            // PlatformUI access, so a thrown workbench failure just means we got past it.
+            return null;
+        }
     }
 }

--- a/tests/e2e/tools/test_get_method_call_hierarchy.py
+++ b/tests/e2e/tools/test_get_method_call_hierarchy.py
@@ -5,7 +5,11 @@ What the tool does
 ------------------
 Reports a BSL method's call hierarchy in ONE direction:
   - direction="callers" (default): who calls this method (incoming).
-  - direction="callees": what this method calls (outgoing).
+  - direction="callees": what this method calls (outgoing, per call site).
+  - direction="outgoing": the AGGREGATED distinct outgoing-call targets of a method
+    (when methodName is given) OR of the WHOLE module (methodName is OPTIONAL for
+    outgoing). Rows are keyed by qualifier+method; an unqualified local call buckets
+    under the '(local)' qualifier (always ExtAPI '-').
 It addresses the *containing* method by (projectName, modulePath, methodName) —
 there is NO line/column parameter; resolution is by method NAME (case-insensitive,
 BslModuleUtils.findMethod). ResponseType is MARKDOWN, so the payload is in r.text
@@ -48,8 +52,9 @@ Error contract (the REAL split — verified against the Java + McpProtocolHandle
 A MARKDOWN tool's response is flagged isError:true ONLY when the returned string is a
 ToolResult.error(...).toJson() payload ({"success":false,...}) — McpProtocolHandler
 .isJsonErrorPayload diverts those to a structured JSON error. These paths set isError:
-  - missing projectName / modulePath / methodName  -> "<name> is required"
-  - direction not in {callers,callees}             -> "direction must be 'callers' or 'callees'"
+  - missing projectName / modulePath                -> "<name> is required"
+  - missing methodName (callers/callees only)       -> "methodName is required for callers/callees"
+  - direction not in {callers,callees,outgoing}     -> "direction must be 'callers', 'callees' or 'outgoing'"
   - project does not exist                          -> "Project not found: <name>"
   - module can't be loaded as a BSL Module          -> "Could not load EMF model for <modulePath>. ..."
 But the METHOD-NOT-FOUND path returns BslModuleUtils.buildMethodNotFoundResponse — a
@@ -69,11 +74,31 @@ from harness import (
     assert_not_contains,
     assert_no_diff,
     e2e_test,
+    _fail,
     PROJECT,
 )
 
 # src/-relative module path of the fixture CommonModule.Calc.
 CALC = "CommonModules/Calc/Module.bsl"
+
+
+def _assert_local_add_row(text):
+    """Structural invariant for the aggregated OUTGOING row of the fixture's one call
+    Test -> Add(1, 2): the row must be '(local)' qualifier + Method Add + ExtAPI '-'.
+
+    Asserts on the row's cells (a single '| ... |' table line that carries BOTH the
+    '(local)' qualifier AND the Add method AND a trailing ' - |' ExtAPI cell) rather than
+    on a brittle exact line number / count, per the slice's uncertainty rule. This proves
+    the frozen classification: an unqualified local call is bucketed under '(local)' and a
+    '(local)' row is ALWAYS extApi=false (rendered '-', never 'yes')."""
+    for line in (text or "").splitlines():
+        cells = [c.strip() for c in line.split("|")]
+        # A data row renders as: '' | Qualifier | Method | Count | First line | ExtAPI | ''
+        # (leading/trailing empties from the surrounding pipes). Match the local Add target.
+        if "(local)" in cells and "Add" in cells and cells and cells[-2] == "-":
+            return
+    _fail("expected an aggregated outgoing row for the local Add call "
+          "(Qualifier '(local)', Method 'Add', ExtAPI '-') in:\n%s" % (text or "")[:500])
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -236,6 +261,94 @@ def test_callees_of_leaf_add_reports_none():
 
 
 # ──────────────────────────────────────────────────────────────────────────────
+# HAPPY PATHS — direction="outgoing" (aggregated outgoing-calls mode)
+#
+# "outgoing" aggregates the DISTINCT call targets of a scope (a single method when
+# methodName is given, else the whole module) into a table keyed by qualifier+method,
+# counting the call sites and reporting the first line. The classification is RESOLVED,
+# not textual: an UNQUALIFIED local call (methodAccess is a StaticFeatureAccess) is
+# bucketed under the '(local)' qualifier token and is ALWAYS extApi=false ('-').
+#
+# Fixture truth used below: Test's body makes ONE unqualified local call — Add(1, 2) on
+# line 6. So both the scoped (methodName="Test") and the module-wide (no methodName,
+# which also walks Test) outgoing views must surface a target row with Method=Add,
+# Qualifier=(local), ExtAPI=-. Add itself calls nothing, so it contributes no target.
+# We assert the frozen wire shape (heading, banner, columns, the (local) token, ExtAPI=-)
+# rather than brittle exact counts/line numbers, since the module-wide total depends on
+# how many distinct targets the whole module has.
+# ──────────────────────────────────────────────────────────────────────────────
+@e2e_test(tool="get_method_call_hierarchy", kind="read")
+def test_outgoing_scoped():
+    """direction="outgoing" WITH methodName="Test": the aggregated outgoing-calls view of
+    Test. Test makes exactly one call — the unqualified local Add(1, 2) on line 6 — so the
+    scoped ('... :: Test') outgoing heading, the Outgoing banner, and a single '(local)'
+    target row for Add (ExtAPI '-') prove: (a) the outgoing direction is wired, (b) it
+    walks Test's own AST, (c) an unqualified call is classified as '(local)' (a
+    StaticFeatureAccess), NOT as an ext-API or an '(expr)' qualifier, and (d) a local
+    row is never marked ExtAPI. A finder that mis-classified the qualifier, or reused the
+    callers/callees branch, would fail these asserts."""
+    r = call("get_method_call_hierarchy", {
+        "projectName": PROJECT,
+        "modulePath": CALC,
+        "methodName": "Test",
+        "direction": "outgoing",
+    })
+    assert_ok(r, "outgoing of Calc.Test")
+    assert r.structured is None, \
+        "get_method_call_hierarchy is a MARKDOWN tool; structuredContent must be None"
+
+    # Scoped heading echoes the module path AND the resolved method (the ' :: Test' tail).
+    assert_contains(r.text, "## Outgoing Calls: " + CALC + " :: Test",
+                    "scoped outgoing heading must echo the module path and the method")
+    assert_contains(r.text, "**Direction:** Outgoing calls (aggregated targets)",
+                    "outgoing direction banner must be present")
+    assert_contains(r.text, "**Total distinct targets:**",
+                    "outgoing view must report a distinct-target total")
+    # The exact aggregation table header (the frozen wire columns).
+    assert_contains(r.text, "| Qualifier | Method | Count | First line | ExtAPI |",
+                    "outgoing table must use the frozen aggregated-columns header")
+    # The one target: the unqualified local Add call -> Qualifier '(local)', Method Add,
+    # ExtAPI '-' (a local row is always non-ext-API).
+    assert_contains(r.text, "| Add |",
+                    "the aggregated outgoing target must include the Add call")
+    assert_contains(r.text, "| (local) |",
+                    "an unqualified local call must be bucketed under the '(local)' qualifier")
+    _assert_local_add_row(r.text)
+    assert_no_diff("a read tool must not touch the project on disk")
+
+
+@e2e_test(tool="get_method_call_hierarchy", kind="read")
+def test_outgoing_module_wide():
+    """direction="outgoing" WITHOUT methodName: methodName is OPTIONAL for outgoing, so the
+    tool aggregates the outgoing calls of the WHOLE module. Asserting the module-wide
+    heading (no ' :: ' scope tail), the Outgoing banner, and that the local Add target
+    still appears proves the module-wide walk (module.eAllContents) collected Test's call
+    to Add — i.e. omitting methodName does NOT error and does NOT scope to a single method.
+    A tool that still required methodName for outgoing would error here."""
+    r = call("get_method_call_hierarchy", {
+        "projectName": PROJECT,
+        "modulePath": CALC,
+        "direction": "outgoing",
+    })
+    assert_ok(r, "module-wide outgoing of Calc")
+    # Module-wide heading has NO ' :: <method>' scope tail.
+    assert_contains(r.text, "## Outgoing Calls: " + CALC,
+                    "module-wide outgoing heading must echo the module path")
+    assert_not_contains(r.text, "## Outgoing Calls: " + CALC + " ::",
+                        "module-wide outgoing (no methodName) must NOT carry a ' :: <method>' scope tail")
+    assert_contains(r.text, "**Direction:** Outgoing calls (aggregated targets)",
+                    "outgoing direction banner must be present module-wide")
+    assert_contains(r.text, "| Qualifier | Method | Count | First line | ExtAPI |",
+                    "module-wide outgoing table must use the frozen aggregated-columns header")
+    # The module's only call is Test -> Add (unqualified local), so the (local) Add target
+    # must appear in the module-wide aggregation too.
+    assert_contains(r.text, "| Add |",
+                    "the module-wide aggregation must include the Add target from Test")
+    _assert_local_add_row(r.text)
+    assert_no_diff("a read tool must not touch the project on disk")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
 # NEGATIVE MATRIX (mandatory) — true ToolResult.error (isError:true) paths
 # ──────────────────────────────────────────────────────────────────────────────
 @e2e_test(tool="get_method_call_hierarchy", kind="read")
@@ -274,27 +387,30 @@ def test_missing_modulepath_errors():
 
 @e2e_test(tool="get_method_call_hierarchy", kind="read")
 def test_missing_methodname_errors():
-    """projectName + modulePath present but methodName omitted -> the third
-    requireArguments check fires -> "methodName is required"."""
+    """projectName + modulePath present but methodName omitted (direction omitted ->
+    defaults to callers, where methodName IS required) -> the methodName guard fires ->
+    "methodName is required for callers/callees". (methodName is OPTIONAL only for
+    direction="outgoing" — see test_outgoing_module_wide; here the default callers
+    direction still requires it.)"""
     r = call("get_method_call_hierarchy", {
         "projectName": PROJECT,
         "modulePath": CALC,
     })
     e = assert_error(r, "missing methodName")
-    # AUDIT: names the param but no actionable next step (no hint to use
-    # get_module_structure to list method names). suggests=[] -> fix-card.
-    assert_error_quality(e, names=["methodName"], suggests=[],
-                         ctx="missing methodName names the param")
+    # Actionable: names the missing param AND points at get_module_structure (the sibling
+    # tool that lists the module's procedures and functions) as the next step.
+    assert_error_quality(e, names=["methodName"], suggests=["get_module_structure"],
+                         ctx="missing methodName names the param and points at get_module_structure")
     assert_no_diff("an invalid call must not touch the project on disk")
 
 
 @e2e_test(tool="get_method_call_hierarchy", kind="read")
 def test_invalid_direction_enum_errors_and_names_valid_values():
-    """direction is an enum {callers,callees}. A value outside it ("sideways") is
+    """direction is an enum {callers,callees,outgoing}. A value outside it ("sideways") is
     rejected AFTER the required-arg check -> ToolResult.error("direction must be
-    'callers' or 'callees'"). The message is actionable: it enumerates the two valid
-    values. A tool that silently treated an unknown direction as the default would NOT
-    error here -> this guards the enum validation."""
+    'callers', 'callees' or 'outgoing'"). The message is actionable: it enumerates the
+    three valid values. A tool that silently treated an unknown direction as the default
+    would NOT error here -> this guards the enum validation."""
     r = call("get_method_call_hierarchy", {
         "projectName": PROJECT,
         "modulePath": CALC,
@@ -302,8 +418,8 @@ def test_invalid_direction_enum_errors_and_names_valid_values():
         "direction": "sideways",
     })
     e = assert_error(r, "invalid direction enum")
-    # Actionable: names the offending param AND lists the two valid enum values.
-    assert_error_quality(e, names=["direction"], suggests=["callers", "callees"],
+    # Actionable: names the offending param AND lists the three valid enum values.
+    assert_error_quality(e, names=["direction"], suggests=["callers", "callees", "outgoing"],
                          ctx="invalid direction names the param and the valid values")
     assert_no_diff("an invalid call must not touch the project on disk")
 

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -1878,11 +1878,16 @@
     "inputSchema": {
       "properties": {
         "direction": {
-          "description": "'callers' (default) or 'callees'",
+          "description": "'callers' (default) = who calls this method; 'callees' = what this method calls; 'outgoing' = aggregated distinct call targets (module-wide when methodName omitted)",
           "enum": [
             "callers",
-            "callees"
+            "callees",
+            "outgoing"
           ],
+          "type": "string"
+        },
+        "extApiPrefix": {
+          "description": "For direction 'outgoing': literal call-qualifier prefix (case-insensitive) that flags a target as an external service API. Default: the 1C region name 'ПрограммныйИнтерфейсСервиса'.",
           "type": "string"
         },
         "limit": {
@@ -1890,7 +1895,7 @@
           "type": "integer"
         },
         "methodName": {
-          "description": "Name of the procedure/function (case-insensitive, required)",
+          "description": "Name of the procedure/function (case-insensitive). Required for direction 'callers'/'callees'; optional for 'outgoing' (omit to aggregate the whole module).",
           "type": "string"
         },
         "modulePath": {
@@ -1904,8 +1909,7 @@
       },
       "required": [
         "projectName",
-        "modulePath",
-        "methodName"
+        "modulePath"
       ],
       "type": "object"
     },


### PR DESCRIPTION
## Что

Расширяет существующий инструмент `get_method_call_hierarchy` новым значением `direction='outgoing'` — агрегированной сводкой **исходящих** вызовов (без нового тула — по решению из #212).

Для целого модуля (`methodName` опционален) или одного метода возвращает **различные цели** `квалификатор.метод` с полями `count` (число мест вызова), `firstLine` и флагом `extApi`.

- `extApi` — литеральное совпадение префикса квалификатора (без учёта регистра), настраивается параметром `extApiPrefix` (по умолчанию — конвенциональное имя слоя сервис-API 1С).
- `methodName` теперь **опционален** (убран из `required`); поведение `callers`/`callees` не изменилось.
- Неквалифицированные локальные вызовы → токен `(local)`, вызовы со сложным источником → `(expr)`; оба никогда не `extApi`.
- Вывод: таблица `| Qualifier | Method | Count | First line | ExtAPI |`.

## Происхождение

Clean-room по публичной модели EDT BSL (`Invocation` / `DynamicFeatureAccess`). Идея — из независимого плагина [keyfire/edt-bridge](https://github.com/keyfire/edt-bridge) (`edt_outgoing_calls`, Apache-2.0); исходный код **не копировался**, в комментарии класса и в гайде сохранено указание на источник идеи.

## Как проверено

- **Юнит:** `bash source/compile.sh` → BUILD SUCCESS, **2828 тестов зелёные** (включая новые кейсы `GetMethodCallHierarchyToolTest` и ратчеты `BuiltInToolTestCoverageTest` / `ToolContractConsistencyTest`).
- **e2e (изолированно, живой EDT 2025.2.6):** `test_get_method_call_hierarchy.py` — **17/17 passed, fixture clean** (outgoing scoped + module-wide, обновлённый invalid-direction, без регрессий callers/callees).
- **Живой вызов** на `CommonModule.Calc`: scoped `Calc::Test` → `(local) | Add | 1 | 6 | -`; module-wide — тот же таргет без ` :: `.
- **golden** (`tools_list.golden.json`) регенерирован — дифф только по этому тулу; **docs** (`docs/tools/get_method_call_hierarchy.md`) обновлены.
- Полный e2e-набор дополнительно прогоняется на Linux-стенде (окружение как на CI автора).

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
