### PR TITLE
edt-mcp-autopilot: скан лога воркспейса на этапе живой проверки

### DIFF
--- a/.claude/skills/edt-mcp-autopilot/SKILL.md
+++ b/.claude/skills/edt-mcp-autopilot/SKILL.md
@@ -136,6 +136,13 @@ continue. If a tool's wire surface changed, regenerate the golden and review the
 If the task is live-verifiable (a tool behaviour, a form/metadata effect, a runtime contract):
 - Redeploy the fresh build to the **throwaway** stand and run the real scenarios (the e2e
   matrix or targeted MCP calls) — delegate to `edt-mcp-e2e-testing` / `edt-mcp-ready-to-deploy`.
+- **Scan the workspace log after exercising the feature.** Grep `<workspace>/.metadata/.log`
+  for stack traces / errors from our code (`com.ditrix.edt.mcp.server`) logged since the redeploy.
+  Runtime failures often log there WITHOUT surfacing through the MCP wire — an exception in a UI
+  `Job`, a caught `Activator.logError`, or a per-item failure swallowed into a degraded result
+  (a real case: a single-image `CommonPicture` whose decode threw but showed only as "No variants"
+  in the gallery, found only in `.log`). A green tool response does NOT prove a clean run — treat
+  any such stack as a real finding to diagnose BEFORE the operator gate, not after a user hits it.
 - **Operator gate (the one human touchpoint):** use `AskUserQuestion` to show the live result
   and ask the operator to confirm it before shipping (see `references/autonomy.md`). Do not open
   the PR until the operator confirms.


### PR DESCRIPTION
Дополнение к скиллу автопилота (Phase 8): после прогона фичи на стенде — **грепать `<workspace>/.metadata/.log` на стек-трейсы нашего кода** (`com.ditrix.edt.mcp.server`).

Зелёный ответ MCP-тула НЕ доказывает чистый прогон: runtime-ошибки часто логируются в лог воркспейса, но не всплывают в MCP-ответе — исключение в UI-`Job`, пойманный `Activator.logError`, или пофакторная ошибка, «проглоченная» в деградировавший результат.

Реальный случай (из-за которого и добавляем): single-image `CommonPicture`, у которой декодирование бросало исключение, показывалась в галерее просто как «No variants» — нашлось только в `.log`. Теперь этот шаг стоит перед operator-gate, чтобы такие вещи ловились до того, как на них наткнётся пользователь.

🤖 Generated with [Claude Code](https://claude.com/claude-code)