### PR TITLE
Скоуп супрессора auth-диалога ИБ по активности MCP — ручной ввод кредов в GUI снова работает (#230)

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,29 @@ it overrides the preference and lets every gated operation proceed without a dia
 e2e suite uses). When there is no active workbench window (a headless server), the gate never blocks
 either. The dialog only ever appears on a live UI session at the *Ask* level.
 
+### Infobase authentication dialog
+
+When a target infobase has a **user list**, connecting to it during `update_database` or `debug_launch`
+can raise 1C's blocking **"Configure Infobase access Settings"** login dialog. To keep unattended MCP
+calls from hanging on it, the server **auto-cancels that dialog while a tool is running** — the
+MCP-triggered connect fails fast with a hint to `set_infobase_credentials` instead of blocking forever
+(issue #194). Store the credentials once with `set_infobase_credentials` and the connect no longer
+needs the dialog.
+
+The auto-cancel is **activity-scoped**: it fires only while an MCP tool is in flight (plus a short grace
+window for the asynchronous read-back that follows a tool). So when the **MCP server is idle**, you can
+open EDT's **"Configure Infobase access"** dialog **by hand in the GUI** and use it normally — the
+credentials you enter are stored into EDT's encrypted **Secure Storage** (the leak-free path), exactly
+as the configurator does it. Only dialogs raised by MCP activity are cancelled; a human configuring
+credentials between agent runs is never interrupted. (The Secure-Storage password-hint dialog stays
+suppressed unconditionally — it is internal and never human-configured.)
+
+**Automation / CI bypass.** The auto-cancel is **on by default**. To turn it **off** — e.g. to debug the
+login flow interactively, or on a stand where you want the prompt to appear even during MCP calls — set
+the environment variable **`EDT_MCP_SUPPRESS_AUTH_DIALOG=false`** (also `0` / `no`) on the EDT process
+before launch. Any other value — or leaving it unset — keeps auto-cancel enabled, so an unattended run
+never regresses into a hang.
+
 ## Metadata Tags
 
 Organize your metadata objects with custom tags for easier navigation and filtering.

--- a/docs/tools/set_infobase_credentials.md
+++ b/docs/tools/set_infobase_credentials.md
@@ -52,9 +52,17 @@ JSON with `success`, `project`, `applicationId`, `applicationName`, the stored `
 set_infobase_credentials  launchConfigurationName="ERP - thin client"  user="Admin"  password="secret"
 ```
 
+## Storing credentials from the EDT GUI (when MCP is idle)
+
+You do not have to use this tool. When the **MCP server is idle**, you can open EDT's built-in **"Configure Infobase access"** dialog by hand (the same dialog the configurator uses) and enter the user / password there. EDT stores them in its encrypted **Secure Storage** — the leak-free path — and `update_database` / `debug_launch` pick them up exactly as if you had called this tool. This works because the auto-cancel below is **activity-scoped**: it fires only while an MCP tool is running, so a human configuring credentials between agent runs is never interrupted.
+
+## Auto-cancel of the login dialog (unattended safety)
+
+While an MCP tool is in flight (plus a short grace window for the asynchronous read-back that follows a tool), the server **auto-cancels** the "Configure Infobase access Settings" login dialog so an unattended call never blocks on it — the operation instead fails fast with a hint back to this tool. This auto-cancel is **on by default** and **activity-scoped** — it is NOT always-on, so an idle server leaves the GUI dialog usable (see above). To turn it off — e.g. to debug the login flow interactively — set **`EDT_MCP_SUPPRESS_AUTH_DIALOG=false`** (also `0` / `no`) on the EDT process before launch; any other value, or leaving it unset, keeps auto-cancel enabled.
+
 ## Gotchas
 
-- **The user must exist in the infobase.** Storing credentials for a user that does not exist makes the next connect fail authentication (the MCP server auto-cancels the resulting dialog and the operation fails fast with a hint back to this tool). Add the user first, then set credentials.
+- **The user must exist in the infobase.** Storing credentials for a user that does not exist makes the next connect fail authentication (while a tool is running the MCP server auto-cancels the resulting dialog — see the auto-cancel note above — and the operation fails fast with a hint back to this tool). Add the user first, then set credentials.
 - **`create_infobase` can store credentials too** (its `user`/`password`/`access` parameters) — handy with `mode='register'` (the existing base already has users). For a brand-new `mode='create'` base there are no users yet, so set credentials only after adding a matching user.
 - **Wrong password / wrong user** → `update_database`/`debug_launch` fail fast with "the infobase requires authentication — set the connection credentials with set_infobase_credentials" instead of hanging.
 - These are connection credentials, not a permission grant: the user's rights inside the infobase are unchanged.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/set_infobase_credentials.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/set_infobase_credentials.md
@@ -37,9 +37,17 @@ JSON with `success`, `project`, `applicationId`, `applicationName`, the stored `
 set_infobase_credentials  launchConfigurationName="ERP - thin client"  user="Admin"  password="secret"
 ```
 
+## Storing credentials from the EDT GUI (when MCP is idle)
+
+You do not have to use this tool. When the **MCP server is idle**, you can open EDT's built-in **"Configure Infobase access"** dialog by hand (the same dialog the configurator uses) and enter the user / password there. EDT stores them in its encrypted **Secure Storage** — the leak-free path — and `update_database` / `debug_launch` pick them up exactly as if you had called this tool. This works because the auto-cancel below is **activity-scoped**: it fires only while an MCP tool is running, so a human configuring credentials between agent runs is never interrupted.
+
+## Auto-cancel of the login dialog (unattended safety)
+
+While an MCP tool is in flight (plus a short grace window for the asynchronous read-back that follows a tool), the server **auto-cancels** the "Configure Infobase access Settings" login dialog so an unattended call never blocks on it — the operation instead fails fast with a hint back to this tool. This auto-cancel is **on by default** and **activity-scoped** — it is NOT always-on, so an idle server leaves the GUI dialog usable (see above). To turn it off — e.g. to debug the login flow interactively — set **`EDT_MCP_SUPPRESS_AUTH_DIALOG=false`** (also `0` / `no`) on the EDT process before launch; any other value, or leaving it unset, keeps auto-cancel enabled.
+
 ## Gotchas
 
-- **The user must exist in the infobase.** Storing credentials for a user that does not exist makes the next connect fail authentication (the MCP server auto-cancels the resulting dialog and the operation fails fast with a hint back to this tool). Add the user first, then set credentials.
+- **The user must exist in the infobase.** Storing credentials for a user that does not exist makes the next connect fail authentication (while a tool is running the MCP server auto-cancels the resulting dialog — see the auto-cancel note above — and the operation fails fast with a hint back to this tool). Add the user first, then set credentials.
 - **`create_infobase` can store credentials too** (its `user`/`password`/`access` parameters) — handy with `mode='register'` (the existing base already has users). For a brand-new `mode='create'` base there are no users yet, so set credentials only after adding a matching user.
 - **Wrong password / wrong user** → `update_database`/`debug_launch` fail fast with "the infobase requires authentication — set the connection credentials with set_infobase_credentials" instead of hanging.
 - These are connection credentials, not a permission grant: the user's rights inside the infobase are unchanged.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/McpProtocolHandler.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/McpProtocolHandler.java
@@ -311,6 +311,12 @@ public class McpProtocolHandler
         // headless. set_infobase_credentials provides the credentials so the dialog never needs to
         // appear on a correctly configured base.
         InfobaseAuthDialogSuppressor.ensureInstalled();
+        // Scope the auth-dialog suppression to actual MCP activity (#230): mark this dispatch
+        // in-flight so the suppressor auto-cancels an auth dialog raised during (and briefly
+        // after, via the trailing grace window that bridges async read-back Jobs) the call,
+        // while a human who opens the same dialog in the GUI when the server is idle can still
+        // use it. markActivityEnd() runs in the finally below so the counter never leaks.
+        InfobaseAuthDialogSuppressor.markActivityStart();
         try
         {
             result = tool.execute(params);
@@ -319,6 +325,7 @@ public class McpProtocolHandler
         }
         finally
         {
+            InfobaseAuthDialogSuppressor.markActivityEnd();
             // Clear current tool name after execution
             if (server != null)
             {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/BuildExternalObjectsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/BuildExternalObjectsTool.java
@@ -69,10 +69,12 @@ import com.ditrix.edt.mcp.server.utils.WorkspacePaths;
  *
  * <h2>Unattended-safety</h2>
  * The dump loop runs in a background {@link Job} (never on the JSON-RPC / UI thread)
- * with a bounded timeout. The always-on {@link InfobaseAuthDialogSuppressor} and the
- * armed {@link LaunchUpdateDialogAutoConfirmer} keep any blocking EDT/1C modal from
- * hanging the call. Per-object success/failure is captured honestly: the response lists
- * each object's output path on success or its error on failure, and {@code success} is
+ * with a bounded timeout. The {@link InfobaseAuthDialogSuppressor} (auth-dialog auto-cancel
+ * is activity-scoped since #230; this tool joins its Job synchronously inside the dispatch,
+ * so it stays in scope) and the armed {@link LaunchUpdateDialogAutoConfirmer} keep any
+ * blocking EDT/1C modal from hanging the call. Per-object success/failure is captured
+ * honestly: the response lists each object's output path on success or its error on
+ * failure, and {@code success} is
  * {@code false} when any object failed.
  *
  * <p>The dumper resolution, the per-object output file name and the {@code .epf}/{@code
@@ -477,9 +479,11 @@ public class BuildExternalObjectsTool implements IMcpTool
 
     /**
      * Runs the per-object dump loop in a background {@link Job} with a bounded timeout, the
-     * always-on auth-dialog suppressor ensured and the launch update/restructure auto-confirmer
-     * armed, so the unattended call never blocks on an EDT/1C modal. Captures per-object
-     * success/failure honestly and builds the JSON response.
+     * auth-dialog suppressor filter installed and the launch update/restructure auto-confirmer
+     * armed, so the unattended call never blocks on an EDT/1C modal. Auth-dialog auto-cancel is
+     * now activity-scoped (#230); this build joins its {@link Job} synchronously inside the tool
+     * dispatch, so IN_FLIGHT stays &gt; 0 and the auth modal raised by the dump Job is still
+     * auto-cancelled. Captures per-object success/failure honestly and builds the JSON response.
      *
      * @param bc the resolved build context
      * @return the JSON response
@@ -495,8 +499,10 @@ public class BuildExternalObjectsTool implements IMcpTool
             return buildResponse(bc, new ArrayList<>(), System.currentTimeMillis() - buildStartMs);
         }
 
-        // Ensure the always-on auth-dialog suppressor is installed (it auto-cancels the
-        // "Configure Infobase access Settings" modal raised by EDT background jobs).
+        // Ensure the auth-dialog suppressor filter is installed. Auth-dialog auto-cancel is now
+        // activity-scoped (#230); this build runs synchronously inside the tool dispatch (the Job
+        // is joined below), so IN_FLIGHT stays > 0 and the "Configure Infobase access Settings"
+        // modal raised by the build's background Job is still auto-cancelled.
         InfobaseAuthDialogSuppressor.ensureInstalled();
 
         // Synchronized: the Job thread appends while the calling thread may snapshot it on timeout.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
@@ -29,6 +29,7 @@ import com.ditrix.edt.mcp.server.protocol.McpKeys;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
 import com.ditrix.edt.mcp.server.utils.DebugServerTargetSupport;
+import com.ditrix.edt.mcp.server.utils.InfobaseAuthDialogSuppressor;
 import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
 import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils;
 import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils.ExistingClientSession;
@@ -959,7 +960,11 @@ public class DebugLaunchTool implements IMcpTool
             return null;
         }
         // No workbench (headless tests): launch synchronously and surface errors.
+        // The infobase auth-dialog suppression is held across the synchronous connect for
+        // the same #230 reason as the async Job body above (kept symmetric with the
+        // arm/disarm pattern; a no-op headless where no dialog can appear).
         LaunchUpdateDialogAutoConfirmer.arm(autoConfirmUpdateDialog, true);
+        InfobaseAuthDialogSuppressor.markActivityStart();
         try
         {
             config.launch(ILaunchManager.DEBUG_MODE, null);
@@ -972,6 +977,7 @@ public class DebugLaunchTool implements IMcpTool
         }
         finally
         {
+            InfobaseAuthDialogSuppressor.markActivityEnd();
             LaunchUpdateDialogAutoConfirmer.disarm(autoConfirmUpdateDialog, true);
         }
     }
@@ -1005,6 +1011,16 @@ public class DebugLaunchTool implements IMcpTool
         // auto-confirmed on this debug path (it is independent of the update
         // opt-out). Manual EDT launches outside this window still prompt.
         LaunchUpdateDialogAutoConfirmer.arm(autoConfirmUpdateDialog, true);
+        // Keep the infobase auth-dialog suppression active for the WHOLE async launch
+        // (#230). This launch is fire-and-forget: tool.execute() has already returned and
+        // stamped lastActivityEndMillis, and with updateBeforeLaunch=false there is no
+        // synchronous preflight connect — the FIRST (and only) infobase connect happens
+        // right here in config.launch, which can run for minutes (e.g. the standalone-
+        // server mode-switch restart). The in-flight counter — not the short trailing
+        // grace window — must therefore cover it, so a "Configure Infobase access Settings"
+        // dialog raised by this connect (missing/wrong stored creds) is still auto-cancelled
+        // instead of hanging the unattended call (mirrors the arm/disarm pattern above).
+        InfobaseAuthDialogSuppressor.markActivityStart();
         try
         {
             config.launch(ILaunchManager.DEBUG_MODE, monitor);
@@ -1025,6 +1041,7 @@ public class DebugLaunchTool implements IMcpTool
         }
         finally
         {
+            InfobaseAuthDialogSuppressor.markActivityEnd();
             LaunchUpdateDialogAutoConfirmer.disarm(autoConfirmUpdateDialog, true);
         }
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
@@ -47,6 +47,7 @@ import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
 import com.ditrix.edt.mcp.server.utils.DebugSessionRegistry;
+import com.ditrix.edt.mcp.server.utils.InfobaseAuthDialogSuppressor;
 import com.ditrix.edt.mcp.server.utils.JUnitMarkdownFormatter;
 import com.ditrix.edt.mcp.server.utils.JUnitTestResults;
 import com.ditrix.edt.mcp.server.utils.JUnitXmlParser;
@@ -1081,8 +1082,12 @@ public class RunYaxunitTestsTool implements IMcpTool
      * logging and the Job display name). Bundling these keeps
      * {@link #awaitPreparedOrPending} and {@link #schedulePrepJob} below the
      * 7-parameter limit without changing any value or order.
+     *
+     * <p>Package-private (not {@code private}) so the same-package
+     * {@code runPrepJobBody} ratchet can construct a request, exactly as
+     * {@code DebugLaunchTool.runLaunchJobBody} is a package-private seam.
      */
-    private static final class PrepRequest
+    static final class PrepRequest
     {
         final String projectName;
         final ILaunchManager launchManager;
@@ -1161,40 +1166,76 @@ public class RunYaxunitTestsTool implements IMcpTool
             @Override
             protected IStatus run(IProgressMonitor monitor)
             {
-                try
-                {
-                    jobEntry.phase = "recompute"; //$NON-NLS-1$
-                    int terminateTimeout =
-                        LaunchLifecycleUtils.getDefaultTerminateTimeoutSeconds();
-                    PreLaunchResult result = LaunchLifecycleUtils.prepareForFreshLaunch(
-                        req.launchManager, req.project, req.applicationId,
-                        req.appManager, terminateTimeout, req.updateScope);
-                    jobEntry.phase = "db-update"; //$NON-NLS-1$
-                    resultHolder[0] = result;
-                    if (!result.isOk())
-                    {
-                        jobEntry.error = result.getError();
-                    }
-                }
-                catch (Throwable e) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
-                {
-                    // Throwable, not Exception: an Error escaping the prep must still
-                    // surface as a prep failure — otherwise the retry call would see
-                    // done-without-error and proceed as if preparation succeeded.
-                    jobEntry.error = e.getMessage() != null ? e.getMessage()
-                        : e.getClass().getSimpleName();
-                    Activator.logError("Pre-launch preparation job failed: " + req.projectName, e); //$NON-NLS-1$
-                }
-                finally
-                {
-                    jobEntry.done = true;
-                    jobEntry.latch.countDown();
-                }
-                return Status.OK_STATUS;
+                return runPrepJobBody(jobEntry, req, resultHolder);
             }
         };
         prepJob.setPriority(Job.INTERACTIVE);
         prepJob.schedule();
+    }
+
+    /**
+     * Body of the background pre-launch preparation {@link Job} that
+     * {@link #schedulePrepJob} schedules — extracted as a package-private static seam so
+     * the headless ratchet can exercise it directly (scheduling a real Job needs a live
+     * workbench). Runs {@link LaunchLifecycleUtils#prepareForFreshLaunch}, stores the
+     * {@link PreLaunchResult} in {@code resultHolder[0]} and always completes the entry
+     * ({@code error}/{@code done}/latch) — identical to the inline body it replaces.
+     *
+     * <p><b>#230:</b> brackets the whole prep with the {@link InfobaseAuthDialogSuppressor}
+     * in-flight counter. This Job is fire-and-forget: {@code execute()} only blocks on it
+     * for {@code PRELAUNCH_BUDGET_MS} before returning a "pending" response, so
+     * {@code tool.execute()} has already returned and stamped {@code lastActivityEndMillis}.
+     * {@code prepareForFreshLaunch}'s db-update phase does the infobase-connecting
+     * {@code appManager.update} — the SAME connect that raises the blocking "Configure
+     * Infobase access Settings" auth dialog — and the recompute phase before it can
+     * legitimately run for minutes on a real config, far past the trailing grace window.
+     * The in-flight counter — not the short grace window — must therefore cover the whole
+     * recompute+db-update, so a dialog raised by this connect (missing/wrong stored creds)
+     * is still auto-cancelled instead of hanging the unattended call (mirrors
+     * {@code DebugLaunchTool.runLaunchJobBody}). The counter is ALWAYS released in
+     * {@code finally}, so it never leaks even on an {@link Error} escaping the prep.
+     *
+     * @param jobEntry the in-flight entry to complete (phase / error / done / latch)
+     * @param req the immutable prep pass-throughs
+     * @param resultHolder receives the {@link PreLaunchResult} in slot {@code [0]}
+     * @return {@link Status#OK_STATUS} (the Job outcome is carried on {@code jobEntry},
+     *         not on the returned status)
+     */
+    static IStatus runPrepJobBody(PrepInFlight jobEntry, PrepRequest req,
+            PreLaunchResult[] resultHolder)
+    {
+        InfobaseAuthDialogSuppressor.markActivityStart();
+        try
+        {
+            jobEntry.phase = "recompute"; //$NON-NLS-1$
+            int terminateTimeout =
+                LaunchLifecycleUtils.getDefaultTerminateTimeoutSeconds();
+            PreLaunchResult result = LaunchLifecycleUtils.prepareForFreshLaunch(
+                req.launchManager, req.project, req.applicationId,
+                req.appManager, terminateTimeout, req.updateScope);
+            jobEntry.phase = "db-update"; //$NON-NLS-1$
+            resultHolder[0] = result;
+            if (!result.isOk())
+            {
+                jobEntry.error = result.getError();
+            }
+        }
+        catch (Throwable e) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+        {
+            // Throwable, not Exception: an Error escaping the prep must still
+            // surface as a prep failure — otherwise the retry call would see
+            // done-without-error and proceed as if preparation succeeded.
+            jobEntry.error = e.getMessage() != null ? e.getMessage()
+                : e.getClass().getSimpleName();
+            Activator.logError("Pre-launch preparation job failed: " + req.projectName, e); //$NON-NLS-1$
+        }
+        finally
+        {
+            InfobaseAuthDialogSuppressor.markActivityEnd();
+            jobEntry.done = true;
+            jobEntry.latch.countDown();
+        }
+        return Status.OK_STATUS;
     }
 
     /** Shared "Pre-launch preparation failed" error payload (identical wording in both surfacing sites). */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/InfobaseAuthDialogSuppressor.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/InfobaseAuthDialogSuppressor.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
@@ -43,18 +44,36 @@ import com.ditrix.edt.mcp.server.Activator;
  * no public hook, so it is intercepted at the SWT level, like the launch modals in
  * {@link LaunchUpdateDialogAutoConfirmer}.
  *
- * <h2>Why always-on (not per-call)</h2>
- * EDT computes an application's update state (and connects to the infobase) inside
- * <b>background {@link org.eclipse.core.runtime.jobs.Job Jobs}</b> — e.g. the
- * read-back of {@code get_applications}/{@code create_infobase} — which raise the
- * dialog <em>after</em> the originating {@code tool.execute(...)} has already
- * returned. A filter that was armed only around the call would miss those. So the
- * filter is installed once (lazily, the first time a workbench {@link Display} is
- * available — {@link #ensureInstalled()} is called on every tool dispatch) and
- * stays installed for the workbench's lifetime: the MCP server runs unattended, so
- * this dialog must never block, whoever raises it. Credentials are provided through
- * {@code set_infobase_credentials} / {@code create_infobase}, so on a correctly
- * configured base the dialog never needs to appear at all.
+ * <h2>Why activity-scoped (not always-on) — issue #230</h2>
+ * The auth (access-settings) dialog is auto-cancelled only while an MCP tool call is
+ * <em>active or has just finished</em>, so a human who opens EDT's
+ * "Configure Infobase access" dialog in the GUI while the server is <b>idle</b> can
+ * still use it to store credentials into Secure Storage. Two mechanisms decide "active":
+ * <ul>
+ *   <li>an in-flight <b>counter</b> ({@link #IN_FLIGHT}, bumped by
+ *       {@link #markActivityStart()} / {@link #markActivityEnd()} around
+ *       {@code tool.execute(...)}) covers the whole <em>synchronous</em> call —
+ *       {@code update_database}'s minutes included — regardless of duration;</li>
+ *   <li>a trailing <b>grace window</b> ({@link #DEFAULT_ACTIVITY_GRACE_MILLIS}, from
+ *       {@link #lastActivityEndMillis}) bridges the short gap to the <em>asynchronous</em>
+ *       read-back {@link org.eclipse.core.runtime.jobs.Job Jobs} — e.g.
+ *       {@code get_applications}/{@code create_infobase} — that raise the dialog
+ *       <em>after</em> {@code tool.execute(...)} has already returned. Without this a
+ *       missed async dialog would hang an unattended call (a #194 regression).</li>
+ * </ul>
+ * An env <b>kill-switch</b> {@link #ENV_SUPPRESS_AUTH_DIALOG} (default ON — set it to
+ * {@code false}/{@code 0}/{@code no} to disable) lets an operator turn the auth-dialog
+ * suppression off entirely. The filter itself is still installed once (lazily, the
+ * first time a workbench {@link Display} is available — {@link #ensureInstalled()} is
+ * called on every tool dispatch) and stays installed for the workbench's lifetime;
+ * the activity/env decision is applied per event, only to the auth dialog.
+ * <p>The Secure Storage password-<b>hint</b> dialog stays <b>always-suppressed</b>
+ * (dismissed unconditionally, ignoring both the activity window and the env flag): it
+ * is an internal follow-up to the MCP server supplying the keyring master password
+ * programmatically ({@link McpSecureStorageProvider}) and is never something a human
+ * configures. Credentials are provided through {@code set_infobase_credentials} /
+ * {@code create_infobase}, so on a correctly configured base the auth dialog never
+ * needs to appear at all.
  *
  * <h2>Scope &amp; safety</h2>
  * <ul>
@@ -101,6 +120,45 @@ public final class InfobaseAuthDialogSuppressor
      */
     static final String SECURE_STORAGE_HINT_TITLE_PREFIX = "Secure Storage - Password Hint"; //$NON-NLS-1$
 
+    /**
+     * Kill-switch environment variable for the infobase access-settings ("auth") dialog suppression
+     * (issue #230). Default <b>ON</b>: unset / blank / any value other than a trimmed case-insensitive
+     * {@code false}/{@code 0}/{@code no} keeps the suppression enabled (so the #194 unattended-safety
+     * behaviour is preserved by default). Set it to {@code false} (or {@code 0}/{@code no}) on the EDT
+     * launch to disable auth-dialog suppression entirely.
+     *
+     * <p>The polarity is <em>inverted</em> vs {@code DestructiveConsentGate.ENV_DESTRUCTIVE_CONSENT}
+     * (that is opt-<em>IN</em>: only {@code allow} enables the bypass). Here the safe default is ON, so
+     * the classifier defaults to {@code true} and only an explicit negative value disables it.
+     */
+    static final String ENV_SUPPRESS_AUTH_DIALOG = "EDT_MCP_SUPPRESS_AUTH_DIALOG"; //$NON-NLS-1$
+
+    /**
+     * Trailing grace window (ms) after the last MCP call ends during which an auth dialog is still
+     * auto-cancelled. The in-flight {@link #IN_FLIGHT} counter already covers the whole synchronous
+     * {@code execute()} window regardless of duration; this window only bridges the short gap from
+     * execute-completion to an asynchronous read-back Job raising the dialog
+     * ({@code get_applications}/{@code create_infobase} — realistically a few seconds). 30 s gives a
+     * wide margin against a #194 regression while a human deliberately configuring credentials (idle
+     * for minutes) is far past the window.
+     */
+    static final long DEFAULT_ACTIVITY_GRACE_MILLIS = 30_000L;
+
+    /**
+     * Number of MCP tool calls currently executing. Incremented by {@link #markActivityStart()} before
+     * {@code tool.execute(...)} and decremented by {@link #markActivityEnd()} in the dispatch
+     * {@code finally}, so a still-running call keeps the auth dialog suppressed for its whole duration.
+     * An {@link AtomicInteger} because MCP worker threads call the mutators concurrently.
+     */
+    static final AtomicInteger IN_FLIGHT = new AtomicInteger();
+
+    /**
+     * {@link System#currentTimeMillis()} of the most recent {@link #markActivityEnd()}. Combined with
+     * {@link #DEFAULT_ACTIVITY_GRACE_MILLIS} it bridges the gap to an asynchronous read-back Job's
+     * dialog. Volatile: written on worker threads, read on the SWT event thread.
+     */
+    static volatile long lastActivityEndMillis;
+
     private static final Object LOCK = new Object();
 
     /** Fast-path flag: once the filter is installed on a live display, dispatch skips the UI round-trip. */
@@ -111,6 +169,89 @@ public final class InfobaseAuthDialogSuppressor
 
     private InfobaseAuthDialogSuppressor()
     {
+    }
+
+    /**
+     * Marks the start of an MCP tool call: increments the {@link #IN_FLIGHT} counter so an auth dialog
+     * raised while the call runs is auto-cancelled. Paired with {@link #markActivityEnd()} in the
+     * dispatch {@code finally} ({@code McpProtocolHandler.executeToolTimed}). Also armed around the
+     * <em>fire-and-forget</em> launch in {@code DebugLaunchTool} (whose infobase connect happens in a
+     * background Job after {@code execute()} has returned, so the trailing grace alone would not cover a
+     * minutes-long launch — see issue #230).
+     */
+    public static void markActivityStart()
+    {
+        IN_FLIGHT.incrementAndGet();
+    }
+
+    /**
+     * Marks the end of an MCP tool call: decrements the {@link #IN_FLIGHT} counter (clamped at zero as a
+     * defence against an unbalanced call) and stamps {@link #lastActivityEndMillis} so the trailing
+     * grace window keeps a briefly-later asynchronous read-back dialog suppressed. Always runs in the
+     * dispatch {@code finally} so the counter never leaks on a thrown {@code execute}.
+     */
+    public static void markActivityEnd()
+    {
+        if (IN_FLIGHT.decrementAndGet() < 0)
+        {
+            IN_FLIGHT.set(0);
+        }
+        lastActivityEndMillis = System.currentTimeMillis();
+    }
+
+    /**
+     * Reads the {@link #ENV_SUPPRESS_AUTH_DIALOG} environment variable and reports whether auth-dialog
+     * suppression is enabled. Delegates to the pure {@link #envAllowsSuppression(String)} so the
+     * classification is unit-testable without touching the process environment.
+     *
+     * @return {@code true} when the env flag leaves suppression enabled (the default)
+     */
+    static boolean isEnvSuppressEnabled()
+    {
+        return envAllowsSuppression(System.getenv(ENV_SUPPRESS_AUTH_DIALOG));
+    }
+
+    /**
+     * Pure classifier for the {@link #ENV_SUPPRESS_AUTH_DIALOG} value, <b>default ON</b>: returns
+     * {@code false} ONLY for a trimmed case-insensitive {@code false}/{@code 0}/{@code no}; every other
+     * value — including {@code null}, blank, {@code true}, or garbage — returns {@code true}. The
+     * default-ON polarity preserves the #194 unattended-safety behaviour for anyone who does not set the
+     * flag (a naive copy of {@code DestructiveConsentGate.envForcesAllow} would default suppression OFF
+     * and silently regress it).
+     *
+     * @param rawEnvValue the raw environment value (may be {@code null})
+     * @return {@code true} to keep suppression enabled, {@code false} only for an explicit off value
+     */
+    static boolean envAllowsSuppression(String rawEnvValue)
+    {
+        if (rawEnvValue == null)
+        {
+            return true;
+        }
+        String value = rawEnvValue.trim();
+        return !("false".equalsIgnoreCase(value) //$NON-NLS-1$
+            || "0".equals(value) //$NON-NLS-1$
+            || "no".equalsIgnoreCase(value)); //$NON-NLS-1$
+    }
+
+    /**
+     * Pure decision (and test seam): should the infobase access-settings ("auth") dialog be
+     * auto-cancelled right now? Suppress only when the env kill-switch leaves suppression enabled AND
+     * there is current MCP activity — either a call is in flight, or the last call ended within the
+     * grace window (so an asynchronous read-back dialog is still covered). When the server is idle
+     * (no in-flight call and past the window) the dialog is left alone so a human can use it.
+     *
+     * @param envEnabled whether the env kill-switch leaves suppression enabled
+     * @param inFlight the current {@link #IN_FLIGHT} count
+     * @param now the current time ({@link System#currentTimeMillis()})
+     * @param lastActivityEnd the timestamp of the last {@link #markActivityEnd()}
+     * @param grace the trailing grace window in ms ({@link #DEFAULT_ACTIVITY_GRACE_MILLIS})
+     * @return {@code true} to auto-cancel the auth dialog, {@code false} to leave it for the human
+     */
+    static boolean shouldSuppressAuthDialog(boolean envEnabled, int inFlight, long now,
+        long lastActivityEnd, long grace)
+    {
+        return envEnabled && (inFlight > 0 || now - lastActivityEnd < grace);
     }
 
     /**
@@ -221,6 +362,15 @@ public final class InfobaseAuthDialogSuppressor
             boolean authDialog = isAuthDialogTitle(title);
             boolean hintDialog = !authDialog && isSecureStorageHintDialogTitle(title);
             if (!authDialog && !hintDialog)
+            {
+                return;
+            }
+            // The Secure Storage hint dialog is dismissed unconditionally (internal follow-up, never
+            // human-configured). The auth dialog is dismissed only while there is MCP activity (a call
+            // in flight or within the trailing grace window) and the env kill-switch leaves suppression
+            // enabled — so a human who opens it in the GUI while the server is idle can use it (#230).
+            if (authDialog && !shouldSuppressAuthDialog(isEnvSuppressEnabled(), IN_FLIGHT.get(),
+                System.currentTimeMillis(), lastActivityEndMillis, DEFAULT_ACTIVITY_GRACE_MILLIS))
             {
                 return;
             }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsToolTest.java
@@ -12,12 +12,18 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import org.eclipse.core.runtime.IStatus;
 import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.InfobaseAuthDialogSuppressor;
+import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils.PreLaunchResult;
+import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils.PrepInFlight;
 
 /**
  * Tests for {@link RunYaxunitTestsTool}.
@@ -379,5 +385,86 @@ public class RunYaxunitTestsToolTest
             guide.contains("background")); //$NON-NLS-1$
         assertTrue("guide must document the pending-retry contract for prep",
             guide.contains("same arguments")); //$NON-NLS-1$
+    }
+
+    // ============ #230 — the async prep body brackets the auth-dialog suppressor ============
+
+    @Test
+    public void testPrepJobBodyBracketsTheAuthDialogSuppressorCounter() throws Exception
+    {
+        // #230 regression guard: schedulePrepJob runs prepareForFreshLaunch (whose db-update
+        // phase does the infobase connect that raises the blocking "Configure Infobase access
+        // Settings" dialog) in a fire-and-forget background Job. execute() only blocks on it for
+        // the 25s budget and then returns "pending", so the trailing grace window alone would NOT
+        // cover a minutes-long prep — the in-flight COUNTER must span the whole body, exactly like
+        // DebugLaunchTool.runLaunchJobBody. This drives the extracted body seam headlessly and
+        // asserts it holds the counter up for its whole duration and never leaks it.
+        AtomicInteger inFlight = inFlightCounter();
+        int original = inFlight.get();
+
+        // Pre-arm one activity level so a MISSING markActivityStart is detectable: a lone
+        // markActivityEnd would drop the counter BELOW this level, a leaked markActivityStart
+        // would leave it ABOVE — a plain net-zero-from-idle check could tell neither apart.
+        InfobaseAuthDialogSuppressor.markActivityStart();
+        int armed = inFlight.get();
+        assertEquals("pre-arm must raise the in-flight level by one", original + 1, armed);
+
+        long beforeBody = System.currentTimeMillis();
+
+        // A null launchManager makes prepareForFreshLaunch return a clean PreLaunchResult error
+        // immediately (see LaunchLifecycleUtils.prepareForFreshLaunch) — a fully headless,
+        // deterministic drive of the body that needs no EDT services (the real db-update phase,
+        // which would raise the dialog on a live base, never runs here).
+        RunYaxunitTestsTool.PrepRequest req = new RunYaxunitTestsTool.PrepRequest(
+            "TestConfiguration", null, null, "TestConfiguration.SomeApp", //$NON-NLS-1$ //$NON-NLS-2$
+            null, null, "prep-job-suppressor-ratchet"); //$NON-NLS-1$
+        PrepInFlight entry = new PrepInFlight(System.currentTimeMillis());
+        PreLaunchResult[] holder = new PreLaunchResult[1];
+
+        IStatus status = RunYaxunitTestsTool.runPrepJobBody(entry, req, holder);
+
+        // The body always ran to completion: it OKs (the real outcome rides on the entry),
+        // completes the entry and counts its latch down for the awaiting caller.
+        assertNotNull(status);
+        assertTrue("prep body always returns OK (the outcome is carried on the entry)", status.isOK());
+        assertTrue("prep body must mark the entry done", entry.done);
+        assertEquals("prep body must count the entry latch down", 0L, entry.latch.getCount());
+        assertNotNull("a null launch manager must surface a prep error on the entry", entry.error);
+
+        // Bracketed, not leaked: the counter is back to EXACTLY the pre-armed level
+        // (markActivityStart +1 then markActivityEnd -1 inside the body), proving it was held
+        // above the idle baseline for the whole prep. A missing start would read armed-1 here;
+        // a missing end would read armed+1.
+        assertEquals("runPrepJobBody must leave the in-flight counter at the pre-armed level",
+            armed, inFlight.get());
+
+        // markActivityEnd stamped the trailing-grace timestamp during the body.
+        assertTrue("runPrepJobBody must stamp lastActivityEndMillis via markActivityEnd",
+            lastActivityEndMillis() >= beforeBody);
+
+        // Undo the pre-arm so the shared static baseline is restored for the other tests.
+        InfobaseAuthDialogSuppressor.markActivityEnd();
+        assertEquals("cleanup must restore the original in-flight baseline",
+            original, inFlight.get());
+    }
+
+    /**
+     * Reads the package-private {@code InfobaseAuthDialogSuppressor.IN_FLIGHT} counter via
+     * reflection — the field lives in the {@code utils} package, out of this test's package,
+     * and the suppressor exposes no public getter (only the {@code markActivity*} mutators).
+     */
+    private static AtomicInteger inFlightCounter() throws Exception
+    {
+        Field f = InfobaseAuthDialogSuppressor.class.getDeclaredField("IN_FLIGHT"); //$NON-NLS-1$
+        f.setAccessible(true);
+        return (AtomicInteger)f.get(null);
+    }
+
+    /** Reads the package-private {@code InfobaseAuthDialogSuppressor.lastActivityEndMillis} via reflection. */
+    private static long lastActivityEndMillis() throws Exception
+    {
+        Field f = InfobaseAuthDialogSuppressor.class.getDeclaredField("lastActivityEndMillis"); //$NON-NLS-1$
+        f.setAccessible(true);
+        return f.getLong(null);
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/InfobaseAuthDialogSuppressorTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/InfobaseAuthDialogSuppressorTest.java
@@ -6,19 +6,45 @@
 
 package com.ditrix.edt.mcp.server.utils;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
 /**
- * Tests for the pure title-prefix matchers of {@link InfobaseAuthDialogSuppressor} — EDT's
- * "Configure Infobase access Settings" dialog and Eclipse Secure Storage's "Password Hint Needed"
- * follow-up dialog (#194). The SWT install/dismiss path needs a live workbench display and is verified
- * on the e2e stand.
+ * Headless ratchet for {@link InfobaseAuthDialogSuppressor}. Covers the pure, SWT-free seams:
+ * <ul>
+ *   <li>the two title-prefix matchers — EDT's "Configure Infobase access Settings" dialog and Eclipse
+ *       Secure Storage's "Password Hint Needed" follow-up (#194);</li>
+ *   <li>the env kill-switch classifier {@link InfobaseAuthDialogSuppressor#envAllowsSuppression} —
+ *       <b>default ON</b> polarity (#230), the inverse of {@code DestructiveConsentGate.envForcesAllow};</li>
+ *   <li>the activity-scoping decision {@link InfobaseAuthDialogSuppressor#shouldSuppressAuthDialog} —
+ *       the full env × in-flight × grace-window truth table incl. the grace boundary (#230);</li>
+ *   <li>the {@link InfobaseAuthDialogSuppressor#markActivityStart()} /
+ *       {@link InfobaseAuthDialogSuppressor#markActivityEnd()} effect on the {@code IN_FLIGHT} counter and
+ *       {@code lastActivityEndMillis} timestamp;</li>
+ *   <li>the <b>scope split</b>: the auth dialog is gated by the activity/env decision while the Secure
+ *       Storage hint dialog is dismissed unconditionally — asserted through a mirror of the filter's own
+ *       dismiss predicate.</li>
+ * </ul>
+ * The SWT install/dismiss path itself needs a live workbench display and is verified on the e2e stand.
  */
 public class InfobaseAuthDialogSuppressorTest
 {
+    /** A fixed "now" far from zero so a {@code now - grace} never underflows negative. */
+    private static final long NOW_MS = 1_000_000_000L;
+
+    /** The trailing grace window used by the truth-table cases (matches the production default). */
+    private static final long GRACE_MS = InfobaseAuthDialogSuppressor.DEFAULT_ACTIVITY_GRACE_MILLIS;
+
+    private static final String AUTH_TITLE = "Configure Infobase \"ERP\" access Settings"; //$NON-NLS-1$
+    private static final String HINT_TITLE = "Secure Storage - Password Hint Needed"; //$NON-NLS-1$
+
+    // =====================================================================
+    // Title-prefix matchers (auth dialog)
+    // =====================================================================
+
     @Test
     public void testEnglishTitleWithInfobaseNameMatches()
     {
@@ -64,6 +90,10 @@ public class InfobaseAuthDialogSuppressorTest
         assertFalse(InfobaseAuthDialogSuppressor.isAuthDialogTitle("")); //$NON-NLS-1$
     }
 
+    // =====================================================================
+    // Title-prefix matchers (secure-storage hint dialog)
+    // =====================================================================
+
     @Test
     public void testSecureStorageHintTitleMatches()
     {
@@ -89,5 +119,242 @@ public class InfobaseAuthDialogSuppressorTest
     {
         assertFalse(InfobaseAuthDialogSuppressor.isSecureStorageHintDialogTitle(null));
         assertFalse(InfobaseAuthDialogSuppressor.isSecureStorageHintDialogTitle("")); //$NON-NLS-1$
+    }
+
+    // =====================================================================
+    // #230 A — env kill-switch EDT_MCP_SUPPRESS_AUTH_DIALOG (pure classifier, DEFAULT ON)
+    // =====================================================================
+
+    @Test
+    public void envDefaultsOnWhenUnsetOrBlank()
+    {
+        // Default ON: unset / blank keep suppression enabled (preserves the #194 unattended-safety
+        // behaviour for anyone who does not set the flag). This is the INVERSE polarity of
+        // DestructiveConsentGate.envForcesAllow (which defaults to the non-bypass path).
+        assertTrue("null (unset) must keep suppression ON", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.envAllowsSuppression(null));
+        assertTrue("empty string must keep suppression ON", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.envAllowsSuppression("")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void envKeepsSuppressionOnForNonNegativeValues()
+    {
+        // Anything that is not an explicit off value leaves suppression enabled — including garbage,
+        // so a typo can never silently disable the #194 safety net.
+        assertTrue("'true' must keep suppression ON", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.envAllowsSuppression("true")); //$NON-NLS-1$
+        assertTrue("'1' must keep suppression ON", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.envAllowsSuppression("1")); //$NON-NLS-1$
+        assertTrue("'yes' must keep suppression ON", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.envAllowsSuppression("yes")); //$NON-NLS-1$
+        assertTrue("garbage must keep suppression ON (fail-safe default)", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.envAllowsSuppression("garbage")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void envDisablesSuppressionOnlyForExplicitOffValues()
+    {
+        // The ONLY values that turn suppression off: a trimmed, case-insensitive false / 0 / no.
+        assertFalse("'false' must disable suppression", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.envAllowsSuppression("false")); //$NON-NLS-1$
+        assertFalse("env value is case-insensitive ('FALSE')", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.envAllowsSuppression("FALSE")); //$NON-NLS-1$
+        assertFalse("'0' must disable suppression", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.envAllowsSuppression("0")); //$NON-NLS-1$
+        assertFalse("env value is trimmed (' 0 ')", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.envAllowsSuppression(" 0 ")); //$NON-NLS-1$
+        assertFalse("'no' must disable suppression", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.envAllowsSuppression("no")); //$NON-NLS-1$
+        assertFalse("env value is case-insensitive ('No')", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.envAllowsSuppression("No")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void isEnvSuppressEnabledDelegatesToClassifier()
+    {
+        // The thin env reader must agree with the pure classifier over the ambient process value —
+        // proving delegation without depending on whether the flag is actually set in this JVM.
+        assertEquals(
+            InfobaseAuthDialogSuppressor.envAllowsSuppression(
+                System.getenv(InfobaseAuthDialogSuppressor.ENV_SUPPRESS_AUTH_DIALOG)),
+            InfobaseAuthDialogSuppressor.isEnvSuppressEnabled());
+    }
+
+    // =====================================================================
+    // #230 B — activity scoping shouldSuppressAuthDialog (env × in-flight × grace)
+    // =====================================================================
+
+    @Test
+    public void graceWindowIsThirtySeconds()
+    {
+        assertEquals("the activity grace window is 30s (documented in the #230 architecture)", //$NON-NLS-1$
+            30_000L, InfobaseAuthDialogSuppressor.DEFAULT_ACTIVITY_GRACE_MILLIS);
+    }
+
+    @Test
+    public void envOffNeverSuppresses()
+    {
+        // The env kill-switch is a HARD override: with it off, the auth dialog is left for the human
+        // regardless of any in-flight call or how recently one ended.
+        assertFalse("env off + call in flight must NOT suppress", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.shouldSuppressAuthDialog(false, 2, NOW_MS, NOW_MS, GRACE_MS));
+        assertFalse("env off + idle within grace must NOT suppress", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.shouldSuppressAuthDialog(
+                false, 0, NOW_MS, NOW_MS - 5_000L, GRACE_MS));
+        assertFalse("env off + idle beyond grace must NOT suppress", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.shouldSuppressAuthDialog(
+                false, 0, NOW_MS, NOW_MS - 60_000L, GRACE_MS));
+    }
+
+    @Test
+    public void envOnSuppressesWhileCallInFlight()
+    {
+        // A call in flight suppresses for its WHOLE duration — even if the last recorded end is already
+        // far outside the grace window (update_database's minutes are covered by the counter, not the
+        // window).
+        assertTrue("env on + call in flight must suppress (even past the grace window)", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.shouldSuppressAuthDialog(
+                true, 1, NOW_MS, NOW_MS - 60_000L, GRACE_MS));
+    }
+
+    @Test
+    public void envOnSuppressesWithinGraceAfterLastCall()
+    {
+        // No call in flight, but the last one ended within the grace window: the async read-back dialog
+        // is still covered.
+        assertTrue("env on + idle within grace must suppress", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.shouldSuppressAuthDialog(
+                true, 0, NOW_MS, NOW_MS - 5_000L, GRACE_MS));
+    }
+
+    @Test
+    public void envOnDoesNotSuppressWhenIdleBeyondGrace()
+    {
+        // Idle past the window: leave the dialog alone so a human can configure credentials in the GUI.
+        assertFalse("env on + idle beyond grace must NOT suppress", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.shouldSuppressAuthDialog(
+                true, 0, NOW_MS, NOW_MS - 60_000L, GRACE_MS));
+    }
+
+    @Test
+    public void graceBoundaryIsExclusive()
+    {
+        // The window is half-open [.., grace): now - lastActivityEnd == grace is already OUTSIDE it.
+        assertFalse("now - lastActivityEnd == grace must NOT suppress (boundary is exclusive)", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.shouldSuppressAuthDialog(
+                true, 0, NOW_MS, NOW_MS - GRACE_MS, GRACE_MS));
+        assertTrue("one ms inside the window still suppresses", //$NON-NLS-1$
+            InfobaseAuthDialogSuppressor.shouldSuppressAuthDialog(
+                true, 0, NOW_MS, NOW_MS - (GRACE_MS - 1L), GRACE_MS));
+    }
+
+    // =====================================================================
+    // #230 B — markActivityStart / markActivityEnd effect on the shared state
+    // =====================================================================
+
+    @Test
+    public void markActivityStartEndAdjustCounterAndTimestamp()
+    {
+        // Balanced start/end pair restores IN_FLIGHT, so the shared static state stays clean for the
+        // other (param-driven) truth-table tests.
+        int baseline = InfobaseAuthDialogSuppressor.IN_FLIGHT.get();
+        long before = System.currentTimeMillis();
+
+        InfobaseAuthDialogSuppressor.markActivityStart();
+        assertEquals("markActivityStart must increment IN_FLIGHT", //$NON-NLS-1$
+            baseline + 1, InfobaseAuthDialogSuppressor.IN_FLIGHT.get());
+
+        InfobaseAuthDialogSuppressor.markActivityEnd();
+        assertEquals("markActivityEnd must decrement IN_FLIGHT back to the baseline", //$NON-NLS-1$
+            baseline, InfobaseAuthDialogSuppressor.IN_FLIGHT.get());
+
+        long stamped = InfobaseAuthDialogSuppressor.lastActivityEndMillis;
+        assertTrue("markActivityEnd must stamp lastActivityEndMillis to ~now", //$NON-NLS-1$
+            stamped >= before && stamped <= System.currentTimeMillis());
+    }
+
+    @Test
+    public void markActivityEndClampsCounterAtZero()
+    {
+        // Requirement 3 ("the counter never goes negative"): an UNBALANCED markActivityEnd() — a decrement
+        // with no matching markActivityStart() — must land at max(0, baseline - 1), never below zero, so a
+        // stray end can never starve shouldSuppressAuthDialog's `inFlight > 0` guard. This drives the clamp
+        // (decrementAndGet() < 0 -> set(0)) that the balanced start/end pair above never reaches: at the
+        // usual idle baseline of 0 the decrement goes to -1 and is clamped back to 0.
+        int baseline = InfobaseAuthDialogSuppressor.IN_FLIGHT.get();
+        try
+        {
+            InfobaseAuthDialogSuppressor.markActivityEnd();
+            assertEquals("unbalanced markActivityEnd must clamp IN_FLIGHT at zero (never negative)", //$NON-NLS-1$
+                Math.max(0, baseline - 1), InfobaseAuthDialogSuppressor.IN_FLIGHT.get());
+        }
+        finally
+        {
+            // Restore the shared static so the other (order-independent) tests keep their baseline.
+            InfobaseAuthDialogSuppressor.IN_FLIGHT.set(baseline);
+        }
+    }
+
+    // =====================================================================
+    // #230 — scope split: the auth branch is gated, the hint branch is NOT
+    // =====================================================================
+
+    @Test
+    public void hintDialogIsDismissedRegardlessOfTheGate()
+    {
+        // The Secure Storage password-hint dialog is an internal follow-up (never human-configured), so
+        // it is dismissed UNCONDITIONALLY — even with the env kill-switch off and the server fully idle
+        // beyond the grace window, i.e. exactly the state in which the auth dialog would be left alone.
+        assertTrue("hint dialog must be dismissed even with the auth gate fully closed", //$NON-NLS-1$
+            filterDismisses(HINT_TITLE, false, 0, NOW_MS, NOW_MS - 60_000L, GRACE_MS));
+    }
+
+    @Test
+    public void authDialogIsLeftWhenTheGateIsClosed()
+    {
+        // Same fully-closed-gate state, but for the AUTH dialog: it is left for the human. This is the
+        // #230 fix — the difference between this and the hint case above IS the scope split.
+        assertFalse("auth dialog must be left for the human when the gate is closed", //$NON-NLS-1$
+            filterDismisses(AUTH_TITLE, false, 0, NOW_MS, NOW_MS - 60_000L, GRACE_MS));
+    }
+
+    @Test
+    public void authDialogIsDismissedWhileTheGateIsOpen()
+    {
+        // With the env kill-switch on and a call in flight (an MCP-triggered dialog), the auth dialog is
+        // auto-cancelled — the #194 unattended-safety behaviour, preserved.
+        assertTrue("auth dialog must be dismissed while an MCP call is in flight", //$NON-NLS-1$
+            filterDismisses(AUTH_TITLE, true, 1, NOW_MS, NOW_MS, GRACE_MS));
+    }
+
+    @Test
+    public void unrelatedDialogIsNeverTouched()
+    {
+        // Neither branch claims an unrelated shell, whatever the gate state.
+        assertFalse("unrelated dialog must never be dismissed (gate open)", //$NON-NLS-1$
+            filterDismisses("Some other dialog", true, 1, NOW_MS, NOW_MS, GRACE_MS)); //$NON-NLS-1$
+        assertFalse("unrelated dialog must never be dismissed (gate closed)", //$NON-NLS-1$
+            filterDismisses("Some other dialog", false, 0, NOW_MS, NOW_MS - 60_000L, GRACE_MS)); //$NON-NLS-1$
+    }
+
+    /**
+     * Mirrors {@code InfobaseAuthDialogSuppressor.createFilterListener}'s dismiss predicate over the pure
+     * seams, so the scope split is asserted headlessly (the real predicate lives in SWT code verified on
+     * the stand). Dismiss when the shell is the hint dialog (UNCONDITIONAL) OR it is the auth dialog and
+     * {@link InfobaseAuthDialogSuppressor#shouldSuppressAuthDialog} allows it. If the auth gate ever
+     * leaked into the hint branch (e.g. {@code hint && shouldSuppress}), the hint-with-closed-gate case
+     * would flip to {@code false} and fail; if the env polarity were inverted, the env-off cases would
+     * flip and fail.
+     *
+     * @return {@code true} when the filter would dismiss the shell with the given title and gate state
+     */
+    private static boolean filterDismisses(String title, boolean envEnabled, int inFlight, long now,
+        long lastActivityEnd, long grace)
+    {
+        boolean auth = InfobaseAuthDialogSuppressor.isAuthDialogTitle(title);
+        boolean hint = !auth && InfobaseAuthDialogSuppressor.isSecureStorageHintDialogTitle(title);
+        return hint || (auth && InfobaseAuthDialogSuppressor.shouldSuppressAuthDialog(
+            envEnabled, inFlight, now, lastActivityEnd, grace));
     }
 }


### PR DESCRIPTION
Closes #230.

## Проблема
`InfobaseAuthDialogSuppressor` (из #194) — глобальный **always-on** SWT-фильтр, гасит диалог «Сконфигурируйте доступ к информационной базе» по заголовку, **не различая инициатора**. Когда человек руками открывает настройки доступа к ИБ в GUI EDT, диалог мгновенно закрывается → **единственный безопасный путь ввода кредов** (штатный диалог → зашифрованный Eclipse Secure Storage) ломается, а `set_infobase_credentials`/env сливают пароль в контекст LLM / открытый текст.

## Решение — гейтим ТОЛЬКО ветку auth-диалога
**A — env kill-switch `EDT_MCP_SUPPRESS_AUTH_DIALOG`** (default ON; `false`/`0`/`no` полностью отключает авто-гашение auth-диалога). Чистый `envAllowsSuppression()` зеркалит `DestructiveConsentGate`, но **инвертирует полярность в default-on** — не заданный env сохраняет поведение #194.

**B — activity-scoping.** Статический счётчик `IN_FLIGHT` + 30с trailing grace-окно; auth-диалог гасится только когда `envEnabled && (inFlight>0 || now-lastActivityEnd<grace)`. `markActivityStart/End` оборачивают `tool.execute` в `McpProtocolHandler.executeToolTimed` → счётчик покрывает **весь синхронный execute()** (минутный `appManager.update` в update_database; joined-Job в build_external_objects). Grace-окно мостит короткий разрыв до async read-back джобов (get_applications/create_infobase). **Два длинных fire-and-forget async-пути**, чей диалог поднимается далеко за execute()+grace, забракечены явно: `DebugLaunchTool.runLaunchJobBody` + headless-fallback, и prep-Job в `RunYaxunitTestsTool`.

Secure Storage **password-HINT диалог (#205) остаётся always-suppressed** (безусловное гашение) — он внутренний (мастер-пароль подаётся программно), человек его не настраивает.

## Что человек получает
Пока MCP-сервер простаивает (нет вызовов, `inFlight==0`, окно истекло), открытый руками диалог «Configure Infobase access» **больше не отменяется** — креды пишутся в Secure Storage. При активной MCP-операции (sync + async) диалог по-прежнему авто-гасится — **регресса #194 нет**.

## ⚠️ Два дизайн-решения приняты мной (вынес на твоё ревью)
1. **grace = 30000ms.** Счётчик держит весь sync-период любой длины, поэтому окну нужно мостить лишь короткий хвост до async read-back джоба (реально < 5с) — 30с даёт ~6× запас против регресса #194 (пропущенный async-диалог = зависание, худший исход), а человек настраивает креды в простое, далеко за окном. Легко подкрутить константой `DEFAULT_ACTIVITY_GRACE_MILLIS`.
2. **A+B без отдельного Preference** (env-флаг = escape hatch, проще). Если предпочитаешь только A (env), или ещё Preference в UI — скажи, поправлю.

## Проверка
- `compile.sh` + юнит-тесты зелёные (чистые статические сими `envAllowsSuppression` / `shouldSuppressAuthDialog` — headless truth-table, полярность default-on, границы окна).
- Internal-only: схемы тулов не менялись, `tools_list.golden` без изменений.
- Живой стенд 2025.2.6: горячий dispatch-путь цел (тулы отвечают sub-second, без утечки счётчика при повторах), golden байт-в-байт.
- **Ручной тест** (диалог выживает в простое / гасится при async-активности) требует ИБ с авторизацией — не автоматизирован здесь.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
