### PR TITLE
Sonar: полная чистка code-smell на master (без изменения поведения)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteInfobaseTool.java
@@ -81,6 +81,9 @@ public class DeleteInfobaseTool implements IMcpTool
     private static final String CONSENT_DELETE_FILES_SUFFIX =
         " and may delete its database files from disk (irreversible)."; //$NON-NLS-1$
 
+    /** Message fragment joining an infobase/server name to its owning project name. */
+    private static final String MSG_FROM_PROJECT = "' from project '"; //$NON-NLS-1$
+
     /** Background-Job timeout for the standalone-server deletion (stop + remove). */
     private static final long DELETE_TIMEOUT_SECONDS = 120;
 
@@ -255,7 +258,7 @@ public class DeleteInfobaseTool implements IMcpTool
         // Destructive-operation consent gate: the LAST check before the infobase is dissociated /
         // deregistered / its files removed. On REJECT nothing is mutated.
         String declined = checkDestructiveConsent(ibPlan.resolvedName, "This dissociates infobase '" //$NON-NLS-1$
-            + ibPlan.resolvedName + "' from project '" + projectName + "'" //$NON-NLS-1$ //$NON-NLS-2$
+            + ibPlan.resolvedName + MSG_FROM_PROJECT + projectName + "'" //$NON-NLS-1$
             + (deleteRegistration ? " and deregisters it from the EDT infobases list" : "") //$NON-NLS-1$ //$NON-NLS-2$
             + (deleteDatabaseFiles ? CONSENT_DELETE_FILES_SUFFIX : ".")); //$NON-NLS-1$
         if (declined != null)
@@ -332,7 +335,7 @@ public class DeleteInfobaseTool implements IMcpTool
         {
             Activator.logError("delete_infobase: dissociate failed", e); //$NON-NLS-1$
             return ToolResult.error("Failed to dissociate infobase '" + id.resolvedName //$NON-NLS-1$
-                + "' from project '" + projectName + "': " + e.getMessage()).toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+                + MSG_FROM_PROJECT + projectName + "': " + e.getMessage()).toJson(); //$NON-NLS-1$
         }
 
         // Step 2: optionally deregister from the global EDT infobases list. A non-null result is the
@@ -579,7 +582,7 @@ public class DeleteInfobaseTool implements IMcpTool
             .put(KEY_INFOBASE_NAME, id.resolvedName)
             .put(KEY_DELETE_REGISTRATION, deleteRegistration)
             .put(McpKeys.MESSAGE, "PREVIEW: this would dissociate infobase '" + id.resolvedName //$NON-NLS-1$
-                + "' from project '" + id.projectName + "'" //$NON-NLS-1$ //$NON-NLS-2$
+                + MSG_FROM_PROJECT + id.projectName + "'" //$NON-NLS-1$
                 + (deleteRegistration
                     ? " AND deregister it from the EDT infobases list" //$NON-NLS-1$
                     : " (EDT infobases list entry kept)") //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetOutgoingStructuresTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetOutgoingStructuresTool.java
@@ -287,7 +287,7 @@ public class GetOutgoingStructuresTool implements IMcpTool
     boolean collectMethodRecords(Method method, String qualifierFilter, int limit, JsonArray records)
     {
         String methodName = method.getName();
-        for (Iterator<EObject> iter = method.eAllContents(); iter.hasNext();)
+        for (Iterator<EObject> iter = method.eAllContents(); iter.hasNext();) // NOSONAR guard-continue filter chain; merging into nested ifs deepens nesting and hurts readability
         {
             if (records.size() >= limit)
             {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -92,6 +92,36 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
     /** Error message prefix for an unresolved form FQN. */
     private static final String ERR_FORM_NOT_FOUND_PREFIX = "Form not found for '"; //$NON-NLS-1$
 
+    /** Payload / output key: the ROLE rights array. */
+    private static final String KEY_RIGHTS = "rights"; //$NON-NLS-1$
+
+    /** Payload / output key: the ROLE RLS templates array. */
+    private static final String KEY_TEMPLATES = "templates"; //$NON-NLS-1$
+
+    /** Payload / output key: the ROLE properties object. */
+    private static final String KEY_ROLE_PROPERTIES = "roleProperties"; //$NON-NLS-1$
+
+    /** Payload / output key: the membership content array / counts object. */
+    private static final String KEY_CONTENT = "content"; //$NON-NLS-1$
+
+    /** Output count key: members attached. */
+    private static final String KEY_ADDED = "added"; //$NON-NLS-1$
+
+    /** Output count key: members detached. */
+    private static final String KEY_REMOVED = "removed"; //$NON-NLS-1$
+
+    /** The form attribute's value-type feature / property alias. */
+    private static final String PROP_VALUE_TYPE = "valueType"; //$NON-NLS-1$
+
+    /** Confirmation-message prefix for a completed modify. */
+    private static final String MSG_MODIFIED_PREFIX = "Modified "; //$NON-NLS-1$
+
+    /** Error-message fragment between an FQN and its EClass name (e.g. "'X' is a Catalog"). */
+    private static final String MSG_IS_A = "' is a "; //$NON-NLS-1$
+
+    /** Confirmation-message fragment before a removed count. */
+    private static final String MSG_REMOVED_COUNT = ", removed: "; //$NON-NLS-1$
+
     @Override
     public String getName()
     {
@@ -151,7 +181,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 + "value; 'language' is the code for a synonym (default: config default). Required " //$NON-NLS-1$
                 + "unless the FQN is a Role and a role payload (rights / templates / roleProperties) " //$NON-NLS-1$
                 + "is given.") //$NON-NLS-1$
-            .objectArrayProperty("rights", //$NON-NLS-1$
+            .objectArrayProperty(KEY_RIGHTS,
                 "ROLE only: per-object access rights to set, as [{object, right, value?, rls?, " //$NON-NLS-1$
                 + "rlsFields?}]. 'object' is a metadata FQN (e.g. 'Catalog.Products' or the Russian " //$NON-NLS-1$
                 + "'Справочник.Товары'); 'right' is a bilingual right name (e.g. 'Read'/'Чтение', " //$NON-NLS-1$
@@ -160,15 +190,15 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 + "optional Row-Level-Security restriction condition (1C query text); 'rlsFields' is " //$NON-NLS-1$
                 + "an optional array of field names the RLS applies to (omit / empty = whole-object " //$NON-NLS-1$
                 + "restriction).") //$NON-NLS-1$
-            .objectArrayProperty("templates", //$NON-NLS-1$
+            .objectArrayProperty(KEY_TEMPLATES,
                 "ROLE only: RLS restriction templates to change, as [{op?, name, condition?}]. 'op' is " //$NON-NLS-1$
                 + "'add' (default) / 'edit' / 'delete'; 'name' is the template name; 'condition' is " //$NON-NLS-1$
                 + "the RLS restriction text (required for add/edit).") //$NON-NLS-1$
-            .objectProperty("roleProperties", //$NON-NLS-1$
+            .objectProperty(KEY_ROLE_PROPERTIES,
                 "ROLE only: the three role properties, as optional booleans {setForNewObjects, " //$NON-NLS-1$
                 + "setForAttributesByDefault, independentRightsOfChildObjects}. Only supplied flags " //$NON-NLS-1$
                 + "are changed.") //$NON-NLS-1$
-            .objectArrayProperty("content", //$NON-NLS-1$
+            .objectArrayProperty(KEY_CONTENT,
                 "Members to attach / detach in a structured membership list, dispatched by the FQN's " //$NON-NLS-1$
                 + "kind (a COMMON ATTRIBUTE's owners, an EXCHANGE PLAN's content objects, a CATALOG's " //$NON-NLS-1$
                 + "owners, a DOCUMENT's register records), as [{op?, metadata, use?, autoRecord?}]. 'op' " //$NON-NLS-1$
@@ -200,7 +230,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             .stringArrayProperty(KEY_APPLIED, "Names of the properties that were set (for a Role " //$NON-NLS-1$
                 + "rights change this is instead an object {rights, templates, roleProperties} with " //$NON-NLS-1$
                 + "the applied counts)") //$NON-NLS-1$
-            .objectProperty("content", "For a membership-list content change: the counts object. A " //$NON-NLS-1$ //$NON-NLS-2$
+            .objectProperty(KEY_CONTENT, "For a membership-list content change: the counts object. A " //$NON-NLS-1$
                 + "CommonAttribute / ExchangePlan change reports {added, updated, removed} (members " //$NON-NLS-1$
                 + "attached / had their per-entry flag - 'use' / 'autoRecord' - updated / detached); a " //$NON-NLS-1$
                 + "Catalog owners / Document register records change (a plain reference list, no " //$NON-NLS-1$
@@ -231,8 +261,8 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         // Role payload (rights[] / templates[] / roleProperties): dispatched when the resolved FQN is a
         // Role. When present, 'properties' is optional (a role is modified through the rights surface,
         // not the generic property bag).
-        List<JsonObject> rolePayloadRights = JsonUtils.extractObjectArray(params, "rights"); //$NON-NLS-1$
-        List<JsonObject> rolePayloadTemplates = JsonUtils.extractObjectArray(params, "templates"); //$NON-NLS-1$
+        List<JsonObject> rolePayloadRights = JsonUtils.extractObjectArray(params, KEY_RIGHTS);
+        List<JsonObject> rolePayloadTemplates = JsonUtils.extractObjectArray(params, KEY_TEMPLATES);
         JsonObject roleProperties = parseRolePropertiesArg(params);
         boolean hasRolePayload =
             !rolePayloadRights.isEmpty() || !rolePayloadTemplates.isEmpty() || roleProperties != null;
@@ -242,7 +272,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         // Document's register records). When present, 'properties' is optional (the membership list is
         // edited through its own surface, not the generic property bag) - mirrors the Role rights[]
         // precedent.
-        List<JsonObject> content = JsonUtils.extractObjectArray(params, "content"); //$NON-NLS-1$
+        List<JsonObject> content = JsonUtils.extractObjectArray(params, KEY_CONTENT);
         boolean hasContentPayload = !content.isEmpty();
 
         if (properties.isEmpty() && !hasRolePayload && !hasContentPayload)
@@ -267,28 +297,14 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
 
         String normFqn = MetadataTypeUtils.normalizeFqn(fqn);
 
-        // A FQN that addresses a FORM member (item / attribute / command) is handled by a dedicated
+        // A FQN that addresses a FORM member (item / attribute / command) is dispatched to its own
         // branch: form members live on the editable Form content model (a cross-model hop), not the
-        // mdclass tree. The validation + change pipeline (prepare / PreparedChange) is reused as-is.
+        // mdclass tree. A Role / content payload addressed to a form member is refused there.
         FormElementWriter.FormMemberRef formRef = FormElementWriter.parse(normFqn);
         if (formRef != null)
         {
-            // A Role payload (rights / templates / roleProperties) or a membership 'content' payload
-            // addressed to a FORM-member FQN is refused here, BEFORE the form dispatch: a form member
-            // is neither a Role nor a membership-list owner (CommonAttribute / ExchangePlan / Catalog /
-            // Document), so those siblings do not apply to it. Without this guard the form branch would
-            // apply only 'properties' (or nothing) and report success while the sibling payload
-            // vanished silently. Both siblings are rejected together to keep them symmetric.
-            if (hasRolePayload || hasContentPayload)
-            {
-                return ToolResult.error("'" + normFqn + "' addresses a FORM member, which cannot " //$NON-NLS-1$ //$NON-NLS-2$
-                    + "take a Role payload ('rights' / 'templates' / 'roleProperties') or a " //$NON-NLS-1$
-                    + "membership 'content' payload. 'rights' / 'templates' / 'roleProperties' " //$NON-NLS-1$
-                    + "are valid only for a Role.<Name> FQN, and 'content' only for a " //$NON-NLS-1$
-                    + "CommonAttribute / ExchangePlan / Catalog / Document FQN. Use 'properties' to " //$NON-NLS-1$
-                    + "change a form member.").toJson(); //$NON-NLS-1$
-            }
-            return modifyFormMember(ctx, normFqn, formRef, properties, normReport);
+            return dispatchFormMember(ctx, normFqn, formRef, properties, normReport, hasRolePayload,
+                hasContentPayload);
         }
 
         // Exact-first resolve with the yo-addressing fallback: create_metadata normalizes
@@ -313,61 +329,136 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         MdObject target = node.object;
 
         // A ROLE FQN carrying a role payload (rights / templates / roleProperties) is dispatched to the
-        // dedicated rights writer: a role is modified through its access-rights surface, not the generic
-        // property bag. The mutation goes through the EDT-native rights tasks + a forceExport of the
-        // Role FQN (draining the sibling Rights.rights sub-resource).
+        // rights writer; the same payload on a NON-Role FQN is refused. Returns null only when there is
+        // no role payload, so the content / generic property path below still runs.
+        String rolePayloadResult = dispatchRolePayload(ctx, normFqn, target, properties,
+            rolePayloadRights, rolePayloadTemplates, roleProperties, hasRolePayload);
+        if (rolePayloadResult != null)
+        {
+            return rolePayloadResult;
+        }
+
+        // A FQN carrying a content payload (content[]) is dispatched by the resolved object's KIND to
+        // its dedicated membership writer (or refused for an unsupported kind); the branch always
+        // returns.
+        if (hasContentPayload)
+        {
+            return dispatchContentPayload(ctx, normFqn, target, properties, content);
+        }
+
+        // The remaining case: a generic 'properties' change applied through the BM write boundary.
+        return applyGenericPropertyChanges(ctx, projectName, normFqn, node, target, properties,
+            normReport);
+    }
+
+    /**
+     * Dispatches a FORM-member FQN (item / attribute / command): the member lives on the editable Form
+     * content model (a cross-model hop), not the mdclass tree, and the validation + change pipeline is
+     * reused as-is. A Role payload ('rights' / 'templates' / 'roleProperties') or a membership 'content'
+     * payload addressed to a FORM-member FQN is refused here, BEFORE the form dispatch: a form member is
+     * neither a Role nor a membership-list owner (CommonAttribute / ExchangePlan / Catalog / Document),
+     * so those siblings do not apply to it. Without this guard the form branch would apply only
+     * 'properties' (or nothing) and report success while the sibling payload vanished silently. Both
+     * siblings are rejected together to keep them symmetric. Extracted verbatim from
+     * {@link #executeOnUiThread}.
+     */
+    private String dispatchFormMember(ProjectContext ctx, String normFqn,
+        FormElementWriter.FormMemberRef formRef, List<JsonObject> properties,
+        MdNameNormalizer.Report normReport, boolean hasRolePayload, boolean hasContentPayload)
+    {
+        if (hasRolePayload || hasContentPayload)
+        {
+            return ToolResult.error("'" + normFqn + "' addresses a FORM member, which cannot " //$NON-NLS-1$ //$NON-NLS-2$
+                + "take a Role payload ('rights' / 'templates' / 'roleProperties') or a " //$NON-NLS-1$
+                + "membership 'content' payload. 'rights' / 'templates' / 'roleProperties' " //$NON-NLS-1$
+                + "are valid only for a Role.<Name> FQN, and 'content' only for a " //$NON-NLS-1$
+                + "CommonAttribute / ExchangePlan / Catalog / Document FQN. Use 'properties' to " //$NON-NLS-1$
+                + "change a form member.").toJson(); //$NON-NLS-1$
+        }
+        return modifyFormMember(ctx, normFqn, formRef, properties, normReport);
+    }
+
+    /**
+     * Dispatches a ROLE payload ('rights' / 'templates' / 'roleProperties'): a Role FQN carrying the
+     * payload goes to {@link #modifyRoleRights} (the access-rights surface, not the generic property
+     * bag; the mutation runs through the EDT-native rights tasks + a forceExport draining the sibling
+     * Rights.rights sub-resource); the same payload on a NON-Role FQN is refused (it must not fall
+     * through to the generic property path, which - with an empty 'properties' - would apply nothing yet
+     * report a false success and silently drop the payload). Returns {@code null} when there is NO role
+     * payload, so the caller continues to the content / generic path. Extracted verbatim from
+     * {@link #executeOnUiThread}.
+     */
+    private String dispatchRolePayload(ProjectContext ctx, String normFqn, MdObject target,
+        List<JsonObject> properties, List<JsonObject> rolePayloadRights,
+        List<JsonObject> rolePayloadTemplates, JsonObject roleProperties, boolean hasRolePayload)
+    {
         if (target instanceof Role && hasRolePayload)
         {
             return modifyRoleRights(ctx, normFqn, (Role)target, properties, rolePayloadRights,
                 rolePayloadTemplates, roleProperties);
         }
-
-        // A role payload addressed to a NON-Role FQN is rejected here (it must not fall through to the
-        // generic property path, which - with an empty 'properties' - would apply nothing yet report a
-        // false success and silently drop the rights / templates / roleProperties payload).
         if (hasRolePayload)
         {
             return ToolResult.error("'rights' / 'templates' / 'roleProperties' are only valid for a " //$NON-NLS-1$
-                + "Role FQN; '" + normFqn + "' is a " + target.eClass().getName() + ". Use " //$NON-NLS-1$ //$NON-NLS-2$
+                + "Role FQN; '" + normFqn + MSG_IS_A + target.eClass().getName() + ". Use " //$NON-NLS-1$ //$NON-NLS-2$
                 + "'properties' for its generic properties, or address a Role.<Name>.").toJson(); //$NON-NLS-1$
         }
+        return null;
+    }
 
-        // A FQN carrying a content payload (content[]) is dispatched by the resolved object's KIND to its
-        // dedicated membership writer: a member of that kind's structured list (a common attribute's
-        // owner, an exchange plan's content object, a catalog's owner, a document's register record) is
-        // attached / detached through the list surface, not the generic property bag. Each mutation goes
-        // through a BM write tx + a single forceExport of the resolved TOP FQN. Every branch refuses
-        // mixing the content payload with a generic 'properties' change (the same policy the Role rights
-        // branch enforces).
-        if (hasContentPayload)
+    /**
+     * Dispatches a content payload (content[]) by the resolved object's KIND to its dedicated membership
+     * writer: a member of that kind's structured list (a common attribute's owner, an exchange plan's
+     * content object, a catalog's owner, a document's register record) is attached / detached through
+     * the list surface, not the generic property bag. Each per-kind writer runs a BM write tx + a single
+     * forceExport of the resolved TOP FQN and refuses mixing the content payload with a generic
+     * 'properties' change (the same policy the Role rights branch enforces). A content payload addressed
+     * to an unsupported kind is refused here (it must not fall through to the generic property path,
+     * which - with an empty 'properties' - would apply nothing yet report a false success and silently
+     * drop the content payload). Extracted verbatim from {@link #executeOnUiThread} (entered only when a
+     * content payload is present).
+     */
+    private String dispatchContentPayload(ProjectContext ctx, String normFqn, MdObject target,
+        List<JsonObject> properties, List<JsonObject> content)
+    {
+        if (target instanceof CommonAttribute)
         {
-            if (target instanceof CommonAttribute)
-            {
-                return modifyCommonAttributeContent(ctx, normFqn, (CommonAttribute)target, properties,
-                    content);
-            }
-            if (target instanceof ExchangePlan)
-            {
-                return modifyExchangePlanContent(ctx, normFqn, (ExchangePlan)target, properties, content);
-            }
-            if (target instanceof Catalog)
-            {
-                return modifyCatalogOwners(ctx, normFqn, (Catalog)target, properties, content);
-            }
-            if (target instanceof Document)
-            {
-                return modifyDocumentRegisterRecords(ctx, normFqn, (Document)target, properties, content);
-            }
-
-            // A content payload addressed to a FQN of an unsupported kind is rejected here (it must not
-            // fall through to the generic property path, which - with an empty 'properties' - would apply
-            // nothing yet report a false success and silently drop the content payload).
-            return ToolResult.error("'content' is only valid for a CommonAttribute, ExchangePlan, " //$NON-NLS-1$
-                + "Catalog or Document FQN; '" + normFqn + "' is a " + target.eClass().getName() //$NON-NLS-1$ //$NON-NLS-2$
-                + ". Use 'properties' for its generic properties, or address a CommonAttribute.<Name> " //$NON-NLS-1$
-                + "(owners), ExchangePlan.<Name> (content objects), Catalog.<Name> (owners) or " //$NON-NLS-1$
-                + "Document.<Name> (register records).").toJson(); //$NON-NLS-1$
+            return modifyCommonAttributeContent(ctx, normFqn, (CommonAttribute)target, properties,
+                content);
         }
+        if (target instanceof ExchangePlan)
+        {
+            return modifyExchangePlanContent(ctx, normFqn, (ExchangePlan)target, properties, content);
+        }
+        if (target instanceof Catalog)
+        {
+            return modifyCatalogOwners(ctx, normFqn, (Catalog)target, properties, content);
+        }
+        if (target instanceof Document)
+        {
+            return modifyDocumentRegisterRecords(ctx, normFqn, (Document)target, properties, content);
+        }
+        return ToolResult.error("'content' is only valid for a CommonAttribute, ExchangePlan, " //$NON-NLS-1$
+            + "Catalog or Document FQN; '" + normFqn + MSG_IS_A + target.eClass().getName() //$NON-NLS-1$
+            + ". Use 'properties' for its generic properties, or address a CommonAttribute.<Name> " //$NON-NLS-1$
+            + "(owners), ExchangePlan.<Name> (content objects), Catalog.<Name> (owners) or " //$NON-NLS-1$
+            + "Document.<Name> (register records).").toJson(); //$NON-NLS-1$
+    }
+
+    /**
+     * Applies a generic 'properties' change to the resolved node through the BM write boundary (the
+     * remaining case once the form / role / content branches are ruled out): resolves the BM re-fetch
+     * strategy and the platform version, validates + prepares every change (fail fast, no partial
+     * mutation), runs the destructive-consent gate for a retype, then applies the changes inside ONE BM
+     * write transaction and force-exports the TOP object. Extracted verbatim from
+     * {@link #executeOnUiThread}; the reject conditions, the consent-gate call and the force-export are
+     * unchanged.
+     */
+    private String applyGenericPropertyChanges(ProjectContext ctx, String projectName, String normFqn,
+        MetadataNodeResolver.MetadataNode node, MdObject target, List<JsonObject> properties,
+        MdNameNormalizer.Report normReport)
+    {
+        Configuration config = ctx.config;
 
         // Resolve the BM re-fetch strategy (mutation must re-fetch inside the write tx). Only TOP
         // objects are re-fetchable by bmId, so for a member we re-fetch the TOP object and
@@ -556,7 +647,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         for (JsonObject prop : properties)
         {
             String name = asString(prop.get("name")); //$NON-NLS-1$
-            if ("type".equalsIgnoreCase(name) || "valueType".equalsIgnoreCase(name)) //$NON-NLS-1$ //$NON-NLS-2$
+            if ("type".equalsIgnoreCase(name) || PROP_VALUE_TYPE.equalsIgnoreCase(name)) //$NON-NLS-1$
             {
                 retype = true;
                 break;
@@ -569,7 +660,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         ConsentPreview preview = new ConsentPreview(
             "Change the data type of " + normFqn, //$NON-NLS-1$
             "Retyping a form attribute can drop stored values on the next database update.", //$NON-NLS-1$
-            1, java.util.Collections.singletonList("valueType")); //$NON-NLS-1$
+            1, java.util.Collections.singletonList(PROP_VALUE_TYPE));
         if (DestructiveConsentGate.getInstance().requireConsent(NAME, preview) == ConsentDecision.REJECT)
         {
             return ToolResult.error("Operation declined by user").toJson(); //$NON-NLS-1$
@@ -592,7 +683,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             .put(KEY_PERSISTED, persisted);
         normReport.addTo(result);
         return result
-            .put(McpKeys.MESSAGE, "Modified " + normFqn + " (" + String.join(", ", applied) + ")") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            .put(McpKeys.MESSAGE, MSG_MODIFIED_PREFIX + normFqn + " (" + String.join(", ", applied) + ")") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             .toJson();
     }
 
@@ -604,7 +695,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
      */
     private static JsonObject parseRolePropertiesArg(Map<String, String> params)
     {
-        String raw = params.get("roleProperties"); //$NON-NLS-1$
+        String raw = params.get(KEY_ROLE_PROPERTIES);
         if (raw == null || raw.trim().isEmpty())
         {
             return null;
@@ -664,9 +755,9 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         boolean persisted = exported && rightsFqn != null;
 
         JsonObject applied = new JsonObject();
-        applied.addProperty("rights", result.rights); //$NON-NLS-1$
-        applied.addProperty("templates", result.templates); //$NON-NLS-1$
-        applied.addProperty("roleProperties", result.roleProperties); //$NON-NLS-1$
+        applied.addProperty(KEY_RIGHTS, result.rights);
+        applied.addProperty(KEY_TEMPLATES, result.templates);
+        applied.addProperty(KEY_ROLE_PROPERTIES, result.roleProperties);
         return ToolResult.success()
             .put(McpKeys.ACTION, VAL_MODIFIED)
             .put("fqn", normFqn) //$NON-NLS-1$
@@ -710,16 +801,16 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         boolean persisted = BmTransactions.forceExportToDisk(ctx.project, normFqn);
 
         JsonObject applied = new JsonObject();
-        applied.addProperty("added", result.added); //$NON-NLS-1$
+        applied.addProperty(KEY_ADDED, result.added);
         applied.addProperty("updated", result.updated); //$NON-NLS-1$
-        applied.addProperty("removed", result.removed); //$NON-NLS-1$
+        applied.addProperty(KEY_REMOVED, result.removed);
         return ToolResult.success()
             .put(McpKeys.ACTION, VAL_MODIFIED)
             .put("fqn", normFqn) //$NON-NLS-1$
-            .put("content", applied) //$NON-NLS-1$
+            .put(KEY_CONTENT, applied)
             .put(KEY_PERSISTED, persisted)
             .put(McpKeys.MESSAGE, "Modified common attribute " + normFqn + " content (added: " //$NON-NLS-1$ //$NON-NLS-2$
-                + result.added + ", updated: " + result.updated + ", removed: " + result.removed //$NON-NLS-1$ //$NON-NLS-2$
+                + result.added + ", updated: " + result.updated + MSG_REMOVED_COUNT + result.removed //$NON-NLS-1$
                 + ")") //$NON-NLS-1$
             .toJson();
     }
@@ -756,16 +847,16 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         boolean persisted = BmTransactions.forceExportToDisk(ctx.project, normFqn);
 
         JsonObject applied = new JsonObject();
-        applied.addProperty("added", result.added); //$NON-NLS-1$
+        applied.addProperty(KEY_ADDED, result.added);
         applied.addProperty("updated", result.updated); //$NON-NLS-1$
-        applied.addProperty("removed", result.removed); //$NON-NLS-1$
+        applied.addProperty(KEY_REMOVED, result.removed);
         return ToolResult.success()
             .put(McpKeys.ACTION, VAL_MODIFIED)
             .put("fqn", normFqn) //$NON-NLS-1$
-            .put("content", applied) //$NON-NLS-1$
+            .put(KEY_CONTENT, applied)
             .put(KEY_PERSISTED, persisted)
             .put(McpKeys.MESSAGE, "Modified exchange plan " + normFqn + " content (added: " //$NON-NLS-1$ //$NON-NLS-2$
-                + result.added + ", updated: " + result.updated + ", removed: " + result.removed //$NON-NLS-1$ //$NON-NLS-2$
+                + result.added + ", updated: " + result.updated + MSG_REMOVED_COUNT + result.removed //$NON-NLS-1$
                 + ")") //$NON-NLS-1$
             .toJson();
     }
@@ -850,15 +941,15 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         ReferenceMembershipWriter.Result result, boolean persisted)
     {
         JsonObject applied = new JsonObject();
-        applied.addProperty("added", result.added); //$NON-NLS-1$
-        applied.addProperty("removed", result.removed); //$NON-NLS-1$
+        applied.addProperty(KEY_ADDED, result.added);
+        applied.addProperty(KEY_REMOVED, result.removed);
         return ToolResult.success()
             .put(McpKeys.ACTION, VAL_MODIFIED)
             .put("fqn", normFqn) //$NON-NLS-1$
-            .put("content", applied) //$NON-NLS-1$
+            .put(KEY_CONTENT, applied)
             .put(KEY_PERSISTED, persisted)
-            .put(McpKeys.MESSAGE, "Modified " + kindNoun + " " + normFqn + " " + listNoun + " (added: " //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-                + result.added + ", removed: " + result.removed + ")") //$NON-NLS-1$ //$NON-NLS-2$
+            .put(McpKeys.MESSAGE, MSG_MODIFIED_PREFIX + kindNoun + " " + normFqn + " " + listNoun + " (added: " //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                + result.added + MSG_REMOVED_COUNT + result.removed + ")") //$NON-NLS-1$
             .toJson();
     }
 
@@ -1083,7 +1174,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             .put(KEY_PERSISTED, persisted);
         normReport.addTo(result);
         return result
-            .put(McpKeys.MESSAGE, "Modified " + normFqn + " (" + String.join(", ", applied) + ")") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            .put(McpKeys.MESSAGE, MSG_MODIFIED_PREFIX + normFqn + " (" + String.join(", ", applied) + ")") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             .toJson();
     }
 
@@ -1815,10 +1906,10 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         String name = asString(prop.get("name")); //$NON-NLS-1$
         if ("type".equalsIgnoreCase(name) //$NON-NLS-1$
             && member.eClass().getEStructuralFeature("type") == null //$NON-NLS-1$
-            && member.eClass().getEStructuralFeature("valueType") != null) //$NON-NLS-1$
+            && member.eClass().getEStructuralFeature(PROP_VALUE_TYPE) != null)
         {
             JsonObject copy = prop.deepCopy();
-            copy.addProperty("name", "valueType"); //$NON-NLS-1$ //$NON-NLS-2$
+            copy.addProperty("name", PROP_VALUE_TYPE); //$NON-NLS-1$
             return copy;
         }
         return prop;
@@ -2093,7 +2184,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         EClass targetType = ((EReference)feature).getEReferenceType();
         if (targetType != null && !targetType.isSuperTypeOf(target.eClass()))
         {
-            return ToolResult.error("'" + fqn + "' is a " + target.eClass().getName() + " but '" + prop //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            return ToolResult.error("'" + fqn + MSG_IS_A + target.eClass().getName() + " but '" + prop //$NON-NLS-1$ //$NON-NLS-2$
                 + "' requires a " + targetType.getName() + ".").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
         }
         return null;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -2243,7 +2243,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
          */
         private final boolean typeChange;
 
-        private PreparedChange(EStructuralFeature feature, Kind kind, Object scalarValue,
+        private PreparedChange(EStructuralFeature feature, Kind kind, Object scalarValue, // NOSONAR cohesive discriminated-union payload, one field per Kind (already reduced by StyleBinding); a further param-object would fragment it
             String language, String localizedValue, List<Long> referenceBmIds,
             StyleBinding styleBinding, boolean typeChange)
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/CommonAttributeContentWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/CommonAttributeContentWriter.java
@@ -142,7 +142,7 @@ public final class CommonAttributeContentWriter
         }
 
         // Validate + resolve every entry up front so nothing is mutated on a shape / resolution error.
-        List<PlannedEntry> plan = new ArrayList<>();
+        List<PlannedEntry> plan = new ArrayList<>(); // NOSONAR plan is read inside the write lambda (capture)
         for (JsonObject entry : content)
         {
             EntryPlan resolved = planEntry(config, entry);
@@ -175,29 +175,10 @@ public final class CommonAttributeContentWriter
                 int removed = 0;
                 for (PlannedEntry planned : plan)
                 {
-                    MdObject owner = resolveOwnerInTx(tx, planned.ownerBmId);
-                    if (owner == null)
-                    {
-                        throw new ContentWriteException(ToolResult.error("Owner '" + planned.fqn //$NON-NLS-1$
-                            + "' could not be resolved inside the transaction.").toJson()); //$NON-NLS-1$
-                    }
-                    if (planned.remove)
-                    {
-                        if (removeOwner(inTx, owner) == 0)
-                        {
-                            throw new ContentWriteException(ToolResult.error("Owner '" + planned.fqn //$NON-NLS-1$
-                                + "' is not in the content list of common attribute '" //$NON-NLS-1$
-                                + inTx.getName() + "'; nothing to remove. Read the current content " //$NON-NLS-1$
-                                + "with get_metadata_details on the common attribute FQN.").toJson()); //$NON-NLS-1$
-                        }
-                        removed++;
-                    }
-                    else
-                    {
-                        int[] delta = addOwner(inTx, owner, planned.use, services.factory, services.version);
-                        added += delta[0];
-                        updated += delta[1];
-                    }
+                    int[] delta = applyPlannedEntry(tx, inTx, planned, services);
+                    added += delta[0];
+                    updated += delta[1];
+                    removed += delta[2];
                 }
                 return Result.ok(added, updated, removed);
             });
@@ -216,6 +197,38 @@ public final class CommonAttributeContentWriter
     }
 
     // ---- mutation (inside the write boundary) -------------------------------------------------
+
+    /**
+     * Applies a single validated {@link PlannedEntry} to the in-transaction common attribute: re-fetches
+     * the owner by its stable BM id, then either removes it from the content (a remove that finds nothing
+     * is a clean error that rolls the whole write back) or adds / updates it via {@link #addOwner}. MUST
+     * run inside the write boundary.
+     *
+     * @return a three-slot delta {@code [added, updated, removed]}
+     */
+    private static int[] applyPlannedEntry(IBmTransaction tx, CommonAttribute inTx, PlannedEntry planned,
+        Services services)
+    {
+        MdObject owner = resolveOwnerInTx(tx, planned.ownerBmId);
+        if (owner == null)
+        {
+            throw new ContentWriteException(ToolResult.error("Owner '" + planned.fqn //$NON-NLS-1$
+                + "' could not be resolved inside the transaction.").toJson()); //$NON-NLS-1$
+        }
+        if (planned.remove)
+        {
+            if (removeOwner(inTx, owner) == 0)
+            {
+                throw new ContentWriteException(ToolResult.error("Owner '" + planned.fqn //$NON-NLS-1$
+                    + "' is not in the content list of common attribute '" //$NON-NLS-1$
+                    + inTx.getName() + "'; nothing to remove. Read the current content " //$NON-NLS-1$
+                    + "with get_metadata_details on the common attribute FQN.").toJson()); //$NON-NLS-1$
+            }
+            return new int[] {0, 0, 1};
+        }
+        int[] delta = addOwner(inTx, owner, planned.use, services.factory, services.version);
+        return new int[] {delta[0], delta[1], 0};
+    }
 
     /**
      * Adds an owner to the content, or updates its {@code use} when already present. Scans

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/CommonPictureContentReader.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/CommonPictureContentReader.java
@@ -417,9 +417,9 @@ public final class CommonPictureContentReader
      *
      * @param svgIn the SVG input stream
      * @return the PNG input stream, or {@code null} when neither signature is present
-     * @throws Exception on reflective invocation failure
+     * @throws ReflectiveOperationException on reflective invocation failure
      */
-    private static InputStream renderSvgToPngCompat(InputStream svgIn) throws Exception
+    private static InputStream renderSvgToPngCompat(InputStream svgIn) throws ReflectiveOperationException
     {
         Object svgUtils = SVGUtils.INSTANCE;
         Class<?> cls = svgUtils.getClass();
@@ -481,7 +481,7 @@ public final class CommonPictureContentReader
          * @return the PNG bytes, or {@code null} when the entry cannot be decoded
          * @throws Exception on I/O or reflective failure
          */
-        byte[] decodeToPng(String name) throws Exception;
+        byte[] decodeToPng(String name) throws Exception; // NOSONAR aggregates I/O (IOException) and reflective (ReflectiveOperationException) checked failures across both PictureContent implementations; caught at the tool boundary
     }
 
     /**
@@ -556,11 +556,9 @@ public final class CommonPictureContentReader
             List<RasterCandidate> candidates = new ArrayList<>();
             for (IZipPictureManifestEntry entry : content.getPictureEntries())
             {
-                if (entry == null)
-                {
-                    continue;
-                }
-                String name = entry.getName();
+                // Single early-exit guard (S135): fold the null-entry check into a null-safe name read so
+                // one continue filters absent/manifest/SVG entries while keeping the guard-clause style.
+                String name = entry == null ? null : entry.getName();
                 if (name == null || isManifestEntry(name) || isSvgName(name))
                 {
                     continue;
@@ -993,9 +991,9 @@ public final class CommonPictureContentReader
      *
      * @param in the stream (closed by the caller)
      * @return the bytes
-     * @throws Exception on I/O failure
+     * @throws IOException on I/O failure
      */
-    private static byte[] readAll(InputStream in) throws Exception
+    private static byte[] readAll(InputStream in) throws IOException
     {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         byte[] buffer = new byte[8192];

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -2289,7 +2289,7 @@ public final class FormElementWriter
         // The field binds to a form attribute by name. A DOTTED path binds to a SUB-attribute of the
         // head form attribute. Two heads are valid for a dotted path:
         //   - a dynamic-list attribute (e.g. "List.Number"): the tail is one of its query fields // NOSONAR explanatory prose, not commented-out code
-        //     (auto-filled by EDT - not a model attribute);
+        //     (auto-filled by EDT - not a model attribute); // NOSONAR explanatory prose, not commented-out code
         //   - the form's MAIN object attribute (e.g. "Object.Number"): the tail is a sub-attribute of // NOSONAR explanatory prose, not commented-out code
         //     the object type, like the designer's bound object fields.
         // Validate the head attribute, and require one of those two heads when a dotted path is used.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -1135,16 +1135,18 @@ public final class FormElementWriter
             if (fieldError != null)
             {
                 skipped.add(trimmed);
-                continue;
             }
-            // The designer's object-form wizard creates these bound object fields with editMode
-            // "EnterOnInput" (the table-column path already uses it), whereas createField's default
-            // "Enter" is for a manually-created standalone field. Re-set the just-created field
-            // (named after the attribute) for byte-parity with the designer. Issue #208.
-            EObject seededField = findItem(content, trimmed);
-            if (seededField != null)
+            else
             {
-                setEnumFeature(seededField, FEATURE_EDIT_MODE, "EnterOnInput"); //$NON-NLS-1$
+                // The designer's object-form wizard creates these bound object fields with editMode
+                // "EnterOnInput" (the table-column path already uses it), whereas createField's default
+                // "Enter" is for a manually-created standalone field. Re-set the just-created field
+                // (named after the attribute) for byte-parity with the designer. Issue #208.
+                EObject seededField = findItem(content, trimmed);
+                if (seededField != null)
+                {
+                    setEnumFeature(seededField, FEATURE_EDIT_MODE, "EnterOnInput"); //$NON-NLS-1$
+                }
             }
         }
         if (!skipped.isEmpty())

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ReferenceMembershipWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ReferenceMembershipWriter.java
@@ -15,6 +15,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.emf.common.util.EList;
 
 import com._1c.g5.v8.bm.core.IBmObject;
+import com._1c.g5.v8.bm.core.IBmTransaction;
 import com._1c.g5.v8.bm.integration.IBmModel;
 import com._1c.g5.v8.dt.core.platform.IBmModelManager;
 import com._1c.g5.v8.dt.metadata.mdclass.BasicRegister;
@@ -231,7 +232,7 @@ public final class ReferenceMembershipWriter
         }
 
         // Validate + resolve every entry up front so nothing is mutated on a shape / resolution error.
-        List<PlannedEntry> plan = new ArrayList<>();
+        List<PlannedEntry> plan = new ArrayList<>(); // NOSONAR plan is read inside the write lambda (capture)
         for (JsonObject entry : content)
         {
             EntryPlan resolved = planEntry(config, entry, kind);
@@ -265,30 +266,9 @@ public final class ReferenceMembershipWriter
                 int removed = 0;
                 for (PlannedEntry planned : plan)
                 {
-                    Object refObj = tx.getObjectById(planned.refBmId);
-                    if (!(refObj instanceof MdObject))
-                    {
-                        throw new ContentWriteException(ToolResult.error("The " + kind.memberLabel //$NON-NLS-1$
-                            + " '" + planned.fqn //$NON-NLS-1$
-                            + "' could not be resolved inside the transaction.").toJson()); //$NON-NLS-1$
-                    }
-                    MdObject ref = (MdObject)refObj;
-                    if (planned.remove)
-                    {
-                        if (!removeRef(kind, topInTx, ref))
-                        {
-                            throw new ContentWriteException(ToolResult.error("The " + kind.memberLabel //$NON-NLS-1$
-                                + " '" + planned.fqn + "' is not in the " + kind.memberLabel //$NON-NLS-1$ //$NON-NLS-2$
-                                + " list of '" + topInTx.getName() //$NON-NLS-1$
-                                + "'; nothing to remove. Read the current list with " //$NON-NLS-1$
-                                + "get_metadata_details on the object FQN.").toJson()); //$NON-NLS-1$
-                        }
-                        removed++;
-                    }
-                    else if (addRef(kind, topInTx, ref))
-                    {
-                        added++;
-                    }
+                    int[] delta = applyPlannedEntry(kind, tx, topInTx, planned);
+                    added += delta[0];
+                    removed += delta[1];
                 }
                 return Result.ok(added, removed);
             });
@@ -307,6 +287,44 @@ public final class ReferenceMembershipWriter
     }
 
     // ---- mutation (inside the write boundary) -------------------------------------------------
+
+    /**
+     * Applies a single validated {@link PlannedEntry} to the in-transaction top object: re-fetches the
+     * referenced member by its stable BM id, then either removes it from the kind's list (a remove that
+     * finds nothing is a clean error that rolls the whole write back) or appends it idempotently via
+     * {@link #addRef}. MUST run inside the write boundary.
+     *
+     * @return a two-slot delta {@code [added, removed]}
+     */
+    private static int[] applyPlannedEntry(Kind kind, IBmTransaction tx, MdObject topInTx,
+        PlannedEntry planned)
+    {
+        Object refObj = tx.getObjectById(planned.refBmId);
+        if (!(refObj instanceof MdObject))
+        {
+            throw new ContentWriteException(ToolResult.error("The " + kind.memberLabel //$NON-NLS-1$
+                + " '" + planned.fqn //$NON-NLS-1$
+                + "' could not be resolved inside the transaction.").toJson()); //$NON-NLS-1$
+        }
+        MdObject ref = (MdObject)refObj;
+        if (planned.remove)
+        {
+            if (!removeRef(kind, topInTx, ref))
+            {
+                throw new ContentWriteException(ToolResult.error("The " + kind.memberLabel //$NON-NLS-1$
+                    + " '" + planned.fqn + "' is not in the " + kind.memberLabel //$NON-NLS-1$ //$NON-NLS-2$
+                    + " list of '" + topInTx.getName() //$NON-NLS-1$
+                    + "'; nothing to remove. Read the current list with " //$NON-NLS-1$
+                    + "get_metadata_details on the object FQN.").toJson()); //$NON-NLS-1$
+            }
+            return new int[] {0, 1};
+        }
+        if (addRef(kind, topInTx, ref))
+        {
+            return new int[] {1, 0};
+        }
+        return new int[] {0, 0};
+    }
 
     /**
      * Appends a reference to the kind's list if it is not already present by identity (idempotent). MUST

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/RoleRightsWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/RoleRightsWriter.java
@@ -1021,7 +1021,7 @@ public final class RoleRightsWriter
         final IEventBroker eventBroker;
         final IModelObjectCollectionRuntimeOrderSorter sorter;
 
-        Context(IProject project, Configuration config, IBmModel model, Role role, long roleBmId,
+        Context(IProject project, Configuration config, IBmModel model, Role role, long roleBmId, // NOSONAR cohesive per-call context; a holder would not improve clarity
             IRightInfosService rightInfos, IEventBroker eventBroker,
             IModelObjectCollectionRuntimeOrderSorter sorter)
         {


### PR DESCRIPTION
## Что

Чистка SonarCloud на master (только `CODE_SMELL`, поведение не меняется). Закрывает **ВСЕ оставшиеся замечания, кроме 2** в `ExchangePlanContentWriter` — они заблокированы ещё не слитым #228 (переписывает этот файл); добью их микро-PR сразу после мержа #228, чтобы три почти идентичных content-writer'а починить консистентно.

**Реальные фиксы:**
- `ModifyMetadataTool` — 10 дублей строковых литералов → `private static final` константы; переусложнённый execute/dispatch-метод (S3776 + S6541) → 4 когезивных приватных хелпера (`dispatchFormMember`/`dispatchRolePayload`/`dispatchContentPayload`/`applyGenericPropertyChanges`) — dispatch `rights[]`/`content[]`/`properties`, consent-гейт и force-export не тронуты;
- `CommonAttributeContentWriter` / `ReferenceMembershipWriter` — S3776 → извлечён `applyPlannedEntry`;
- `DeleteInfobaseTool` — дубль → константа;
- где чистый фикс для S112/S135/S107 был очевиден — сделан.

**`// NOSONAR` с обоснованием** (false-positive или спорно-инвазивное — без ухудшения читаемости / churn'а вызывателей):
- **S4030** — список `plan` используется ВНУТРИ лямбды `BmTransactions.write` (Sonar-поток этого не видит) → ложное;
- **S112** — generic `Exception` агрегирует reflection/IO/model, ловится на границе тула;
- **S135** — early-exit'ы — самая ясная форма скана;
- **S107** — когезивные внутренние конструкторы (param-object читаемость не улучшит);
- **S125** — пояснительный комментарий, а не мёртвый код.

## Как проверено
- `compile.sh` зелёный (компиляция + юнит-тесты, включая `ModifyMetadataToolTest` + рэтчеты). Схема / `tools_list.golden.json` не тронуты.
- Собрано автопилотом с build-gate (каждый раунд компиляция + тесты).

**После мержа этого PR + #228 дашборд Sonar на master будет чист.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
