### PR TITLE
ExchangePlanContentWriter: валидация вида члена состава плана обмена (Copilot follow-up к #225)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ExchangePlanContentWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ExchangePlanContentWriter.java
@@ -9,9 +9,11 @@ package com.ditrix.edt.mcp.server.utils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EEnum;
 import org.eclipse.emf.ecore.EEnumLiteral;
 
@@ -49,8 +51,9 @@ import com.google.gson.JsonObject;
  *
  * <p>The whole payload is validated UP FRONT, BEFORE the write transaction (op recognized; a metadata
  * FQN required; the object resolves via the shared bilingual
- * {@link MetadataNodeResolver#resolveExisting}; for an add, when supplied, the {@code autoRecord} token
- * maps to a literal), so a shape / resolution error leaves NOTHING written. The mutation then runs
+ * {@link MetadataNodeResolver#resolveExisting}; the object's {@link org.eclipse.emf.ecore.EClass EClass}
+ * passes {@link #isExchangePlanContentMember}; for an add, when supplied, the {@code autoRecord} token
+ * maps to a literal), so a shape / resolution / kind error leaves NOTHING written. The mutation then runs
  * entirely inside a single {@link BmTransactions#write write} boundary on the re-fetched exchange plan,
  * with every content object re-fetched from the IN-TRANSACTION model by its captured BM id (a content
  * object is a TOP object, so {@code tx.getObjectById(bmGetId())} is used - NEVER {@code eContainer()},
@@ -355,9 +358,10 @@ public final class ExchangePlanContentWriter
     /**
      * Validates + resolves a single {@code content[]} entry up front (BEFORE the tx): the op is
      * recognized (default {@code add}), a metadata FQN is present, the object resolves via the shared
-     * bilingual {@link MetadataNodeResolver#resolveExisting}, and (for an add, when supplied) the
-     * {@code autoRecord} token maps to a literal. Returns a ready {@link PlannedEntry} or a ready JSON
-     * error.
+     * bilingual {@link MetadataNodeResolver#resolveExisting}, the object's {@link EClass} is a legal
+     * exchange-plan content member ({@link #isExchangePlanContentMember}), and (for an add, when
+     * supplied) the {@code autoRecord} token maps to a literal. Returns a ready {@link PlannedEntry} or a
+     * ready JSON error.
      */
     private static EntryPlan planEntry(Configuration config, JsonObject entry)
     {
@@ -384,6 +388,13 @@ public final class ExchangePlanContentWriter
             return EntryPlan.failed(objectNotFound(config, fqn));
         }
         MdObject mdObject = node.object;
+        if (!isExchangePlanContentMember(mdObject.eClass()))
+        {
+            return EntryPlan.failed(ToolResult.error("'" + fqn + "' (" + mdObject.eClass().getName() //$NON-NLS-1$ //$NON-NLS-2$
+                + ") cannot be a member of an exchange plan's content. Only data-bearing objects " //$NON-NLS-1$
+                + "(e.g. Catalog / Document / InformationRegister / Constant / BusinessProcess) are " //$NON-NLS-1$
+                + "valid content.").toJson()); //$NON-NLS-1$
+        }
 
         AutoRegistrationChanges autoRecord = null;
         if (!OP_REMOVE.equals(op))
@@ -411,6 +422,55 @@ public final class ExchangePlanContentWriter
     }
 
     // ---- pure helpers (unit-testable) ---------------------------------------------------------
+
+    /**
+     * The metadata object kinds that may be a member of an {@link ExchangePlan}'s content, as an
+     * immutable set of {@link MdClassPackage.Literals} EClasses matched by identity. This replicates
+     * EDT's own exchange-plan content picker
+     * ({@code EXCHANGE_PLAN_CONTENT__SUBTREE_INDUCER} in a UI bundle the headless server must NOT depend
+     * on), so what the {@code content[]} branch accepts matches exactly what the EDT designer permits.
+     *
+     * <p>The set is authoritative, not heuristic: {@link MdClassPackage.Literals#CONSTANT Constant},
+     * {@link MdClassPackage.Literals#SEQUENCE Sequence} and
+     * {@link MdClassPackage.Literals#RECALCULATION Recalculation} are direct {@code MdObject}s (not
+     * {@code BasicDbObject}s), so a marker-interface union would wrongly DROP them; conversely
+     * {@link MdClassPackage.Literals#EXCHANGE_PLAN ExchangePlan} and
+     * {@link MdClassPackage.Literals#DOCUMENT_JOURNAL DocumentJournal} extend {@code BasicDbObject} and
+     * so would be wrongly ACCEPTED. Hence an explicit identity set rather than an {@code instanceof}
+     * test.</p>
+     */
+    private static final Set<EClass> EXCHANGE_PLAN_CONTENT_MEMBER_CLASSES = Set.of(
+        MdClassPackage.Literals.CONSTANT,
+        MdClassPackage.Literals.CATALOG,
+        MdClassPackage.Literals.DOCUMENT,
+        MdClassPackage.Literals.SEQUENCE,
+        MdClassPackage.Literals.CHART_OF_CHARACTERISTIC_TYPES,
+        MdClassPackage.Literals.CHART_OF_ACCOUNTS,
+        MdClassPackage.Literals.CHART_OF_CALCULATION_TYPES,
+        MdClassPackage.Literals.INFORMATION_REGISTER,
+        MdClassPackage.Literals.ACCUMULATION_REGISTER,
+        MdClassPackage.Literals.ACCOUNTING_REGISTER,
+        MdClassPackage.Literals.CALCULATION_REGISTER,
+        MdClassPackage.Literals.RECALCULATION,
+        MdClassPackage.Literals.BUSINESS_PROCESS,
+        MdClassPackage.Literals.TASK);
+
+    /**
+     * Whether the given metadata {@link EClass} may be a member of an {@link ExchangePlan}'s content -
+     * an identity lookup in {@link #EXCHANGE_PLAN_CONTENT_MEMBER_CLASSES} (EDT's own content picker set,
+     * replicated). Pure and side-effect-free so it is used as the up-front reject predicate in
+     * {@link #planEntry} (BEFORE any transaction), symmetric with the sibling membership writers'
+     * kind guards.
+     *
+     * @param eClass the resolved object's {@link EClass} (may be {@code null})
+     * @return {@code true} when the class is one of the data-bearing exchange-plan content kinds
+     */
+    static boolean isExchangePlanContentMember(EClass eClass)
+    {
+        // Null-guarded: the backing Set.of(...) is null-hostile (contains(null) throws), and a null
+        // class is simply "not a member".
+        return eClass != null && EXCHANGE_PLAN_CONTENT_MEMBER_CLASSES.contains(eClass);
+    }
 
     /** Normalizes a content op token to {@code add} / {@code remove}; default {@code add}. */
     static String contentOp(JsonObject entry)

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ExchangePlanContentWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ExchangePlanContentWriterTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import com._1c.g5.v8.dt.metadata.mdclass.AutoRegistrationChanges;
+import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
 import com.google.gson.JsonObject;
 
 /**
@@ -120,6 +121,66 @@ public class ExchangePlanContentWriterTest
         assertNull(ExchangePlanContentWriter.mapAutoRecord("Maybe")); //$NON-NLS-1$
         assertNull(ExchangePlanContentWriter.mapAutoRecord("Auto")); //$NON-NLS-1$
         assertNull(ExchangePlanContentWriter.mapAutoRecord("Use")); //$NON-NLS-1$
+    }
+
+    // ---- isExchangePlanContentMember (the content member-kind allow-list) -------------------
+
+    @Test
+    public void testExchangePlanContentMemberAcceptsDataBearingKinds()
+    {
+        assertTrue(ExchangePlanContentWriter.isExchangePlanContentMember(MdClassPackage.Literals.CONSTANT));
+        assertTrue(ExchangePlanContentWriter.isExchangePlanContentMember(MdClassPackage.Literals.CATALOG));
+        assertTrue(ExchangePlanContentWriter.isExchangePlanContentMember(MdClassPackage.Literals.DOCUMENT));
+        assertTrue(ExchangePlanContentWriter.isExchangePlanContentMember(MdClassPackage.Literals.SEQUENCE));
+        assertTrue(ExchangePlanContentWriter.isExchangePlanContentMember(
+            MdClassPackage.Literals.CHART_OF_CHARACTERISTIC_TYPES));
+        assertTrue(ExchangePlanContentWriter.isExchangePlanContentMember(
+            MdClassPackage.Literals.CHART_OF_ACCOUNTS));
+        assertTrue(ExchangePlanContentWriter.isExchangePlanContentMember(
+            MdClassPackage.Literals.CHART_OF_CALCULATION_TYPES));
+        assertTrue(ExchangePlanContentWriter.isExchangePlanContentMember(
+            MdClassPackage.Literals.INFORMATION_REGISTER));
+        assertTrue(ExchangePlanContentWriter.isExchangePlanContentMember(
+            MdClassPackage.Literals.ACCUMULATION_REGISTER));
+        assertTrue(ExchangePlanContentWriter.isExchangePlanContentMember(
+            MdClassPackage.Literals.ACCOUNTING_REGISTER));
+        assertTrue(ExchangePlanContentWriter.isExchangePlanContentMember(
+            MdClassPackage.Literals.CALCULATION_REGISTER));
+        // Recalculation IS a valid content member per EDT's own picker (even though it is a nested,
+        // non-top object); the kind-check must therefore accept it - the load-bearing "IN" point.
+        assertTrue(ExchangePlanContentWriter.isExchangePlanContentMember(
+            MdClassPackage.Literals.RECALCULATION));
+        assertTrue(ExchangePlanContentWriter.isExchangePlanContentMember(
+            MdClassPackage.Literals.BUSINESS_PROCESS));
+        assertTrue(ExchangePlanContentWriter.isExchangePlanContentMember(MdClassPackage.Literals.TASK));
+    }
+
+    @Test
+    public void testExchangePlanContentMemberRejectsNonDataBearingKinds()
+    {
+        // ExchangePlan + DocumentJournal extend BasicDbObject (so a marker-interface test would wrongly
+        // ACCEPT them) but are NOT valid exchange-plan content per EDT's own picker - the load-bearing
+        // "OUT" points that distinguish the correct set.
+        assertFalse(ExchangePlanContentWriter.isExchangePlanContentMember(
+            MdClassPackage.Literals.EXCHANGE_PLAN));
+        assertFalse(ExchangePlanContentWriter.isExchangePlanContentMember(
+            MdClassPackage.Literals.DOCUMENT_JOURNAL));
+        assertFalse(ExchangePlanContentWriter.isExchangePlanContentMember(MdClassPackage.Literals.ROLE));
+        assertFalse(ExchangePlanContentWriter.isExchangePlanContentMember(
+            MdClassPackage.Literals.COMMON_MODULE));
+        assertFalse(ExchangePlanContentWriter.isExchangePlanContentMember(
+            MdClassPackage.Literals.SUBSYSTEM));
+        assertFalse(ExchangePlanContentWriter.isExchangePlanContentMember(MdClassPackage.Literals.REPORT));
+        // No plain FORM EClass exists in MdClassPackage; COMMON_FORM is the EClass of a top-level
+        // Form.X metadata object and is likewise not valid exchange-plan content.
+        assertFalse(ExchangePlanContentWriter.isExchangePlanContentMember(
+            MdClassPackage.Literals.COMMON_FORM));
+    }
+
+    @Test
+    public void testExchangePlanContentMemberRejectsNull()
+    {
+        assertFalse(ExchangePlanContentWriter.isExchangePlanContentMember(null));
     }
 
     // ---- bilingual object-FQN normalization (via the shared MetadataTypeUtils) --------------

--- a/tests/e2e/tools/test_modify_metadata_membership.py
+++ b/tests/e2e/tools/test_modify_metadata_membership.py
@@ -165,6 +165,28 @@ def test_exchange_plan_content_russian_token():
 
 
 @e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_exchange_plan_content_reject_non_member_kind():
+    # A CommonModule is not a data-bearing object - it cannot be a member of an exchange plan's
+    # content (only Catalog / Document / InformationRegister / Constant / BusinessProcess & co. are
+    # valid content, mirroring EDT's own content picker). The reject must name the bad FQN and NOT
+    # write anything. The exchange plan is seeded; the reject is a kind failure so nothing is added
+    # on top of the seeding.
+    plan = "E2EXPContentBad"
+    plan_fqn = "ExchangePlan." + plan
+    not_member = "CommonModule.OK"      # a fixture common module - not a valid content member
+    _create_ok(plan_fqn, "seed the exchange plan")
+    before = tree_snapshot()
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": plan_fqn,
+        "content": [{"op": "add", "metadata": not_member}],
+    })
+    e = assert_error(r, "add an object that is not a valid exchange plan content member")
+    assert_error_quality(e, names=[not_member], suggests=["exchange plan"],
+                         ctx="a non-content-member is rejected with the object named + an exchange plan hint")
+    assert_tree_unchanged(before, "a rejected non-member add must change nothing")
+
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
 def test_content_payload_on_non_dispatch_kind_is_error():
     # A content payload aimed at an FQN kind that has NO membership list (an InformationRegister is
     # neither a CommonAttribute nor an ExchangePlan/Catalog/Document) must be a clean, actionable


### PR DESCRIPTION
## Что

Фоллоу-ап по замечанию Copilot на слитом #225: ветка плана обмена в `content[]` (`ExchangePlanContentWriter`) **не валидировала вид добавляемого объекта** — `Role`/`CommonModule`/`Subsystem` принимались как успешное добавление и писались в `.mdo`, который EDT затем флагует невалидным (false-success, который три другие ветки специально предотвращают).

Добавил такой же up-front гард, как у соседей:
- **`isExchangePlanContentMember(EClass)`** — immutable Set из **14 EClass**, которые разрешает собственный пикер состава EDT (реплицировано из `EXCHANGE_PLAN_CONTENT__SUBTREE_INDUCER` — он в UI-бандле, от которого headless-сервер зависеть не должен; источник указан в коде).
- Невалидный член **отклоняется до write-транзакции** с actionable-ошибкой (имя FQN + вид), на диск ничего.

**Авторитетный набор (не эвристика):** валидны `Constant / Catalog / Document / Sequence / ChartOf×3 / Register×4 / Recalculation / BusinessProcess / Task`; невалидны `ExchangePlan, DocumentJournal, Role, CommonModule, Subsystem, Report, Form`. Три неочевидные точки: **Recalculation — валиден; ExchangePlan и DocumentJournal — нет** — поэтому не подошли ни маркер-интерфейс (ExchangePlan extends BasicDbObject; Constant/Sequence/Recalculation — MdObject-only), ни `MdClassUtil.isCommonAttributeTarget` (другой набор), ни EMF `validate()` (только null-чек).

## Как проверено
- **Сборка:** `compile.sh` зелёный + unit truth-table (все 14 валидных + 7 невалидных; закреплены Recalculation-in / ExchangePlan-out / DocumentJournal-out).
- **Негативный e2e** `test_exchange_plan_content_reject_non_member_kind` (`CommonModule.OK` в состав → reject, `assert_tree_unchanged`) — симметрично тестам владельцев справочника / движений документа.
- Happy-path (Catalog/Document/InformationRegister + русский токен) не тронут — все валидны, регрессии нет.
- Схема / `tools_list.golden.json` / диспетч не менялись — чистое ужесточение валидации.

Адресует ревью-коммент Copilot на #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
