### PR TITLE
Sonar: чистка code-smell на master (без изменения поведения)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/pictures/CommonPicturesGalleryRenderer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/pictures/CommonPicturesGalleryRenderer.java
@@ -70,6 +70,9 @@ public final class CommonPicturesGalleryRenderer
     /** The best-thumbnail selector understood by {@link CommonPictureContentReader#exportPng}. */
     private static final String VARIANT_BEST = "best"; //$NON-NLS-1$
 
+    /** Placeholder used in log messages when a picture/variant has no name. */
+    private static final String UNNAMED = "<unnamed>"; //$NON-NLS-1$
+
     private CommonPicturesGalleryRenderer()
     {
         // Static seam.
@@ -293,7 +296,7 @@ public final class CommonPicturesGalleryRenderer
         catch (Exception e) // NOSONAR a corrupt densest raster only drops the inline 'best' thumbnail
         {
             Activator.logError("Could not decode the 'best' thumbnail of common picture " //$NON-NLS-1$
-                + (entry.name != null ? entry.name : "<unnamed>"), e); //$NON-NLS-1$
+                + (entry.name != null ? entry.name : UNNAMED), e);
         }
 
         try
@@ -309,7 +312,7 @@ public final class CommonPicturesGalleryRenderer
         catch (Exception e) // NOSONAR one unreadable/corrupt Picture.zip is surfaced per-picture, never aborts the page
         {
             Activator.logError("Could not read variants of common picture " //$NON-NLS-1$
-                + (entry.name != null ? entry.name : "<unnamed>"), e); //$NON-NLS-1$
+                + (entry.name != null ? entry.name : UNNAMED), e);
             entry.error = e.getMessage() != null ? e.getMessage() : e.toString();
         }
         return entry;
@@ -336,8 +339,8 @@ public final class CommonPicturesGalleryRenderer
         catch (Exception e) // NOSONAR one undecodable variant is logged and surfaced per-variant, never aborts the picture
         {
             Activator.logError("Could not decode variant " //$NON-NLS-1$
-                + (variant.name != null ? variant.name : "<unnamed>") //$NON-NLS-1$
-                + " of CommonPicture " + (picture.getName() != null ? picture.getName() : "<unnamed>"), e); //$NON-NLS-1$ //$NON-NLS-2$
+                + (variant.name != null ? variant.name : UNNAMED)
+                + " of CommonPicture " + (picture.getName() != null ? picture.getName() : UNNAMED), e); //$NON-NLS-1$
             Variant thumb = new Variant();
             thumb.label = variant.name;
             thumb.base64Png = null;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/pictures/CommonPicturesHtmlGenerator.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/pictures/CommonPicturesHtmlGenerator.java
@@ -48,6 +48,9 @@ public final class CommonPicturesHtmlGenerator
     /** Newline used between emitted lines (LF for a deterministic, platform-independent document). */
     private static final String NL = "\n"; //$NON-NLS-1$
 
+    /** Closing {@code </div>} tag, emitted for every opened block wrapper. */
+    private static final String CLOSE_DIV = "</div>"; //$NON-NLS-1$
+
     /**
      * The custom URL scheme+path the Prev/Next/search controls navigate to. The SWT-Browser host
      * editor's {@code LocationListener} recognises this prefix, cancels the real navigation, parses
@@ -101,7 +104,7 @@ public final class CommonPicturesHtmlGenerator
         {
             appendCard(sb, entry);
         }
-        sb.append("</div>").append(NL); //$NON-NLS-1$
+        sb.append(CLOSE_DIV).append(NL);
 
         sb.append("</body>").append(NL); //$NON-NLS-1$
         sb.append("</html>").append(NL); //$NON-NLS-1$
@@ -125,7 +128,7 @@ public final class CommonPicturesHtmlGenerator
             .append(escapeHtml(query))
             .append("\" onkeydown=\"if(event.keyCode===13){edtmcpSearch();return false;}\">").append(NL); //$NON-NLS-1$
         sb.append("<button type=\"button\" onclick=\"edtmcpSearch()\">Найти</button>").append(NL); //$NON-NLS-1$
-        sb.append("</div>").append(NL); //$NON-NLS-1$
+        sb.append(CLOSE_DIV).append(NL);
         // encodeURIComponent runs in the Browser; the editor's LocationListener does the decode. A
         // search always resets to page 0.
         sb.append("<script>function edtmcpSearch(){") //$NON-NLS-1$
@@ -176,7 +179,7 @@ public final class CommonPicturesHtmlGenerator
         sb.append("<span class=\"pageinfo\">Страница ").append(pageIndex + 1).append(" из ") //$NON-NLS-1$ //$NON-NLS-2$
             .append(pageCount).append("</span>").append(NL); //$NON-NLS-1$
         appendPagerLink(sb, "next", "След ▶", query, pageIndex + 1, pageIndex < pageCount - 1); //$NON-NLS-1$ //$NON-NLS-2$
-        sb.append("</div>").append(NL); //$NON-NLS-1$
+        sb.append(CLOSE_DIV).append(NL);
     }
 
     /**
@@ -293,12 +296,12 @@ public final class CommonPicturesHtmlGenerator
         {
             sb.append(" <span class=\"synonym\">(").append(escapeHtml(entry.synonym)).append(")</span>"); //$NON-NLS-1$ //$NON-NLS-2$
         }
-        sb.append("</div>").append(NL); //$NON-NLS-1$
+        sb.append(CLOSE_DIV).append(NL);
 
         if (hasError)
         {
             sb.append("<div class=\"error\">Could not read this picture's Picture.zip: ") //$NON-NLS-1$
-                .append(escapeHtml(entry.error)).append("</div>").append(NL); //$NON-NLS-1$
+                .append(escapeHtml(entry.error)).append(CLOSE_DIV).append(NL);
         }
         else if (entry.variants == null || entry.variants.isEmpty())
         {
@@ -310,7 +313,7 @@ public final class CommonPicturesHtmlGenerator
             appendVariants(sb, entry.variants);
         }
 
-        sb.append("</div>").append(NL); //$NON-NLS-1$
+        sb.append(CLOSE_DIV).append(NL);
     }
 
     /**
@@ -333,7 +336,7 @@ public final class CommonPicturesHtmlGenerator
         // URI; the alt text is a 1C-derived label and is escaped.
         sb.append("<img src=\"").append(DATA_URI_PREFIX).append(best.base64Png) //$NON-NLS-1$
             .append("\" alt=\"").append(escapeHtml(safe(best.label))).append("\">").append(NL); //$NON-NLS-1$ //$NON-NLS-2$
-        sb.append("</div>").append(NL); //$NON-NLS-1$
+        sb.append(CLOSE_DIV).append(NL);
     }
 
     /**
@@ -366,11 +369,11 @@ public final class CommonPicturesHtmlGenerator
             {
                 // A single variant that failed to decode: surfaced under its label, never aborts the card.
                 sb.append("<div class=\"variant-error\">").append(escapeHtml(variant.error)) //$NON-NLS-1$
-                    .append("</div>").append(NL); //$NON-NLS-1$
+                    .append(CLOSE_DIV).append(NL);
             }
             sb.append("</figure>").append(NL); //$NON-NLS-1$
         }
-        sb.append("</div>").append(NL); //$NON-NLS-1$
+        sb.append(CLOSE_DIV).append(NL);
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/pictures/editor/CommonPicturesGalleryEditor.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/pictures/editor/CommonPicturesGalleryEditor.java
@@ -112,7 +112,9 @@ public final class CommonPicturesGalleryEditor extends EditorPart
      * @param query the (decoded) search query
      * @param page the requested 0-based page index
      */
-    private void reRender(String query, int page)
+    private void reRender(String query, int page) // NOSONAR S3398: kept on the editor (not the inner
+                                                  // interceptor) as it uses the outer instance's input
+                                                  // + applyRenderedPage callback; moving it in adds no value
     {
         String projectName = htmlInput.getProjectName();
         if (projectName == null || projectName.isEmpty())
@@ -216,13 +218,11 @@ public final class CommonPicturesGalleryEditor extends EditorPart
         {
             return URLDecoder.decode(text, StandardCharsets.UTF_8.name());
         }
-        catch (UnsupportedEncodingException e) // NOSONAR UTF-8 is always available; unreachable
+        catch (UnsupportedEncodingException | IllegalArgumentException e)
         {
-            return text;
-        }
-        catch (IllegalArgumentException e)
-        {
-            // A malformed %-escape: treat the raw text as the query rather than failing the nav.
+            // Both fall back to the raw text: UnsupportedEncodingException is unreachable (UTF-8 is
+            // always available); a malformed %-escape (IllegalArgumentException) is treated as the raw
+            // query rather than failing the nav.
             return text;
         }
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/pictures/editor/StringHtmlEditorInput.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/pictures/editor/StringHtmlEditorInput.java
@@ -122,7 +122,8 @@ public final class StringHtmlEditorInput implements IEditorInput
     @Override
     public String getToolTipText()
     {
-        return title;
+        // The tooltip defaults to the tab name (there is no separate tooltip for this detached input).
+        return getName();
     }
 
     @Override

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/pictures/handlers/ShowCommonPicturesHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/pictures/handlers/ShowCommonPicturesHandler.java
@@ -108,7 +108,7 @@ public class ShowCommonPicturesHandler extends AbstractHandler
             return null;
         }
 
-        // Resolve the configuration on the UI thread only to resolve the synonym language once (cheap);
+        // Resolve the configuration on the UI thread only to resolve the synonym language once (cheap); // NOSONAR explanatory comment, not commented-out code
         // the heavy work is scheduled below and re-resolves the project/configuration fresh.
         ProjectContext.ConfigurationResult resolved = ProjectContext.of(project.getName()).resolveConfiguration();
         if (!resolved.ok())

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteInfobaseTool.java
@@ -77,6 +77,10 @@ public class DeleteInfobaseTool implements IMcpTool
     /** Infobase application type ID. */
     private static final String INFOBASE_APP_TYPE = "com.e1c.g5.dt.applications.type.infobase"; //$NON-NLS-1$
 
+    /** Consent-subtitle fragment appended when deleteDatabaseFiles=true (irreversible file deletion). */
+    private static final String CONSENT_DELETE_FILES_SUFFIX =
+        " and may delete its database files from disk (irreversible)."; //$NON-NLS-1$
+
     /** Background-Job timeout for the standalone-server deletion (stop + remove). */
     private static final long DELETE_TIMEOUT_SECONDS = 120;
 
@@ -253,7 +257,7 @@ public class DeleteInfobaseTool implements IMcpTool
         String declined = checkDestructiveConsent(ibPlan.resolvedName, "This dissociates infobase '" //$NON-NLS-1$
             + ibPlan.resolvedName + "' from project '" + projectName + "'" //$NON-NLS-1$ //$NON-NLS-2$
             + (deleteRegistration ? " and deregisters it from the EDT infobases list" : "") //$NON-NLS-1$ //$NON-NLS-2$
-            + (deleteDatabaseFiles ? " and may delete its database files from disk (irreversible)." : ".")); //$NON-NLS-1$ //$NON-NLS-2$
+            + (deleteDatabaseFiles ? CONSENT_DELETE_FILES_SUFFIX : ".")); //$NON-NLS-1$
         if (declined != null)
         {
             return declined;
@@ -789,7 +793,7 @@ public class DeleteInfobaseTool implements IMcpTool
         // is mutated.
         String declined = checkDestructiveConsent(resolvedName, "This deletes standalone server '" //$NON-NLS-1$
             + resolvedName + "' (stops it, removes the WST server and its config folder)" //$NON-NLS-1$
-            + (deleteDatabaseFiles ? " and may delete its database files from disk (irreversible)." : ".")); //$NON-NLS-1$ //$NON-NLS-2$
+            + (deleteDatabaseFiles ? CONSENT_DELETE_FILES_SUFFIX : ".")); //$NON-NLS-1$
         if (declined != null)
         {
             return declined;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ExportCommonPictureTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ExportCommonPictureTool.java
@@ -192,7 +192,7 @@ public class ExportCommonPictureTool implements IMcpTool
                     + "to find the exact name.").toJson(); //$NON-NLS-1$
             }
             // Guard the resolved type. The resolver already keys off the bilingual CommonPicture
-            // type token, so a non-picture object cannot reach here through a CommonPicture FQN;
+            // type token, so a non-picture object cannot reach here through a CommonPicture FQN; // NOSONAR explanatory comment, not commented-out code
             // this defensive check keeps the error clear if that ever changes.
             String eClassName = node.object.eClass().getName();
             if (!MetadataTypeUtils.MetadataTypeInfo.COMMON_PICTURE.getEnglishSingular()

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMethodCallHierarchyTool.java
@@ -95,6 +95,13 @@ public class GetMethodCallHierarchyTool implements IMcpTool
     /** Qualifier token for a chained/expression call whose source is not a StaticFeatureAccess. */
     private static final String QUALIFIER_EXPR = "(expr)"; //$NON-NLS-1$
 
+    /**
+     * Explanatory suffix appended to the module-load-failure error. Shared by every direction so
+     * the message stays identical (deduplicated from three inline literals).
+     */
+    private static final String MODULE_LOAD_FAILURE_SUFFIX =
+        ". Call hierarchy requires BSL AST (EMF). Check EDT Error Log for details."; //$NON-NLS-1$
+
     @Override
     public String getName()
     {
@@ -182,6 +189,19 @@ public class GetMethodCallHierarchyTool implements IMcpTool
         return t.isEmpty() ? null : t;
     }
 
+    /**
+     * Builds the identical "could not load the BSL AST for this module" error JSON shared by every
+     * direction. Names the failing module path and points at the EDT Error Log.
+     *
+     * @param modulePath the source-relative module path that failed to load
+     * @return the {@link ToolResult#error} JSON string
+     */
+    private static String moduleLoadFailure(String modulePath)
+    {
+        return ToolResult.error("Could not load EMF model for " + modulePath //$NON-NLS-1$
+            + MODULE_LOAD_FAILURE_SUFFIX).toJson();
+    }
+
     @Override
     public String execute(Map<String, String> params)
     {
@@ -202,11 +222,35 @@ public class GetMethodCallHierarchyTool implements IMcpTool
             return err;
         }
 
+        // Normalize + validate direction/methodName/extApiPrefix; a non-null result is an error JSON.
+        RequestArgs request = new RequestArgs(direction, methodName, extApiPrefix, limit);
+        String validationError = validateRequest(request);
+        if (validationError != null)
+        {
+            return validationError;
+        }
+
+        return runOnDisplay(projectName, modulePath, request);
+    }
+
+    /**
+     * Normalizes {@code direction} (blank → callers, lower-cased) and validates it, applies the
+     * callers/callees methodName guard, defaults a blank {@code extApiPrefix} and clamps the limit.
+     * On success the normalized values are written back into {@code request}; on failure the ready
+     * error JSON is returned and {@code request} is left partially normalized (unused by the caller).
+     *
+     * @param request the mutable request holder to normalize in place
+     * @return {@code null} when the arguments are valid, otherwise the {@link ToolResult#error} JSON
+     */
+    private String validateRequest(RequestArgs request)
+    {
+        String direction = request.direction;
         if (direction == null || direction.isEmpty())
         {
             direction = KEY_CALLERS;
         }
         direction = direction.toLowerCase();
+        request.direction = direction;
 
         if (!KEY_CALLERS.equals(direction) && !"callees".equals(direction) //$NON-NLS-1$
             && !KEY_OUTGOING.equals(direction))
@@ -214,42 +258,39 @@ public class GetMethodCallHierarchyTool implements IMcpTool
             return ToolResult.error("direction must be 'callers', 'callees' or 'outgoing'").toJson(); //$NON-NLS-1$
         }
 
-        if ((methodName == null || methodName.trim().isEmpty()) && !KEY_OUTGOING.equals(direction))
+        if ((request.methodName == null || request.methodName.trim().isEmpty())
+            && !KEY_OUTGOING.equals(direction))
         {
             return ToolResult.error("methodName is required for callers/callees" //$NON-NLS-1$
                 + ". Use get_module_structure to list the module's procedures and functions.").toJson(); //$NON-NLS-1$
         }
 
-        if (extApiPrefix == null || extApiPrefix.isEmpty())
+        if (request.extApiPrefix == null || request.extApiPrefix.isEmpty())
         {
-            extApiPrefix = DEFAULT_EXT_API_PREFIX;
+            request.extApiPrefix = DEFAULT_EXT_API_PREFIX;
         }
 
-        limit = Pagination.clampLimit(limit, 500);
+        request.limit = Pagination.clampLimit(request.limit, 500);
+        return null;
+    }
 
+    /**
+     * Runs the direction dispatch on the UI thread and returns its rendered result. All BSL model
+     * access happens inside {@link Display#syncExec} because it touches the shared EMF model.
+     *
+     * @param projectName the EDT project name (already validated as present)
+     * @param modulePath the source-relative module path (already validated as present)
+     * @param request the normalized/validated request arguments
+     * @return the rendered Markdown, or a {@link ToolResult#error} JSON string on failure
+     */
+    private String runOnDisplay(String projectName, String modulePath, RequestArgs request)
+    {
         AtomicReference<String> resultRef = new AtomicReference<>();
-        final String dir = direction;
-        final int maxResults = limit;
-        final String prefix = extApiPrefix;
-
         Display display = PlatformUI.getWorkbench().getDisplay();
         display.syncExec(() -> {
             try
             {
-                String result;
-                if (KEY_OUTGOING.equals(dir))
-                {
-                    result = findOutgoing(projectName, modulePath, methodName, prefix, maxResults);
-                }
-                else if (KEY_CALLERS.equals(dir))
-                {
-                    result = findCallers(projectName, modulePath, methodName, maxResults);
-                }
-                else
-                {
-                    result = findCallees(projectName, modulePath, methodName, maxResults);
-                }
-                resultRef.set(result);
+                resultRef.set(dispatch(projectName, modulePath, request));
             }
             catch (Exception e)
             {
@@ -257,8 +298,52 @@ public class GetMethodCallHierarchyTool implements IMcpTool
                 resultRef.set(ToolResult.error(e.getMessage()).toJson());
             }
         });
-
         return resultRef.get();
+    }
+
+    /**
+     * Routes a normalized request to the matching finder (outgoing / callers / callees). Must be
+     * called on the UI thread (see {@link #runOnDisplay}).
+     *
+     * @param projectName the EDT project name
+     * @param modulePath the source-relative module path
+     * @param request the normalized/validated request arguments
+     * @return the rendered result of the selected finder
+     */
+    private String dispatch(String projectName, String modulePath, RequestArgs request)
+    {
+        String dir = request.direction;
+        if (KEY_OUTGOING.equals(dir))
+        {
+            return findOutgoing(projectName, modulePath, request.methodName,
+                request.extApiPrefix, request.limit);
+        }
+        if (KEY_CALLERS.equals(dir))
+        {
+            return findCallers(projectName, modulePath, request.methodName, request.limit);
+        }
+        return findCallees(projectName, modulePath, request.methodName, request.limit);
+    }
+
+    /**
+     * Mutable holder for the normalized/validated request arguments, threaded from
+     * {@link #execute(Map)} through {@link #validateRequest} and {@link #dispatch}. Bundling them
+     * keeps the individual method signatures small without changing any value.
+     */
+    private static final class RequestArgs
+    {
+        String direction;
+        final String methodName;
+        String extApiPrefix;
+        int limit;
+
+        RequestArgs(String direction, String methodName, String extApiPrefix, int limit)
+        {
+            this.direction = direction;
+            this.methodName = methodName;
+            this.extApiPrefix = extApiPrefix;
+            this.limit = limit;
+        }
     }
 
     /**
@@ -282,8 +367,7 @@ public class GetMethodCallHierarchyTool implements IMcpTool
         Module module = BslModuleUtils.loadModule(project, modulePath);
         if (module == null)
         {
-            return ToolResult.error("Could not load EMF model for " + modulePath + //$NON-NLS-1$
-                   ". Call hierarchy requires BSL AST (EMF). Check EDT Error Log for details.").toJson(); //$NON-NLS-1$
+            return moduleLoadFailure(modulePath);
         }
 
         Method method = BslModuleUtils.findMethod(module, methodName);
@@ -673,8 +757,7 @@ public class GetMethodCallHierarchyTool implements IMcpTool
         Module module = BslModuleUtils.loadModule(project, modulePath);
         if (module == null)
         {
-            return ToolResult.error("Could not load EMF model for " + modulePath + //$NON-NLS-1$
-                   ". Call hierarchy requires BSL AST (EMF). Check EDT Error Log for details.").toJson(); //$NON-NLS-1$
+            return moduleLoadFailure(modulePath);
         }
 
         Method method = BslModuleUtils.findMethod(module, methodName);
@@ -913,8 +996,7 @@ public class GetMethodCallHierarchyTool implements IMcpTool
         Module module = BslModuleUtils.loadModule(project, modulePath);
         if (module == null)
         {
-            return ToolResult.error("Could not load EMF model for " + modulePath + //$NON-NLS-1$
-                   ". Call hierarchy requires BSL AST (EMF). Check EDT Error Log for details.").toJson(); //$NON-NLS-1$
+            return moduleLoadFailure(modulePath);
         }
 
         boolean scoped = methodName != null && !methodName.trim().isEmpty();
@@ -933,48 +1015,37 @@ public class GetMethodCallHierarchyTool implements IMcpTool
             scope = module;
         }
 
+        Map<String, OutgoingTarget> targets = aggregateOutgoing(scope, extApiPrefix, modulePath);
+
+        return formatOutgoingOutput(modulePath, scoped ? methodName : null,
+            new ArrayList<>(targets.values()), limit);
+    }
+
+    /**
+     * Walks a scope's AST and aggregates every {@link Invocation} into distinct outgoing targets,
+     * keyed by {@code qualifier + "." + method} in first-seen order. A per-file parse failure never
+     * aborts the aggregation: it is logged and the targets collected so far are returned (mirroring
+     * the candidate-scan resilience of {@link #findCallers}). Extracted from {@link #findOutgoing}
+     * to keep that method's complexity in check.
+     *
+     * @param scope the AST root to walk (a single method or the whole module)
+     * @param extApiPrefix the literal external-API qualifier prefix (case-insensitive)
+     * @param modulePath the module path, used only for the failure log message
+     * @return the first-seen-ordered map of aggregated targets (possibly empty, never {@code null})
+     */
+    private Map<String, OutgoingTarget> aggregateOutgoing(EObject scope, String extApiPrefix,
+        String modulePath)
+    {
         // First-seen-ordered aggregation keyed by qualifier + "." + method.
         Map<String, OutgoingTarget> targets = new LinkedHashMap<>();
-
         try
         {
             for (Iterator<EObject> iter = scope.eAllContents(); iter.hasNext();)
             {
                 EObject obj = iter.next();
-                if (!(obj instanceof Invocation))
+                if (obj instanceof Invocation)
                 {
-                    continue;
-                }
-                Invocation inv = (Invocation)obj;
-                // Reuse the frozen resolveInvocationName (it re-derives the method access from the
-                // Invocation) rather than a duplicate name-resolver; classify the qualifier separately.
-                String method = resolveInvocationName(inv);
-                if (method == null || method.isEmpty())
-                {
-                    continue;
-                }
-                String qualifier = qualifierKey(inv.getMethodAccess());
-                int line = BslModuleUtils.getStartLine(inv);
-
-                String key = aggregationKey(qualifier, method);
-                OutgoingTarget target = targets.get(key);
-                if (target == null)
-                {
-                    target = new OutgoingTarget();
-                    target.qualifier = qualifier;
-                    target.method = method;
-                    target.count = 0;
-                    target.firstLine = line;
-                    target.extApi = isExtApi(qualifier, extApiPrefix);
-                    targets.put(key, target);
-                }
-                target.count++;
-                // firstLine = smallest POSITIVE start line across the call sites. getStartLine() returns
-                // 0 when a node has no line info; 0 must not win the min (it renders as '-', like
-                // callers/callees), so only positive lines lower firstLine.
-                if (line > 0 && (target.firstLine <= 0 || line < target.firstLine))
-                {
-                    target.firstLine = line;
+                    accumulateOutgoing((Invocation)obj, extApiPrefix, targets);
                 }
             }
         }
@@ -985,9 +1056,52 @@ public class GetMethodCallHierarchyTool implements IMcpTool
             Activator.logWarning("Failed to walk module for outgoing calls " + modulePath //$NON-NLS-1$
                 + ": " + e.getMessage()); //$NON-NLS-1$
         }
+        return targets;
+    }
 
-        return formatOutgoingOutput(modulePath, scoped ? methodName : null,
-            new ArrayList<>(targets.values()), limit);
+    /**
+     * Aggregates a single {@link Invocation} into the shared {@code targets} map: resolves the called
+     * method name (skipping non-invocations / unnamed accesses), classifies the qualifier, then bumps
+     * the matching {@link OutgoingTarget}'s count and shrinks its {@code firstLine} to the smallest
+     * positive start line seen. Extracted from {@link #findOutgoing} to flatten its aggregation loop.
+     *
+     * @param inv the invocation to fold in
+     * @param extApiPrefix the literal external-API qualifier prefix (case-insensitive)
+     * @param targets the first-seen-ordered accumulator (appended to / updated, never reassigned)
+     */
+    private void accumulateOutgoing(Invocation inv, String extApiPrefix,
+        Map<String, OutgoingTarget> targets)
+    {
+        // Reuse the frozen resolveInvocationName (it re-derives the method access from the
+        // Invocation) rather than a duplicate name-resolver; classify the qualifier separately.
+        String method = resolveInvocationName(inv);
+        if (method == null || method.isEmpty())
+        {
+            return;
+        }
+        String qualifier = qualifierKey(inv.getMethodAccess());
+        int line = BslModuleUtils.getStartLine(inv);
+
+        String key = aggregationKey(qualifier, method);
+        OutgoingTarget target = targets.get(key);
+        if (target == null)
+        {
+            target = new OutgoingTarget();
+            target.qualifier = qualifier;
+            target.method = method;
+            target.count = 0;
+            target.firstLine = line;
+            target.extApi = isExtApi(qualifier, extApiPrefix);
+            targets.put(key, target);
+        }
+        target.count++;
+        // firstLine = smallest POSITIVE start line across the call sites. getStartLine() returns
+        // 0 when a node has no line info; 0 must not win the min (it renders as '-', like
+        // callers/callees), so only positive lines lower firstLine.
+        if (line > 0 && (target.firstLine <= 0 || line < target.firstLine))
+        {
+            target.firstLine = line;
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListCommonPicturesTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListCommonPicturesTool.java
@@ -181,7 +181,7 @@ public class ListCommonPicturesTool implements IMcpTool
         }
 
         // Model reads happen ONLY inside the BM read boundary (CLAUDE.md hard rule): enumerate the
-        // pictures and read each one's variants there. The reader touches the picture content API;
+        // pictures and read each one's variants there. The reader touches the picture content API; // NOSONAR explanatory comment, not commented-out code
         // the resolved model object is handed to it already inside this transaction.
         List<PictureInfo> pictures = BmTransactions.read(bmModel, "ListCommonPictures", (tx, monitor) -> //$NON-NLS-1$
             collectPictures(config, effectiveLanguage, limit));
@@ -236,7 +236,7 @@ public class ListCommonPicturesTool implements IMcpTool
             PictureInfo info = new PictureInfo();
             info.name = picture.getName();
             info.synonym = synonymForLanguage(picture, language);
-            // Read (decompress) variants ONLY for the pictures formatOutput will actually render;
+            // Read (decompress) variants ONLY for the pictures formatOutput will actually render; // NOSONAR explanatory comment, not commented-out code
             // pictures beyond `limit` count toward the Total but are not decompressed.
             if (reader != null && index < limit)
             {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/CommonPictureContentReader.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/CommonPictureContentReader.java
@@ -200,7 +200,7 @@ public final class CommonPictureContentReader
         String selected;
         if (VARIANT_BEST.equalsIgnoreCase(selector))
         {
-            // 'best' = the densest RASTER variant by explicit screen-density rank (NOT entry order);
+            // 'best' = the densest RASTER variant by explicit screen-density rank (NOT entry order); // NOSONAR explanatory comment, not commented-out code
             // fall back to the first entry for an SVG-only picture (and the single synthetic entry of a
             // variant-less single-image picture).
             selected = content.selectBestRasterName();
@@ -329,12 +329,12 @@ public final class CommonPictureContentReader
     {
         if (raw == null || raw.length == 0)
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (not decodable/sentinel), not an empty array: decodeBytesToPng falls through to the SVG branch
         }
         BufferedImage image = ImageIO.read(new ByteArrayInputStream(raw));
         if (image == null)
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (not decodable/sentinel), not an empty array: decodeBytesToPng falls through to the SVG branch
         }
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ImageIO.write(image, PNG_FORMAT, baos);
@@ -354,7 +354,7 @@ public final class CommonPictureContentReader
     {
         if (raw == null || raw.length == 0)
         {
-            return null;
+            return null; // NOSONAR null is a deliberate signal (not rasterizable/sentinel), not an empty array: exportPng reports a decode error on null
         }
         // Vector branch: rasterize via SVGUtils, called REFLECTIVELY so the reader works on both
         // EDT targets (see renderSvgToPngCompat / its javadoc).
@@ -363,7 +363,7 @@ public final class CommonPictureContentReader
             InputStream pngIn = renderSvgToPngCompat(svgIn);
             if (pngIn == null)
             {
-                return null;
+                return null; // NOSONAR null is a deliberate signal (not rasterizable/sentinel), not an empty array: exportPng reports a decode error on null
             }
             try
             {
@@ -646,7 +646,7 @@ public final class CommonPictureContentReader
             Optional<ByteArrayInputStream> raw = resolveInputStream(name);
             if (!raw.isPresent())
             {
-                return null;
+                return null; // NOSONAR null is a deliberate signal (entry not readable/sentinel), not an empty array
             }
             try (InputStream in = raw.get())
             {
@@ -727,7 +727,7 @@ public final class CommonPictureContentReader
         {
             PictureVariantInfo info = new PictureVariantInfo();
             info.name = name != null ? name : entryName();
-            // A single-image picture carries no per-variant dpi/theme/interface/direction bookkeeping;
+            // A single-image picture carries no per-variant dpi/theme/interface/direction bookkeeping; // NOSONAR explanatory comment, not commented-out code
             // report the neutral literal for each (matching the "-" the zip path uses for unset enums).
             info.dpi = NONE;
             info.theme = NONE;
@@ -807,7 +807,7 @@ public final class CommonPictureContentReader
             }
             catch (Exception e) // NOSONAR a size/name probe degrades to "unknown", never aborts the read
             {
-                return null;
+                return null; // NOSONAR null is a deliberate signal (unknown/unreadable/sentinel), not an empty array
             }
         }
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -92,6 +92,8 @@ public final class FormElementWriter
     private static final String FEATURE_VIEW = "view"; //$NON-NLS-1$
     /** The form attribute's "use in edit mode" presentation flag (an {@code AdjustableBoolean}). */
     private static final String FEATURE_EDIT = "edit"; //$NON-NLS-1$
+    /** A FormField/column's edit-mode enum feature (Enter / EnterOnInput). */
+    private static final String FEATURE_EDIT_MODE = "editMode"; //$NON-NLS-1$
     /** The English programmatic Name of a managed object form's main attribute. */
     private static final String MAIN_ATTRIBUTE_NAME_EN = "Object"; //$NON-NLS-1$
     /** The dynamic-list ext-info EClass and its query-carrying features. */
@@ -1142,7 +1144,7 @@ public final class FormElementWriter
             EObject seededField = findItem(content, trimmed);
             if (seededField != null)
             {
-                setEnumFeature(seededField, "editMode", "EnterOnInput"); //$NON-NLS-1$ //$NON-NLS-2$
+                setEnumFeature(seededField, FEATURE_EDIT_MODE, "EnterOnInput"); //$NON-NLS-1$
             }
         }
         if (!skipped.isEmpty())
@@ -2286,9 +2288,9 @@ public final class FormElementWriter
         }
         // The field binds to a form attribute by name. A DOTTED path binds to a SUB-attribute of the
         // head form attribute. Two heads are valid for a dotted path:
-        //   - a dynamic-list attribute (e.g. "List.Number"): the tail is one of its query fields
+        //   - a dynamic-list attribute (e.g. "List.Number"): the tail is one of its query fields // NOSONAR explanatory prose, not commented-out code
         //     (auto-filled by EDT - not a model attribute);
-        //   - the form's MAIN object attribute (e.g. "Object.Number"): the tail is a sub-attribute of
+        //   - the form's MAIN object attribute (e.g. "Object.Number"): the tail is a sub-attribute of // NOSONAR explanatory prose, not commented-out code
         //     the object type, like the designer's bound object fields.
         // Validate the head attribute, and require one of those two heads when a dotted path is used.
         int dot = attrName.indexOf('.');
@@ -2340,7 +2342,7 @@ public final class FormElementWriter
         setBooleanFeature(item, "showInHeader", true); //$NON-NLS-1$
         setBooleanFeature(item, "showInFooter", true); //$NON-NLS-1$
         setEnumFeature(item, "headerHorizontalAlign", "Left"); //$NON-NLS-1$ //$NON-NLS-2$
-        setEnumFeature(item, "editMode", "Enter"); //$NON-NLS-1$ //$NON-NLS-2$
+        setEnumFeature(item, FEATURE_EDIT_MODE, "Enter"); //$NON-NLS-1$
         EObject extInfo = singleReference(item, FEATURE_EXT_INFO);
         if (extInfo != null)
         {
@@ -2495,7 +2497,7 @@ public final class FormElementWriter
         setBooleanFeature(column, "showInHeader", true); //$NON-NLS-1$
         setBooleanFeature(column, "showInFooter", true); //$NON-NLS-1$
         setEnumFeature(column, "headerHorizontalAlign", "Left"); //$NON-NLS-1$ //$NON-NLS-2$
-        setEnumFeature(column, "editMode", "EnterOnInput"); //$NON-NLS-1$ //$NON-NLS-2$
+        setEnumFeature(column, FEATURE_EDIT_MODE, "EnterOnInput"); //$NON-NLS-1$
         setExtInfoClassifier(formModel, column, ECLASS_INPUT_FIELD_EXT_INFO);
         EObject extInfo = singleReference(column, FEATURE_EXT_INFO);
         if (extInfo != null)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/RoleRightsReader.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/RoleRightsReader.java
@@ -143,9 +143,37 @@ public final class RoleRightsReader
     {
         sb.append("## Rights matrix\n\n"); //$NON-NLS-1$
 
-        // Select the objects to render: in full mode every ObjectRights with any cell, otherwise only the
-        // objects that carry an authored (non-default) cell (an explicit SET/UNSET or an RLS). This is the
-        // eIsSet filter - a designer's untouched PROVIDED cell is the metamodel default and is noise.
+        MatrixSelection selection = selectMatrixObjects(description, full);
+        List<ObjectRights> selected = selection.selected;
+        if (selected.isEmpty())
+        {
+            sb.append(full ? "_(no rights)_\n\n" : "_(no non-default rights)_\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+            return;
+        }
+
+        int total = selected.size();
+        int limit = full ? MAX_OBJECT_LIMIT : DEFAULT_OBJECT_LIMIT;
+        int from = full ? 0 : Math.max(0, offset);
+        from = Math.min(from, total);
+        int to = Math.min(from + limit, total);
+
+        sb.append("**Objects with non-default rights:** ").append(selection.totalWithAuthored); //$NON-NLS-1$
+        sb.append(matrixWindowNotice(from, to, total, full));
+        sb.append("\n\n"); //$NON-NLS-1$
+
+        sb.append(MarkdownUtils.tableHeader("Object", "Right", "Value")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        renderMatrixRows(sb, selected, from, to, full, language);
+        sb.append('\n');
+    }
+
+    /**
+     * Selects the {@link ObjectRights} to render and counts the objects carrying an authored cell. In
+     * {@code full} mode every object with any right cell is selected; otherwise only the objects that
+     * carry an authored (non-default) cell - an explicit {@code SET}/{@code UNSET} or an RLS. This is the
+     * eIsSet filter: a designer's untouched {@code PROVIDED} cell is the metamodel default and is noise.
+     */
+    private static MatrixSelection selectMatrixObjects(RoleDescription description, boolean full)
+    {
         List<ObjectRights> selected = new ArrayList<>();
         int totalWithAuthored = 0;
         for (ObjectRights objectRights : description.getRights())
@@ -160,33 +188,24 @@ public final class RoleRightsReader
                 selected.add(objectRights);
             }
         }
+        return new MatrixSelection(selected, totalWithAuthored);
+    }
 
-        if (selected.isEmpty())
-        {
-            sb.append(full ? "_(no rights)_\n\n" : "_(no non-default rights)_\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
-            return;
-        }
-
-        int total = selected.size();
-        int limit = full ? MAX_OBJECT_LIMIT : DEFAULT_OBJECT_LIMIT;
-        int from = full ? 0 : Math.max(0, offset);
-        from = Math.min(from, total);
-        int to = Math.min(from + limit, total);
-
-        sb.append("**Objects with non-default rights:** ").append(totalWithAuthored); //$NON-NLS-1$
-        sb.append(matrixWindowNotice(from, to, total, full));
-        sb.append("\n\n"); //$NON-NLS-1$
-
-        sb.append(MarkdownUtils.tableHeader("Object", "Right", "Value")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    /**
+     * Appends one matrix row per rendered cell for the selected objects in the {@code [from, to)} window.
+     * In the default (non-full) view the individual {@code PROVIDED} cells of an object that still
+     * qualifies (via another {@code SET}/{@code UNSET} cell or an RLS) are dropped so the matrix shows
+     * only what was authored; {@code full} mode keeps every cell.
+     */
+    private static void renderMatrixRows(StringBuilder sb, List<ObjectRights> selected, int from, int to,
+        boolean full, String language)
+    {
         for (int i = from; i < to; i++)
         {
             ObjectRights objectRights = selected.get(i);
             String objectFqn = objectFqnOf(objectRights.getObject());
             for (ObjectRight right : objectRights.getRights())
             {
-                // In the default (non-full) view, drop the individual PROVIDED cells of an object that
-                // still qualifies (via another SET/UNSET cell or an RLS) so the matrix shows only what was
-                // authored; full mode keeps every cell.
                 if (!full && !isNonDefault(right))
                 {
                     continue;
@@ -195,7 +214,19 @@ public final class RoleRightsReader
                     rightValueLabel(right.getValue())));
             }
         }
-        sb.append('\n');
+    }
+
+    /** The selected matrix objects plus the count of objects carrying an authored (non-default) cell. */
+    private static final class MatrixSelection
+    {
+        final List<ObjectRights> selected;
+        final int totalWithAuthored;
+
+        MatrixSelection(List<ObjectRights> selected, int totalWithAuthored)
+        {
+            this.selected = selected;
+            this.totalWithAuthored = totalWithAuthored;
+        }
     }
 
     /**
@@ -439,7 +470,8 @@ public final class RoleRightsReader
             {
                 DuallyNamedElement named = (DuallyNamedElement)field;
                 String preferred = safe(ru ? named.getNameRu() : named.getName());
-                names.add(preferred.isEmpty() ? safe(ru ? named.getName() : named.getNameRu()) : preferred);
+                String fallback = safe(ru ? named.getName() : named.getNameRu());
+                names.add(preferred.isEmpty() ? fallback : preferred);
             }
         }
         if (names.isEmpty())

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/RoleRightsWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/RoleRightsWriter.java
@@ -100,6 +100,13 @@ public final class RoleRightsWriter
     private static final String OP_EDIT = "edit"; //$NON-NLS-1$
     private static final String OP_DELETE = "delete"; //$NON-NLS-1$
 
+    /** Wire (JSON payload) keys read from an entry - centralized so the apply and validate paths agree. */
+    private static final String KEY_OBJECT = "object"; //$NON-NLS-1$
+    private static final String KEY_RIGHT = "right"; //$NON-NLS-1$
+    private static final String KEY_VALUE = "value"; //$NON-NLS-1$
+    private static final String KEY_NAME = "name"; //$NON-NLS-1$
+    private static final String KEY_CONDITION = "condition"; //$NON-NLS-1$
+
     // ---- result -------------------------------------------------------------------------------
 
     /**
@@ -236,7 +243,7 @@ public final class RoleRightsWriter
         int applied = 0;
         for (JsonObject entry : rights)
         {
-            String objectFqn = str(entry.get("object")); //$NON-NLS-1$
+            String objectFqn = str(entry.get(KEY_OBJECT));
             MdObject targetMd = resolveObject(ctx.config, objectFqn);
             if (targetMd == null)
             {
@@ -244,7 +251,7 @@ public final class RoleRightsWriter
             }
             EObject target = targetMd;
 
-            String rightName = str(entry.get("right")); //$NON-NLS-1$
+            String rightName = str(entry.get(KEY_RIGHT));
             // The right is resolved by walking rightInfos.getRights(object) - a model read - so it runs
             // inside a read boundary; only the resolved Right handle (a task input) escapes.
             Right right = BmTransactions.read(ctx.model, "ResolveRight", //$NON-NLS-1$
@@ -255,7 +262,7 @@ public final class RoleRightsWriter
                     (tx, pm) -> rightNotFound(ctx.rightInfos, target, rightName, objectFqn)));
             }
 
-            RightValue value = parseRightValue(entry.get("value")); //$NON-NLS-1$
+            RightValue value = parseRightValue(entry.get(KEY_VALUE));
             setRightValue(ctx, target, right, value);
 
             String rls = str(entry.get("rls")); //$NON-NLS-1$
@@ -382,11 +389,11 @@ public final class RoleRightsWriter
         for (JsonObject entry : templates)
         {
             String op = templateOp(entry);
-            String name = str(entry.get("name")); //$NON-NLS-1$
-            String condition = str(entry.get("condition")); //$NON-NLS-1$
+            String name = str(entry.get(KEY_NAME));
+            String condition = str(entry.get(KEY_CONDITION));
             // Resolve the role description (and, for edit/delete, the named template) INSIDE a read
-            // boundary that re-fetches by bm id, so getTemplates() is never walked outside a boundary;
-            // only the handles the task consumes escape.
+            // boundary that re-fetches by bm id, so the template collection is never walked outside a
+            // boundary; only the handles the task consumes escape.
             IBmTask<?> task = BmTransactions.read(ctx.model, "ResolveTemplateTask", (tx, pm) -> //$NON-NLS-1$
             {
                 RoleDescription roleDescription = roleDescriptionInTx(tx, ctx.roleBmId);
@@ -816,17 +823,17 @@ public final class RoleRightsWriter
     /** Validates a single {@code rights[]} entry (object + right required, value recognizable). */
     static String validateRightsEntry(JsonObject entry)
     {
-        if (str(entry.get("object")) == null || str(entry.get("object")).isEmpty()) //$NON-NLS-1$ //$NON-NLS-2$
+        if (str(entry.get(KEY_OBJECT)) == null || str(entry.get(KEY_OBJECT)).isEmpty())
         {
             return ToolResult.error("Each 'rights' entry needs an 'object' FQN, e.g. " //$NON-NLS-1$
                 + "'Catalog.Products' (or the Russian 'Справочник.Товары').").toJson(); //$NON-NLS-1$
         }
-        if (str(entry.get("right")) == null || str(entry.get("right")).isEmpty()) //$NON-NLS-1$ //$NON-NLS-2$
+        if (str(entry.get(KEY_RIGHT)) == null || str(entry.get(KEY_RIGHT)).isEmpty())
         {
             return ToolResult.error("Each 'rights' entry needs a 'right' name, e.g. 'Read' / " //$NON-NLS-1$
                 + "'Update' (or the Russian 'Чтение' / 'Изменение').").toJson(); //$NON-NLS-1$
         }
-        if (!isValidRightValue(entry.get("value"))) //$NON-NLS-1$
+        if (!isValidRightValue(entry.get(KEY_VALUE)))
         {
             return ToolResult.error("The right 'value' must be 'set' / 'unset' / 'provided' or a " //$NON-NLS-1$
                 + "boolean (true = set, false = unset); default is 'set'.").toJson(); //$NON-NLS-1$
@@ -843,12 +850,12 @@ public final class RoleRightsWriter
             return ToolResult.error("Each 'templates' entry 'op' must be 'add', 'edit' or 'delete' " //$NON-NLS-1$
                 + "(default 'add'); got '" + op + "'.").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
         }
-        if (str(entry.get("name")) == null || str(entry.get("name")).isEmpty()) //$NON-NLS-1$ //$NON-NLS-2$
+        if (str(entry.get(KEY_NAME)) == null || str(entry.get(KEY_NAME)).isEmpty())
         {
             return ToolResult.error("Each 'templates' entry needs a 'name'.").toJson(); //$NON-NLS-1$
         }
         if ((OP_ADD.equals(op) || OP_EDIT.equals(op))
-            && (str(entry.get("condition")) == null || str(entry.get("condition")).isEmpty())) //$NON-NLS-1$ //$NON-NLS-2$
+            && (str(entry.get(KEY_CONDITION)) == null || str(entry.get(KEY_CONDITION)).isEmpty()))
         {
             return ToolResult.error("A 'templates' " + op + " entry needs a 'condition' (the RLS " //$NON-NLS-1$ //$NON-NLS-2$
                 + "restriction text).").toJson(); //$NON-NLS-1$


### PR DESCRIPTION
## Что

Чистка SonarCloud (только `CODE_SMELL`, **поведение не меняется**) на master: **~31 замечание в 13 файлах**. Каждое либо исправлено без изменения поведения, либо подавлено `// NOSONAR` с причиной — там, где это false-positive или фикс был бы инвазивным:

- **S1192** (дубли строковых литералов) → `private static final` константы;
- **S3776 / S6541** (когнитивная сложность / «brain method») → извлечены приватные хелперы (те же `throws`/возвраты — чистый рефакторинг);
- **S3358** (вложенный тернарник) → if/else; **S2147** (дубль catch) → multi-catch; **S4144** (идентичные тела) → делегирование;
- **S125** (пояснительные prose-комментарии, которые Sonar принимает за закомментированный код) → `// NOSONAR` (комментарии осмысленные — оставлены);
- **S1168** (возврат `null` для коллекции) — это **осознанные сентинелы** «не найдено / не декодируется» (вызыватели проверяют на `null`) → `// NOSONAR`, **НЕ** конвертированы в пустую коллекцию (иначе это была бы реальная регрессия).

## Осознанно НЕ вошло
- Спорные кластеры #164 (**S135 ×4, S107 ×2, S112 ×3**) — по решению прошлых сессий (won't-fix / инвазивно).
- Замечания в `ModifyMetadataTool` (6 шт.) — **отложены до слияния PR #225** (который переписывает этот файл), чтобы не поймать конфликт.

## Как проверено
- `compile.sh` зелёный (компиляция + юнит-тесты). Поведение не меняется, `tools_list.golden.json` не тронут, новых инструментов/схем нет.
- Собрано автопилотом (fan-out по непересекающимся файлам + build-gate + adversarial-review); ревьюеры поймали и починили неверную вставку `NOSONAR` в середину prose-комментария.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
