### PR TITLE
modify_metadata: layout-свойства формы-группы из UsualGroupExtInfo (group/united/…) + фикс get_metadata_details (#235)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataDetailsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataDetailsTool.java
@@ -397,17 +397,25 @@ public class GetMetadataDetailsTool implements IMcpTool
         // allowed values, no Current) when the <extInfo> slot is empty, and to the single-arg
         // introspection for a plain mdclass object (no extInfo - byte-identical, mdclass view unchanged).
         EObject liveExtInfo = FormElementWriter.extInfoInstance(obj);
+        EClass extInfoEClass = FormElementWriter.resolveExtInfoEClass(obj); // type-authoritative
+        // Read Current values off the live instance ONLY when it MATCHES the type-derived class. A form
+        // group whose `type` was changed carries a STALE extInfo (class != the type-derived one); list the
+        // NEW type's props (kind + allowed, no Current) rather than the stale instance's, so the assignable
+        // view stays consistent with the group's current type (#235 review).
+        boolean liveMatches = liveExtInfo != null && extInfoEClass != null
+            && liveExtInfo.eClass().getName().equals(extInfoEClass.getName());
         Iterable<MetadataPropertyIntrospector.PropertyInfo> props;
-        if (liveExtInfo != null)
+        if (liveMatches)
         {
             props = MetadataPropertyIntrospector.introspect(obj, liveExtInfo);
         }
+        else if (extInfoEClass != null)
+        {
+            props = MetadataPropertyIntrospector.introspect(obj, extInfoEClass);
+        }
         else
         {
-            EClass extInfoEClass = FormElementWriter.resolveExtInfoEClass(obj);
-            props = extInfoEClass == null
-                ? MetadataPropertyIntrospector.introspect(obj)
-                : MetadataPropertyIntrospector.introspect(obj, extInfoEClass);
+            props = MetadataPropertyIntrospector.introspect(obj);
         }
         for (MetadataPropertyIntrospector.PropertyInfo p : props)
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataDetailsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataDetailsTool.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PlatformUI;
@@ -243,13 +244,35 @@ public class GetMetadataDetailsTool implements IMcpTool
         // resolver and render its assignable-property table - what modify_metadata can set.
         if (ctx.assignable)
         {
+            String normFqn = MetadataTypeUtils.normalizeFqn(fqn);
+            // A form-member FQN (a group / field / table / decoration inside a form's editable content
+            // model) is NOT part of the mdclass tree, so MetadataNodeResolver cannot see it and the
+            // assignable view used to fail with "Object not found". Route it - BEFORE the mdclass
+            // resolver - through the SAME form resolver modify_metadata uses, and render the element's
+            // own features UNION its extInfo's layout props (the general reflective extInfo path,
+            // issue #235). A plain mdclass FQN yields no FormMemberRef, so its path is unchanged.
+            FormElementWriter.FormMemberRef memberRef = FormElementWriter.parse(normFqn);
+            if (memberRef != null)
+            {
+                String memberAssignable =
+                    renderFormMemberAssignable(ctx.config, ctx.bmModel, normFqn, memberRef);
+                if (memberAssignable == null)
+                {
+                    failures.add(new String[] { fqn, "the form member could not be resolved (the form " //$NON-NLS-1$
+                        + "may have no editable content model, or the element does not exist)" }); //$NON-NLS-1$
+                    return;
+                }
+                sb.append(memberAssignable);
+                sb.append(SECTION_SEPARATOR);
+                return;
+            }
             MetadataNodeResolver.MetadataNode node = MetadataNodeResolver.resolveExisting(ctx.config, fqn);
             if (node == null || node.object == null)
             {
                 failures.add(new String[] { fqn, describeResolutionFailure(fqn) });
                 return;
             }
-            sb.append(formatAssignable(MetadataTypeUtils.normalizeFqn(fqn), node.object));
+            sb.append(formatAssignable(normFqn, node.object));
             sb.append(SECTION_SEPARATOR);
             return;
         }
@@ -348,19 +371,45 @@ public class GetMetadataDetailsTool implements IMcpTool
      * current value, and (for an enum) the allowed values. This is the discovery view for
      * modify_metadata - it lists exactly what can be set and the valid enum literals. The shared
      * {@link MarkdownUtils} builder escapes every cell.
+     * <p>
+     * Widened to any {@link EObject} so it also serves a FORM MEMBER: for a form element the table is
+     * the element's own assignable features UNION its {@code extInfo}'s layout properties (the general
+     * reflective extInfo path, issue #235). A plain mdclass object has no {@code extInfo}
+     * ({@link FormElementWriter#resolveExtInfoEClass} returns {@code null}), so it takes the
+     * single-argument introspection and its output is byte-identical - the mdclass assignable view is
+     * unchanged.
      *
      * @param fqn the (normalized) FQN, for the section heading
-     * @param obj the resolved node (top object or member)
+     * @param obj the resolved node (a top object, an mdclass member, or a form member)
      * @return the Markdown section
      */
-    private static String formatAssignable(String fqn, MdObject obj)
+    static String formatAssignable(String fqn, EObject obj)
     {
         StringBuilder sb = new StringBuilder();
         sb.append("## Assignable properties: ").append(fqn).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
         sb.append("Set these with `modify_metadata`. For an ENUM property the value must be one of " //$NON-NLS-1$
             + "the listed Allowed values.\n\n"); //$NON-NLS-1$
         sb.append(MarkdownUtils.tableHeader("Property", "Kind", "Current", "Allowed values")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-        for (MetadataPropertyIntrospector.PropertyInfo p : MetadataPropertyIntrospector.introspect(obj))
+        // A form element additionally exposes the assignable properties nested in its <extInfo> (e.g. a
+        // UsualGroup's group / united layout props). When it carries a LIVE extInfo instance (the common
+        // designer-authored case) render those props off that instance, so their Current column shows the
+        // SET values just like the direct features do; fall back to the EClass-only listing (kind +
+        // allowed values, no Current) when the <extInfo> slot is empty, and to the single-arg
+        // introspection for a plain mdclass object (no extInfo - byte-identical, mdclass view unchanged).
+        EObject liveExtInfo = FormElementWriter.extInfoInstance(obj);
+        Iterable<MetadataPropertyIntrospector.PropertyInfo> props;
+        if (liveExtInfo != null)
+        {
+            props = MetadataPropertyIntrospector.introspect(obj, liveExtInfo);
+        }
+        else
+        {
+            EClass extInfoEClass = FormElementWriter.resolveExtInfoEClass(obj);
+            props = extInfoEClass == null
+                ? MetadataPropertyIntrospector.introspect(obj)
+                : MetadataPropertyIntrospector.introspect(obj, extInfoEClass);
+        }
+        for (MetadataPropertyIntrospector.PropertyInfo p : props)
         {
             String allowed = p.allowedValues.isEmpty() ? null : String.join(", ", p.allowedValues); //$NON-NLS-1$
             sb.append(MarkdownUtils.tableRow(p.name, p.valueKind.toString(), p.currentValue, allowed));
@@ -408,6 +457,57 @@ public class GetMetadataDetailsTool implements IMcpTool
                 return null;
             }
             return FormStructureReader.render(normalized, formModel, language);
+        });
+    }
+
+    /**
+     * Renders the ASSIGNABLE-property table for a FORM MEMBER (a group / field / table / decoration /
+     * attribute / command inside a form's editable content model). A form member is NOT in the mdclass
+     * tree, so {@link MetadataNodeResolver} cannot see it; this reuses modify_metadata's proven form
+     * resolver instead - the SAME BM-read hop {@link #renderFormStructure} uses. It resolves the
+     * {@code BasicForm} from {@code ref.formPath}, then INSIDE a BM READ transaction hops to the
+     * editable content form, resolves the member and renders its assignable table (the element's own
+     * features UNION its {@code extInfo}'s layout properties, issue #235). The member EObject must not
+     * escape the read task, so the whole render runs inside it.
+     *
+     * @param config the resolved configuration
+     * @param bmModel the (best-effort) BM model; {@code null} yields {@code null}
+     * @param normFqn the normalized member FQN, for the section heading
+     * @param ref the parsed form-member reference (see {@link FormElementWriter#parse})
+     * @return the Markdown assignable table, or {@code null} when the BM model is unavailable, the form
+     *     has no editable content model, or the member does not exist
+     */
+    private static String renderFormMemberAssignable(Configuration config, IBmModel bmModel,
+        String normFqn, FormElementWriter.FormMemberRef ref)
+    {
+        if (bmModel == null)
+        {
+            return null;
+        }
+        MdObject mdForm = FormStructureReader.resolveMdForm(config, ref.formPath);
+        if (!(mdForm instanceof IBmObject))
+        {
+            return null;
+        }
+        final long mdFormBmId = ((IBmObject)mdForm).bmGetId();
+        return BmTransactions.read(bmModel, "GetMetadataDetailsFormMember", (tx, monitor) -> //$NON-NLS-1$
+        {
+            EObject txMdForm = tx.getObjectById(mdFormBmId);
+            if (txMdForm == null)
+            {
+                return null;
+            }
+            EObject formModel = FormElementWriter.getEditableForm(txMdForm);
+            if (formModel == null)
+            {
+                return null;
+            }
+            EObject member = FormElementWriter.resolveFormMember(formModel, ref);
+            if (member == null)
+            {
+                return null;
+            }
+            return formatAssignable(normFqn, member);
         });
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -1608,21 +1608,25 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
     static FormHolder resolveFormHolder(EObject member, String propName)
     {
         EObject extInfo = extInfoOf(member);
-        PropertyInfo info = MetadataPropertyIntrospector.findFeature(member, extInfo, propName);
-        if (info == null && extInfo == null && propName != null && !propName.isEmpty())
+        // A form group whose live extInfo no longer matches its `type` is STALE (the type was changed):
+        // classify against the type-AUTHORITATIVE extInfo, not the stale holder, so a property is
+        // validated against the class ensureExtInfo will actually (re)create at apply time (#235 review).
+        EClass authoritative = FormElementWriter.resolveExtInfoEClass(member);
+        boolean stale = extInfo != null && authoritative != null
+            && !extInfo.eClass().getName().equals(authoritative.getName());
+        EObject classifyAgainst = stale ? null : extInfo;
+        PropertyInfo info = MetadataPropertyIntrospector.findFeature(member, classifyAgainst, propName);
+        if (info == null && classifyAgainst == null && propName != null && !propName.isEmpty()
+            && authoritative != null && !authoritative.isAbstract() && authoritative.getEPackage() != null)
         {
-            EClass extInfoEClass = FormElementWriter.resolveExtInfoEClass(member);
-            if (extInfoEClass != null && !extInfoEClass.isAbstract() && extInfoEClass.getEPackage() != null)
+            EObject probe = authoritative.getEPackage().getEFactoryInstance().create(authoritative);
+            PropertyInfo onProbe = MetadataPropertyIntrospector.findFeature(member, probe, propName);
+            if (onProbe != null && onProbe.onExtInfo)
             {
-                EObject probe = extInfoEClass.getEPackage().getEFactoryInstance().create(extInfoEClass);
-                PropertyInfo onProbe = MetadataPropertyIntrospector.findFeature(member, probe, propName);
-                if (onProbe != null && onProbe.onExtInfo)
-                {
-                    return new FormHolder(true, probe);
-                }
+                return new FormHolder(true, probe);
             }
         }
-        return new FormHolder(info != null && info.onExtInfo, extInfo);
+        return new FormHolder(info != null && info.onExtInfo, classifyAgainst);
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -1016,7 +1016,9 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
     {
         for (JsonObject prop : properties)
         {
-            String pErr = prepare(config, version, target, prop, changes, normReport);
+            // The mdclass path has no <extInfo> (extInfo == null): findFeature then classifies only the
+            // object's own features, so this stays byte-identical to the pre-extInfo behaviour.
+            String pErr = prepare(config, version, target, null, prop, changes, normReport);
             if (pErr != null)
             {
                 return pErr;
@@ -1145,12 +1147,17 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                             + ref.name + " (kind '" + ref.kindToken + "') on " + ref.formPath //$NON-NLS-1$ //$NON-NLS-2$
                             + ". Use get_metadata_details to list the members.").toJson()); //$NON-NLS-1$
                     }
-                    List<PreparedChange> changes =
+                    List<HolderChange> changes =
                         prepareFormMemberChanges(config, version, member, properties, normReport);
-                    for (PreparedChange change : changes)
+                    for (HolderChange hc : changes)
                     {
-                        change.applyTo(member, tx);
-                        applied.add(change.featureName());
+                        // A direct feature lands on the member; a property on the nested <extInfo> lands
+                        // on the extInfo holder, created (or reused) here now that every property has
+                        // validated. Mixing both in one call routes each change to its correct receiver.
+                        EObject holder = hc.onExtInfo
+                            ? FormElementWriter.ensureExtInfo(formModel, member) : member;
+                        hc.change.applyTo(holder, tx);
+                        applied.add(hc.change.featureName());
                     }
                 });
         }
@@ -1479,17 +1486,28 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
 
     /**
      * Validates every property of a form-member modify against the introspected schema and builds the
-     * ordered list of {@link PreparedChange}s to apply. Runs inside the BM write transaction (called
-     * from the {@code writeEditableForm} callback) but performs NO model mutation itself - it only
-     * reads {@code member}'s schema and constructs the changes; a structural-property guard or an
-     * invalid value throws {@link FormValidationException} BEFORE any {@code eSet}, exactly as the
-     * inline loop did, so the transaction rolls back with no partial mutation. The returned changes are
-     * applied by the caller.
+     * ordered list of {@link HolderChange}s to apply - each pairing a {@link PreparedChange} with the
+     * receiver it targets: the member itself for a direct feature, or the member's nested
+     * {@code <extInfo>} holder for a layout / kind-specific property (a UsualGroup's grouping / united /
+     * ... live under {@code <extInfo>}, not on the group element). Runs inside the BM write transaction
+     * (called from the {@code writeEditableForm} callback) but performs NO model mutation itself - it
+     * only reads {@code member}'s (and its extInfo's) schema and constructs the changes; a
+     * structural-property guard or an invalid value throws {@link FormValidationException} BEFORE any
+     * {@code eSet}, so the transaction rolls back with no partial mutation. The extInfo holder is
+     * created (when absent) only at APPLY time by the caller, once every property has validated.
      */
-    private List<PreparedChange> prepareFormMemberChanges(Configuration config, Version version,
+    private List<HolderChange> prepareFormMemberChanges(Configuration config, Version version,
         EObject member, List<JsonObject> properties, MdNameNormalizer.Report normReport)
     {
-        List<PreparedChange> changes = new ArrayList<>();
+        // Reject a classifier `type` change batched with a nested-extInfo layout prop BEFORE building any
+        // change: the extInfo props are validated against the pre-change type's extInfo EClass, so
+        // applying both in one tx is order-dependent and unsafe (see formTypeExtInfoComboError).
+        String comboErr = formTypeExtInfoComboError(member, properties);
+        if (comboErr != null)
+        {
+            throw new FormValidationException(comboErr);
+        }
+        List<HolderChange> changes = new ArrayList<>();
         for (JsonObject prop : properties)
         {
             String guard = guardFormProperty(prop);
@@ -1497,14 +1515,133 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             {
                 throw new FormValidationException(guard);
             }
-            String pErr = prepare(config, version, member,
-                normalizeFormProperty(member, prop), changes, normReport);
-            if (pErr != null)
-            {
-                throw new FormValidationException(pErr);
-            }
+            changes.add(prepareFormMemberChange(config, version, member, prop, normReport));
         }
         return changes;
+    }
+
+    /**
+     * Rejects a form-member modify that UNSAFELY combines a classifier {@code type} change (a group's /
+     * field's / decoration's {@code type} decides which concrete {@code <extInfo>} EClass applies) with a
+     * property that lives on that nested {@code <extInfo>}, in the SAME call. The extInfo props are
+     * classified / validated against the PRE-change type's extInfo EClass (in {@link #resolveFormHolder}),
+     * so applying both in one transaction is order-dependent and unsafe:
+     * <ul>
+     * <li>{@code type} first &rarr; {@link FormElementWriter#ensureExtInfo} creates the NEW type's extInfo
+     * EClass and the extInfo {@code eSet} throws {@link IllegalArgumentException} on a feature the new
+     * EClass lacks (surfaced as an opaque "Failed to modify form member");</li>
+     * <li>the extInfo prop first &rarr; a stale-typed extInfo is force-exported onto a now-differently
+     * typed element (a silent inconsistency EDT serialization rejects).</li>
+     * </ul>
+     * The {@code type} change must be a SEPARATE call so the extInfo is re-resolved against the new type.
+     * Detection is fully reflective (the direct-vs-extInfo routing from {@link #resolveFormHolder} plus the
+     * normalized property name) - a form attribute's {@code type} is normalized to {@code valueType} and so
+     * never counts here, and an mdclass object has no extInfo so this is a no-op. Package-visible so it is
+     * unit-testable headlessly. Returns a ready JSON error to reject, or {@code null} when the batch is safe.
+     */
+    static String formTypeExtInfoComboError(EObject member, List<JsonObject> properties)
+    {
+        boolean hasDirectTypeChange = false;
+        boolean hasExtInfoChange = false;
+        for (JsonObject prop : properties)
+        {
+            String name = asString(normalizeFormProperty(member, prop).get("name")); //$NON-NLS-1$
+            if (name == null || name.isEmpty())
+            {
+                continue;
+            }
+            if (resolveFormHolder(member, name).onExtInfo)
+            {
+                hasExtInfoChange = true;
+            }
+            else if ("type".equalsIgnoreCase(name)) //$NON-NLS-1$
+            {
+                hasDirectTypeChange = true;
+            }
+        }
+        if (hasDirectTypeChange && hasExtInfoChange)
+        {
+            return ToolResult.error("Changing a form group's 'type' cannot be combined with a layout " //$NON-NLS-1$
+                + "property that lives on its <extInfo> (e.g. 'group' / 'united' / 'showLeftMargin' / " //$NON-NLS-1$
+                + "'throughAlign' / 'currentRowUse' / 'representation') in the same call, because the " //$NON-NLS-1$
+                + "'type' decides which extInfo applies. Change the 'type' first, then set the layout " //$NON-NLS-1$
+                + "properties in a separate call.").toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Validates ONE form-member property and pairs the resulting {@link PreparedChange} with the
+     * receiver it must be applied to. The receiver is decided reflectively: a DIRECT feature of the
+     * member stays on the member; a property that lives on the member's nested {@code <extInfo>} (a
+     * layout / kind-specific sub-object) is flagged {@code onExtInfo} so the caller routes the
+     * {@code eSet} to the extInfo holder. The change is BUILT against the same extInfo the receiver was
+     * chosen from (so the enum / boolean / ... value is coerced to the correct feature); an invalid
+     * value throws {@link FormValidationException} BEFORE any mutation.
+     */
+    private HolderChange prepareFormMemberChange(Configuration config, Version version, EObject member,
+        JsonObject prop, MdNameNormalizer.Report normReport)
+    {
+        JsonObject normProp = normalizeFormProperty(member, prop);
+        FormHolder holder = resolveFormHolder(member, asString(normProp.get("name"))); //$NON-NLS-1$
+        List<PreparedChange> built = new ArrayList<>();
+        String pErr = prepare(config, version, member, holder.classifyExtInfo, normProp, built, normReport);
+        if (pErr != null)
+        {
+            throw new FormValidationException(pErr);
+        }
+        // prepare() appends exactly one change on success.
+        return new HolderChange(holder.onExtInfo, built.get(0));
+    }
+
+    /**
+     * Resolves the write receiver for a form-member property named {@code propName}: whether it lives
+     * on the member directly or on the member's nested {@code <extInfo>}, plus the extInfo instance the
+     * property is classified against. A DIRECT feature wins (mirroring {@link
+     * MetadataPropertyIntrospector#findFeature(EObject, EObject, String)}). When the element carries no
+     * extInfo instance yet but CAN (a form group's layout props live under an as-yet-uncreated
+     * {@code <extInfo>}), the property is classified against a THROWAWAY (unattached) instance of the
+     * element's concrete extInfo EClass, so an extInfo property is visible WITHOUT mutating the model
+     * during validation - the real extInfo holder is created (and reused) at apply time via
+     * {@link FormElementWriter#ensureExtInfo}. Fully reflective; a no-op for an element with no extInfo.
+     */
+    static FormHolder resolveFormHolder(EObject member, String propName)
+    {
+        EObject extInfo = extInfoOf(member);
+        PropertyInfo info = MetadataPropertyIntrospector.findFeature(member, extInfo, propName);
+        if (info == null && extInfo == null && propName != null && !propName.isEmpty())
+        {
+            EClass extInfoEClass = FormElementWriter.resolveExtInfoEClass(member);
+            if (extInfoEClass != null && !extInfoEClass.isAbstract() && extInfoEClass.getEPackage() != null)
+            {
+                EObject probe = extInfoEClass.getEPackage().getEFactoryInstance().create(extInfoEClass);
+                PropertyInfo onProbe = MetadataPropertyIntrospector.findFeature(member, probe, propName);
+                if (onProbe != null && onProbe.onExtInfo)
+                {
+                    return new FormHolder(true, probe);
+                }
+            }
+        }
+        return new FormHolder(info != null && info.onExtInfo, extInfo);
+    }
+
+    /**
+     * The element's nested {@code <extInfo>} EObject, read reflectively from the single-valued
+     * {@code extInfo} containment reference, or {@code null} when the element has no such feature (an
+     * mdclass object) or the slot is empty. Self-contained (no form-model import).
+     */
+    private static EObject extInfoOf(EObject element)
+    {
+        EStructuralFeature feature = element.eClass().getEStructuralFeature("extInfo"); //$NON-NLS-1$
+        if (feature instanceof EReference && !feature.isMany())
+        {
+            Object value = element.eGet(feature);
+            if (value instanceof EObject)
+            {
+                return (EObject)value;
+            }
+        }
+        return null;
     }
 
     /**
@@ -1920,9 +2057,16 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
      * {@link PreparedChange}. Returns a JSON error string on failure, or {@code null} on success.
      * Accepts any {@link EObject} so it serves both mdclass nodes and form members (the introspector
      * and the prepared change are EClass-driven, not mdclass-specific).
+     *
+     * <p>{@code extInfo} is the element's nested {@code <extInfo>} EObject (a form element's layout /
+     * kind-specific sub-object, e.g. a UsualGroup's {@code UsualGroupExtInfo}) when the property may
+     * live there, or {@code null} on the mdclass path (an mdclass object has no extInfo, so the
+     * extInfo traversal is a no-op and this behaves exactly as before). A property found on the
+     * extInfo carries {@code info.onExtInfo == true}; the {@link PreparedChange} is built against the
+     * extInfo's feature, and the caller routes the {@code eSet} to the extInfo holder.</p>
      */
-    private String prepare(Configuration config, Version version, EObject target, JsonObject prop,
-        List<PreparedChange> out, MdNameNormalizer.Report normReport)
+    private String prepare(Configuration config, Version version, EObject target, EObject extInfo,
+        JsonObject prop, List<PreparedChange> out, MdNameNormalizer.Report normReport)
     {
         String name = asString(prop.get("name")); //$NON-NLS-1$
         if (name == null || name.isEmpty())
@@ -1940,12 +2084,19 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         // findFeature classifies ONLY the matched feature and skips the current-value rendering
         // (eGet + proxy + type rendering) that the full introspect() performs for EVERY assignable
         // feature - prepare() never reads currentValue, and this runs on the UI thread per property.
-        PropertyInfo info = MetadataPropertyIntrospector.findFeature(target, name);
+        // A direct feature of `target` wins; only when it has none does a matching feature on the
+        // element's `extInfo` win (info.onExtInfo). On the mdclass path extInfo is null - a no-op.
+        PropertyInfo info = MetadataPropertyIntrospector.findFeature(target, extInfo, name);
         if (info == null)
         {
+            // The "available properties" hint covers the extInfo layout props too (the now-extended
+            // assignable set): its EClass comes from the live extInfo instance, or - when the slot is
+            // empty - is derived reflectively; null on the mdclass path (member-only, unchanged).
+            EClass extInfoEClass = extInfo != null ? extInfo.eClass()
+                : FormElementWriter.resolveExtInfoEClass(target);
             return ToolResult.error("Property '" + name + "' is not assignable on " //$NON-NLS-1$ //$NON-NLS-2$
                 + target.eClass().getName() + ". Assignable properties: " //$NON-NLS-1$
-                + String.join(", ", MetadataPropertyIntrospector.assignableNames(target)) //$NON-NLS-1$
+                + String.join(", ", MetadataPropertyIntrospector.assignableNames(target, extInfoEClass)) //$NON-NLS-1$
                 + ". Use get_metadata_details with assignable:true for kinds + allowed values.").toJson(); //$NON-NLS-1$
         }
 
@@ -2202,6 +2353,45 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
     }
 
     // ---- helpers --------------------------------------------------------------------------------
+
+    /**
+     * A {@link PreparedChange} paired with WHERE it must be applied: {@code onExtInfo == false} targets
+     * the form member itself (a direct feature); {@code onExtInfo == true} targets the member's nested
+     * {@code <extInfo>} holder (a layout / kind-specific property - a UsualGroup's grouping / united /
+     * ... live under {@code <extInfo>}). Threading the receiver per property lets a mixed direct +
+     * extInfo batch apply each change to the correct EObject inside the one form write transaction.
+     */
+    private static final class HolderChange
+    {
+        private final boolean onExtInfo;
+        private final PreparedChange change;
+
+        HolderChange(boolean onExtInfo, PreparedChange change)
+        {
+            this.onExtInfo = onExtInfo;
+            this.change = change;
+        }
+    }
+
+    /**
+     * The resolved receiver for a form-member property: {@code onExtInfo} tells the caller whether the
+     * write goes to the member's nested {@code <extInfo>} holder (vs the member itself), and
+     * {@code classifyExtInfo} is the extInfo instance the property was classified against (a live
+     * instance, a throwaway probe for an as-yet-uncreated extInfo, or {@code null} for a pure-direct
+     * member) - passed to {@link #prepare} so the value is coerced to the correct feature. Carries no
+     * behaviour. Package-visible so {@link #resolveFormHolder} is unit-testable.
+     */
+    static final class FormHolder
+    {
+        final boolean onExtInfo;
+        final EObject classifyExtInfo;
+
+        FormHolder(boolean onExtInfo, EObject classifyExtInfo)
+        {
+            this.onExtInfo = onExtInfo;
+            this.classifyExtInfo = classifyExtInfo;
+        }
+    }
 
     /**
      * The STYLE_VALUE-only binding of a {@link PreparedChange}: the sibling {@code type} feature

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -2935,11 +2935,24 @@ public final class FormElementWriter
             return null;
         }
         EObject existing = singleReference(element, FEATURE_EXT_INFO);
+        String classifierName = extInfoClassifierNameFor(element);
         if (existing != null)
         {
+            // A form group's `type` is authoritative: a live extInfo whose class no longer matches the
+            // group's current type is STALE (the type was changed via modify_metadata), so the
+            // type-derived class wins - the stale holder is re-resolved here and RECREATED by
+            // ensureExtInfo instead of being reused against the wrong type (#235 review: a separate
+            // `type` change previously left a stale extInfo the next call reused).
+            if (classifierName != null && !existing.eClass().getName().equals(classifierName))
+            {
+                EClass derived = formEClass(element, classifierName);
+                if (derived != null)
+                {
+                    return derived;
+                }
+            }
             return existing.eClass();
         }
-        String classifierName = extInfoClassifierNameFor(element);
         return classifierName != null ? formEClass(element, classifierName) : null;
     }
 
@@ -3005,17 +3018,23 @@ public final class FormElementWriter
             return null;
         }
         EObject existing = singleReference(element, FEATURE_EXT_INFO);
-        if (existing != null)
+        // resolveExtInfoEClass is type-authoritative: for a form group whose `type` was changed it
+        // returns the NEW type's extInfo class (not the stale live instance's), so a matching extInfo is
+        // REUSED verbatim (never clobbered) while a STALE one (class != the type-derived class) is
+        // recreated below - closing the #235-review gap where a separate `type` change left the old-type
+        // extInfo in place for the next call to reuse.
+        EClass extInfoClass = resolveExtInfoEClass(element);
+        if (existing != null
+            && (extInfoClass == null || existing.eClass().getName().equals(extInfoClass.getName())))
         {
             return existing;
         }
-        EClass extInfoClass = resolveExtInfoEClass(element);
         if (extInfoClass == null || extInfoClass.isAbstract() || extInfoClass.getEPackage() == null)
         {
-            return null;
+            return existing; // stale/empty but no better class resolvable - keep what is there (may be null)
         }
         EObject created = extInfoClass.getEPackage().getEFactoryInstance().create(extInfoClass);
-        element.eSet(feature, created);
+        element.eSet(feature, created); // fills an empty slot or replaces a stale (type-mismatched) holder
         return created;
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -2902,6 +2902,123 @@ public final class FormElementWriter
         }
     }
 
+    // ---- general extInfo access (the layout/style properties nested under <extInfo>) --------------
+    //
+    // A form element's layout / style properties (a UsualGroup's grouping + united / showLeftMargin /
+    // throughAlign / representation, a field's input options, ...) do not live on the element itself but
+    // on its nested extInfo EObject. The two helpers below are the ONE general, fully reflective path
+    // that both the read listing (get_metadata_details) and the write path (modify_metadata) share so a
+    // property that lives under <extInfo> is resolved / created for ANY element kind, not just groups.
+
+    /**
+     * Resolves the CONCRETE {@code extInfo} EClass of a form {@code element} for READ-ONLY listing (no
+     * instantiation, no mutation). When the element already carries an {@code extInfo} instance its own
+     * EClass is returned - the fully general path that works for ANY element kind (field, decoration,
+     * table, ...), since those carry their extInfo from creation. When the slot is empty the concrete
+     * class is derived from the element's kind: a {@code FormGroup}'s matches its {@code type} literal
+     * (the {@code FormObjectFactory} pairs, via {@link #groupExtInfoClassifierFor}). Returns
+     * {@code null} when the element has no {@code extInfo} feature (e.g. an mdclass object - the extInfo
+     * path is then a no-op) or the concrete class cannot be resolved.
+     *
+     * @param element the form element to inspect
+     * @return the concrete extInfo EClass, or {@code null}
+     */
+    public static EClass resolveExtInfoEClass(EObject element)
+    {
+        if (element == null)
+        {
+            return null;
+        }
+        EStructuralFeature feature = element.eClass().getEStructuralFeature(FEATURE_EXT_INFO);
+        if (!(feature instanceof EReference) || feature.isMany())
+        {
+            return null;
+        }
+        EObject existing = singleReference(element, FEATURE_EXT_INFO);
+        if (existing != null)
+        {
+            return existing.eClass();
+        }
+        String classifierName = extInfoClassifierNameFor(element);
+        return classifierName != null ? formEClass(element, classifierName) : null;
+    }
+
+    /**
+     * The form {@code element}'s LIVE nested {@code extInfo} instance, read reflectively from the
+     * single-valued {@code extInfo} reference, or {@code null} when the element has no {@code extInfo}
+     * feature (e.g. an mdclass object) or the slot is empty. The READ-ONLY counterpart of
+     * {@link #ensureExtInfo} - no instantiation, no mutation: {@code get_metadata_details} uses it to
+     * render the extInfo layout props' CURRENT values off the live instance (the same single-valued
+     * {@code extInfo} read the reuse branch of {@link #resolveExtInfoEClass} and
+     * {@code ModifyMetadataTool.extInfoOf} perform). Fully reflective.
+     *
+     * @param element the form element to inspect
+     * @return the element's live extInfo instance, or {@code null}
+     */
+    public static EObject extInfoInstance(EObject element)
+    {
+        return element == null ? null : singleReference(element, FEATURE_EXT_INFO);
+    }
+
+    /**
+     * The concrete extInfo classifier NAME for an element whose {@code extInfo} slot is EMPTY, or
+     * {@code null} when it cannot be derived without an instance. Generalizes
+     * {@link #groupExtInfoClassifierFor}: a {@code FormGroup}'s concrete extInfo matches its
+     * {@code type} literal (defaulting to a {@code UsualGroup} when the type is unset). Other kinds
+     * already carry their extInfo from creation, so the reuse branch of {@link #resolveExtInfoEClass}
+     * covers them and this returns {@code null} for them.
+     */
+    private static String extInfoClassifierNameFor(EObject element)
+    {
+        if (ECLASS_FORM_GROUP.equals(element.eClass().getName()))
+        {
+            String typeLiteral = enumLiteralOf(element, FEATURE_TYPE);
+            return groupExtInfoClassifierFor(typeLiteral != null ? typeLiteral : TYPE_LITERAL_USUAL_GROUP);
+        }
+        return null;
+    }
+
+    /**
+     * Ensures the form {@code element} carries its concrete {@code extInfo} EObject and returns it,
+     * creating one only when the slot is empty. IDEMPOTENT: an existing extInfo is REUSED verbatim (a
+     * 2nd call returns the SAME instance, its already-set layout properties are never reset) - the
+     * resolve-then-create path never runs over a populated slot, so it cannot clobber an existing
+     * extInfo. Returns {@code null} when the element has no {@code extInfo} feature (a no-op, e.g. an
+     * mdclass object) or the concrete extInfo class cannot be resolved / instantiated (kept
+     * unattended-safe).
+     *
+     * <p>Fully reflective: the concrete extInfo EClass is resolved via {@link #resolveExtInfoEClass}
+     * on the element's own EPackage and instantiated through that package's factory - no
+     * {@code com._1c.g5.v8.dt.form.model} import, no {@code IModelObjectFactory} / Guice. The
+     * {@code formModel} identifies the owning content form (bounding {@code element} to a single form
+     * context, and kept for symmetry with the other form-write helpers).</p>
+     *
+     * @param formModel the editable content form owning {@code element}
+     * @param element the form element whose extInfo is ensured
+     * @return the element's (existing or freshly created) extInfo EObject, or {@code null}
+     */
+    public static EObject ensureExtInfo(EObject formModel, EObject element) // NOSONAR formModel bounds the element to a content-form context and keeps the write-helper signature symmetry
+    {
+        EStructuralFeature feature = element.eClass().getEStructuralFeature(FEATURE_EXT_INFO);
+        if (!(feature instanceof EReference) || feature.isMany())
+        {
+            return null;
+        }
+        EObject existing = singleReference(element, FEATURE_EXT_INFO);
+        if (existing != null)
+        {
+            return existing;
+        }
+        EClass extInfoClass = resolveExtInfoEClass(element);
+        if (extInfoClass == null || extInfoClass.isAbstract() || extInfoClass.getEPackage() == null)
+        {
+            return null;
+        }
+        EObject created = extInfoClass.getEPackage().getEFactoryInstance().create(extInfoClass);
+        element.eSet(feature, created);
+        return created;
+    }
+
     // ---- event handlers -------------------------------------------------------------------------
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataPropertyIntrospector.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataPropertyIntrospector.java
@@ -83,9 +83,22 @@ public final class MetadataPropertyIntrospector
         public final List<String> allowedValues;
         /** The owning {@link EStructuralFeature} (for the applier; not serialized). */
         public final EStructuralFeature feature;
+        /**
+         * Whether this property lives on the element's nested {@code <extInfo>} EObject (a layout /
+         * kind-specific sub-object) rather than on the element itself. A caller that WRITES the value
+         * must therefore route the {@code eSet} to the extInfo holder (creating it when absent), not to
+         * the element. Always {@code false} for a direct feature - the only case on the mdclass path.
+         */
+        public final boolean onExtInfo;
 
         PropertyInfo(String name, ValueKind valueKind, String currentValue, List<String> allowedValues,
             EStructuralFeature feature)
+        {
+            this(name, valueKind, currentValue, allowedValues, feature, false);
+        }
+
+        PropertyInfo(String name, ValueKind valueKind, String currentValue, List<String> allowedValues,
+            EStructuralFeature feature, boolean onExtInfo)
         {
             this.name = name;
             this.valueKind = valueKind;
@@ -93,6 +106,7 @@ public final class MetadataPropertyIntrospector
             this.allowedValues = allowedValues == null ? Collections.emptyList()
                 : Collections.unmodifiableList(allowedValues);
             this.feature = feature;
+            this.onExtInfo = onExtInfo;
         }
     }
 
@@ -129,6 +143,43 @@ public final class MetadataPropertyIntrospector
                 allowedValuesFor(feature, kind), feature));
         }
         return result;
+    }
+
+    /**
+     * Extends {@link #introspect(EObject)} with the assignable properties that live on {@code element}'s
+     * nested {@code <extInfo>} EObject - a general, model-agnostic path for ANY element that carries an
+     * extInfo (e.g. a form group's {@code UsualGroupExtInfo} layout props). The direct-element
+     * properties come first (each with {@code onExtInfo == false}); the {@code extInfoEClass}'s
+     * assignable features are then appended (each with {@code onExtInfo == true}), skipping any whose
+     * name collides with a direct feature (DIRECT-precedence). The extInfo properties are listed from
+     * their EClass only (no instance), so their {@code currentValue} is {@code null}; use
+     * {@link #introspect(EObject, EObject)} to also render the current values from a live extInfo
+     * instance.
+     *
+     * <p>{@code extInfoEClass == null} - the mdclass path, where an object has no extInfo - makes this
+     * exactly {@link #introspect(EObject)}.</p>
+     *
+     * @param element the element to introspect (e.g. a form group)
+     * @param extInfoEClass the element's concrete extInfo EClass, or {@code null} when it has none
+     * @return the direct-then-extInfo assignable property schemas (never {@code null})
+     */
+    public static List<PropertyInfo> introspect(EObject element, EClass extInfoEClass)
+    {
+        return introspectWithExtInfo(element, extInfoEClass, null);
+    }
+
+    /**
+     * Like {@link #introspect(EObject, EClass)} but reads the extInfo properties' CURRENT values from
+     * the live {@code extInfo} instance (whose EClass supplies the feature list). {@code extInfo == null}
+     * - the element has no extInfo yet - makes this exactly {@link #introspect(EObject)}.
+     *
+     * @param element the element to introspect
+     * @param extInfo the element's live extInfo instance, or {@code null} when it has none
+     * @return the direct-then-extInfo assignable property schemas, extInfo currents rendered
+     */
+    public static List<PropertyInfo> introspect(EObject element, EObject extInfo)
+    {
+        return introspectWithExtInfo(element, extInfo == null ? null : extInfo.eClass(), extInfo);
     }
 
     /**
@@ -192,6 +243,36 @@ public final class MetadataPropertyIntrospector
     }
 
     /**
+     * Extends {@link #findFeature(EObject, String)} to also resolve a property that lives on
+     * {@code element}'s nested extInfo instance. A DIRECT feature of {@code element} wins on a name
+     * collision (returned with {@code onExtInfo == false}); only when the element has no such direct
+     * assignable feature is {@code extInfo}'s feature returned (with {@code onExtInfo == true}), so the
+     * caller can route the write to the extInfo holder. Like {@link #findFeature(EObject, String)} the
+     * current value is NOT rendered.
+     *
+     * @param element the element (e.g. a form group)
+     * @param extInfo the element's live extInfo instance, or {@code null}
+     * @param name the feature name (case-insensitive)
+     * @return the property info - its {@code onExtInfo} telling the caller which receiver to write - or
+     *         {@code null} if neither the element nor its extInfo has such an assignable property
+     */
+    public static PropertyInfo findFeature(EObject element, EObject extInfo, String name)
+    {
+        PropertyInfo direct = findFeature(element, name);
+        if (direct != null)
+        {
+            return direct;
+        }
+        PropertyInfo onExt = findFeature(extInfo, name);
+        if (onExt == null)
+        {
+            return null;
+        }
+        return new PropertyInfo(onExt.name, onExt.valueKind, onExt.currentValue, onExt.allowedValues,
+            onExt.feature, true);
+    }
+
+    /**
      * Returns the assignable property names of {@code obj}, for an actionable "available properties"
      * error hint. Names-only iteration: no current value is rendered.
      *
@@ -208,6 +289,35 @@ public final class MetadataPropertyIntrospector
         for (EStructuralFeature feature : obj.eClass().getEAllStructuralFeatures())
         {
             if (isAssignable(feature) && classify(feature) != null)
+            {
+                names.add(feature.getName());
+            }
+        }
+        return names;
+    }
+
+    /**
+     * Extends {@link #assignableNames(EObject)} with the assignable feature names on {@code element}'s
+     * nested extInfo (its {@code extInfoEClass}), so an actionable "available properties" hint covers
+     * the extInfo layout props too. Direct names come first; an extInfo name that collides with a
+     * direct one is dropped (DIRECT-precedence). {@code extInfoEClass == null} makes this exactly
+     * {@link #assignableNames(EObject)}.
+     *
+     * @param element the element
+     * @param extInfoEClass the element's concrete extInfo EClass, or {@code null}
+     * @return the direct-then-extInfo assignable feature names (never {@code null})
+     */
+    public static List<String> assignableNames(EObject element, EClass extInfoEClass)
+    {
+        List<String> names = assignableNames(element);
+        if (extInfoEClass == null)
+        {
+            return names;
+        }
+        for (EStructuralFeature feature : extInfoEClass.getEAllStructuralFeatures())
+        {
+            if (isAssignable(feature) && classify(feature) != null
+                && !containsIgnoreCase(names, feature.getName()))
             {
                 names.add(feature.getName());
             }
@@ -241,6 +351,56 @@ public final class MetadataPropertyIntrospector
     }
 
     // ---- internals ------------------------------------------------------------------------------
+
+    /**
+     * Shared body of the extInfo-aware {@link #introspect(EObject, EClass)} /
+     * {@link #introspect(EObject, EObject)}: the direct properties of {@code element} followed by the
+     * assignable features of {@code extInfoEClass} (DIRECT-precedence on a name collision), the latter
+     * marked {@code onExtInfo}, their current value rendered from {@code extInfo} when it is non-null.
+     */
+    private static List<PropertyInfo> introspectWithExtInfo(EObject element, EClass extInfoEClass,
+        EObject extInfo)
+    {
+        List<PropertyInfo> result = introspect(element);
+        if (extInfoEClass == null)
+        {
+            return result;
+        }
+        List<String> directNames = new ArrayList<>();
+        for (PropertyInfo p : result)
+        {
+            directNames.add(p.name);
+        }
+        for (EStructuralFeature feature : extInfoEClass.getEAllStructuralFeatures())
+        {
+            if (!isAssignable(feature) || containsIgnoreCase(directNames, feature.getName()))
+            {
+                continue;
+            }
+            ValueKind kind = classify(feature);
+            if (kind == null)
+            {
+                continue;
+            }
+            String current = extInfo != null ? renderCurrent(extInfo, feature, kind) : null;
+            result.add(new PropertyInfo(feature.getName(), kind, current,
+                allowedValuesFor(feature, kind), feature, true));
+        }
+        return result;
+    }
+
+    /** Whether {@code names} already contains {@code name}, case-insensitively (DIRECT-precedence check). */
+    private static boolean containsIgnoreCase(List<String> names, String name)
+    {
+        for (String existing : names)
+        {
+            if (existing.equalsIgnoreCase(name))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 
     private static boolean isAssignable(EStructuralFeature feature)
     {

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataDetailsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataDetailsToolTest.java
@@ -17,6 +17,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EEnum;
+import org.eclipse.emf.ecore.EEnumLiteral;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.EcoreFactory;
+import org.eclipse.emf.ecore.EcorePackage;
 import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
@@ -342,5 +352,127 @@ public class GetMetadataDetailsToolTest
         assertTrue(section.contains("Catalog.A\\|B")); //$NON-NLS-1$
         assertTrue(section.contains("bad \\| reason")); //$NON-NLS-1$
         assertFalse(section.contains("**Error:**")); //$NON-NLS-1$
+    }
+
+    // ==================== Form-member assignable view: the general reflective extInfo path (#235) ====================
+    //
+    // A form MEMBER (a group / field / table / decoration inside a form's editable content model) is
+    // not an mdclass node, so its assignable schema is rendered from the ELEMENT's own features UNION
+    // its <extInfo>'s layout properties. formatAssignable is widened to any EObject for exactly this;
+    // resolving the live form needs a workbench + BM model (covered by the E2E suite), but the union
+    // RENDERING is verified here headlessly on a synthetic UsualGroup whose UsualGroupExtInfo carries
+    // the `group` (layout enum) and `united` (boolean) props that live inside <extInfo>.
+
+    /**
+     * {@code formatAssignable} on a form GROUP element lists BOTH the element's own features and the
+     * layout properties nested in its {@code extInfo} (issue #235): a UsualGroup's {@code group} (an
+     * enum, so its allowed literals are surfaced for modify_metadata to validate against) and
+     * {@code united} appear in the assignable table.
+     */
+    @Test
+    public void testFormGroupAssignableListsExtInfoLayoutProps()
+    {
+        EObject group = syntheticUsualGroupWithExtInfo();
+        String md = GetMetadataDetailsTool.formatAssignable(
+            "Catalog.Catalog.Form.ItemForm.Group.G", group); //$NON-NLS-1$
+        assertTrue("must render the assignable schema heading", //$NON-NLS-1$
+            md.contains("Assignable properties")); //$NON-NLS-1$
+        assertTrue("the extInfo layout enum 'group' must be listed as assignable", //$NON-NLS-1$
+            md.contains("| group |")); //$NON-NLS-1$
+        assertTrue("the extInfo 'united' layout flag must be listed as assignable", //$NON-NLS-1$
+            md.contains("| united |")); //$NON-NLS-1$
+        // `group` is an enum, so its allowed literals are surfaced so modify_metadata can validate.
+        assertTrue("the group layout enum must surface its allowed literals", //$NON-NLS-1$
+            md.contains("Horizontal")); //$NON-NLS-1$
+    }
+
+    /**
+     * When the form GROUP element carries a LIVE extInfo with values SET, {@code formatAssignable}
+     * renders those values in the Current column (issue #235): it feeds the live extInfo instance
+     * through the instance-aware introspection, so a designer-authored {@code group=Horizontal} /
+     * {@code united=true} shows up rather than a blank Current cell. Guards against regressing to the
+     * EClass-only listing (which renders no current value for the extInfo props while the direct
+     * features show theirs - the inconsistency the reviewer flagged).
+     */
+    @Test
+    public void testFormGroupAssignableRendersExtInfoCurrentValue()
+    {
+        EObject group = syntheticUsualGroupWithExtInfo();
+        // Set group=Horizontal + united=true on the live extInfo, mimicking a designer-authored layout.
+        EObject extInfo = (EObject)group.eGet(group.eClass().getEStructuralFeature("extInfo")); //$NON-NLS-1$
+        EStructuralFeature groupFeature = extInfo.eClass().getEStructuralFeature("group"); //$NON-NLS-1$
+        EEnum grouping = (EEnum)((EAttribute)groupFeature).getEAttributeType();
+        extInfo.eSet(groupFeature, grouping.getEEnumLiteralByLiteral("Horizontal")); //$NON-NLS-1$
+        extInfo.eSet(extInfo.eClass().getEStructuralFeature("united"), Boolean.TRUE); //$NON-NLS-1$
+
+        String md = GetMetadataDetailsTool.formatAssignable(
+            "Catalog.Catalog.Form.ItemForm.Group.G", group); //$NON-NLS-1$
+        // The extInfo props must carry their CURRENT value, not a blank Current cell.
+        assertTrue("the extInfo 'group' current value must render as the set literal", //$NON-NLS-1$
+            md.contains("| group | ENUM | Horizontal |")); //$NON-NLS-1$
+        assertTrue("the extInfo 'united' current value must render as true", //$NON-NLS-1$
+            md.contains("| united | BOOLEAN | true |")); //$NON-NLS-1$
+    }
+
+    /**
+     * Builds a synthetic form GROUP element whose {@code extInfo} is a {@code UsualGroupExtInfo}
+     * carrying the {@code group} (a layout EEnum with Vertical / Horizontal literals) and
+     * {@code united} (a boolean) layout properties - the reflective shape
+     * {@code get_metadata_details(assignable)} renders from, so the union of element + extInfo features
+     * is exercised WITHOUT a live workbench. The concrete {@code extInfo} instance is set so the
+     * extInfo EClass resolves regardless of the resolver's abstract-type strategy.
+     */
+    private static EObject syntheticUsualGroupWithExtInfo()
+    {
+        EcoreFactory f = EcoreFactory.eINSTANCE;
+        EPackage pkg = f.createEPackage();
+        pkg.setName("formlike"); //$NON-NLS-1$
+        pkg.setNsPrefix("formlike"); //$NON-NLS-1$
+        pkg.setNsURI("http://example.com/edt-mcp/formlike/235"); //$NON-NLS-1$
+
+        EEnum groupEnum = f.createEEnum();
+        groupEnum.setName("FormChildrenGroup"); //$NON-NLS-1$
+        addLiteral(f, groupEnum, "Vertical", 0); //$NON-NLS-1$
+        addLiteral(f, groupEnum, "Horizontal", 1); //$NON-NLS-1$
+        pkg.getEClassifiers().add(groupEnum);
+
+        EClass extInfo = f.createEClass();
+        extInfo.setName("UsualGroupExtInfo"); //$NON-NLS-1$
+        EAttribute groupAttr = f.createEAttribute();
+        groupAttr.setName("group"); //$NON-NLS-1$
+        groupAttr.setEType(groupEnum);
+        extInfo.getEStructuralFeatures().add(groupAttr);
+        EAttribute unitedAttr = f.createEAttribute();
+        unitedAttr.setName("united"); //$NON-NLS-1$
+        unitedAttr.setEType(EcorePackage.Literals.EBOOLEAN);
+        extInfo.getEStructuralFeatures().add(unitedAttr);
+        pkg.getEClassifiers().add(extInfo);
+
+        EClass groupClass = f.createEClass();
+        groupClass.setName("UsualGroup"); //$NON-NLS-1$
+        EAttribute nameAttr = f.createEAttribute();
+        nameAttr.setName("name"); //$NON-NLS-1$
+        nameAttr.setEType(EcorePackage.Literals.ESTRING);
+        groupClass.getEStructuralFeatures().add(nameAttr);
+        EReference extInfoRef = f.createEReference();
+        extInfoRef.setName("extInfo"); //$NON-NLS-1$
+        extInfoRef.setEType(extInfo);
+        extInfoRef.setContainment(true);
+        groupClass.getEStructuralFeatures().add(extInfoRef);
+        pkg.getEClassifiers().add(groupClass);
+
+        EObject groupObj = pkg.getEFactoryInstance().create(groupClass);
+        EObject extInfoObj = pkg.getEFactoryInstance().create(extInfo);
+        groupObj.eSet(extInfoRef, extInfoObj);
+        return groupObj;
+    }
+
+    private static void addLiteral(EcoreFactory f, EEnum eEnum, String name, int value)
+    {
+        EEnumLiteral literal = f.createEEnumLiteral();
+        literal.setName(name);
+        literal.setValue(value);
+        literal.setLiteral(name);
+        eEnum.getELiterals().add(literal);
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
@@ -16,9 +16,19 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.Collections;
 
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EEnum;
+import org.eclipse.emf.ecore.EEnumLiteral;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EcoreFactory;
+import org.eclipse.emf.ecore.EcorePackage;
 import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+import com.ditrix.edt.mcp.server.tools.impl.ModifyMetadataTool.FormHolder;
 import com.ditrix.edt.mcp.server.utils.MdNameNormalizer;
 import com.ditrix.edt.mcp.server.utils.MetadataLanguageUtils;
 import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils;
@@ -506,5 +516,214 @@ public class ModifyMetadataToolTest
         String guide = new ModifyMetadataTool().getGuide();
         assertTrue("the no-mixing-with-properties policy must be documented", //$NON-NLS-1$
             guide.contains("CANNOT be combined with a generic")); //$NON-NLS-1$
+    }
+
+    // ===== form-member extInfo routing (#235: a UsualGroup's layout props live under <extInfo>) =====
+    //
+    // A form group's grouping (`group`) + united / layout flags do NOT live on the group element but on
+    // its nested extInfo. resolveFormHolder is the ONE general reflective decision that routes each
+    // property to the correct receiver: a DIRECT feature stays on the member, an extInfo feature is
+    // flagged onExtInfo so the write goes to the extInfo holder. Tested headlessly against a synthetic
+    // form-like EMF model (no live workbench / BM needed for the classification decision).
+
+    /**
+     * A synthetic EMF package shaped like a form group: a {@code FormGroup} EClass with a DIRECT
+     * {@code visible} boolean and a containment {@code extInfo} reference to a {@code UsualGroupExtInfo}
+     * EClass that carries the layout props ({@code group} enum + {@code united} boolean). Mirrors the
+     * real 1C form metamodel closely enough to exercise the reflective extInfo routing without importing
+     * (the forbidden) {@code com._1c.g5.v8.dt.form.model}.
+     */
+    private static EPackage buildFormLikePackage()
+    {
+        EcoreFactory f = EcoreFactory.eINSTANCE;
+        EPackage pkg = f.createEPackage();
+        pkg.setName("formlike"); //$NON-NLS-1$
+        pkg.setNsPrefix("formlike"); //$NON-NLS-1$
+        pkg.setNsURI("http://ditrix.test/formlike/235"); //$NON-NLS-1$
+
+        EEnum grouping = f.createEEnum();
+        grouping.setName("Grouping"); //$NON-NLS-1$
+        EEnumLiteral vertical = f.createEEnumLiteral();
+        vertical.setName("Vertical"); //$NON-NLS-1$
+        vertical.setValue(0);
+        EEnumLiteral horizontal = f.createEEnumLiteral();
+        horizontal.setName("Horizontal"); //$NON-NLS-1$
+        horizontal.setValue(1);
+        grouping.getELiterals().add(vertical);
+        grouping.getELiterals().add(horizontal);
+        pkg.getEClassifiers().add(grouping);
+
+        EClass extInfo = f.createEClass();
+        extInfo.setName("UsualGroupExtInfo"); //$NON-NLS-1$
+        EAttribute group = f.createEAttribute();
+        group.setName("group"); //$NON-NLS-1$
+        group.setEType(grouping);
+        EAttribute united = f.createEAttribute();
+        united.setName("united"); //$NON-NLS-1$
+        united.setEType(EcorePackage.Literals.EBOOLEAN);
+        extInfo.getEStructuralFeatures().add(group);
+        extInfo.getEStructuralFeatures().add(united);
+        pkg.getEClassifiers().add(extInfo);
+
+        EClass formGroup = f.createEClass();
+        formGroup.setName("FormGroup"); //$NON-NLS-1$
+        EAttribute visible = f.createEAttribute();
+        visible.setName("visible"); //$NON-NLS-1$
+        visible.setEType(EcorePackage.Literals.EBOOLEAN);
+        EReference extInfoRef = f.createEReference();
+        extInfoRef.setName("extInfo"); //$NON-NLS-1$
+        extInfoRef.setEType(extInfo);
+        extInfoRef.setContainment(true);
+        formGroup.getEStructuralFeatures().add(visible);
+        formGroup.getEStructuralFeatures().add(extInfoRef);
+        pkg.getEClassifiers().add(formGroup);
+
+        return pkg;
+    }
+
+    /** A synthetic FormGroup instance with its extInfo instance already attached (the common case). */
+    private static EObject newGroupWithExtInfo(EPackage pkg, EObject[] outExtInfo)
+    {
+        EClass formGroupClass = (EClass)pkg.getEClassifier("FormGroup"); //$NON-NLS-1$
+        EClass extInfoClass = (EClass)pkg.getEClassifier("UsualGroupExtInfo"); //$NON-NLS-1$
+        EObject group = pkg.getEFactoryInstance().create(formGroupClass);
+        EObject extInfo = pkg.getEFactoryInstance().create(extInfoClass);
+        group.eSet(formGroupClass.getEStructuralFeature("extInfo"), extInfo); //$NON-NLS-1$
+        outExtInfo[0] = extInfo;
+        return group;
+    }
+
+    @Test
+    public void testResolveFormHolderRoutesExtInfoLayoutPropsToExtInfo()
+    {
+        // `group` + `united` live on the UsualGroupExtInfo, so they must route to the extInfo holder
+        // (onExtInfo == true) and be classified against the extInfo instance.
+        EPackage pkg = buildFormLikePackage();
+        EObject[] extInfoOut = new EObject[1];
+        EObject group = newGroupWithExtInfo(pkg, extInfoOut);
+        EObject extInfo = extInfoOut[0];
+
+        FormHolder g = ModifyMetadataTool.resolveFormHolder(group, "group"); //$NON-NLS-1$
+        assertTrue("the grouping enum lives under <extInfo> -> onExtInfo", g.onExtInfo); //$NON-NLS-1$
+        assertSame("the group prop must be classified against the extInfo instance", //$NON-NLS-1$
+            extInfo, g.classifyExtInfo);
+
+        FormHolder u = ModifyMetadataTool.resolveFormHolder(group, "united"); //$NON-NLS-1$
+        assertTrue("the united flag lives under <extInfo> -> onExtInfo", u.onExtInfo); //$NON-NLS-1$
+
+        // Case-insensitive, mirroring findFeature.
+        assertTrue("routing must be case-insensitive", //$NON-NLS-1$
+            ModifyMetadataTool.resolveFormHolder(group, "GROUP").onExtInfo); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResolveFormHolderKeepsDirectFeatureOnMember()
+    {
+        // `visible` is a DIRECT feature of the group element, so it stays on the member (onExtInfo ==
+        // false) even though the element also carries an extInfo - direct-precedence.
+        EPackage pkg = buildFormLikePackage();
+        EObject[] extInfoOut = new EObject[1];
+        EObject group = newGroupWithExtInfo(pkg, extInfoOut);
+
+        FormHolder v = ModifyMetadataTool.resolveFormHolder(group, "visible"); //$NON-NLS-1$
+        assertFalse("a direct feature must stay on the member (not the extInfo)", v.onExtInfo); //$NON-NLS-1$
+        assertSame("the extInfo is still threaded for classification", //$NON-NLS-1$
+            extInfoOut[0], v.classifyExtInfo);
+    }
+
+    @Test
+    public void testResolveFormHolderUnknownPropertyStaysOnMember()
+    {
+        // A property that is on NEITHER the member nor its extInfo is not routed to the extInfo (the
+        // holder defaults to the member; prepare() then rejects it with the extended assignable set).
+        EPackage pkg = buildFormLikePackage();
+        EObject[] extInfoOut = new EObject[1];
+        EObject group = newGroupWithExtInfo(pkg, extInfoOut);
+
+        FormHolder n = ModifyMetadataTool.resolveFormHolder(group, "noSuchProp_zz235"); //$NON-NLS-1$
+        assertFalse("an unknown property must not be routed to the extInfo", n.onExtInfo); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResolveFormHolderNoExtInfoFeatureIsDirectNoOp()
+    {
+        // An element with NO extInfo feature (the mdclass-like no-op case) always routes a direct feature
+        // to the element itself, and threads a null classification extInfo.
+        EPackage pkg = buildFormLikePackage();
+        EClass extInfoClass = (EClass)pkg.getEClassifier("UsualGroupExtInfo"); //$NON-NLS-1$
+        // A UsualGroupExtInfo has a direct `united` but NO nested `extInfo` feature of its own.
+        EObject plain = pkg.getEFactoryInstance().create(extInfoClass);
+
+        FormHolder h = ModifyMetadataTool.resolveFormHolder(plain, "united"); //$NON-NLS-1$
+        assertFalse("a member with no extInfo feature routes directly", h.onExtInfo); //$NON-NLS-1$
+        assertNull("no extInfo instance is threaded when the element has no extInfo feature", //$NON-NLS-1$
+            h.classifyExtInfo);
+    }
+
+    // ===== reject a classifier `type` change batched with an extInfo layout prop (#235 review) =====
+    //
+    // A group's `type` decides which concrete <extInfo> EClass applies; the extInfo props are classified
+    // against the PRE-change type's EClass, so combining a direct `type` change with any onExtInfo prop in
+    // ONE call is order-dependent and unsafe. formTypeExtInfoComboError rejects that combination up front
+    // (a mixed direct + extInfo batch that does NOT change `type` is still allowed). Reuses the shared
+    // prop(name, value) helper above.
+
+    @Test
+    public void testComboRejectsTypeChangeWithExtInfoLayoutProp()
+    {
+        // `type` (the classifier) + `group` (lives on <extInfo>) in one call must be refused with an
+        // actionable "change the type in a separate call" error.
+        EPackage pkg = buildFormLikePackage();
+        EObject group = newGroupWithExtInfo(pkg, new EObject[1]);
+
+        String err = ModifyMetadataTool.formTypeExtInfoComboError(group,
+            Arrays.asList(prop("type", "Pages"), prop("group", "Horizontal"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        assertNotNull("combining a group type change with an extInfo prop must be rejected", err); //$NON-NLS-1$
+        assertTrue("the error must be a ToolResult error json", err.contains("\"error\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the error must point at making the type change separately", //$NON-NLS-1$
+            err.contains("separate call")); //$NON-NLS-1$
+        // Order-independent: the reverse batch (extInfo prop first) is refused just the same.
+        assertNotNull("the reverse order must be rejected identically", //$NON-NLS-1$
+            ModifyMetadataTool.formTypeExtInfoComboError(group,
+                Arrays.asList(prop("group", "Horizontal"), prop("type", "Pages")))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+    }
+
+    @Test
+    public void testComboAllowsExtInfoPropAlone()
+    {
+        // An extInfo layout prop on its own (no `type` change) is safe - the extInfo is resolved against
+        // the element's current, unchanged type.
+        EPackage pkg = buildFormLikePackage();
+        EObject group = newGroupWithExtInfo(pkg, new EObject[1]);
+
+        assertNull("an extInfo prop with no type change must be allowed", //$NON-NLS-1$
+            ModifyMetadataTool.formTypeExtInfoComboError(group,
+                Collections.singletonList(prop("group", "Horizontal")))); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testComboAllowsTypeChangeAlone()
+    {
+        // A `type` change with no extInfo prop is safe (the extInfo is re-resolved against the new type
+        // on the next call).
+        EPackage pkg = buildFormLikePackage();
+        EObject group = newGroupWithExtInfo(pkg, new EObject[1]);
+
+        assertNull("a type change with no extInfo prop must be allowed", //$NON-NLS-1$
+            ModifyMetadataTool.formTypeExtInfoComboError(group,
+                Collections.singletonList(prop("type", "Pages")))); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testComboAllowsDirectAndExtInfoWithoutTypeChange()
+    {
+        // A mixed batch of a DIRECT feature (`visible`) + an extInfo prop (`group`) that does NOT touch
+        // `type` stays allowed - the classifier is unchanged, so both route to their correct holder.
+        EPackage pkg = buildFormLikePackage();
+        EObject group = newGroupWithExtInfo(pkg, new EObject[1]);
+
+        assertNull("a direct + extInfo batch without a type change must still be allowed", //$NON-NLS-1$
+            ModifyMetadataTool.formTypeExtInfoComboError(group,
+                Arrays.asList(prop("visible", "true"), prop("group", "Horizontal")))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -9,6 +9,7 @@ package com.ditrix.edt.mcp.server.utils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -796,6 +797,29 @@ public class FormElementWriterTest
         EObject ensured = FormElementWriter.ensureExtInfo(newForm(), group);
         assertSame(preset, ensured);
         assertEquals("Horizontal", literalOf(ensured, "group")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testEnsureExtInfoReplacesStaleExtInfoAfterTypeChange()
+    {
+        // #235 review: a form group whose `type` was changed via modify_metadata carries a STALE extInfo of
+        // the OLD type. The `type` is authoritative: resolveExtInfoEClass must report the NEW type's class,
+        // and ensureExtInfo must RECREATE the extInfo for the new type (not reuse the stale one) - so a
+        // later layout write lands on the correct holder instead of the wrong-type extInfo.
+        EObject form = newForm();
+        EObject group = newObject(MODEL.formGroup);
+        setLiteral(group, "type", "UsualGroup"); //$NON-NLS-1$ //$NON-NLS-2$
+        EObject usual = FormElementWriter.ensureExtInfo(form, group);
+        assertEquals("UsualGroupExtInfo", usual.eClass().getName()); //$NON-NLS-1$
+        // Change the classifier: the UsualGroupExtInfo is now stale for a Pages group.
+        setLiteral(group, "type", "Pages"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("the type is authoritative - resolveExtInfoEClass reports the NEW type's class", //$NON-NLS-1$
+            "PagesGroupExtInfo", FormElementWriter.resolveExtInfoEClass(group).getName()); //$NON-NLS-1$
+        EObject replaced = FormElementWriter.ensureExtInfo(form, group);
+        assertEquals("ensureExtInfo recreates the extInfo for the new type", //$NON-NLS-1$
+            "PagesGroupExtInfo", replaced.eClass().getName()); //$NON-NLS-1$
+        assertNotSame("the stale UsualGroupExtInfo must be replaced, not reused", usual, replaced); //$NON-NLS-1$
+        assertSame(replaced, group.eGet(feature(group, "extInfo"))); //$NON-NLS-1$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -751,6 +751,101 @@ public class FormElementWriterTest
         assertTrue(err.contains("command action")); //$NON-NLS-1$
     }
 
+    // ---- general extInfo access (ensureExtInfo / resolveExtInfoEClass, #235) ----------------------
+
+    @Test
+    public void testEnsureExtInfoCreatesUsualGroupExtInfoForEmptyGroup()
+    {
+        // A UsualGroup with an empty <extInfo> slot gets its concrete UsualGroupExtInfo created and
+        // linked - the derive-from-type path (generalized groupExtInfoClassifierFor).
+        EObject group = newObject(MODEL.formGroup);
+        setLiteral(group, "type", "UsualGroup"); //$NON-NLS-1$ //$NON-NLS-2$
+        EObject extInfo = FormElementWriter.ensureExtInfo(newForm(), group);
+        assertNotNull(extInfo);
+        assertEquals("UsualGroupExtInfo", extInfo.eClass().getName()); //$NON-NLS-1$
+        // It is actually attached to the group's extInfo reference.
+        assertSame(extInfo, group.eGet(feature(group, "extInfo"))); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testEnsureExtInfoIsIdempotentAndKeepsSetProperties()
+    {
+        // A 2nd ensureExtInfo returns the SAME instance and does NOT reset properties set on it.
+        EObject form = newForm();
+        EObject group = newObject(MODEL.formGroup);
+        setLiteral(group, "type", "UsualGroup"); //$NON-NLS-1$ //$NON-NLS-2$
+        EObject first = FormElementWriter.ensureExtInfo(form, group);
+        setLiteral(first, "group", "AlwaysHorizontal"); //$NON-NLS-1$ //$NON-NLS-2$
+        first.eSet(feature(first, "united"), Boolean.TRUE); //$NON-NLS-1$
+        EObject second = FormElementWriter.ensureExtInfo(form, group);
+        assertSame(first, second);
+        assertEquals("AlwaysHorizontal", literalOf(second, "group")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(Boolean.TRUE, second.eGet(feature(second, "united"))); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testEnsureExtInfoReusesPresetExtInfoWithoutClobber()
+    {
+        // A designer-created (already present) extInfo carrying a set 'group' is reused verbatim - never
+        // re-created via setExtInfoClassifier (which would clobber the set layout property).
+        EObject group = newObject(MODEL.formGroup);
+        setLiteral(group, "type", "UsualGroup"); //$NON-NLS-1$ //$NON-NLS-2$
+        EObject preset = newObject(MODEL.usualGroupExtInfo);
+        setLiteral(preset, "group", "Horizontal"); //$NON-NLS-1$ //$NON-NLS-2$
+        group.eSet(feature(group, "extInfo"), preset); //$NON-NLS-1$
+        EObject ensured = FormElementWriter.ensureExtInfo(newForm(), group);
+        assertSame(preset, ensured);
+        assertEquals("Horizontal", literalOf(ensured, "group")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testEnsureExtInfoNoOpWhenElementHasNoExtInfoSlot()
+    {
+        // A form root (mdclass-like: no extInfo feature) is a no-op - null, nothing set.
+        EObject form = newForm();
+        assertNull(FormElementWriter.ensureExtInfo(form, form));
+        assertNull(FormElementWriter.resolveExtInfoEClass(form));
+    }
+
+    @Test
+    public void testResolveExtInfoEClassForEmptyGroupDoesNotInstantiate()
+    {
+        // Read-only listing: the concrete class is derived from the group type WITHOUT creating an
+        // instance (the extInfo slot stays empty).
+        EObject group = newObject(MODEL.formGroup);
+        setLiteral(group, "type", "UsualGroup"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertSame(MODEL.usualGroupExtInfo, FormElementWriter.resolveExtInfoEClass(group));
+        assertNull(group.eGet(feature(group, "extInfo"))); //$NON-NLS-1$
+        // A different group type resolves its own concrete extInfo (generalized mapping).
+        EObject popup = newObject(MODEL.formGroup);
+        setLiteral(popup, "type", "Popup"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertSame(modelClass("PopupGroupExtInfo"), FormElementWriter.resolveExtInfoEClass(popup)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResolveExtInfoEClassReusesExistingInstanceForAnyKind()
+    {
+        // The reuse path is element-agnostic: a field carrying an InputFieldExtInfo reports that concrete
+        // class, so the general extInfo path is not group-only.
+        EClass inputExtInfo = modelClass("InputFieldExtInfo"); //$NON-NLS-1$
+        EObject field = newObject(modelClass("FormField")); //$NON-NLS-1$
+        field.eSet(feature(field, "extInfo"), newObject(inputExtInfo)); //$NON-NLS-1$
+        assertSame(inputExtInfo, FormElementWriter.resolveExtInfoEClass(field));
+    }
+
+    @Test
+    public void testUsualGroupExtInfoCarriesLayoutFeatures()
+    {
+        // The synthetic UsualGroupExtInfo exposes the #235 layout features (so the A/C/D unit tests that
+        // read/write them run headlessly).
+        for (String featureName : new String[] {"group", "united", "showLeftMargin", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            "throughAlign", "currentRowUse", "representation"}) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        {
+            assertNotNull(featureName + " must exist on UsualGroupExtInfo", //$NON-NLS-1$
+                MODEL.usualGroupExtInfo.getEStructuralFeature(featureName));
+        }
+    }
+
     /**
      * Builds a synthetic {@code EventHandlerExtension} EClass carrying a {@code callType} EEnum shaped
      * like the form metamodel's {@code ExtendedMethodCallType} (literal == name), so the pure
@@ -1979,6 +2074,12 @@ public class FormElementWriterTest
         return new DynamicEObjectImpl(eClass);
     }
 
+    /** Looks up a classifier of the synthetic form-like package by name (via any exposed EClass). */
+    private static EClass modelClass(String name)
+    {
+        return (EClass)MODEL.formGroup.getEPackage().getEClassifier(name);
+    }
+
     private static EStructuralFeature feature(EObject object, String name)
     {
         return object.eClass().getEStructuralFeature(name);
@@ -2046,6 +2147,7 @@ public class FormElementWriterTest
         final EClass form;
         final EClass formItem;
         final EClass formGroup;
+        final EClass usualGroupExtInfo;
         final EClass autoCommandBar;
         final EClass table;
         final EClass decoration;
@@ -2068,6 +2170,13 @@ public class FormElementWriterTest
                 "ButtonGroup", "ColumnGroup", "CommandBar", "UsualGroup", "Popup", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
                 "Page", "Pages"); //$NON-NLS-1$ //$NON-NLS-2$
             EEnum currentRowUse = newEnum(f, "CurrentRowUse", "DontUse", "Use", "Auto"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            // The UsualGroupExtInfo layout enums (#235): the children grouping and the through-align /
+            // representation tri-states nested under a group's <extInfo>.
+            EEnum formChildrenGroup = newEnum(f, "FormChildrenGroup", //$NON-NLS-1$
+                "Vertical", "Horizontal", "AlwaysHorizontal", "HorizontalIfPossible"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            EEnum throughAlign = newEnum(f, "FormElementsThroughAlign", "Auto", "Use", "DontUse"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            EEnum groupRepresentation = newEnum(f, "UsualGroupRepresentation", //$NON-NLS-1$
+                "None", "WeakSeparation", "NormalSeparation", "StrongSeparation"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
             EEnum decorationType = newEnum(f, "ManagedFormDecorationType", "Label", "Picture"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             EEnum fieldType = newEnum(f, "ManagedFormFieldType", "InputField", "LabelField"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             EEnum horizontalAlign = newEnum(f, "ItemHorizontalAlignment", "Auto", "Left"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
@@ -2083,7 +2192,15 @@ public class FormElementWriterTest
             EClass extInfoBase = f.createEClass();
             extInfoBase.setName("FormItemExtInfo"); //$NON-NLS-1$
             extInfoBase.setAbstract(true);
-            EClass usualGroupExtInfo = subExtInfo(f, extInfoBase, "UsualGroupExtInfo"); //$NON-NLS-1$
+            usualGroupExtInfo = subExtInfo(f, extInfoBase, "UsualGroupExtInfo"); //$NON-NLS-1$
+            // The UsualGroup layout properties that live under <extInfo> (#235): the children grouping
+            // plus united / showLeftMargin / throughAlign / currentRowUse / representation.
+            addEnum(f, usualGroupExtInfo, "group", formChildrenGroup); //$NON-NLS-1$
+            addBoolean(f, usualGroupExtInfo, "united"); //$NON-NLS-1$
+            addBoolean(f, usualGroupExtInfo, "showLeftMargin"); //$NON-NLS-1$
+            addEnum(f, usualGroupExtInfo, "throughAlign", throughAlign); //$NON-NLS-1$
+            addEnum(f, usualGroupExtInfo, "currentRowUse", currentRowUse); //$NON-NLS-1$
+            addEnum(f, usualGroupExtInfo, "representation", groupRepresentation); //$NON-NLS-1$
             EClass popupGroupExtInfo = subExtInfo(f, extInfoBase, "PopupGroupExtInfo"); //$NON-NLS-1$
             EClass pageGroupExtInfo = subExtInfo(f, extInfoBase, "PageGroupExtInfo"); //$NON-NLS-1$
             EClass pagesGroupExtInfo = subExtInfo(f, extInfoBase, "PagesGroupExtInfo"); //$NON-NLS-1$
@@ -2281,6 +2398,9 @@ public class FormElementWriterTest
             pkg.getEClassifiers().add(placementArea);
             pkg.getEClassifiers().add(groupType);
             pkg.getEClassifiers().add(currentRowUse);
+            pkg.getEClassifiers().add(formChildrenGroup);
+            pkg.getEClassifiers().add(throughAlign);
+            pkg.getEClassifiers().add(groupRepresentation);
             pkg.getEClassifiers().add(decorationType);
             pkg.getEClassifiers().add(fieldType);
             pkg.getEClassifiers().add(horizontalAlign);

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataPropertyIntrospectorTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataPropertyIntrospectorTest.java
@@ -6,13 +6,26 @@
 
 package com.ditrix.edt.mcp.server.utils;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EEnum;
+import org.eclipse.emf.ecore.EEnumLiteral;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.EcoreFactory;
+import org.eclipse.emf.ecore.EcorePackage;
 import org.junit.Test;
 
 import com._1c.g5.v8.dt.metadata.mdclass.Catalog;
@@ -275,5 +288,338 @@ public class MetadataPropertyIntrospectorTest
         assertTrue("chartOfAccounts must be a single REFERENCE", coa.valueKind == ValueKind.REFERENCE); //$NON-NLS-1$
         assertTrue("chartOfAccounts must report its ChartOfAccounts target type", //$NON-NLS-1$
             coa.allowedValues.contains("ChartOfAccounts")); //$NON-NLS-1$
+    }
+
+    // ---- extInfo-aware overloads (issue #235) ---------------------------------------------------
+    //
+    // A form element carries its kind-specific / layout properties on a nested <extInfo> EObject (e.g.
+    // a group's UsualGroupExtInfo group/united/showLeftMargin/...). These are exercised headlessly on a
+    // synthetic EPackage (newGroupFixture) shaped like the form metamodel - NO form-model dependency,
+    // the introspector only sees EObjects/EClasses.
+
+    @Test
+    public void testFindFeatureResolvesExtInfoLayoutEnum()
+    {
+        GroupFixture fx = newGroupFixture();
+        PropertyInfo group = MetadataPropertyIntrospector.findFeature(fx.group, fx.extInfo, "group"); //$NON-NLS-1$
+        assertNotNull("the group layout enum lives on the extInfo and must resolve", group); //$NON-NLS-1$
+        assertTrue("group must be an ENUM", group.valueKind == ValueKind.ENUM); //$NON-NLS-1$
+        assertTrue("group must be reported as living on the extInfo", group.onExtInfo); //$NON-NLS-1$
+        assertSame("the resolved feature must be the extInfo's own feature", //$NON-NLS-1$
+            fx.extInfoEClass.getEStructuralFeature("group"), group.feature); //$NON-NLS-1$
+        assertTrue("group must list its grouping literals", //$NON-NLS-1$
+            group.allowedValues.contains("Horizontal") && group.allowedValues.contains("Vertical")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFindFeatureResolvesExtInfoBoolean()
+    {
+        GroupFixture fx = newGroupFixture();
+        PropertyInfo united = MetadataPropertyIntrospector.findFeature(fx.group, fx.extInfo, "united"); //$NON-NLS-1$
+        assertNotNull("the 'united' layout flag lives on the extInfo and must resolve", united); //$NON-NLS-1$
+        assertTrue("united must be a BOOLEAN", united.valueKind == ValueKind.BOOLEAN); //$NON-NLS-1$
+        assertTrue("united must be reported as living on the extInfo", united.onExtInfo); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindFeatureDirectWinsOnNameCollision()
+    {
+        // The synthetic extInfo declares a boolean 'name' that COLLIDES with the element's direct String
+        // 'name'. The DIRECT feature must win: the resolved property is the element's String, onExtInfo
+        // false, so a write targets the element - never the extInfo.
+        GroupFixture fx = newGroupFixture();
+        PropertyInfo name = MetadataPropertyIntrospector.findFeature(fx.group, fx.extInfo, "name"); //$NON-NLS-1$
+        assertNotNull(name);
+        assertFalse("a direct feature must win the name collision (not the extInfo one)", name.onExtInfo); //$NON-NLS-1$
+        assertTrue("the winning direct 'name' is the element's String", name.valueKind == ValueKind.STRING); //$NON-NLS-1$
+        assertSame("the resolved feature must be the element's own feature", //$NON-NLS-1$
+            fx.group.eClass().getEStructuralFeature("name"), name.feature); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindFeatureDirectFeatureHasOnExtInfoFalse()
+    {
+        GroupFixture fx = newGroupFixture();
+        PropertyInfo id = MetadataPropertyIntrospector.findFeature(fx.group, fx.extInfo, "id"); //$NON-NLS-1$
+        assertNotNull(id);
+        assertTrue("id is a direct INTEGER", id.valueKind == ValueKind.INTEGER); //$NON-NLS-1$
+        assertFalse("a direct feature is never onExtInfo", id.onExtInfo); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindFeatureWithNullExtInfoResolvesOnlyDirect()
+    {
+        // A null extInfo (the element has no extInfo instance yet) still resolves the DIRECT features but
+        // cannot reach an extInfo-only property.
+        GroupFixture fx = newGroupFixture();
+        PropertyInfo name = MetadataPropertyIntrospector.findFeature(fx.group, null, "name"); //$NON-NLS-1$
+        assertNotNull("a direct feature must resolve even without an extInfo", name); //$NON-NLS-1$
+        assertFalse(name.onExtInfo);
+        assertNull("an extInfo-only property is unreachable without the extInfo instance", //$NON-NLS-1$
+            MetadataPropertyIntrospector.findFeature(fx.group, null, "group")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindFeatureUnknownReturnsNull()
+    {
+        GroupFixture fx = newGroupFixture();
+        assertNull(MetadataPropertyIntrospector.findFeature(fx.group, fx.extInfo, "noSuchProperty")); //$NON-NLS-1$
+        // The raw containment 'extInfo' reference is not itself an assignable property.
+        assertNull(MetadataPropertyIntrospector.findFeature(fx.group, fx.extInfo, "extInfo")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testAssignableNamesUnionDirectThenExtInfo()
+    {
+        GroupFixture fx = newGroupFixture();
+        List<String> union = MetadataPropertyIntrospector.assignableNames(fx.group, fx.extInfoEClass);
+        for (String direct : new String[] {"name", "id", "type"}) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        {
+            assertTrue("union must keep the direct property " + direct, union.contains(direct)); //$NON-NLS-1$
+        }
+        for (String ext : new String[] {"group", "united", "showLeftMargin", "throughAlign", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            "currentRowUse", "representation"}) //$NON-NLS-1$ //$NON-NLS-2$
+        {
+            assertTrue("union must add the extInfo property " + ext, union.contains(ext)); //$NON-NLS-1$
+        }
+        // Direct-precedence: the colliding 'name' appears exactly once, and the direct names precede the
+        // extInfo ones.
+        assertEquals("the colliding 'name' must appear exactly once", //$NON-NLS-1$
+            1, Collections.frequency(union, "name")); //$NON-NLS-1$
+        assertTrue("direct names must precede extInfo names", //$NON-NLS-1$
+            union.indexOf("type") < union.indexOf("group")); //$NON-NLS-1$ //$NON-NLS-2$
+        // The raw containment extInfo reference is not listed.
+        assertFalse("the raw extInfo containment ref must not be listed", union.contains("extInfo")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testAssignableNamesNullExtInfoEqualsDirect()
+    {
+        GroupFixture fx = newGroupFixture();
+        assertEquals("a null extInfo EClass must reduce to the direct-only listing", //$NON-NLS-1$
+            MetadataPropertyIntrospector.assignableNames(fx.group),
+            MetadataPropertyIntrospector.assignableNames(fx.group, (EClass)null));
+    }
+
+    @Test
+    public void testIntrospectExtInfoEClassListsKindAndAllowedWithoutCurrent()
+    {
+        // The EClass overload lists the extInfo features (kind + allowed enum values) but, having no
+        // instance, renders no current value.
+        GroupFixture fx = newGroupFixture();
+        PropertyInfo group = pick(
+            MetadataPropertyIntrospector.introspect(fx.group, fx.extInfoEClass), "group"); //$NON-NLS-1$
+        assertNotNull(group);
+        assertTrue("group must be an ENUM", group.valueKind == ValueKind.ENUM); //$NON-NLS-1$
+        assertTrue("group must be onExtInfo", group.onExtInfo); //$NON-NLS-1$
+        assertTrue("group must list its allowed literals", //$NON-NLS-1$
+            group.allowedValues.contains("Horizontal")); //$NON-NLS-1$
+        assertNull("the EClass listing renders no current value", group.currentValue); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testIntrospectExtInfoInstanceRendersCurrent()
+    {
+        // The instance overload reads the current values off the live extInfo instance.
+        GroupFixture fx = newGroupFixture();
+        EStructuralFeature groupFeature = fx.extInfoEClass.getEStructuralFeature("group"); //$NON-NLS-1$
+        fx.extInfo.eSet(groupFeature, fx.grouping.getEEnumLiteralByLiteral("Horizontal")); //$NON-NLS-1$
+        fx.extInfo.eSet(fx.extInfoEClass.getEStructuralFeature("united"), Boolean.TRUE); //$NON-NLS-1$
+
+        List<PropertyInfo> props = MetadataPropertyIntrospector.introspect(fx.group, fx.extInfo);
+        PropertyInfo group = pick(props, "group"); //$NON-NLS-1$
+        assertNotNull(group);
+        assertTrue("group must be onExtInfo", group.onExtInfo); //$NON-NLS-1$
+        assertEquals("the current group must render as the set literal name", "Horizontal", //$NON-NLS-1$ //$NON-NLS-2$
+            group.currentValue);
+        assertTrue("the current value must share the allowed vocabulary", //$NON-NLS-1$
+            group.allowedValues.contains(group.currentValue));
+        assertEquals("the current 'united' flag must render", "true", //$NON-NLS-1$ //$NON-NLS-2$
+            pick(props, "united").currentValue); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testIntrospectDirectPropsPrecedeAndKeepOnExtInfoFalse()
+    {
+        GroupFixture fx = newGroupFixture();
+        List<PropertyInfo> direct = MetadataPropertyIntrospector.introspect(fx.group);
+        List<PropertyInfo> union = MetadataPropertyIntrospector.introspect(fx.group, fx.extInfoEClass);
+        // The union starts with exactly the direct properties (same order), each still onExtInfo false.
+        assertTrue("the union must be longer than the direct-only listing", union.size() > direct.size()); //$NON-NLS-1$
+        for (int i = 0; i < direct.size(); i++)
+        {
+            assertEquals(direct.get(i).name, union.get(i).name);
+            assertSame(direct.get(i).feature, union.get(i).feature);
+            assertFalse("a direct property must stay onExtInfo false", union.get(i).onExtInfo); //$NON-NLS-1$
+        }
+    }
+
+    @Test
+    public void testResolveEnumLiteralOnExtInfoFeatureIsCaseInsensitive()
+    {
+        // The shared resolveEnumLiteral works for an extInfo feature exactly as for a direct one.
+        GroupFixture fx = newGroupFixture();
+        EStructuralFeature groupFeature = fx.extInfoEClass.getEStructuralFeature("group"); //$NON-NLS-1$
+        EEnumLiteral lit = MetadataPropertyIntrospector.resolveEnumLiteral(groupFeature, "horizontal"); //$NON-NLS-1$
+        assertNotNull("an extInfo enum must resolve case-insensitively", lit); //$NON-NLS-1$
+        assertEquals("Horizontal", lit.getName()); //$NON-NLS-1$
+        assertNull(MetadataPropertyIntrospector.resolveEnumLiteral(groupFeature, "NotAGrouping_zzz")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSingleArgIntrospectUnaffectedByExtInfoOverloads()
+    {
+        // The mdclass path is unchanged: a real object (no extInfo) introspected with a null extInfo
+        // EClass yields exactly the single-arg listing.
+        CatalogAttribute attr = newAttribute();
+        List<String> viaNull = MetadataPropertyIntrospector.assignableNames(attr, (EClass)null);
+        assertEquals(MetadataPropertyIntrospector.assignableNames(attr), viaNull);
+        // And the direct listing never carries an onExtInfo property.
+        for (PropertyInfo p : MetadataPropertyIntrospector.introspect(attr))
+        {
+            assertFalse("mdclass properties are never onExtInfo", p.onExtInfo); //$NON-NLS-1$
+        }
+    }
+
+    /** Picks the property named {@code name} from a listing, or {@code null}. */
+    private static PropertyInfo pick(List<PropertyInfo> props, String name)
+    {
+        for (PropertyInfo p : props)
+        {
+            if (p.name.equals(name))
+            {
+                return p;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * A synthetic form-group-like element with its nested extInfo, built on a dynamic EPackage so the
+     * extInfo-aware overloads can be exercised headlessly (no form-model dependency). The extInfo
+     * declares the #235 layout features plus a boolean {@code name} that deliberately collides with the
+     * element's direct {@code name} (to probe DIRECT-precedence).
+     */
+    private static final class GroupFixture
+    {
+        final EObject group;
+        final EObject extInfo;
+        final EClass extInfoEClass;
+        final EEnum grouping;
+
+        GroupFixture(EObject group, EObject extInfo, EClass extInfoEClass, EEnum grouping)
+        {
+            this.group = group;
+            this.extInfo = extInfo;
+            this.extInfoEClass = extInfoEClass;
+            this.grouping = grouping;
+        }
+    }
+
+    private static GroupFixture newGroupFixture()
+    {
+        EcoreFactory f = EcoreFactory.eINSTANCE;
+        EPackage pkg = f.createEPackage();
+        pkg.setName("introspectlike"); //$NON-NLS-1$
+        pkg.setNsPrefix("introspectlike"); //$NON-NLS-1$
+        pkg.setNsURI("http://ditrix.com/test/introspectlike"); //$NON-NLS-1$
+
+        EEnum grouping = newEnum(f, "FormChildrenGroup", //$NON-NLS-1$
+            "Auto", "Vertical", "Horizontal", "HorizontalIfPossible"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        EEnum throughAlign = newEnum(f, "UsualGroupThroughAlign", "Auto", "Use", "DontUse"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        EEnum currentRowUse = newEnum(f, "CurrentRowUse", "DontUse", "Use", "Auto"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        EEnum representation = newEnum(f, "UsualGroupRepresentation", //$NON-NLS-1$
+            "None", "StrongSeparation", "WeakSeparation"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        EEnum groupType = newEnum(f, "ManagedFormGroupType", "UsualGroup", "Pages", "Page"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+
+        EClass extInfoBase = f.createEClass();
+        extInfoBase.setName("FormItemExtInfo"); //$NON-NLS-1$
+        extInfoBase.setAbstract(true);
+
+        EClass usualGroupExtInfo = f.createEClass();
+        usualGroupExtInfo.setName("UsualGroupExtInfo"); //$NON-NLS-1$
+        usualGroupExtInfo.getESuperTypes().add(extInfoBase);
+        addEnum(f, usualGroupExtInfo, "group", grouping); //$NON-NLS-1$
+        addBoolean(f, usualGroupExtInfo, "united"); //$NON-NLS-1$
+        addBoolean(f, usualGroupExtInfo, "showLeftMargin"); //$NON-NLS-1$
+        addEnum(f, usualGroupExtInfo, "throughAlign", throughAlign); //$NON-NLS-1$
+        addEnum(f, usualGroupExtInfo, "currentRowUse", currentRowUse); //$NON-NLS-1$
+        addEnum(f, usualGroupExtInfo, "representation", representation); //$NON-NLS-1$
+        // A boolean 'name' that COLLIDES with the element's direct String 'name' (precedence probe).
+        addBoolean(f, usualGroupExtInfo, "name"); //$NON-NLS-1$
+
+        EClass formGroup = f.createEClass();
+        formGroup.setName("FormGroup"); //$NON-NLS-1$
+        addString(f, formGroup, "name"); //$NON-NLS-1$
+        addInt(f, formGroup, "id"); //$NON-NLS-1$
+        addEnum(f, formGroup, "type", groupType); //$NON-NLS-1$
+        EReference extInfoRef = f.createEReference();
+        extInfoRef.setName("extInfo"); //$NON-NLS-1$
+        extInfoRef.setEType(extInfoBase);
+        extInfoRef.setContainment(true);
+        extInfoRef.setUpperBound(1);
+        formGroup.getEStructuralFeatures().add(extInfoRef);
+
+        pkg.getEClassifiers().add(grouping);
+        pkg.getEClassifiers().add(throughAlign);
+        pkg.getEClassifiers().add(currentRowUse);
+        pkg.getEClassifiers().add(representation);
+        pkg.getEClassifiers().add(groupType);
+        pkg.getEClassifiers().add(extInfoBase);
+        pkg.getEClassifiers().add(usualGroupExtInfo);
+        pkg.getEClassifiers().add(formGroup);
+
+        EObject group = pkg.getEFactoryInstance().create(formGroup);
+        EObject extInfo = pkg.getEFactoryInstance().create(usualGroupExtInfo);
+        group.eSet(extInfoRef, extInfo);
+        return new GroupFixture(group, extInfo, usualGroupExtInfo, grouping);
+    }
+
+    private static EEnum newEnum(EcoreFactory f, String name, String... literals)
+    {
+        EEnum eEnum = f.createEEnum();
+        eEnum.setName(name);
+        int value = 0;
+        for (String literal : literals)
+        {
+            EEnumLiteral eLiteral = f.createEEnumLiteral();
+            eLiteral.setName(literal);
+            eLiteral.setLiteral(literal);
+            eLiteral.setValue(value++);
+            eEnum.getELiterals().add(eLiteral);
+        }
+        return eEnum;
+    }
+
+    private static void addString(EcoreFactory f, EClass owner, String name)
+    {
+        EAttribute attribute = f.createEAttribute();
+        attribute.setName(name);
+        attribute.setEType(EcorePackage.Literals.ESTRING);
+        owner.getEStructuralFeatures().add(attribute);
+    }
+
+    private static void addInt(EcoreFactory f, EClass owner, String name)
+    {
+        EAttribute attribute = f.createEAttribute();
+        attribute.setName(name);
+        attribute.setEType(EcorePackage.Literals.EINT);
+        owner.getEStructuralFeatures().add(attribute);
+    }
+
+    private static void addBoolean(EcoreFactory f, EClass owner, String name)
+    {
+        EAttribute attribute = f.createEAttribute();
+        attribute.setName(name);
+        attribute.setEType(EcorePackage.Literals.EBOOLEAN);
+        owner.getEStructuralFeatures().add(attribute);
+    }
+
+    private static void addEnum(EcoreFactory f, EClass owner, String name, EEnum type)
+    {
+        EAttribute attribute = f.createEAttribute();
+        attribute.setName(name);
+        attribute.setEType(type);
+        owner.getEStructuralFeatures().add(attribute);
     }
 }

--- a/tests/e2e/tools/test_get_metadata_details.py
+++ b/tests/e2e/tools/test_get_metadata_details.py
@@ -272,3 +272,46 @@ def test_common_form_fqn_renders_structure():
     # The enriched renderer (FormStructureReader.render) always emits the Event handlers section
     # header, even for a form that declares no handlers (empty-section convention).
     assert_contains(r.text, "Event handlers", "the enriched structure must add an Event handlers section")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# FORM-MEMBER assignable schema — a form GROUP FQN (assignable:true) lists the
+# layout props nested in <extInfo> (issue #235). A form member is NOT an mdclass
+# node, so the assignable view used to fail with "Object not found"; it now routes
+# the FQN through modify_metadata's form resolver and renders the element's own
+# features UNION its extInfo's layout props (the general reflective extInfo path).
+# ──────────────────────────────────────────────────────────────────────────────
+
+@e2e_test(tool="get_metadata_details", kind="write-metadata")
+def test_assignable_on_form_group_lists_extinfo_layout_props():
+    # Seed a UsualGroup on the fixture form, then read its assignable schema.
+    grp = "GMDAsgGrp"
+    r0 = call("create_metadata", {
+        "projectName": PROJECT, "fqn": "Catalog.Catalog.Form.ItemForm.Group." + grp})
+    assert_ok(r0, "seed form group " + grp)
+    wait_for_project_ready()
+
+    r = call("get_metadata_details", {
+        "projectName": PROJECT,
+        "objectFqns": ["Catalog.Catalog.Form.ItemForm.Group." + grp],
+        "assignable": True,
+    })
+    assert_ok(r, "assignable schema for a form-group FQN")
+    # Regression guard for the reported bug: a valid form-group FQN must resolve via the form
+    # resolver, NOT be rejected as an unresolvable mdclass node.
+    assert_not_contains(r.text, "Object not found",
+        "a valid form-group FQN must not fail as 'Object not found'")
+    if "## Errors" in r.text:
+        raise AssertionError(
+            "the form group should resolve, but a ## Errors section was emitted:\n" + r.text[:400])
+    assert_contains(r.text, "Assignable properties",
+        "assignable mode must render the schema heading for a form member")
+    # The UsualGroupExtInfo layout props live INSIDE <extInfo>; the general reflective extInfo path
+    # now surfaces them. `group` (the grouping layout enum) and `united` are the canonical two
+    # from the issue. Assert the table CELLS (| group |) so the FQN heading's "Group" cannot match.
+    assert_contains(r.text, "| group |",
+        "the extInfo layout 'group' enum must be listed as assignable")
+    assert_contains(r.text, "| united |",
+        "the extInfo 'united' layout flag must be listed as assignable")
+    # (No assert_no_diff here: the test intentionally SEEDS the group, so the tree is dirty; the
+    # pure-read nature of the assignable view is covered by the mdclass assignable read tests.)

--- a/tests/e2e/tools/test_modify_metadata.py
+++ b/tests/e2e/tools/test_modify_metadata.py
@@ -956,3 +956,77 @@ def test_rebind_button_command_mixed_with_other_property_rejected():
     assert_error_quality(e, suggests=["cannot be combined", "separate call"],
                          ctx="a button command rebind cannot be mixed with a property change")
     assert_tree_unchanged(before, "a rejected mixed rebind must change nothing")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Happy — form GROUP layout props that live under <extInfo> (UsualGroupExtInfo):
+# the grouping `group` enum + the `united` flag are NOT on the group element but
+# on its nested UsualGroupExtInfo. modify_metadata resolves / creates that extInfo
+# holder reflectively and routes the eSet there (issue #235). A mixed direct +
+# extInfo batch routes each property to its correct holder in one transaction.
+# Fixture: Catalog.Catalog has a managed form "ItemForm".
+# ──────────────────────────────────────────────────────────────────────────────
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_modify_form_group_extinfo_layout_props():
+    # Set a UsualGroup's grouping (`group`) + `united` flag: both live on the group's nested
+    # UsualGroupExtInfo, so the tool must create / reuse that extInfo holder and land the values there.
+    _seed_form_group("ExtGrp")
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": "Catalog.Catalog.Form.ItemForm.Group.ExtGrp",
+        "properties": [
+            # "Vertical" (not the enum default "Horizontal", which EMF omits from disk as eIsSet==false).
+            {"name": "group", "value": "Vertical"},
+            {"name": "united", "value": True},
+        ],
+    })
+    assert_ok(r, "set a UsualGroup's group + united (extInfo layout props)")
+    assert r.structured.get("action") == "modified", "must report modified: %r" % (r.structured,)
+    applied = r.structured.get("applied") or []
+    for f in ("group", "united"):
+        assert f in applied, "%s must be in applied: %r" % (f, r.structured)
+    assert r.structured.get("persisted") is True, \
+        "the extInfo change must force-export the .form to disk: %r" % (r.structured,)
+    # The nested <extInfo xsi:type="form:UsualGroupExtInfo"> + the grouping value land in the .form.
+    poll_diff_contains("UsualGroupExtInfo",
+                       ctx="the nested extInfo (form:UsualGroupExtInfo) must land in the .form on disk")
+    assert_contains(diff(), "<group>Vertical</group>",
+                    "the group's Vertical grouping must land under <extInfo> on disk")
+
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_modify_form_group_mixed_direct_and_extinfo_batch():
+    # A single call mixing a DIRECT feature (visible, on the group element) with an extInfo feature
+    # (group, on UsualGroupExtInfo) must apply each to its correct holder in ONE transaction: both land.
+    _seed_form_group("MixExtGrp")
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": "Catalog.Catalog.Form.ItemForm.Group.MixExtGrp",
+        "properties": [
+            {"name": "visible", "value": False},        # direct feature on the group element
+            {"name": "group", "value": "Vertical"},     # extInfo feature (UsualGroupExtInfo.group); non-default so it serializes
+        ],
+    })
+    assert_ok(r, "mixed direct + extInfo batch on a UsualGroup")
+    applied = r.structured.get("applied") or []
+    for f in ("visible", "group"):
+        assert f in applied, "%s must be in applied: %r" % (f, r.structured)
+    # The extInfo grouping prop from the mixed batch reaches the created UsualGroupExtInfo holder.
+    poll_diff_contains("<group>Vertical</group>",
+                       ctx="the extInfo group prop from a mixed batch must land under <extInfo>")
+    assert_contains(diff(), "UsualGroupExtInfo",
+                    "the mixed batch must create the UsualGroupExtInfo holder for the extInfo prop")
+
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_modify_form_group_unknown_extinfo_property_lists_assignable():
+    # An unknown property on a group is rejected with the now-EXTENDED assignable set (member ∪ extInfo),
+    # so the error steers the caller to the real layout props that live under <extInfo>.
+    _seed_form_group("BadExtGrp")
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": "Catalog.Catalog.Form.ItemForm.Group.BadExtGrp",
+        "properties": [{"name": "definitelyNotAGroupProp_zz", "value": "x"}],
+    })
+    e = assert_error(r, "unknown group property")
+    assert_error_quality(e, names=["definitelyNotAGroupProp_zz"],
+                         suggests=["not assignable", "Assignable properties"],
+                         ctx="an unknown group property lists the assignable set incl. the extInfo props")


### PR DESCRIPTION
Closes #235.

## Проблема
Layout-свойства формы-группы (`UsualGroup`) — `group` (Группировка), `united`, `showLeftMargin`, `throughAlign`, `currentRowUse`, `representation` — **не прямые фичи** FormGroup, они сериализуются внутри вложенного `<extInfo xsi:type="form:UsualGroupExtInfo">`. Резолвер assignable-свойств видел только прямые фичи → `modify_metadata` отклонял их («Property 'group' is not assignable on FormGroup»), а `get_metadata_details(assignable:true)` по FQN формы-группы возвращал «Object not found» (резолвил через mdclass-дерево, а `modify_metadata` — через form-резолвер).

## Решение — один общий рефлективный extInfo-путь
Без импорта `com._1c.g5.v8.dt.form.model` (PLUGIN §2):
- **`MetadataPropertyIntrospector`** — extInfo-overloads: после промаха по прямой фиче обходит фичи `element.extInfo` (приоритет у прямой при коллизии имён); `PropertyInfo.onExtInfo` говорит вызывающему, куда писать. Одноаргументные сигнатуры байт-идентичны → **mdclass не затронут** (у него нет extInfo → обход = no-op).
- **`FormElementWriter.ensureExtInfo()`** — рефлективно **переиспользует** существующий extInfo или создаёт нужный ExtInfo EObject (через form-EFactory), **никогда не затирая** уже заданные свойства; `resolveExtInfoEClass()` — read-only для листинга.
- **`ModifyMetadataTool`** — маршрутизирует eSet extInfo-свойства в extInfo-держатель (микс direct+extInfo в одной BM-транзакции + forceExport). Смена `type` группы вместе с extInfo-свойством в одном вызове **отклоняется чисто** (`formTypeExtInfoComboError`), а не падает сырым EMF `IllegalArgumentException`.
- **`GetMetadataDetailsTool`** — assignable-ветка резолвит FQN формы-члена через form-резолвер и листит `group` + extInfo-свойства (с текущими значениями).

**Общий путь** (не спец-кейс UsualGroup): страницы/таблицы/декорации получают свои extInfo-свойства бесплатно — по комментарию @Ango1eiro о более широкой проблеме.

## ⚠️ Два решения приняты мной (на твоё ревью)
1. **Scope = общий рефлективный extInfo-путь** (не только UsualGroup) — правильная высота, mdclass не задет, покрывает и страницы/таблицы.
2. **Дефолт `united` в `create_metadata` НЕ трогал.** Сделать `united` **задаваемым** (эта задача) уже решает проблему @Ango1eiro (агент теперь может починить раскладку). Ставить ли новым `UsualGroup` `united=true` по умолчанию при создании — **отдельное решение по CREATE**; если нужно — сделаю фоллоу-апом.

## Проверка (стенд 2025.2.6, байт-на-диске)
- `<extInfo xsi:type="form:UsualGroupExtInfo"><group>Vertical</group><united>true</united>` реально ложится на диск; mixed-batch (direct+extInfo — каждое в свой держатель), non-clobber, guard `type`+extInfo, `get_metadata_details` листинг + Current — всё зелёное; mdclass без регресса; лог чист; `tools_list.golden` без изменений.
- Живой байт-гейт поймал грабину: тест ассертил `<group>Horizontal</group>`, но **`Horizontal` — enum-дефолт** `UsualGroupExtInfo.group`, а EMF корректно не сериализует дефолт (`eIsSet==false`) → тест использует `Vertical` (non-default). Мок-юниты это не ловят — только живой .form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
