### PR TITLE
ci: передать EDT p2-репо в overlay-director (фикс системного сбоя OSGi-резолюции)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,7 @@
 # Generated tool docs + e2e golden must stay LF regardless of platform/autocrlf
 docs/tools/** text eol=lf
 tests/e2e/tools_list.golden.json text eol=lf
+
+# Shell scripts run on Linux CI runners — force LF so a Windows checkout can never
+# introduce CRLF (a CRLF shebang / `\r` breaks the script on the runner).
+*.sh text eol=lf

--- a/.github/actions/setup-edt/action.yml
+++ b/.github/actions/setup-edt/action.yml
@@ -176,16 +176,18 @@ runs:
         LOCAL_REPO="file://$GITHUB_WORKSPACE/${{ inputs.plugin-repo }}"
         ls "$GITHUB_WORKSPACE/${{ inputs.plugin-repo }}"/content.* >/dev/null 2>&1 \
           || { echo "ERROR: plugin p2 repository not found at ${{ inputs.plugin-repo }} (no content.* metadata) — build it first (mvn in mcp/)"; exit 1; }
-        # Install the MCP plugin feature into the (possibly cached) EDT base. The plugin's
-        # EDT dependencies are already in the base profile, so only the LOCAL plugin repo +
-        # the non-rate-limited Eclipse/Orbit repos are passed — edt.1c.ru is deliberately NOT
-        # contacted here, so a cache HIT run never touches the rate-limited upstream.
+        # Install the MCP plugin feature into the (possibly cached) EDT base. The EDT p2 repo
+        # (edt-p2) MUST be passed alongside the local plugin repo + Eclipse/Orbit: the director
+        # RE-RESOLVES the EDT platform bundles at overlay time, and without the full EDT metadata
+        # it cannot pick a consistent servlet-api / jetty wiring for dt.html -> activedocument.ui
+        # (a felix uses-constraint conflict once the cached base carries a newer EDT point-release).
+        # The 2-attempt retry below covers the rate-limited edt.1c.ru re-contact.
         ok=0
         for attempt in 1 2; do
           echo "[setup-edt] plugin overlay p2 director attempt $attempt/2 ..."
           if "$ECLIPSE/eclipse" -nosplash -consoleLog \
               -application org.eclipse.equinox.p2.director \
-              -repository "$LOCAL_REPO,${{ inputs.eclipse-p2 }},${{ inputs.orbit-p2 }},${{ inputs.orbit-simrel-p2 }}" \
+              -repository "$LOCAL_REPO,${{ inputs.edt-p2 }},${{ inputs.eclipse-p2 }},${{ inputs.orbit-p2 }},${{ inputs.orbit-simrel-p2 }}" \
               -installIU "com.ditrix.edt.mcp.server.feature.feature.group" \
               -destination "$ECLIPSE" \
               -profileProperties org.eclipse.update.install.features=true \

--- a/.github/actions/setup-edt/action.yml
+++ b/.github/actions/setup-edt/action.yml
@@ -80,20 +80,29 @@ runs:
         # Xvfb is mandatory — fail loudly if it really didn't install.
         sudo apt-get install -y --no-install-recommends xvfb
 
-    - name: Compute EDT-base cache key
+    - name: Pin guard + compute EDT-base cache key
       id: edtcache
       shell: bash
       run: |
         set -euo pipefail
-        # Key on the inputs that define the IMMUTABLE Eclipse+EDT base (NOT the plugin,
-        # which is rebuilt every run and overlaid afterwards). A new EDT version / Eclipse
-        # archive / platform-support IU ⇒ a different key ⇒ a fresh install + a new cache.
-        H=$(printf '%s|%s|%s|%s|%s' \
+        # Pin the EDT build this base is validated against and FAIL if 1C shipped a newer one.
+        # The public ruby/<ver>/ channel is mutated IN PLACE on every point-release (no immutable
+        # per-release URL), so folding the SERVED build qualifier into the cache key makes the
+        # base cache track the served build — it can never go stale (the felix uses-constraint
+        # overlay flap). The channel is the ruby/<ver>/ segment of edt-p2. edt-pin.sh exits 1 on
+        # a drift, which aborts this step under `set -e` (a red gate that forces a re-pin).
+        CHANNEL="$(printf '%s' '${{ inputs.edt-p2 }}' | sed -E 's#.*/ruby/([^/]+)/?$#\1#')"
+        EDT_BUILD="$(bash "$GITHUB_WORKSPACE/.github/scripts/edt-pin.sh" "$CHANNEL" "${{ inputs.edt-p2 }}")"
+        # Key on the inputs that define the IMMUTABLE Eclipse+EDT base (NOT the plugin, which is
+        # rebuilt every run and overlaid afterwards) + the served EDT build qualifier. A new EDT
+        # build / Eclipse archive / platform-support IU ⇒ a different key ⇒ a fresh install.
+        H=$(printf '%s|%s|%s|%s|%s|%s' \
               "${{ inputs.eclipse-archive }}" \
               "${{ inputs.edt-p2 }}" \
               "${{ inputs.eclipse-p2 }}" \
               "${{ inputs.orbit-p2 }}" \
-              "${{ inputs.platform-support-iu }}" | sha256sum | cut -c1-16)
+              "${{ inputs.platform-support-iu }}" \
+              "$EDT_BUILD" | sha256sum | cut -c1-16)
         echo "key=edt-base-${{ runner.os }}-$H" >> "$GITHUB_OUTPUT"
 
     - name: Restore cached EDT base (Eclipse + 1C:EDT, no plugin)

--- a/.github/scripts/edt-pin.sh
+++ b/.github/scripts/edt-pin.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# edt-pin.sh — pin guard for the 1C:EDT base the CI e2e / conformance gate validates against.
+#
+# WHY. The public 1C:EDT p2 channel  https://edt.1c.ru/downloads/releases/ruby/<channel>/
+# is a SIMPLE p2 repository that is MUTATED IN PLACE on every point-release — there is NO
+# immutable per-release URL to pin to. So the EDT-base GitHub cache, keyed only by the channel
+# URL, silently goes stale: an OLD cached base gets overlaid with the NEWLY-served EDT bundles,
+# and the p2 director then cannot pick a consistent servlet-api / jetty wiring for
+# dt.html -> activedocument.ui (a felix uses-constraint conflict) — the systemic, intermittent
+# e2e / conformance failure.
+#
+# WHAT. We PIN the EDT build qualifier each channel is expected to serve, DETECT what the
+# channel actually serves right now (the com._1c.g5.v8.dt.core version inside content.xml.xz),
+# and FAIL LOUDLY when 1C ships a newer build — forcing a conscious re-pin. The detected
+# qualifier is echoed on stdout for the cache key, so the base cache tracks the served build
+# and can never be stale (a new build => a new key => a fresh, self-consistent base).
+#
+# USAGE.  edt-pin.sh <channel> <edt-p2-url>
+#   <channel>     the ruby/<channel>/ segment, e.g. 2025.2 / 2026.1
+#   <edt-p2-url>  the full p2 URL (trailing slash), e.g. https://.../ruby/2026.1/
+# Prints ONE line on stdout: the build qualifier to fold into the cache key. All human /
+# annotation output goes to stderr. Exit 1 on a confirmed drift or an unknown channel.
+#
+# TO RE-PIN after 1C ships a new build: bump the qualifier in the PIN MAP below to the value
+# the failure message reports, then re-run — the base cache refreshes automatically.
+
+set -uo pipefail
+
+log() { echo "$@" >&2; } # keep stdout clean for the single machine-readable value
+
+CHANNEL="${1:-}"
+EDT_P2="${2:-}"
+if [ -z "$CHANNEL" ] || [ -z "$EDT_P2" ]; then
+  log "::error::edt-pin.sh: usage: edt-pin.sh <channel> <edt-p2-url>"
+  exit 1
+fi
+
+# ── PIN MAP (single source of truth) ──────────────────────────────────────────────────
+# channel -> the com._1c.g5.v8.dt.core build qualifier the CI base is validated against.
+case "$CHANNEL" in
+  2025.2) EDT_EXPECTED="26.0.1.v202605050943" ;;
+  2026.1) EDT_EXPECTED="27.0.1.v202605141817" ;;
+  *)
+    log "::error::edt-pin.sh: no pinned EDT build for channel '$CHANNEL'. Add it to the PIN MAP in .github/scripts/edt-pin.sh."
+    exit 1
+    ;;
+esac
+
+# ── DETECT the build the channel currently serves ─────────────────────────────────────
+# content.xml.xz is small (~270 KB). A transient network failure here must NOT become a new
+# CI flake, so on a fetch/parse failure we WARN and fall back to the pinned qualifier for the
+# cache key — skipping only the drift comparison, never blocking the job on a flake.
+WORK="$(mktemp -d)"
+EDT_ACTUAL=""
+if curl -fsSL --retry 3 --retry-delay 10 "${EDT_P2}content.xml.xz" -o "$WORK/content.xml.xz" 2>/dev/null; then
+  EDT_ACTUAL="$(xz -dc "$WORK/content.xml.xz" 2>/dev/null \
+    | grep -oE "id='com\._1c\.g5\.v8\.dt\.core' version='[^']+'" | head -1 \
+    | sed -E "s/.*version='([^']+)'.*/\1/")"
+fi
+rm -rf "$WORK"
+
+if [ -z "$EDT_ACTUAL" ]; then
+  log "::warning::edt-pin.sh: could not read the served EDT build from ${EDT_P2}content.xml.xz (network flake?). Skipping the drift check; pinning the cache key to $EDT_EXPECTED."
+  echo "$EDT_EXPECTED"
+  exit 0
+fi
+
+log "[edt-pin] channel $CHANNEL serves com._1c.g5.v8.dt.core=$EDT_ACTUAL (pinned expected: $EDT_EXPECTED)"
+
+# ── GUARD: fail loudly on a confirmed drift ───────────────────────────────────────────
+if [ "$EDT_ACTUAL" != "$EDT_EXPECTED" ]; then
+  log "::error::EDT $CHANNEL channel now serves $EDT_ACTUAL but CI is pinned to $EDT_EXPECTED. 1C shipped a newer EDT point-release. Review it, bump the '$CHANNEL' qualifier in the PIN MAP in .github/scripts/edt-pin.sh to $EDT_ACTUAL, and re-verify — the EDT-base cache refreshes automatically on the new qualifier."
+  exit 1
+fi
+
+log "[edt-pin] OK: channel $CHANNEL matches the pinned EDT build."
+echo "$EDT_ACTUAL"

--- a/.github/scripts/edt-pin.sh
+++ b/.github/scripts/edt-pin.sh
@@ -39,7 +39,7 @@ fi
 # channel -> the com._1c.g5.v8.dt.core build qualifier the CI base is validated against.
 case "$CHANNEL" in
   2025.2) EDT_EXPECTED="26.0.1.v202605050943" ;;
-  2026.1) EDT_EXPECTED="27.0.1.v202605141817" ;;
+  2026.1) EDT_EXPECTED="27.0.2.v202607090722" ;;
   *)
     log "::error::edt-pin.sh: no pinned EDT build for channel '$CHANNEL'. Add it to the PIN MAP in .github/scripts/edt-pin.sh."
     exit 1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -243,7 +243,7 @@ jobs:
           path: ${{ runner.temp }}/edt/eclipse
           key: ${{ steps.edtcache.outputs.key }}
 
-      - name: "EDT setup 7/8 · overlay MCP plugin [ALWAYS — fresh, local p2, no edt.1c.ru]"
+      - name: "EDT setup 7/8 · overlay MCP plugin [ALWAYS — fresh, local p2 + EDT repo]"
         shell: bash
         run: |
           set -uxo pipefail
@@ -255,9 +255,14 @@ jobs:
           ok=0
           for attempt in 1 2; do
             echo "[edt] plugin overlay attempt $attempt/2 ..."
+            # $EDT_P2 MUST be in the overlay repo list: the director re-resolves the EDT platform
+            # bundles here, and without the full EDT metadata it cannot pick a consistent
+            # servlet-api / jetty wiring for dt.html -> activedocument.ui (a felix uses-constraint
+            # conflict once the cached base carries a newer EDT point-release). The retry covers
+            # the rate-limited edt.1c.ru re-contact.
             if "$ECLIPSE/eclipse" -nosplash -consoleLog \
                 -application org.eclipse.equinox.p2.director \
-                -repository "$LOCAL_REPO,$ECLIPSE_P2,$ORBIT_P2,$ORBIT_SIMREL_P2" \
+                -repository "$LOCAL_REPO,$EDT_P2,$ECLIPSE_P2,$ORBIT_P2,$ORBIT_SIMREL_P2" \
                 -installIU "com.ditrix.edt.mcp.server.feature.feature.group" \
                 -destination "$ECLIPSE" \
                 -profileProperties org.eclipse.update.install.features=true \

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -166,18 +166,27 @@ jobs:
           done
           sudo apt-get install -y --no-install-recommends xvfb
 
-      - name: "EDT setup 2/8 · compute base cache key"
+      - name: "EDT setup 2/8 · pin guard + compute base cache key"
         id: edtcache
         shell: bash
         run: |
           set -euo pipefail
-          # Key on the IMMUTABLE base inputs (NOT the plugin, which is overlaid fresh).
-          H=$(printf '%s|%s|%s|%s|%s|%s|%s' \
+          # Pin the EDT build this base is validated against and FAIL if 1C shipped a newer one.
+          # The public ruby/<ver>/ channel is mutated IN PLACE on every point-release (no
+          # immutable per-release URL), so folding the SERVED build qualifier into the cache key
+          # makes the base cache track the served build — it can never go stale, which is what
+          # caused the felix uses-constraint overlay flap. edt-pin.sh exits 1 on a drift, which
+          # aborts this step under `set -e` (a red gate that forces a conscious re-pin).
+          EDT_BUILD="$(bash "$GITHUB_WORKSPACE/.github/scripts/edt-pin.sh" "${{ inputs.edt }}" "$EDT_P2")"
+          # Key on the IMMUTABLE base inputs (NOT the plugin, which is overlaid fresh) + the
+          # served EDT build qualifier.
+          H=$(printf '%s|%s|%s|%s|%s|%s|%s|%s' \
                 "$ECLIPSE_ARCHIVE" "$EDT_P2" "$ECLIPSE_P2" "$ORBIT_P2" \
                 "$PLATFORM_SUPPORT_IU" "$PROFILING_IU" "$BSL_EXTENSION_IU" \
+                "$EDT_BUILD" \
                 | sha256sum | cut -c1-16)
           echo "key=edt-base-${{ runner.os }}-$H" >> "$GITHUB_OUTPUT"
-          echo "EDT-base cache key: edt-base-${{ runner.os }}-$H"
+          echo "EDT-base cache key: edt-base-${{ runner.os }}-$H (edt build: $EDT_BUILD)"
 
       - name: "EDT setup 3/8 · RESTORE base cache (Eclipse+EDT, no plugin)"
         id: restore-edt


### PR DESCRIPTION
## Проблема

С ~05.07 все PR (и сам master) падают на шаге `overlay MCP plugin` (p2-director) — но НЕ на нашем плагине, а на резолюции **внутренних EDT-бандлов**:
```
Uses constraint violation: com._1c.g5.v8.dt.html exposed to 'javax.servlet.http'
from jakarta.servlet-api [4.0.0] AND org.eclipse.jetty.servlet-api [4.0.6]
→ Could not resolve com._1c.g5.v8.dt.activedocument.ui → [edt] ERROR: plugin overlay failed
```
`build` зелёный; падают только e2e/conformance на overlay, ещё до единого теста.

## Причина

Overlay-director **пере-резолвит EDT-бандлы** при установке нашей фичи, но его `-repository` не содержал `$EDT_P2` (EDT p2-репо) — передавались только local plugin repo + Eclipse/Orbit, в расчёте, что кэш EDT-base уже всё разрешил.

Допущение сломалось, когда per-branch GitHub-кэш EDT-base протух (05.07) и свежая установка подтянула **новый релиз EDT `v202605141817`**, чьи бандлы экспортируют `javax.servlet.http` из ДВУХ провайдеров (`jakarta.servlet-api` + `jetty-servlet-api`) + jetty 12.x. Без полной EDT-метадаты director не может выбрать согласованную обвязку → `dt.html` → `activedocument.ui` не резолвятся (felix uses-constraint) → overlay падает.

**Асимметрия:** база install **ВКЛЮЧАЕТ** `$EDT_P2` и резолвится; overlay **ИСКЛЮЧАЛ** его и падал.

## Фикс

Добавить `$EDT_P2` / `edt-p2` в `-repository` overlay-director в обоих местах:
- `.github/workflows/e2e-tests.yml` — инлайн-overlay e2e;
- `.github/actions/setup-edt/action.yml` — общий composite (его использует conformance).

Existing 2-attempt retry покрывает re-контакт rate-limited edt.1c.ru. (Если оба servlet-api всё же попадут в план — фолбэк отдельным шагом: запинить/исключить один провайдер.)

## Почему это НЕ код (диагностика 2 агентами)

- Два независимых «тот же код: успех→провал»: master **#228 зелёный** vs **#229 красный** этой же цепочкой минуты спустя; ветка с **пустым** re-trigger-коммитом (идентичный tree) — успех, затем провал.
- Наш `com.ditrix.edt.mcp.server` — в **НОЛЕ** строк ошибок резолюции; MANIFEST/pom/feature не менялись; артефакт байт-целый.
- `digest-mismatch` в логе — **red herring**: это эхо входного параметра `download-artifact@v8`; скачивание успешно, дайджесты совпали.

Только CI, исходники не трогает. Разблокирует все PR + master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
