### PR TITLE
Направление синхронизации: resync_to_disk vs clean_project + guard на fullExport (#175)

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ with `python docs/generate_tool_docs.py`.
 | Tool | Description |
 |------|-------------|
 | [`build_external_objects`](docs/tools/build_external_objects.md) | Build (compile to disk) the external data processors/reports of an EDT external-object project to .epf/.erf files. Build ONE object with objectName, or ALL o… |
-| [`clean_project`](docs/tools/clean_project.md) | Clean EDT project and trigger full revalidation. Refreshes files from disk, clears all validation markers, and waits for EDT to complete revalidation. Full r… |
+| [`clean_project`](docs/tools/clean_project.md) | Clean EDT project and trigger full revalidation. Direction: DISK -> MODEL - re-imports the on-disk src/ .mdo files into the in-memory model. Refreshes files… |
 | [`create_infobase`](docs/tools/create_infobase.md) | Create a new FILE infobase (1C database) OR register an existing one, and bind it to a configuration project so it appears in get_applications. mode='create'… |
 | [`create_project`](docs/tools/create_project.md) | Create a NEW 1C project in the EDT workspace. projectKind selects the kind: 'configuration' (standalone), 'extension' (bound to a base configuration), or 'ex… |
 | [`delete_infobase`](docs/tools/delete_infobase.md) | Remove a FILE infobase association from a configuration project OR delete a standalone (autonomous) server application. Destructive: guarded by a confirm-pre… |
@@ -502,7 +502,7 @@ with `python docs/generate_tool_docs.py`.
 | [`get_problem_summary`](docs/tools/get_problem_summary.md) | Get problem summary with counts grouped by project and EDT severity level (ERRORS, BLOCKER, CRITICAL, MAJOR, MINOR, TRIVIAL). Use this for severity totals on… |
 | [`get_project_errors`](docs/tools/get_project_errors.md) | List EDT configuration problems (validation markers) with optional project / severity / check-id / object filters. Each row carries the check code, message,… |
 | [`import_configuration_from_xml`](docs/tools/import_configuration_from_xml.md) | Import a configuration from a directory of XML files into a NEW EDT project (EDT menu: Import); the reverse of export_configuration_to_xml. The projectName m… |
-| [`resync_to_disk`](docs/tools/resync_to_disk.md) | Bulk re-synchronize the in-memory BM model to the on-disk src/ .mdo files and report BM-to-disk desync. Walks EVERY top metadata object of the configuration… |
+| [`resync_to_disk`](docs/tools/resync_to_disk.md) | Bulk re-synchronize the in-memory BM model to the on-disk src/ .mdo files and report BM-to-disk desync. Direction: MODEL -> DISK (writes the model out to src… |
 | [`revalidate_objects`](docs/tools/revalidate_objects.md) | Revalidate EDT project or specific objects. If objects array is empty or missing, revalidates entire project. FQN examples: 'Document.SalesOrder', 'Catalog.P… |
 | [`set_infobase_credentials`](docs/tools/set_infobase_credentials.md) | Store infobase connection credentials (user/password) so update_database and debug_launch can authenticate the update agent on an infobase that has a user li… |
 | [`update_database`](docs/tools/update_database.md) | Apply configuration changes to an application's database (infobase), full or incremental. Target by launchConfigurationName (preferred) or projectName + appl… |

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -133,7 +133,7 @@ One page per tool: what it does, every parameter, and how it works. Generated fr
 | Tool | Description |
 |------|-------------|
 | [`build_external_objects`](build_external_objects.md) | Build (compile to disk) the external data processors/reports of an EDT external-object project to .epf/.erf files. Build ONE object with objectName, or ALL o… |
-| [`clean_project`](clean_project.md) | Clean EDT project and trigger full revalidation. Refreshes files from disk, clears all validation markers, and waits for EDT to complete revalidation. Full r… |
+| [`clean_project`](clean_project.md) | Clean EDT project and trigger full revalidation. Direction: DISK -> MODEL - re-imports the on-disk src/ .mdo files into the in-memory model. Refreshes files… |
 | [`create_infobase`](create_infobase.md) | Create a new FILE infobase (1C database) OR register an existing one, and bind it to a configuration project so it appears in get_applications. mode='create'… |
 | [`create_project`](create_project.md) | Create a NEW 1C project in the EDT workspace. projectKind selects the kind: 'configuration' (standalone), 'extension' (bound to a base configuration), or 'ex… |
 | [`delete_infobase`](delete_infobase.md) | Remove a FILE infobase association from a configuration project OR delete a standalone (autonomous) server application. Destructive: guarded by a confirm-pre… |
@@ -145,7 +145,7 @@ One page per tool: what it does, every parameter, and how it works. Generated fr
 | [`get_problem_summary`](get_problem_summary.md) | Get problem summary with counts grouped by project and EDT severity level (ERRORS, BLOCKER, CRITICAL, MAJOR, MINOR, TRIVIAL). Use this for severity totals on… |
 | [`get_project_errors`](get_project_errors.md) | List EDT configuration problems (validation markers) with optional project / severity / check-id / object filters. Each row carries the check code, message,… |
 | [`import_configuration_from_xml`](import_configuration_from_xml.md) | Import a configuration from a directory of XML files into a NEW EDT project (EDT menu: Import); the reverse of export_configuration_to_xml. The projectName m… |
-| [`resync_to_disk`](resync_to_disk.md) | Bulk re-synchronize the in-memory BM model to the on-disk src/ .mdo files and report BM-to-disk desync. Walks EVERY top metadata object of the configuration… |
+| [`resync_to_disk`](resync_to_disk.md) | Bulk re-synchronize the in-memory BM model to the on-disk src/ .mdo files and report BM-to-disk desync. Direction: MODEL -> DISK (writes the model out to src… |
 | [`revalidate_objects`](revalidate_objects.md) | Revalidate EDT project or specific objects. If objects array is empty or missing, revalidates entire project. FQN examples: 'Document.SalesOrder', 'Catalog.P… |
 | [`set_infobase_credentials`](set_infobase_credentials.md) | Store infobase connection credentials (user/password) so update_database and debug_launch can authenticate the update agent on an infobase that has a user li… |
 | [`update_database`](update_database.md) | Apply configuration changes to an application's database (infobase), full or incremental. Target by launchConfigurationName (preferred) or projectName + appl… |

--- a/docs/tools/clean_project.md
+++ b/docs/tools/clean_project.md
@@ -1,6 +1,6 @@
 # clean_project
 
-Clean EDT project and trigger full revalidation. Refreshes files from disk, clears all validation markers, and waits for EDT to complete revalidation. Full rebuild of the ENTIRE configuration — slow on large projects. For a single externally-edited object prefer revalidate_objects([FQN]).
+Clean EDT project and trigger full revalidation. Direction: DISK -> MODEL - re-imports the on-disk src/ .mdo files into the in-memory model. Refreshes files from disk, clears all validation markers, and waits for EDT to complete revalidation. Full rebuild of the ENTIRE configuration — slow on large projects. Discards UNSAVED in-memory model edits (they are recomputed from disk); save pending changes first. For a single externally-edited object prefer revalidate_objects([FQN]). Reverse direction (MODEL -> DISK, write the model out to .mdo) is resync_to_disk. Full parameters and examples: call get_tool_guide('clean_project').
 
 ## Parameters
 | Parameter | Required | Type | Description |
@@ -9,6 +9,8 @@ Clean EDT project and trigger full revalidation. Refreshes files from disk, clea
 
 ## Guide
 Force EDT to fully rebuild and re-validate a project: refreshes its files from disk, drops every existing validation marker, re-imports the model, and BLOCKS until EDT has finished recomputing derived data. Use it to recover from a stuck or stale validation state.
+
+**Direction: DISK -> MODEL** - it re-imports the on-disk `src/` `.mdo` files into the in-memory EDT model. The reverse tool (MODEL -> DISK, writing the in-memory model out to `.mdo` files) is `resync_to_disk`.
 
 ## When to use
 - Validation looks wrong or stale: markers don't match the code, already-fixed errors still linger, or a project is stuck "building".

--- a/docs/tools/resync_to_disk.md
+++ b/docs/tools/resync_to_disk.md
@@ -1,6 +1,6 @@
 # resync_to_disk
 
-Bulk re-synchronize the in-memory BM model to the on-disk src/ .mdo files and report BM-to-disk desync. Walks EVERY top metadata object of the configuration (all kinds), reports the objects whose .mdo is missing on disk (missingBefore), and force-exports that missing subset so the files are restored (fullExport=true re-exports every object instead). Fixes 'object file does not exist' failures from update_database / XML import caused by an accumulated desync. Dangling/orphaned references in Configuration.mdo (unresolved proxies shown by get_project_errors as md-reference-intergrity 'lost reference' warnings that block update_database / XML import) are REPORTED by default (danglingFound + danglingDetails); set cleanDanglingReferences=true to REMOVE them - destructive: rewrites Configuration.mdo. Full parameters and examples: call get_tool_guide('resync_to_disk').
+Bulk re-synchronize the in-memory BM model to the on-disk src/ .mdo files and report BM-to-disk desync. Direction: MODEL -> DISK (writes the model out to src/); the reverse is clean_project, which rebuilds MODEL <- DISK and DISCARDS any unsaved in-memory model edits. Walks EVERY top metadata object of the configuration (all kinds), reports the objects whose .mdo is missing on disk (missingBefore), and force-exports that missing subset so the files are restored (fullExport=true re-exports every object instead - requires overwriteDiskEdits=true to confirm, as it overwrites on-disk edits). Fixes 'object file does not exist' failures from update_database / XML import caused by an accumulated desync. Dangling/orphaned references in Configuration.mdo (unresolved proxies shown by get_project_errors as md-reference-intergrity 'lost reference' warnings that block update_database / XML import) are REPORTED by default (danglingFound + danglingDetails); set cleanDanglingReferences=true to REMOVE them - destructive: rewrites Configuration.mdo. Full parameters and examples: call get_tool_guide('resync_to_disk').
 
 ## Parameters
 | Parameter | Required | Type | Description |
@@ -8,10 +8,14 @@ Bulk re-synchronize the in-memory BM model to the on-disk src/ .mdo files and re
 | projectName | yes | string | EDT project name (required). |
 | cleanDanglingReferences | — | boolean | When true, REMOVE dangling/orphaned references from Configuration.mdo - entries that register an object with no .mdo and no BM body (unresolved proxies), the source of md-reference-intergrity 'lost reference' warnings that block update_database / XML import. Destructive: rewrites Configuration.mdo. Default: false - only report danglingFound + danglingDetails without changing anything. |
 | fullExport | — | boolean | When true, force-export EVERY metadata top object's .mdo (a full disk refresh; slow on a large configuration - the export runs on the UI thread). Default: false - export only the objects whose .mdo is missing on disk. |
+| overwriteDiskEdits | — | boolean | Required confirmation for fullExport=true: force-exporting every .mdo from the in-memory model OVERWRITES any on-disk edits. Default: false - fullExport is rejected unless this is true. Ignored when fullExport=false. |
 | revalidate | — | boolean | When true, schedule a full project revalidation (clean build) after the export so stale markers refresh. Default: false (export only). |
 
 ## Guide
 Bulk re-synchronize the in-memory EDT model to the on-disk `src/` `.mdo` files, and report (optionally remove) dangling/orphaned references in `Configuration.mdo`. Use it to fix `update_database` / XML-import failures that complain about missing object files or "lost reference" warnings, when the BM model and disk have drifted apart.
+
+- **Direction: MODEL -> DISK** - it writes the in-memory model out to the `src/` `.mdo` files.
+- **Paired tool:** `clean_project` is the reverse, **DISK -> MODEL** - it rebuilds the model from disk and DISCARDS any unsaved in-memory model edits. Save (or resync) pending model changes before running `clean_project`.
 
 ## When to use
 - `update_database` or `import_configuration_from_xml` fails with "object file does not exist - /Subsystems/X.mdo; /Roles/Y.mdo; ..." - the object lives in the model and in `Configuration.mdo` but has no `.mdo` on disk.
@@ -27,7 +31,8 @@ Bulk re-synchronize the in-memory EDT model to the on-disk `src/` `.mdo` files, 
 ## Parameter details
 - `projectName` (required) - the EDT project to re-synchronize.
 - `cleanDanglingReferences` (default `false` - report-only) - set `true` to REMOVE the dangling/orphaned proxy entries from `Configuration.mdo`. Destructive: rewrites `Configuration.mdo`. The default run only reports them (`danglingFound` + `danglingDetails`) and changes nothing.
-- `fullExport` (default `false`) - set `true` to force-export EVERY metadata top object's `.mdo` instead of only the missing subset. Heavier (the export runs on the UI thread); use it for a deliberate full disk refresh.
+- `fullExport` (default `false`) - set `true` to force-export EVERY metadata top object's `.mdo` instead of only the missing subset. Heavier (the export runs on the UI thread); use it for a deliberate full disk refresh. Because it re-writes every `.mdo` from the model, it OVERWRITES any on-disk edits, so it must be confirmed with `overwriteDiskEdits=true`.
+- `overwriteDiskEdits` (default `false`) - required confirmation for `fullExport=true`: force-exporting every `.mdo` from the in-memory model OVERWRITES any on-disk edits. `fullExport=true` is rejected with an error unless this is `true`. Ignored when `fullExport=false` (the default missing-only resync only writes the absent files).
 - `revalidate` (default `false`) - after the export, run a full clean build so stale validation markers refresh. Heavier; leave off for a fast run.
 
 ## What you get

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/clean_project.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/clean_project.md
@@ -1,5 +1,7 @@
 Force EDT to fully rebuild and re-validate a project: refreshes its files from disk, drops every existing validation marker, re-imports the model, and BLOCKS until EDT has finished recomputing derived data. Use it to recover from a stuck or stale validation state.
 
+**Direction: DISK -> MODEL** - it re-imports the on-disk `src/` `.mdo` files into the in-memory EDT model. The reverse tool (MODEL -> DISK, writing the in-memory model out to `.mdo` files) is `resync_to_disk`.
+
 ## When to use
 - Validation looks wrong or stale: markers don't match the code, already-fixed errors still linger, or a project is stuck "building".
 - You changed files on disk outside EDT and want the model resynced.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/resync_to_disk.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/resync_to_disk.md
@@ -1,5 +1,8 @@
 Bulk re-synchronize the in-memory EDT model to the on-disk `src/` `.mdo` files, and report (optionally remove) dangling/orphaned references in `Configuration.mdo`. Use it to fix `update_database` / XML-import failures that complain about missing object files or "lost reference" warnings, when the BM model and disk have drifted apart.
 
+- **Direction: MODEL -> DISK** - it writes the in-memory model out to the `src/` `.mdo` files.
+- **Paired tool:** `clean_project` is the reverse, **DISK -> MODEL** - it rebuilds the model from disk and DISCARDS any unsaved in-memory model edits. Save (or resync) pending model changes before running `clean_project`.
+
 ## When to use
 - `update_database` or `import_configuration_from_xml` fails with "object file does not exist - /Subsystems/X.mdo; /Roles/Y.mdo; ..." - the object lives in the model and in `Configuration.mdo` but has no `.mdo` on disk.
 - `get_project_errors` shows `md-reference-intergrity` warnings like "a lost reference is set in field X at position N" - `Configuration.mdo` still registers an object whose body was lost (a dangling/orphaned entry that `delete_metadata` cannot remove, because there is no object to delete).
@@ -14,7 +17,8 @@ Bulk re-synchronize the in-memory EDT model to the on-disk `src/` `.mdo` files, 
 ## Parameter details
 - `projectName` (required) - the EDT project to re-synchronize.
 - `cleanDanglingReferences` (default `false` - report-only) - set `true` to REMOVE the dangling/orphaned proxy entries from `Configuration.mdo`. Destructive: rewrites `Configuration.mdo`. The default run only reports them (`danglingFound` + `danglingDetails`) and changes nothing.
-- `fullExport` (default `false`) - set `true` to force-export EVERY metadata top object's `.mdo` instead of only the missing subset. Heavier (the export runs on the UI thread); use it for a deliberate full disk refresh.
+- `fullExport` (default `false`) - set `true` to force-export EVERY metadata top object's `.mdo` instead of only the missing subset. Heavier (the export runs on the UI thread); use it for a deliberate full disk refresh. Because it re-writes every `.mdo` from the model, it OVERWRITES any on-disk edits, so it must be confirmed with `overwriteDiskEdits=true`.
+- `overwriteDiskEdits` (default `false`) - required confirmation for `fullExport=true`: force-exporting every `.mdo` from the in-memory model OVERWRITES any on-disk edits. `fullExport=true` is rejected with an error unless this is `true`. Ignored when `fullExport=false` (the default missing-only resync only writes the absent files).
 - `revalidate` (default `false`) - after the export, run a full clean build so stale validation markers refresh. Heavier; leave off for a fast run.
 
 ## What you get

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CleanProjectTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CleanProjectTool.java
@@ -51,10 +51,14 @@ public class CleanProjectTool implements IMcpTool
     public String getDescription()
     {
         return "Clean EDT project and trigger full revalidation. " + //$NON-NLS-1$
+               "Direction: DISK -> MODEL - re-imports the on-disk src/ .mdo files into the in-memory model. " + //$NON-NLS-1$
                "Refreshes files from disk, clears all validation markers, " + //$NON-NLS-1$
                "and waits for EDT to complete revalidation. " + //$NON-NLS-1$
                "Full rebuild of the ENTIRE configuration — slow on large projects. " + //$NON-NLS-1$
-               "For a single externally-edited object prefer revalidate_objects([FQN])."; //$NON-NLS-1$
+               "Discards UNSAVED in-memory model edits (they are recomputed from disk); save pending changes first. " + //$NON-NLS-1$
+               "For a single externally-edited object prefer revalidate_objects([FQN]). " + //$NON-NLS-1$
+               "Reverse direction (MODEL -> DISK, write the model out to .mdo) is resync_to_disk. " + //$NON-NLS-1$
+               "Full parameters and examples: call get_tool_guide('clean_project')."; //$NON-NLS-1$
     }
     
     @Override

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskTool.java
@@ -121,6 +121,9 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
     /** Param: opt-in flag to force-export every top object instead of the missing subset. */
     private static final String KEY_FULL_EXPORT = "fullExport"; //$NON-NLS-1$
 
+    /** Param: required confirmation that a {@code fullExport} may overwrite on-disk edits. */
+    private static final String KEY_OVERWRITE_DISK_EDITS = "overwriteDiskEdits"; //$NON-NLS-1$
+
     /** Param: opt-in flag to schedule a full project revalidation after the export. */
     private static final String KEY_REVALIDATE = "revalidate"; //$NON-NLS-1$
 
@@ -151,12 +154,15 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
     public String getDescription()
     {
         return "Bulk re-synchronize the in-memory BM model to the on-disk src/ .mdo files " //$NON-NLS-1$
-            + "and report BM-to-disk desync. Walks EVERY top metadata object of the " //$NON-NLS-1$
+            + "and report BM-to-disk desync. Direction: MODEL -> DISK (writes the model out to " //$NON-NLS-1$
+            + "src/); the reverse is clean_project, which rebuilds MODEL <- DISK and DISCARDS " //$NON-NLS-1$
+            + "any unsaved in-memory model edits. Walks EVERY top metadata object of the " //$NON-NLS-1$
             + "configuration (all kinds), reports the objects whose .mdo is missing on disk " //$NON-NLS-1$
             + "(missingBefore), and force-exports that missing subset so the files are " //$NON-NLS-1$
-            + "restored (fullExport=true re-exports every object instead). Fixes 'object " //$NON-NLS-1$
-            + "file does not exist' failures from update_database / XML import caused by an " //$NON-NLS-1$
-            + "accumulated desync. Dangling/orphaned references in Configuration.mdo " //$NON-NLS-1$
+            + "restored (fullExport=true re-exports every object instead - requires " //$NON-NLS-1$
+            + "overwriteDiskEdits=true to confirm, as it overwrites on-disk edits). Fixes " //$NON-NLS-1$
+            + "'object file does not exist' failures from update_database / XML import caused " //$NON-NLS-1$
+            + "by an accumulated desync. Dangling/orphaned references in Configuration.mdo " //$NON-NLS-1$
             + "(unresolved proxies shown by get_project_errors as md-reference-intergrity " //$NON-NLS-1$
             + "'lost reference' warnings that block update_database / XML import) are " //$NON-NLS-1$
             + "REPORTED by default (danglingFound + danglingDetails); set " //$NON-NLS-1$
@@ -182,6 +188,10 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
                 "When true, force-export EVERY metadata top object's .mdo (a full disk refresh; " //$NON-NLS-1$
                     + "slow on a large configuration - the export runs on the UI thread). " //$NON-NLS-1$
                     + "Default: false - export only the objects whose .mdo is missing on disk.") //$NON-NLS-1$
+            .booleanProperty(KEY_OVERWRITE_DISK_EDITS,
+                "Required confirmation for fullExport=true: force-exporting every .mdo from the " //$NON-NLS-1$
+                    + "in-memory model OVERWRITES any on-disk edits. Default: false - fullExport is " //$NON-NLS-1$
+                    + "rejected unless this is true. Ignored when fullExport=false.") //$NON-NLS-1$
             .booleanProperty(KEY_REVALIDATE,
                 "When true, schedule a full project revalidation (clean build) after the export so " //$NON-NLS-1$
                     + "stale markers refresh. Default: false (export only).") //$NON-NLS-1$
@@ -231,6 +241,17 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
         // Default FALSE: only the objects whose .mdo is actually missing are exported; // NOSONAR explanatory comment, not commented-out code
         // true re-exports everything (a full disk refresh, slow on the UI thread).
         boolean fullExport = JsonUtils.extractBooleanArgument(params, KEY_FULL_EXPORT, false);
+        // Default FALSE: fullExport re-exports EVERY .mdo from the in-memory model and would
+        // overwrite any on-disk edits, so it must be confirmed with overwriteDiskEdits=true.
+        boolean overwriteDiskEdits = JsonUtils.extractBooleanArgument(params, KEY_OVERWRITE_DISK_EDITS, false);
+        // Guard is an early-return BEFORE any BM read (unattended-safe): an unconfirmed fullExport
+        // is rejected without touching the model. Only gates fullExport - the default missing-only
+        // resync and cleanDanglingReferences paths are unaffected.
+        String guardError = fullExportGuardError(fullExport, overwriteDiskEdits);
+        if (guardError != null)
+        {
+            return guardError;
+        }
 
         ProjectContext ctx = resolveProjectAndConfig(projectName);
         if (ctx.hasError())
@@ -367,6 +388,34 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
                 Activator.logError("Error revalidating after resync_to_disk: " + projectName, e); //$NON-NLS-1$
                 return unwrapCauseMessage(e);
             }
+        }
+        return null;
+    }
+
+    /**
+     * The confirm guard for {@code fullExport}: a full export re-serializes EVERY
+     * {@code .mdo} from the in-memory model and would OVERWRITE any edits made
+     * directly on disk, so it must be explicitly confirmed with
+     * {@code overwriteDiskEdits=true}. Returns the JSON error to short-circuit
+     * {@link #executeOnUiThread} with when a {@code fullExport} was requested without
+     * that confirmation, otherwise {@code null} (the call proceeds).
+     * <p>
+     * Pure and package-private so the gate can be unit-tested headlessly. It is a
+     * pre-BM early return, so an unconfirmed {@code fullExport} never touches the
+     * model (unattended-safe). Only {@code fullExport} is gated: the default
+     * missing-only resync and the {@code cleanDanglingReferences} path both pass
+     * {@code fullExport=false} and are never blocked.
+     *
+     * @param fullExport whether a full export of every top object was requested
+     * @param overwriteDiskEdits whether the caller confirmed overwriting on-disk edits
+     * @return the JSON error when the guard rejects, otherwise {@code null}
+     */
+    static String fullExportGuardError(boolean fullExport, boolean overwriteDiskEdits)
+    {
+        if (fullExport && !overwriteDiskEdits)
+        {
+            return ToolResult.error("fullExport=true re-exports EVERY .mdo from the in-memory model and " //$NON-NLS-1$
+                + "would overwrite on-disk edits; pass overwriteDiskEdits=true to confirm.").toJson(); //$NON-NLS-1$
         }
         return null;
     }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskToolTest.java
@@ -105,11 +105,24 @@ public class ResyncToDiskToolTest
             schema.contains("\"cleanDanglingReferences\"")); //$NON-NLS-1$
         assertTrue("schema must declare the fullExport toggle", //$NON-NLS-1$
             schema.contains("\"fullExport\"")); //$NON-NLS-1$
+        assertTrue("schema must declare the overwriteDiskEdits confirm toggle", //$NON-NLS-1$
+            schema.contains("\"overwriteDiskEdits\"")); //$NON-NLS-1$
         assertTrue("schema must declare the revalidate toggle", //$NON-NLS-1$
             schema.contains("\"revalidate\"")); //$NON-NLS-1$
         // projectName is the only required parameter.
         assertTrue("projectName must be required", //$NON-NLS-1$
             schema.contains("\"required\"") && schema.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testInputSchemaDeclaresTheOverwriteDiskEditsConfirmGuard()
+    {
+        // The fullExport confirm guard reads overwriteDiskEdits in executeOnUiThread, so it MUST be
+        // declared in getInputSchema() (ToolContractConsistencyTest) - else it is invisible to
+        // schema-driven clients and lowerCamelCase-checked.
+        String schema = new ResyncToDiskTool().getInputSchema();
+        assertTrue("schema must declare the overwriteDiskEdits confirm guard read in execute()", //$NON-NLS-1$
+            schema.contains("\"overwriteDiskEdits\"")); //$NON-NLS-1$
     }
 
     @Test
@@ -243,6 +256,45 @@ public class ResyncToDiskToolTest
         List<String> all = Arrays.asList("Catalog.A", "Document.C"); //$NON-NLS-1$ //$NON-NLS-2$
         assertEquals("fullExport=true must export all even with an empty missing set", //$NON-NLS-1$
             all, ResyncToDiskTool.selectExportFqns(true, all, Collections.emptyList()));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // fullExportGuardError: the fullExport confirm guard. A fullExport re-serializes EVERY .mdo from
+    // the in-memory model and would overwrite on-disk edits, so it must be confirmed with
+    // overwriteDiskEdits=true. The guard is a pure, pre-BM early return (unattended-safe) and ONLY
+    // gates fullExport - the default missing-only resync and cleanDanglingReferences paths pass
+    // fullExport=false and are never blocked.
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void testFullExportGuardRejectsUnconfirmedFullExport()
+    {
+        // fullExport=true without overwriteDiskEdits=true must be rejected before any BM read.
+        String guardError = ResyncToDiskTool.fullExportGuardError(true, false);
+        assertNotNull("an unconfirmed fullExport must be rejected", guardError); //$NON-NLS-1$
+        assertTrue("the rejection must be a JSON error envelope", //$NON-NLS-1$
+            guardError.contains("\"error\"")); //$NON-NLS-1$
+        assertTrue("the error must name the overwriteDiskEdits confirmation to unblock", //$NON-NLS-1$
+            guardError.contains("overwriteDiskEdits")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFullExportGuardAllowsConfirmedFullExport()
+    {
+        // fullExport=true WITH overwriteDiskEdits=true is the confirmed full refresh: no error.
+        assertNull("a confirmed fullExport must pass the guard", //$NON-NLS-1$
+            ResyncToDiskTool.fullExportGuardError(true, true));
+    }
+
+    @Test
+    public void testFullExportGuardDoesNotGateTheDefaultResync()
+    {
+        // The default missing-only resync (fullExport=false) is never gated, regardless of the
+        // overwriteDiskEdits value - the guard only concerns the full export.
+        assertNull("the default missing-only resync must never be gated", //$NON-NLS-1$
+            ResyncToDiskTool.fullExportGuardError(false, false));
+        assertNull("overwriteDiskEdits is ignored when fullExport=false", //$NON-NLS-1$
+            ResyncToDiskTool.fullExportGuardError(false, true));
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/tests/e2e/tools/test_resync_to_disk.py
+++ b/tests/e2e/tools/test_resync_to_disk.py
@@ -181,12 +181,16 @@ def test_full_export_reexports_every_top_object():
     echoed back, and — because the fixture is in-sync — the re-export rewrites the SAME
     bytes, so the committed tree still must not change.
 
+    fullExport=true would overwrite on-disk edits, so it is gated behind the
+    overwriteDiskEdits confirm (see test_full_export_without_confirm_is_rejected); this
+    happy path passes overwriteDiskEdits=true to clear the guard.
+
     Mutation thinking: a fullExport that silently stayed on the subset path would
     report objectsExported==0 here; an export that produced different bytes for an
     unchanged model would fail assert_no_diff."""
     wait_for_project_ready()  # a slow runner may still be recomputing after a prior test
-    r = call("resync_to_disk", {"projectName": PROJECT, "fullExport": True})
-    assert_ok(r, "resync_to_disk fullExport=true")
+    r = call("resync_to_disk", {"projectName": PROJECT, "fullExport": True, "overwriteDiskEdits": True})
+    assert_ok(r, "resync_to_disk fullExport=true overwriteDiskEdits=true")
 
     sc = _success_envelope(r, "full-export resync")
     if sc.get("fullExport") is not True:
@@ -382,3 +386,24 @@ def test_nonexistent_project_errors_clearly():
     assert_error_quality(e, names=[bad], suggests=["list_projects"],
                          ctx="non-existent project names the bad value and points at list_projects")
     assert_no_diff("a rejected call must not touch the project tree")
+
+
+@e2e_test(tool="resync_to_disk", kind="action")
+def test_full_export_without_confirm_is_rejected():
+    """fullExport=true WITHOUT overwriteDiskEdits must be rejected by the confirm guard:
+    force-exporting every .mdo from the in-memory model would overwrite on-disk edits, so
+    the destructive full re-export is gated behind an explicit overwriteDiskEdits=true (it
+    mirrors the cleanDanglingReferences opt-in / delete_project confirm early-return). The
+    guard fires BEFORE any BM read, so nothing is exported and the tree stays clean.
+
+    Mutation thinking: a tool that dropped the guard would run the full export here and
+    (on a project with on-disk edits) silently clobber them; the error must name
+    overwriteDiskEdits so the caller knows how to confirm, and assert_no_diff pins that the
+    rejected call wrote nothing."""
+    wait_for_project_ready()  # a slow runner may still be recomputing after a prior test
+    r = call("resync_to_disk", {"projectName": PROJECT, "fullExport": True})
+    e = assert_error(r, "fullExport=true without overwriteDiskEdits")
+    assert_error_quality(e, names=["overwriteDiskEdits"], suggests=["overwriteDiskEdits"],
+                         ctx="the fullExport guard names overwriteDiskEdits and tells the caller to confirm")
+    # The guard early-returns before the export, so a rejected fullExport must write nothing.
+    assert_no_diff("a fullExport rejected by the confirm guard must not touch the project tree")

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -144,7 +144,7 @@
       "openWorldHint": false,
       "readOnlyHint": false
     },
-    "description": "Clean EDT project and trigger full revalidation. Refreshes files from disk, clears all validation markers, and waits for EDT to complete revalidation. Full rebuild of the ENTIRE configuration — slow on large projects. For a single externally-edited object prefer revalidate_objects([FQN]).",
+    "description": "Clean EDT project and trigger full revalidation. Direction: DISK -> MODEL - re-imports the on-disk src/ .mdo files into the in-memory model. Refreshes files from disk, clears all validation markers, and waits for EDT to complete revalidation. Full rebuild of the ENTIRE configuration — slow on large projects. Discards UNSAVED in-memory model edits (they are recomputed from disk); save pending changes first. For a single externally-edited object prefer revalidate_objects([FQN]). Reverse direction (MODEL -> DISK, write the model out to .mdo) is resync_to_disk. Full parameters and examples: call get_tool_guide('clean_project').",
     "inputSchema": {
       "properties": {
         "projectName": {
@@ -3304,7 +3304,7 @@
       "openWorldHint": false,
       "readOnlyHint": false
     },
-    "description": "Bulk re-synchronize the in-memory BM model to the on-disk src/ .mdo files and report BM-to-disk desync. Walks EVERY top metadata object of the configuration (all kinds), reports the objects whose .mdo is missing on disk (missingBefore), and force-exports that missing subset so the files are restored (fullExport=true re-exports every object instead). Fixes 'object file does not exist' failures from update_database / XML import caused by an accumulated desync. Dangling/orphaned references in Configuration.mdo (unresolved proxies shown by get_project_errors as md-reference-intergrity 'lost reference' warnings that block update_database / XML import) are REPORTED by default (danglingFound + danglingDetails); set cleanDanglingReferences=true to REMOVE them - destructive: rewrites Configuration.mdo. Full parameters and examples: call get_tool_guide('resync_to_disk').",
+    "description": "Bulk re-synchronize the in-memory BM model to the on-disk src/ .mdo files and report BM-to-disk desync. Direction: MODEL -> DISK (writes the model out to src/); the reverse is clean_project, which rebuilds MODEL <- DISK and DISCARDS any unsaved in-memory model edits. Walks EVERY top metadata object of the configuration (all kinds), reports the objects whose .mdo is missing on disk (missingBefore), and force-exports that missing subset so the files are restored (fullExport=true re-exports every object instead - requires overwriteDiskEdits=true to confirm, as it overwrites on-disk edits). Fixes 'object file does not exist' failures from update_database / XML import caused by an accumulated desync. Dangling/orphaned references in Configuration.mdo (unresolved proxies shown by get_project_errors as md-reference-intergrity 'lost reference' warnings that block update_database / XML import) are REPORTED by default (danglingFound + danglingDetails); set cleanDanglingReferences=true to REMOVE them - destructive: rewrites Configuration.mdo. Full parameters and examples: call get_tool_guide('resync_to_disk').",
     "inputSchema": {
       "properties": {
         "cleanDanglingReferences": {
@@ -3313,6 +3313,10 @@
         },
         "fullExport": {
           "description": "When true, force-export EVERY metadata top object's .mdo (a full disk refresh; slow on a large configuration - the export runs on the UI thread). Default: false - export only the objects whose .mdo is missing on disk.",
+          "type": "boolean"
+        },
+        "overwriteDiskEdits": {
+          "description": "Required confirmation for fullExport=true: force-exporting every .mdo from the in-memory model OVERWRITES any on-disk edits. Default: false - fullExport is rejected unless this is true. Ignored when fullExport=false.",
           "type": "boolean"
         },
         "projectName": {


### PR DESCRIPTION
Closes #175.

## Что (A + B, по твоему решению — одним PR)

**A — направление в описании + guide обоих инструментов:**
- `resync_to_disk`: «Direction: MODEL → DISK … the reverse is `clean_project`, which rebuilds MODEL ← DISK and DISCARDS any unsaved in-memory model edits»;
- `clean_project`: «Direction: DISK → MODEL … Discards UNSAVED in-memory model edits (save first) … Reverse direction (MODEL → DISK) is `resync_to_disk`», + описание теперь заканчивается указателем `get_tool_guide('clean_project')` (симметрия с resync).

**B — guard на реальный footgun:** `resync_to_disk` с `fullExport=true` теперь требует нового `overwriteDiskEdits=true`; без него — понятный `ToolResult.error` и **ничего не экспортируется** (package-private `fullExportGuardError`, early-return ДО любого BM-чтения, зеркало `cleanDanglingReferences`). Дефолт-resync (missing-only), `cleanDanglingReferences` и действие `clean_project` — байт-в-байт как были. `destructiveHint` оставлен как задаёт центральный name-derived классификатор (static-флип пере-заявил бы для безопасного дефолта + сломал drift-тесты).

## Как проверено (стенд 2025.2.6)
- `fullExport=true` без флага → ошибка с `overwriteDiskEdits` + **0 файлов** (0ms early-return);
- `fullExport=true` + `overwriteDiskEdits=true` → 102 объекта экспортированы, как раньше;
- дефолт-resync не сломан; лог чист; golden + docs регенерированы (только 2 инструмента).

## Особый шаг (твоя просьба): свежий ИИ БЕЗ контекста оценил оба инструмента
Дал саб-агенту только тексты описаний/guide (ни issue, ни дизайна). **Он правильно выбрал `clean_project`** для «загрузить правки с диска в модель» и опознал `resync_to_disk` как неверный → **направление теперь читается верно**. Полный вердикт + его доп-замечания — в комментарии к #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
