### PR TITLE
set_variable: запись значения переменной BSL в приостановленном кадре отладки (#244)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Control which MCP tools are exposed to AI assistants. This lets you reduce conte
 
 ### Tool Groups
 
-All 66 tools are organized into 9 semantic groups:
+All 67 tools are organized into 9 semantic groups:
 
 | Group | Description | Tools |
 |-------|-------------|-------|
@@ -202,7 +202,7 @@ All 66 tools are organized into 9 semantic groups:
 | **Code Intelligence** | Content assist, documentation, metadata browsing | `get_content_assist`, `get_platform_documentation`, `get_metadata_objects`, `get_metadata_details`, `list_subsystems`, `get_subsystem_content`, `find_references` |
 | **Tags** | Tag management | `get_tags`, `get_objects_by_tags` |
 | **Applications & Testing** | App management, infobase create/delete, database updates, launch, termination, testing | `get_applications`, `create_infobase`, `delete_infobase`, `list_configurations`, `update_database`, `debug_launch`, `terminate_launch`, `run_yaxunit_tests` |
-| **Debugging** | Breakpoints, stepping, variable inspection | `set_breakpoint`, `remove_breakpoint`, `list_breakpoints`, `wait_for_break`, `get_variables`, `step`, `resume`, `evaluate_expression`, `debug_yaxunit_tests`, `debug_status`, `start_profiling`, `stop_profiling`, `get_profiling_results` |
+| **Debugging** | Breakpoints, stepping, variable inspection and modification | `set_breakpoint`, `remove_breakpoint`, `list_breakpoints`, `wait_for_break`, `get_variables`, `set_variable`, `step`, `resume`, `evaluate_expression`, `debug_yaxunit_tests`, `debug_status`, `start_profiling`, `stop_profiling`, `get_profiling_results` |
 | **BSL Code** | Module browsing, code reading/writing, search, form layout inspection | `read_module_source`, `write_module_source`, `get_module_structure`, `list_modules`, `search_in_code`, `read_method_source`, `get_method_call_hierarchy`, `go_to_definition`, `get_symbol_info`, `get_form_layout_snapshot`, `get_form_screenshot`, `get_template_screenshot`, `validate_query` |
 | **Refactoring** | Metadata create (objects, members and form members), rename, delete, set properties, adopt into an extension | `create_metadata`, `rename_metadata_object`, `delete_metadata`, `modify_metadata`, `adopt_metadata_object` |
 | **Translation (LanguageTool)** | Translation strings generation, configuration synchronization, project info | `generate_translation_strings`, `translate_configuration`, `get_translation_project_info` |
@@ -215,7 +215,7 @@ Quickly switch between common tool configurations using presets:
 
 | Preset | Description |
 |--------|-------------|
-| **All Tools** | All 66 tools enabled (default) |
+| **All Tools** | All 67 tools enabled (default) |
 | **Analysis Only** | Read-only analysis — Core, Errors, Code Intelligence, Tags |
 | **Code Review** | Analysis + BSL code reading (excludes `write_module_source`) |
 | **Development** | Full development without debugging tools |

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/set_variable.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/set_variable.md
@@ -1,0 +1,27 @@
+Sets a BSL variable's value in a suspended debug stack frame - the "poke a new value in at the breakpoint" tool. It complements `get_variables` (read the frame) and `evaluate_expression` (compute a value): this one WRITES a variable you then keep running with.
+
+## When to use
+- You are suspended at a breakpoint (via `wait_for_break`) and want to change a local/parameter value before continuing - e.g. to reproduce a branch, step past a bad state, or inject test data.
+- Correcting a value mid-debug instead of restarting the whole session.
+
+## Parameter details
+Identify the frame exactly as `get_variables` does (same addressing rules):
+- `frameRef` (preferred) - the stable frame reference from `wait_for_break` / `step`.
+- `threadId` + `frameIndex` - a thread id plus a 0-based frame index (re-resolved against the live thread).
+- Pass neither and, if exactly one debug launch is suspended, its top frame is used.
+
+Then the two required inputs:
+- `variableName` (required) - the name of the variable in that frame to set.
+- `value` (required) - the new value as a BSL expression. It is evaluated live in the frame's context (a literal like `42`, `"text"`, `True`, or any BSL expression), then assigned to the variable.
+
+## What you get
+JSON: the variable after the write (`variableName`, `value`, `type`), so you can confirm the new value took hold. On failure, an actionable error (see below). A not-found / read-only / invalid-value error is raised *before* the write, so the frame is left unchanged. A **timeout** is different: the bounded worker can still complete the write after the timeout is reported, so the value may or may not have taken effect - re-read with `get_variables` to confirm.
+
+## Notes & gotchas
+- **This executes the `value` expression in the running 1C application** - like `evaluate_expression`, it can have side effects. Treat it as running code, not a plain assignment.
+- **Read-only variables cannot be set.** If the target does not support modification (e.g. a computed / read-only node), the tool returns an actionable error naming the variable instead of silently doing nothing.
+- **An invalid value is rejected up front.** If the `value` expression is malformed or its type is not assignable to the variable, the tool returns an "invalid value" error naming the variable - the frame's state is left unchanged.
+- **`variableName` not found in the frame** returns an actionable error - list the frame's variables with `get_variables` first to get the exact name.
+- **The change takes effect on `resume`/`step`.** The new value is written into the live frame now; execution uses it once you continue the thread.
+- **`frameRef`s go stale after every `step` or `resume`** - use the freshest one; a stale ref returns "call wait_for_break again" (the same frame-addressing rules as `get_variables`).
+- The write is bounded by a short timeout; a wedged client returns a timeout error rather than blocking indefinitely.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolGroup.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolGroup.java
@@ -47,7 +47,7 @@ public enum ToolGroup
     DEBUG("debug", "Debugging", //$NON-NLS-1$ //$NON-NLS-2$
         "Breakpoints, stepping, variables, expression evaluation, and profiling", //$NON-NLS-1$
         "set_breakpoint", "remove_breakpoint", "list_breakpoints", "wait_for_break", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-        "get_variables", "step", "resume", "evaluate_expression", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        "get_variables", "set_variable", "step", "resume", "evaluate_expression", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
         "debug_yaxunit_tests", "debug_status", "start_profiling", "get_profiling_results"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 
     BSL_CODE("bslCode", "BSL Code", //$NON-NLS-1$ //$NON-NLS-2$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/BuiltInToolRegistrar.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/BuiltInToolRegistrar.java
@@ -73,6 +73,7 @@ import com.ditrix.edt.mcp.server.tools.impl.RevalidateObjectsTool;
 import com.ditrix.edt.mcp.server.tools.impl.RunYaxunitTestsTool;
 import com.ditrix.edt.mcp.server.tools.impl.SearchInCodeTool;
 import com.ditrix.edt.mcp.server.tools.impl.SetBreakpointTool;
+import com.ditrix.edt.mcp.server.tools.impl.SetVariableTool;
 import com.ditrix.edt.mcp.server.tools.impl.ModifyMetadataTool;
 import com.ditrix.edt.mcp.server.tools.impl.StartProfilingTool;
 import com.ditrix.edt.mcp.server.tools.impl.StepTool;
@@ -164,6 +165,7 @@ public final class BuiltInToolRegistrar
         registry.register(new ListBreakpointsTool());
         registry.register(new WaitForBreakTool());
         registry.register(new GetVariablesTool());
+        registry.register(new SetVariableTool());
         registry.register(new StepTool());
         registry.register(new ResumeTool());
         registry.register(new EvaluateExpressionTool());

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/Toolsets.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/Toolsets.java
@@ -137,8 +137,8 @@ public final class Toolsets
 
         assign(DEBUG,
             "debug_launch", "debug_status", "set_breakpoint", "remove_breakpoint", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-            "list_breakpoints", "wait_for_break", "get_variables", "step", "resume", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
-            "evaluate_expression", "get_applications", "terminate_launch"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            "list_breakpoints", "wait_for_break", "get_variables", "set_variable", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            "step", "resume", "evaluate_expression", "get_applications", "terminate_launch"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 
         assign(TESTING,
             "run_yaxunit_tests", "debug_yaxunit_tests"); //$NON-NLS-1$ //$NON-NLS-2$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetVariablesTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetVariablesTool.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.debug.core.model.IStackFrame;
-import org.eclipse.debug.core.model.IThread;
 import org.eclipse.debug.core.model.IVariable;
 
 import com.ditrix.edt.mcp.server.Activator;
@@ -18,8 +17,8 @@ import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
 import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.DebugFrameResolver;
 import com.ditrix.edt.mcp.server.utils.DebugSessionRegistry;
-import com.ditrix.edt.mcp.server.utils.DebugTargetResolver;
 import com.ditrix.edt.mcp.server.utils.VariableSerializer;
 
 /**
@@ -89,7 +88,7 @@ public class GetVariablesTool implements IMcpTool
 
         try
         {
-            FrameResolution fr = resolveFrame(registry, frameRef, threadId, frameIndex);
+            DebugFrameResolver.Resolution fr = DebugFrameResolver.resolve(registry, frameRef, threadId, frameIndex);
             if (fr.error != null)
             {
                 return fr.error;
@@ -101,90 +100,6 @@ public class GetVariablesTool implements IMcpTool
             Activator.logError("Error in get_variables", e); //$NON-NLS-1$
             return ToolResult.error(e.getMessage()).toJson(); //$NON-NLS-1$
         }
-    }
-
-    /**
-     * Resolves the target stack frame from (in priority order) {@code frameRef},
-     * {@code threadId + frameIndex}, or the auto-resolved single active debug
-     * session. Returns a holder carrying either the resolved frame or the exact
-     * error JSON the original inline branch produced — the caller re-checks
-     * {@code error} and returns it unchanged.
-     *
-     * @return a {@link FrameResolution} with a non-null {@code frame} on success,
-     *         or a non-null {@code error} (same value/case as before) otherwise
-     */
-    private static FrameResolution resolveFrame(DebugSessionRegistry registry, long frameRef, long threadId,
-        int frameIndex)
-        throws org.eclipse.debug.core.DebugException
-    {
-        if (frameRef > 0)
-        {
-            return resolveByFrameRef(registry, frameRef);
-        }
-        if (threadId > 0)
-        {
-            return resolveByThreadId(registry, threadId, frameIndex);
-        }
-        return resolveByAutoSession(registry, frameIndex);
-    }
-
-    /** Resolves the frame stored under a stable {@code frameRef} from wait_for_break. */
-    private static FrameResolution resolveByFrameRef(DebugSessionRegistry registry, long frameRef)
-    {
-        IStackFrame frame = registry.getFrame(frameRef);
-        if (frame == null)
-        {
-            return FrameResolution.failed(
-                ToolResult.error("stale frameRef — call wait_for_break again").toJson()); //$NON-NLS-1$
-        }
-        return FrameResolution.of(frame);
-    }
-
-    /** Resolves the {@code frameIndex}-th frame of the live thread {@code threadId}. */
-    private static FrameResolution resolveByThreadId(DebugSessionRegistry registry, long threadId, int frameIndex)
-        throws org.eclipse.debug.core.DebugException
-    {
-        IThread thread = registry.getThread(threadId);
-        if (thread == null)
-        {
-            return FrameResolution.failed(
-                ToolResult.error("stale threadId — call wait_for_break again").toJson()); //$NON-NLS-1$
-        }
-        IStackFrame[] frames = thread.getStackFrames();
-        if (frameIndex < 0 || frameIndex >= frames.length)
-        {
-            return FrameResolution.failed(ToolResult.error("frameIndex out of range (0.." //$NON-NLS-1$
-                + (frames.length - 1) + ")").toJson()); //$NON-NLS-1$
-        }
-        return FrameResolution.of(frames[frameIndex]);
-    }
-
-    /**
-     * Fallback: auto-resolve the single active debug session through the SAME
-     * blank-id policy every applicationId-based tool uses (DebugTargetResolver:
-     * the lone Eclipse launch, else the lone server target) and read its snapshot
-     * under the canonical key — replaces a hand-rolled condensed copy of that
-     * policy. The frame index is clamped into range.
-     */
-    private static FrameResolution resolveByAutoSession(DebugSessionRegistry registry, int frameIndex)
-        throws org.eclipse.debug.core.DebugException
-    {
-        DebugTargetResolver.Resolution res = DebugTargetResolver.resolve(null);
-        DebugSessionRegistry.SuspendSnapshot snap =
-            res != null ? registry.getSnapshot(res.canonicalId) : null;
-        if (snap == null)
-        {
-            return FrameResolution.failed(
-                ToolResult.error("Provide frameRef or threadId — no single suspended debug " //$NON-NLS-1$
-                    + "session available for auto-resolution. Call wait_for_break first.").toJson()); //$NON-NLS-1$
-        }
-        IStackFrame[] frames = snap.thread.getStackFrames();
-        if (frames.length == 0)
-        {
-            return FrameResolution.failed(
-                ToolResult.error("suspended thread has no stack frames").toJson()); //$NON-NLS-1$
-        }
-        return FrameResolution.of(frames[Math.min(Math.max(frameIndex, 0), frames.length - 1)]);
     }
 
     /**
@@ -213,33 +128,6 @@ public class GetVariablesTool implements IMcpTool
             .put("variables", vars) //$NON-NLS-1$
             .put("count", vars.size()) //$NON-NLS-1$
             .toJson();
-    }
-
-    /**
-     * Holder threading a frame-resolution early-return out of {@link #resolveFrame}:
-     * exactly one of {@code frame} / {@code error} is non-null. {@code error} carries
-     * the same error JSON (same case) the inline branches returned.
-     */
-    private static final class FrameResolution
-    {
-        final IStackFrame frame;
-        final String error;
-
-        private FrameResolution(IStackFrame frame, String error)
-        {
-            this.frame = frame;
-            this.error = error;
-        }
-
-        static FrameResolution of(IStackFrame frame)
-        {
-            return new FrameResolution(frame, null);
-        }
-
-        static FrameResolution failed(String error)
-        {
-            return new FrameResolution(null, error);
-        }
     }
 
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetVariableTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetVariableTool.java
@@ -97,7 +97,10 @@ public class SetVariableTool implements IMcpTool
             .stringProperty(KEY_VARIABLE_NAME,
                 "Name of the variable to set (dot-separated to reach a nested member)", true) //$NON-NLS-1$
             .stringProperty(KEY_VALUE,
-                "New value as a BSL literal/expression (e.g. 42, \"text\", True, Дата(2025,1,1))", true) //$NON-NLS-1$
+                // The example ends in Дата(2025,1,1), the BSL Date() constructor; the Cyrillic is escaped
+                // as unicode escapes because this description ships in tools/list (ASCII-safe under any tooling).
+                "New value as a BSL literal/expression (e.g. 42, \"text\", True, " //$NON-NLS-1$
+                    + "\u0414\u0430\u0442\u0430(2025,1,1))", true) //$NON-NLS-1$
             .build();
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetVariableTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetVariableTool.java
@@ -1,0 +1,296 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.debug.core.DebugException;
+import org.eclipse.debug.core.model.IStackFrame;
+import org.eclipse.debug.core.model.IVariable;
+
+import com.ditrix.edt.mcp.server.Activator;
+import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
+import com.ditrix.edt.mcp.server.protocol.JsonUtils;
+import com.ditrix.edt.mcp.server.protocol.ToolResult;
+import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.DebugFrameResolver;
+import com.ditrix.edt.mcp.server.utils.DebugSessionRegistry;
+import com.ditrix.edt.mcp.server.utils.VariableSerializer;
+
+/**
+ * Sets the value of a single BSL variable in a suspended stack frame.
+ *
+ * <p>This is a WRITE / side-effecting tool: the entered {@code value} is applied
+ * as a BSL literal/expression live in the running 1C application through the
+ * standard Eclipse {@link IVariable#setValue(String)} modification path. The 1C
+ * debug variable model implements the platform {@code IValueModification} contract
+ * verbatim: {@code supportsValueModification()} returns a per-variable
+ * "modifiable" flag delivered by the debug protocol (an ordinary settable local
+ * returns {@code true}; a genuinely read-only node returns {@code false}), and
+ * {@code setValue(String)} routes the write through the running application's
+ * runtime evaluation engine. No 1C-internal type is referenced — the write goes
+ * through the plain Eclipse {@code IVariable} API, exactly like {@code get_variables}
+ * reads. The target frame is addressed exactly like {@code get_variables} — by
+ * {@code frameRef} (preferred, returned from {@code wait_for_break}) or
+ * {@code threadId + frameIndex} — and the variable is located by
+ * {@code variableName} (dot-separated for a nested member).
+ *
+ * <p>Read the current state first with {@code get_variables}; use
+ * {@code evaluate_expression} to compute a value WITHOUT mutating anything (in BSL
+ * an expression {@code X = 42} is a comparison that yields a Boolean, it does not
+ * assign). Both model round-trips — the {@code verifyValue} pre-flight and the
+ * {@code setValue} write — run inside a single bounded guard so a wedged debug
+ * client can never block the MCP request thread indefinitely.
+ *
+ * <p>The modification is submitted asynchronously: the running application applies
+ * it — and reports a value it rejects — on the debug evaluation thread after
+ * {@code setValue} returns. The {@code value}/{@code type} echoed back is therefore
+ * a best-effort immediate re-read that can still show the prior value; confirm the
+ * applied result with a follow-up {@code get_variables}.
+ */
+public class SetVariableTool implements IMcpTool
+{
+    public static final String NAME = "set_variable"; //$NON-NLS-1$
+
+    /** Input key: name (dot-path) of the variable to modify. */
+    private static final String KEY_VARIABLE_NAME = "variableName"; //$NON-NLS-1$
+
+    /** Input key: the new value, as a BSL literal/expression string. */
+    private static final String KEY_VALUE = "value"; //$NON-NLS-1$
+
+    /** DTO/output key: the variable's serialised type. */
+    private static final String KEY_TYPE = "type"; //$NON-NLS-1$
+
+    /** Upper bound on the blocking {@code setValue} call — mirrors evaluate_expression. */
+    private static final long SET_TIMEOUT_MS = 15_000L;
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Set a BSL variable's value in a suspended debug frame. " //$NON-NLS-1$
+            + "WRITE/side-effect: EXECUTES the entered value as a BSL literal/expression live in the running " //$NON-NLS-1$
+            + "1C application, mutating the variable. Address the frame by frameRef from wait_for_break " //$NON-NLS-1$
+            + "(preferred) or threadId+frameIndex; name the variable (dot-path for a nested member). " //$NON-NLS-1$
+            + "Read current values with get_variables first; use evaluate_expression to compute without mutating."; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getInputSchema()
+    {
+        return JsonSchemaBuilder.object()
+            .integerProperty("frameRef", "Stable frame reference returned from wait_for_break (preferred)") //$NON-NLS-1$ //$NON-NLS-2$
+            .integerProperty("threadId", "Thread id (alternative to frameRef)") //$NON-NLS-1$ //$NON-NLS-2$
+            .integerProperty("frameIndex", "0-based frame index when using threadId") //$NON-NLS-1$ //$NON-NLS-2$
+            .stringProperty(KEY_VARIABLE_NAME,
+                "Name of the variable to set (dot-separated to reach a nested member)", true) //$NON-NLS-1$
+            .stringProperty(KEY_VALUE,
+                "New value as a BSL literal/expression (e.g. 42, \"text\", True, Дата(2025,1,1))", true) //$NON-NLS-1$
+            .build();
+    }
+
+    @Override
+    public String getOutputSchema()
+    {
+        return JsonSchemaBuilder.object()
+            .booleanProperty("success", "Whether the operation succeeded", true) //$NON-NLS-1$ //$NON-NLS-2$
+            .stringProperty(KEY_VARIABLE_NAME, "The variable that was set") //$NON-NLS-1$
+            .stringProperty(KEY_VALUE, "The variable's new value after the set (may be truncated)") //$NON-NLS-1$
+            .stringProperty(KEY_TYPE, "BSL reference type name of the new value") //$NON-NLS-1$
+            .build();
+    }
+
+    @Override
+    public ResponseType getResponseType()
+    {
+        return ResponseType.JSON;
+    }
+
+    @Override
+    public String execute(Map<String, String> params)
+    {
+        String argErr = JsonUtils.requireArguments(params, KEY_VARIABLE_NAME, KEY_VALUE);
+        if (argErr != null)
+        {
+            return argErr;
+        }
+
+        long frameRef = JsonUtils.extractLongArgument(params, "frameRef", -1L); //$NON-NLS-1$
+        long threadId = JsonUtils.extractLongArgument(params, "threadId", -1L); //$NON-NLS-1$
+        int frameIndex = JsonUtils.extractIntArgument(params, "frameIndex", 0); //$NON-NLS-1$
+        String variableName = JsonUtils.extractStringArgument(params, KEY_VARIABLE_NAME);
+        String value = JsonUtils.extractStringArgument(params, KEY_VALUE);
+
+        DebugSessionRegistry registry = DebugSessionRegistry.get();
+
+        try
+        {
+            DebugFrameResolver.Resolution fr = DebugFrameResolver.resolve(registry, frameRef, threadId, frameIndex);
+            if (fr.error != null)
+            {
+                return fr.error;
+            }
+            IStackFrame frame = fr.frame;
+
+            IVariable var = VariableSerializer.resolvePath(frame, variableName);
+            if (var == null)
+            {
+                return ToolResult.error("variable not found: '" + variableName //$NON-NLS-1$
+                    + "'. Use get_variables to list the variables visible in this frame " //$NON-NLS-1$
+                    + "(use a dot-separated path to reach a nested member).").toJson(); //$NON-NLS-1$
+            }
+
+            if (!var.supportsValueModification())
+            {
+                return ToolResult.error("variable '" + variableName //$NON-NLS-1$
+                    + "' is read-only and cannot be modified in this frame.").toJson(); //$NON-NLS-1$
+            }
+
+            String setErr = setValueBounded(var, variableName, value);
+            if (setErr != null)
+            {
+                return setErr;
+            }
+
+            Map<String, Object> dto = VariableSerializer.serializeVariable(var, registry);
+            return ToolResult.success()
+                .put(KEY_VARIABLE_NAME, variableName)
+                .put(KEY_VALUE, dto.get(KEY_VALUE))
+                .put(KEY_TYPE, dto.get(KEY_TYPE))
+                .toJson();
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            return ToolResult.error("interrupted").toJson(); //$NON-NLS-1$
+        }
+        catch (Exception e)
+        {
+            Activator.logError("Error in set_variable", e); //$NON-NLS-1$
+            return ToolResult.error(e.getMessage()).toJson();
+        }
+    }
+
+    /**
+     * Optional pre-flight: rejects a value the debug model already knows it cannot
+     * accept for this variable's type. A model that does not implement
+     * {@code verifyValue} (throws) is treated as inconclusive — the authoritative
+     * {@code setValue} attempt then decides — so this guard never turns a settable
+     * variable into a false negative.
+     *
+     * <p>Invoked only from inside {@link #setValueBounded}'s bounded worker: like
+     * {@code setValue}, {@code verifyValue} may round-trip to the (possibly wedged)
+     * 1C debug client, so it must run under the same timeout — never on the MCP
+     * request thread.
+     *
+     * @return the actionable error JSON when the value is invalid, or {@code null}
+     *         when it is accepted (or the check is inconclusive)
+     */
+    private static String verifyValue(IVariable var, String variableName, String value)
+    {
+        boolean verified;
+        try
+        {
+            verified = var.verifyValue(value);
+        }
+        catch (DebugException de) // NOSONAR model may not implement verifyValue: fall through to setValue
+        {
+            verified = true;
+        }
+        if (!verified)
+        {
+            return ToolResult.error("invalid value for variable '" + variableName + "': '" + value //$NON-NLS-1$ //$NON-NLS-2$
+                + "' is not accepted for this variable's type. Provide a valid BSL literal/expression.").toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Runs the {@link #verifyValue} pre-flight and the blocking
+     * {@link IVariable#setValue(String)} write inside a single bounded guard
+     * (mirrors evaluate_expression's latch/timeout) so a wedged debug client can
+     * never block the MCP request thread indefinitely: BOTH model round-trips are
+     * performed on one daemon worker and awaited for at most {@link #SET_TIMEOUT_MS}.
+     *
+     * @return the error JSON on timeout, on an invalid value (from the pre-flight),
+     *         or on any failure of the write (a {@link DebugException} or an unchecked
+     *         exception from the live 1C model); {@code null} on success
+     */
+    private static String setValueBounded(IVariable var, String variableName, String value)
+        throws InterruptedException
+    {
+        final AtomicReference<String> resultRef = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        Thread worker = new Thread(() -> {
+            try
+            {
+                String verifyErr = verifyValue(var, variableName, value);
+                if (verifyErr != null)
+                {
+                    resultRef.set(verifyErr);
+                    return;
+                }
+                var.setValue(value);
+            }
+            catch (DebugException de)
+            {
+                resultRef.set(ToolResult.error(unwrapMessage(de)).toJson());
+            }
+            catch (RuntimeException re)
+            {
+                // The 1C BslVariable model can throw an unchecked exception (NPE/IllegalStateException)
+                // from a live round-trip instead of wrapping it in a DebugException. Surface it as an
+                // actionable error so a failed write is never reported as a (null->) success.
+                resultRef.set(ToolResult.error(re.getMessage() != null ? re.getMessage() : re.toString()).toJson());
+            }
+            finally
+            {
+                latch.countDown();
+            }
+        }, "mcp-set-variable"); //$NON-NLS-1$
+        worker.setDaemon(true);
+        worker.start();
+
+        if (!latch.await(SET_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+        {
+            return ToolResult.error("set_variable timed out after " + SET_TIMEOUT_MS + "ms").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return resultRef.get();
+    }
+
+    /**
+     * Extracts the most informative message from a {@link DebugException}: the
+     * message of its wrapped status exception, then the status message, then the
+     * exception's own message — so the caller sees the underlying 1C debug error
+     * rather than a generic wrapper.
+     */
+    private static String unwrapMessage(DebugException de)
+    {
+        if (de.getStatus() != null)
+        {
+            Throwable cause = de.getStatus().getException();
+            if (cause != null && cause.getMessage() != null && !cause.getMessage().isEmpty())
+            {
+                return cause.getMessage();
+            }
+            String statusMessage = de.getStatus().getMessage();
+            if (statusMessage != null && !statusMessage.isEmpty())
+            {
+                return statusMessage;
+            }
+        }
+        return de.getMessage() != null ? de.getMessage() : de.toString();
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DebugFrameResolver.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DebugFrameResolver.java
@@ -1,0 +1,151 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import org.eclipse.debug.core.DebugException;
+import org.eclipse.debug.core.model.IStackFrame;
+import org.eclipse.debug.core.model.IThread;
+
+import com.ditrix.edt.mcp.server.protocol.ToolResult;
+
+/**
+ * Resolves the target stack frame for a suspended-debug tool from (in priority
+ * order) a stable {@code frameRef}, a {@code threadId + frameIndex}, or the
+ * single auto-resolved active debug session. Shared by every tool that operates
+ * on a stack frame (get_variables, set_variable, …) so the frame-resolution
+ * policy and its exact error messages live in exactly one place.
+ *
+ * <p>Pure and headless: it touches only the in-memory {@link DebugSessionRegistry}
+ * and the shared {@link DebugTargetResolver}; it re-implements neither the
+ * OSGi/service lookup (that stays inside {@link DebugTargetResolver} /
+ * {@link DebugSessionRegistry}) nor any SWT/UI access.
+ */
+public final class DebugFrameResolver
+{
+    private DebugFrameResolver()
+    {
+        // utility class
+    }
+
+    /**
+     * Resolves the target stack frame from (in priority order) {@code frameRef},
+     * {@code threadId + frameIndex}, or the auto-resolved single active debug
+     * session. Returns a holder carrying either the resolved frame or the exact
+     * error JSON to return to the caller unchanged.
+     *
+     * @param registry the debug session registry (non-null)
+     * @param frameRef a stable frame reference returned from wait_for_break, or a
+     *            non-positive value when unused
+     * @param threadId a stable thread id, or a non-positive value when unused
+     * @param frameIndex the 0-based frame index used with {@code threadId} or the
+     *            auto-resolved session
+     * @return a {@link Resolution} with a non-null {@code frame} on success, or a
+     *         non-null {@code error} (the same error JSON the inline branches
+     *         produced) otherwise
+     */
+    public static Resolution resolve(DebugSessionRegistry registry, long frameRef, long threadId, int frameIndex)
+        throws DebugException
+    {
+        if (frameRef > 0)
+        {
+            return resolveByFrameRef(registry, frameRef);
+        }
+        if (threadId > 0)
+        {
+            return resolveByThreadId(registry, threadId, frameIndex);
+        }
+        return resolveByAutoSession(registry, frameIndex);
+    }
+
+    /** Resolves the frame stored under a stable {@code frameRef} from wait_for_break. */
+    private static Resolution resolveByFrameRef(DebugSessionRegistry registry, long frameRef)
+    {
+        IStackFrame frame = registry.getFrame(frameRef);
+        if (frame == null)
+        {
+            return Resolution.failed(
+                ToolResult.error("stale frameRef — call wait_for_break again").toJson()); //$NON-NLS-1$
+        }
+        return Resolution.of(frame);
+    }
+
+    /** Resolves the {@code frameIndex}-th frame of the live thread {@code threadId}. */
+    private static Resolution resolveByThreadId(DebugSessionRegistry registry, long threadId, int frameIndex)
+        throws DebugException
+    {
+        IThread thread = registry.getThread(threadId);
+        if (thread == null)
+        {
+            return Resolution.failed(
+                ToolResult.error("stale threadId — call wait_for_break again").toJson()); //$NON-NLS-1$
+        }
+        IStackFrame[] frames = thread.getStackFrames();
+        if (frameIndex < 0 || frameIndex >= frames.length)
+        {
+            return Resolution.failed(ToolResult.error("frameIndex out of range (0.." //$NON-NLS-1$
+                + (frames.length - 1) + ")").toJson()); //$NON-NLS-1$
+        }
+        return Resolution.of(frames[frameIndex]);
+    }
+
+    /**
+     * Fallback: auto-resolve the single active debug session through the SAME
+     * blank-id policy every applicationId-based tool uses (DebugTargetResolver:
+     * the lone Eclipse launch, else the lone server target) and read its snapshot
+     * under the canonical key — replaces a hand-rolled condensed copy of that
+     * policy. The frame index is clamped into range.
+     */
+    private static Resolution resolveByAutoSession(DebugSessionRegistry registry, int frameIndex)
+        throws DebugException
+    {
+        DebugTargetResolver.Resolution res = DebugTargetResolver.resolve(null);
+        DebugSessionRegistry.SuspendSnapshot snap =
+            res != null ? registry.getSnapshot(res.canonicalId) : null;
+        if (snap == null)
+        {
+            return Resolution.failed(
+                ToolResult.error("Provide frameRef or threadId — no single suspended debug " //$NON-NLS-1$
+                    + "session available for auto-resolution. Call wait_for_break first.").toJson()); //$NON-NLS-1$
+        }
+        IStackFrame[] frames = snap.thread.getStackFrames();
+        if (frames.length == 0)
+        {
+            return Resolution.failed(
+                ToolResult.error("suspended thread has no stack frames").toJson()); //$NON-NLS-1$
+        }
+        return Resolution.of(frames[Math.min(Math.max(frameIndex, 0), frames.length - 1)]);
+    }
+
+    /**
+     * Holder threading a frame-resolution early-return out of {@link #resolve}:
+     * exactly one of {@code frame} / {@code error} is non-null. {@code error}
+     * carries the ready-to-return error JSON produced by
+     * {@link ToolResult#error(String)} — the exact same value (same case) the
+     * inline branches returned.
+     */
+    public static final class Resolution
+    {
+        public final IStackFrame frame;
+        public final String error;
+
+        private Resolution(IStackFrame frame, String error)
+        {
+            this.frame = frame;
+            this.error = error;
+        }
+
+        static Resolution of(IStackFrame frame)
+        {
+            return new Resolution(frame, null);
+        }
+
+        static Resolution failed(String error)
+        {
+            return new Resolution(null, error);
+        }
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupTest.java
@@ -173,7 +173,8 @@ public class ToolGroupTest
         assertTrue(tools.contains("set_breakpoint"));
         assertTrue(tools.contains("resume"));
         assertTrue(tools.contains("get_variables"));
-        assertEquals(12, tools.size());
+        assertTrue(tools.contains("set_variable"));
+        assertEquals(13, tools.size());
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/SetVariableToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/SetVariableToolTest.java
@@ -84,7 +84,7 @@ public class SetVariableToolTest
     public void testMissingValueIsRejected()
     {
         Map<String, String> params = new HashMap<>();
-        params.put("variableName", "МояПеременная"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("variableName", "\u041c\u043e\u044f\u041f\u0435\u0440\u0435\u043c\u0435\u043d\u043d\u0430\u044f"); //$NON-NLS-1$ //$NON-NLS-2$
         String result = new SetVariableTool().execute(params);
         assertTrue(result.contains("value is required")); //$NON-NLS-1$
     }
@@ -94,7 +94,7 @@ public class SetVariableToolTest
     {
         Map<String, String> params = new HashMap<>();
         params.put("frameRef", "999999"); //$NON-NLS-1$ //$NON-NLS-2$
-        params.put("variableName", "МояПеременная"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("variableName", "\u041c\u043e\u044f\u041f\u0435\u0440\u0435\u043c\u0435\u043d\u043d\u0430\u044f"); //$NON-NLS-1$ //$NON-NLS-2$
         params.put("value", "42"); //$NON-NLS-1$ //$NON-NLS-2$
         // frameRef > 0 but no suspended session: the shared DebugFrameResolver reads a
         // null frame from the in-memory registry and reports a stale frameRef before

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/SetVariableToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/SetVariableToolTest.java
@@ -1,0 +1,105 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+
+/**
+ * Tests for {@link SetVariableTool}.
+ * <p>
+ * Covers tool metadata, the input schema, and the early-validation branches that
+ * are reachable headlessly (without a live suspended debug session): the required
+ * {@code variableName}/{@code value} guards, and the shared frame resolver's
+ * "stale frameRef" branch — with a positive {@code frameRef} but no suspended
+ * session the in-memory {@code DebugSessionRegistry} returns a null frame, so the
+ * tool reports the stale reference before any live {@code DebugPlugin} access. The
+ * actual value modification (supportsValueModification / verifyValue / setValue)
+ * needs a real suspended frame and is covered by the E2E suite.
+ */
+public class SetVariableToolTest
+{
+    @Test
+    public void testName()
+    {
+        assertEquals("set_variable", new SetVariableTool().getName()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNameConstant()
+    {
+        assertEquals(SetVariableTool.NAME, new SetVariableTool().getName());
+    }
+
+    @Test
+    public void testResponseTypeJson()
+    {
+        assertEquals(ResponseType.JSON, new SetVariableTool().getResponseType());
+    }
+
+    @Test
+    public void testDescriptionNotEmpty()
+    {
+        String desc = new SetVariableTool().getDescription();
+        assertNotNull(desc);
+        assertTrue(desc.length() > 0);
+    }
+
+    @Test
+    public void testSchemaDeclaresParameters()
+    {
+        String schema = new SetVariableTool().getInputSchema();
+        assertNotNull(schema);
+        assertTrue(schema.contains("\"frameRef\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"threadId\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"frameIndex\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"variableName\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"value\"")); //$NON-NLS-1$
+    }
+
+    // ==================== Argument validation (no live debug session needed) ====================
+
+    @Test
+    public void testMissingVariableNameIsRejected()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("value", "42"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new SetVariableTool().execute(params);
+        assertTrue(result.contains("variableName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingValueIsRejected()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("variableName", "МояПеременная"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new SetVariableTool().execute(params);
+        assertTrue(result.contains("value is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStaleFrameRefWhenNoLiveSession()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("frameRef", "999999"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("variableName", "МояПеременная"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("value", "42"); //$NON-NLS-1$ //$NON-NLS-2$
+        // frameRef > 0 but no suspended session: the shared DebugFrameResolver reads a
+        // null frame from the in-memory registry and reports a stale frameRef before
+        // any live access.
+        String result = new SetVariableTool().execute(params);
+        assertTrue(result.contains("stale frameRef")); //$NON-NLS-1$
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/DebugFrameResolverTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/DebugFrameResolverTest.java
@@ -1,0 +1,165 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.debug.core.DebugException;
+import org.eclipse.debug.core.model.IStackFrame;
+import org.eclipse.debug.core.model.IThread;
+import org.junit.After;
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.protocol.ToolResult;
+
+/**
+ * Tests for {@link DebugFrameResolver} — the shared frame-resolution policy
+ * extracted from {@code GetVariablesTool}. Each error branch must return the
+ * EXACT same error JSON the tool produced before the extraction; the expected
+ * value is rebuilt here through {@link ToolResult#error(String)} (the same
+ * factory the resolver uses) so the assertion proves byte-identity, not merely a
+ * substring.
+ * <p>
+ * The headless-reachable branches are exercised directly against the in-memory
+ * {@link DebugSessionRegistry} (a plain map lookup returns a null frame/thread
+ * with no live {@code DebugPlugin} access) and against mocked {@link IThread}s
+ * injected into the registry. The auto-resolution fallback goes through the live
+ * launch manager, which yields no session headless ({@code DebugTargetResolver
+ * .resolve(null)} returns {@code null}), so it deterministically produces the
+ * "no single suspended debug session" error here.
+ * <p>
+ * <b>Coverage boundary (e2e-only):</b> five of the six error strings are pinned
+ * byte-identically below. The sixth — {@code "suspended thread has no stack
+ * frames"} ({@code DebugFrameResolver.resolveByAutoSession}) — is intentionally
+ * NOT pinned here because it is not headlessly reachable: it fires only when
+ * auto-resolution finds a live suspended session whose thread reports zero stack
+ * frames, but headless {@code DebugTargetResolver.resolve(null)} returns
+ * {@code null} (no live launch manager), so the resolver short-circuits at the
+ * "no single suspended debug session" branch ({@link #testNoAutoSessionReturnsExactError})
+ * before that code can run. Reaching it would require a live launch manager and a
+ * real suspended-with-empty-stack session, so this one branch is verified by the
+ * e2e suite rather than this unit test — an inherent gap, not an omission.
+ */
+public class DebugFrameResolverTest
+{
+    /** Keep the shared singleton clean between cases that mutate it. */
+    @After
+    public void clearRegistry()
+    {
+        DebugSessionRegistry.get().clear();
+    }
+
+    // ==================== error branches (byte-identical JSON) ====================
+
+    @Test
+    public void testStaleFrameRefReturnsExactError() throws DebugException
+    {
+        DebugSessionRegistry registry = DebugSessionRegistry.get();
+        registry.clear();
+        // frameRef > 0 but no suspended session: the registry returns a null frame.
+        DebugFrameResolver.Resolution res = DebugFrameResolver.resolve(registry, 999999L, -1L, 0);
+        assertNull("stale frameRef must not resolve a frame", res.frame); //$NON-NLS-1$
+        assertEquals(ToolResult.error("stale frameRef — call wait_for_break again").toJson(), //$NON-NLS-1$
+            res.error);
+    }
+
+    @Test
+    public void testStaleThreadIdReturnsExactError() throws DebugException
+    {
+        DebugSessionRegistry registry = DebugSessionRegistry.get();
+        registry.clear();
+        // threadId > 0 (no frameRef): the registry returns a null thread.
+        DebugFrameResolver.Resolution res = DebugFrameResolver.resolve(registry, -1L, 999999L, 0);
+        assertNull("stale threadId must not resolve a frame", res.frame); //$NON-NLS-1$
+        assertEquals(ToolResult.error("stale threadId — call wait_for_break again").toJson(), //$NON-NLS-1$
+            res.error);
+    }
+
+    @Test
+    public void testFrameIndexOutOfRangeReturnsExactError() throws DebugException
+    {
+        DebugSessionRegistry registry = DebugSessionRegistry.get();
+        registry.clear();
+        IThread thread = mock(IThread.class);
+        when(thread.getStackFrames())
+            .thenReturn(new IStackFrame[] {mock(IStackFrame.class), mock(IStackFrame.class)});
+        registry.injectSuspend("launch:Cfg", thread); //$NON-NLS-1$
+        long threadId = registry.getSnapshot("launch:Cfg").threadId; //$NON-NLS-1$
+
+        // frameIndex 5 with a 2-frame thread → out of range (0..1).
+        DebugFrameResolver.Resolution res = DebugFrameResolver.resolve(registry, -1L, threadId, 5);
+        assertNull("out-of-range index must not resolve a frame", res.frame); //$NON-NLS-1$
+        assertEquals(ToolResult.error("frameIndex out of range (0..1)").toJson(), res.error); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNegativeFrameIndexReturnsExactError() throws DebugException
+    {
+        DebugSessionRegistry registry = DebugSessionRegistry.get();
+        registry.clear();
+        IThread thread = mock(IThread.class);
+        when(thread.getStackFrames())
+            .thenReturn(new IStackFrame[] {mock(IStackFrame.class), mock(IStackFrame.class)});
+        registry.injectSuspend("launch:Cfg", thread); //$NON-NLS-1$
+        long threadId = registry.getSnapshot("launch:Cfg").threadId; //$NON-NLS-1$
+
+        DebugFrameResolver.Resolution res = DebugFrameResolver.resolve(registry, -1L, threadId, -1);
+        assertNull("a negative index must not resolve a frame", res.frame); //$NON-NLS-1$
+        assertEquals(ToolResult.error("frameIndex out of range (0..1)").toJson(), res.error); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNoAutoSessionReturnsExactError() throws DebugException
+    {
+        DebugSessionRegistry registry = DebugSessionRegistry.get();
+        registry.clear();
+        // Neither frameRef nor threadId: auto-resolution finds no live session
+        // headless (DebugTargetResolver.resolve(null) is null).
+        DebugFrameResolver.Resolution res = DebugFrameResolver.resolve(registry, -1L, -1L, 0);
+        assertNull("no auto session must not resolve a frame", res.frame); //$NON-NLS-1$
+        assertEquals(
+            ToolResult.error("Provide frameRef or threadId — no single suspended debug " //$NON-NLS-1$
+                + "session available for auto-resolution. Call wait_for_break first.").toJson(), //$NON-NLS-1$
+            res.error);
+    }
+
+    // ==================== success branches ====================
+
+    @Test
+    public void testResolvesRegisteredFrameByRef() throws DebugException
+    {
+        DebugSessionRegistry registry = DebugSessionRegistry.get();
+        registry.clear();
+        IStackFrame frame = mock(IStackFrame.class);
+        long frameRef = registry.registerFrame(frame);
+
+        DebugFrameResolver.Resolution res = DebugFrameResolver.resolve(registry, frameRef, -1L, 0);
+        assertNull("a successful resolution carries no error", res.error); //$NON-NLS-1$
+        assertSame("the frame registered under frameRef must be returned", frame, res.frame); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testResolvesFrameByThreadIdAndIndex() throws DebugException
+    {
+        DebugSessionRegistry registry = DebugSessionRegistry.get();
+        registry.clear();
+        IStackFrame frame0 = mock(IStackFrame.class);
+        IStackFrame frame1 = mock(IStackFrame.class);
+        IThread thread = mock(IThread.class);
+        when(thread.getStackFrames()).thenReturn(new IStackFrame[] {frame0, frame1});
+        registry.injectSuspend("launch:Cfg", thread); //$NON-NLS-1$
+        long threadId = registry.getSnapshot("launch:Cfg").threadId; //$NON-NLS-1$
+
+        DebugFrameResolver.Resolution res = DebugFrameResolver.resolve(registry, -1L, threadId, 1);
+        assertNull("a successful resolution carries no error", res.error); //$NON-NLS-1$
+        assertSame("the frameIndex-th frame of the thread must be returned", frame1, res.frame); //$NON-NLS-1$
+    }
+}

--- a/tests/e2e/tools/test_set_variable.py
+++ b/tests/e2e/tools/test_set_variable.py
@@ -1,0 +1,225 @@
+"""
+e2e tests for set_variable (kind: read).
+
+Registered kind="read" — the debug-tool convention in this suite (every debug tool,
+INCLUDING the mutating ones resume / step / set_breakpoint, uses kind="read"): it
+mutates the LIVE debug model, never the git-tracked project, so the isolation idiom is
+the read guardrail assert_no_diff(), not a file-write diff. The tool is nonetheless a
+WRITE semantically — it sets a variable's value.
+
+set_variable WRITES a BSL variable's value into a stack frame of a SUSPENDED debug
+thread and returns the variable after the write. It is a pure DEBUG/RUNTIME tool: it
+never touches the project source — it resolves the frame through the SAME shared
+frame resolver get_variables uses (utils/DebugFrameResolver over the live Eclipse
+debug model / DebugSessionRegistry), then sets the value via the plain Eclipse
+IValueModification API. getResponseType() == JSON, so on the wire the payload is
+structuredContent and a ToolResult.error (success:false / error field) is flagged
+isError:true; the harness surfaces that error string via r.error_text()
+(structured["error"]). See SetVariableTool.java + DebugFrameResolver.java.
+
+ENVIRONMENT (the realistic happy contract here):
+  In THIS EDT there is NO active debug session and TestConfiguration has NO running
+  infobase / launched application, so DebugSessionRegistry holds no snapshots /
+  threads / frames. set_variable therefore CANNOT reach a real variable to write; the
+  REAL, CORRECT contract for every frame reference we can supply is a CLEAR,
+  ACTIONABLE SENTINEL naming the missing precondition + the next step
+  (wait_for_break). That sentinel IS the coverage — we deliberately do NOT start an
+  infobase / debug_launch (heavy, not configured for this fixture), so the
+  happy/resume path (set a var -> get_variables re-read shows it -> resume -> new
+  value in effect) is exercised MANUALLY on a live suspended session, not here.
+
+  set_variable resolves the frame FIRST (through DebugFrameResolver, the exact triplet
+  get_variables uses), so with no live session every call short-circuits on the SAME
+  frame-resolution sentinels — the strings are shared with get_variables verbatim:
+    - no frameRef AND no threadId, and no lone suspended debug launch
+        -> "Provide frameRef or threadId — no single suspended debug session
+            available for auto-resolution. Call wait_for_break first."
+    - frameRef > 0 but not in the registry (stale / never issued)
+        -> "stale frameRef — call wait_for_break again"
+    - threadId > 0 but not in the registry (stale / never issued)
+        -> "stale threadId — call wait_for_break again"
+
+  # AUDIT: the set_variable-SPECIFIC error branches — a resolved frame whose
+  # `variableName` is not found ("variable not found"), a variable that is read-only
+  # / does not support modification, and an "invalid value" rejected by verifyValue —
+  # are all UNREACHABLE without a live suspended frame, so they are not exercised
+  # here. Reaching them needs a real debug_launch + a breakpoint hit (e.g. inside
+  # CommonModule.Calc) with a live frame whose variables can be addressed. Deferred to
+  # a live-session run; flagged here so the gap is explicit rather than silently
+  # skipped.
+
+PARAMETERS:
+  variableName:str (required), value:str (required); frame addressing is OPTIONAL and
+  identical to get_variables — frameRef:int, threadId:int, frameIndex:int(default 0).
+  Resolution order in the shared resolver: frameRef > 0 -> threadId > 0 -> lone-
+  suspended fallback. Every call below supplies variableName + value so it is the
+  FRAME-RESOLUTION branch (shared with get_variables) that is under test, not a
+  missing-argument path. That ordering is itself a behavior under test (a stale
+  threadId must surface the threadId sentinel, NOT the no-arg fallback sentinel).
+
+DIFF: a debug-write tool mutates the running infobase / EDT debug model, never the
+git-tracked project, so EVERY test asserts assert_no_diff() — a debug tool that
+changed TestConfiguration source on disk would be a bug, and this catches it.
+"""
+
+from harness import (
+    _post,
+    call,
+    assert_error,
+    assert_error_quality,
+    assert_contains,
+    assert_no_diff,
+    e2e_test,
+    _fail,
+)
+
+# A concrete (name, value) pair used on every call so the frame-resolution branch — not
+# a missing-required-argument path — is the one exercised. The value is a BSL literal.
+_VAR = {"variableName": "Counter", "value": "42"}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# PRESENCE / SCHEMA CONTRACT — the tool is registered and advertises its inputs
+# ──────────────────────────────────────────────────────────────────────────────
+@e2e_test(tool="set_variable", kind="read")
+def test_tool_is_advertised_with_the_expected_input_contract():
+    """set_variable appears in tools/list and declares exactly its documented inputs.
+
+    Proves registration on the live wire AND the parameter contract from the spec:
+    variableName + value are REQUIRED; the frame-addressing trio
+    (frameRef/threadId/frameIndex) is present but OPTIONAL (same addressing as
+    get_variables). Mutation-sensitive: dropping the tool, misnaming a param, or
+    forgetting to mark variableName/value required would fail here.
+    """
+    raw = _post("tools/list", {})
+    tools = {t.get("name"): t for t in (raw.get("result", {}) or {}).get("tools", []) or []}
+    tool = tools.get("set_variable")
+    if tool is None:
+        _fail("set_variable is not advertised in tools/list — is it registered in "
+              "BuiltInToolRegistrar and the debug ToolGroup?")
+
+    schema = tool.get("inputSchema") or {}
+    props = schema.get("properties") or {}
+    for p in ("frameRef", "threadId", "frameIndex", "variableName", "value"):
+        if p not in props:
+            _fail("set_variable inputSchema is missing the %r property; has %s"
+                  % (p, sorted(props)))
+
+    required = set(schema.get("required") or [])
+    if required != {"variableName", "value"}:
+        _fail("set_variable must require exactly variableName + value (the frame-addressing "
+              "params are optional); required=%s" % sorted(required))
+
+    assert_no_diff("reading tools/list must not modify the project")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# HAPPY / SENTINEL — the realistic correct contract in a no-session environment
+# ──────────────────────────────────────────────────────────────────────────────
+@e2e_test(tool="set_variable", kind="read")
+def test_no_session_returns_clear_actionable_sentinel():
+    """variableName+value but no frame ref and no suspended launch -> no-session sentinel.
+
+    With neither frameRef nor threadId, the shared resolver falls to the lone-suspended
+    fallback; in this EDT there is no debug launch, so it returns the no-session
+    sentinel. This IS the happy contract here: a clear message naming the missing
+    precondition (no suspended debug session) AND the actionable next step (call
+    wait_for_break first) — the write never fabricates a frame to poke.
+
+    Mutation-sensitive: a broken tool that silently "succeeded", returned a bare
+    "Error", or claimed it set the variable would fail assert_error + the sentinel
+    assertions below.
+    """
+    r = call("set_variable", _VAR)
+    err = assert_error(r, "no active suspended debug session")
+    assert_error_quality(
+        err,
+        names=["frameRef", "threadId"],
+        suggests=["wait_for_break"],
+        ctx="no-session sentinel names the inputs to provide and the recovery tool",
+    )
+    assert_contains(
+        err, "no single suspended debug",
+        "sentinel must state WHY auto-resolution failed (no suspended session)",
+    )
+    assert_no_diff("a debug-write tool must not touch the project on disk")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# NEGATIVE MATRIX — invalid / stale references + resolution-order proof
+# ──────────────────────────────────────────────────────────────────────────────
+@e2e_test(tool="set_variable", kind="read")
+def test_stale_frameref_errors_and_names_recovery():
+    """frameRef > 0 that the registry does not know (never issued / session gone).
+
+    Because there has never been a suspend in this EDT, framesById is empty, so the
+    shared resolver's getFrame(N) is null and the tool returns the stale-frameRef
+    sentinel — BEFORE it ever tries to write. The bad branch (frameRef) must be the one
+    reported, not the no-arg fallback, proving the frameRef branch was entered and the
+    id validated.
+
+    Mutation-sensitive: a tool that ignored an unknown frameRef and silently fell back
+    (or claimed a write) would NOT produce this specific sentinel.
+    """
+    r = call("set_variable", dict(_VAR, frameRef=999999))
+    err = assert_error(r, "stale / unknown frameRef")
+    assert_error_quality(
+        err,
+        names=["frameRef"],
+        suggests=["wait_for_break"],
+        ctx="stale-frameRef sentinel names the param and the recovery tool",
+    )
+    assert_contains(
+        err, "stale",
+        "must diagnose the frameRef as stale, not a generic failure",
+    )
+    assert_no_diff("a debug-write tool must not touch the project on disk")
+
+
+@e2e_test(tool="set_variable", kind="read")
+def test_stale_threadid_errors_and_names_recovery():
+    """threadId > 0 that the registry does not know -> stale-threadId sentinel.
+
+    With no frameRef supplied and threadId > 0, the resolver enters the threadId branch;
+    getThread(N) is null (empty registry) -> "stale threadId — call wait_for_break
+    again". Distinct from the frameRef sentinel: confirms the two reference kinds are
+    diagnosed independently, and that the write is never attempted.
+    """
+    r = call("set_variable", dict(_VAR, threadId=888888))
+    err = assert_error(r, "stale / unknown threadId")
+    assert_error_quality(
+        err,
+        names=["threadId"],
+        suggests=["wait_for_break"],
+        ctx="stale-threadId sentinel names the param and the recovery tool",
+    )
+    assert_contains(
+        err, "stale threadId",
+        "the threadId branch must name threadId specifically, not frameRef",
+    )
+    assert_no_diff("a debug-write tool must not touch the project on disk")
+
+
+@e2e_test(tool="set_variable", kind="read")
+def test_resolution_order_frameref_takes_precedence_over_threadid():
+    """Both frameRef and threadId supplied (both stale) -> frameRef wins.
+
+    The shared resolver checks `frameRef > 0` BEFORE `threadId > 0`, so when both are
+    present the frameRef branch resolves first and a stale frameRef must surface as the
+    frameRef sentinel — NOT the threadId one. This pins the documented precedence
+    (frameRef preferred over threadId+frameIndex) for set_variable too; a refactor that
+    flipped the branch order would flip the sentinel and fail here.
+    """
+    r = call("set_variable", dict(_VAR, frameRef=777777, threadId=666666))
+    err = assert_error(r, "frameRef precedence over threadId")
+    assert_contains(
+        err, "stale frameRef",
+        "with both refs present the frameRef branch must resolve first",
+    )
+    assert_error_quality(
+        err,
+        names=["frameRef"],
+        suggests=["wait_for_break"],
+        ctx="precedence sentinel is the frameRef one",
+    )
+    assert_no_diff("a debug-write tool must not touch the project on disk")

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -3747,6 +3747,68 @@
       "openWorldHint": false,
       "readOnlyHint": false
     },
+    "description": "Set a BSL variable's value in a suspended debug frame. WRITE/side-effect: EXECUTES the entered value as a BSL literal/expression live in the running 1C application, mutating the variable. Address the frame by frameRef from wait_for_break (preferred) or threadId+frameIndex; name the variable (dot-path for a nested member). Read current values with get_variables first; use evaluate_expression to compute without mutating.",
+    "inputSchema": {
+      "properties": {
+        "frameIndex": {
+          "description": "0-based frame index when using threadId",
+          "type": "integer"
+        },
+        "frameRef": {
+          "description": "Stable frame reference returned from wait_for_break (preferred)",
+          "type": "integer"
+        },
+        "threadId": {
+          "description": "Thread id (alternative to frameRef)",
+          "type": "integer"
+        },
+        "value": {
+          "description": "New value as a BSL literal/expression (e.g. 42, \"text\", True, Дата(2025,1,1))",
+          "type": "string"
+        },
+        "variableName": {
+          "description": "Name of the variable to set (dot-separated to reach a nested member)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "variableName",
+        "value"
+      ],
+      "type": "object"
+    },
+    "name": "set_variable",
+    "outputSchema": {
+      "properties": {
+        "success": {
+          "description": "Whether the operation succeeded",
+          "type": "boolean"
+        },
+        "type": {
+          "description": "BSL reference type name of the new value",
+          "type": "string"
+        },
+        "value": {
+          "description": "The variable's new value after the set (may be truncated)",
+          "type": "string"
+        },
+        "variableName": {
+          "description": "The variable that was set",
+          "type": "string"
+        }
+      },
+      "required": [
+        "success"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false
+    },
     "description": "Start performance measurement on the active debug target. Enables line-level profiling: call counts and timing for every executed BSL line. Start-only and idempotent: if profiling is already active for this applicationId it stays on. Call stop_profiling to stop, then get_profiling_results to see which code was covered. Requires an active debug session (debug_launch or debug_yaxunit_tests).",
     "inputSchema": {
       "properties": {


### PR DESCRIPTION
Closes #244.

## Что
Новый минимальный инструмент **`set_variable`** — задать значение переменной BSL в приостановленном кадре отладки (у нас были `get_variables` = чтение и `evaluate_expression` = вычисление, но записи не было).

```
set_variable(frameRef=..., variableName="Сумма", value="100")
```

## Как (рефлективно, без запретных импортов, минимум тулзов)
- 1С-переменная (`BslVariable`) реализует стандартный Eclipse `org.eclipse.debug.core.model.IValueModification` (`supportsValueModification`/`verifyValue`/`setValue`), а `IVariable` его уже расширяет — запись идёт через **тот же Eclipse `IVariable`-API, что уже читает `get_variables`**, без `com._1c.*.internal`.
- **Folding в `evaluate_expression` отклонён по фактам:** его 1С watch-evaluator read-only, а в BSL `=` внутри выражения — сравнение (Булево), не присваивание.
- **Резолвинг кадра переиспользован, не продублирован:** триплет из `GetVariablesTool` вынесен в общий `utils/DebugFrameResolver` (заодно убирает hand-rolled дубль по CLAUDE.md #4/#5); `GetVariablesTool` делегирует туда, поведение и строки ошибок byte-identical (пинятся `DebugFrameResolverTest`).
- **Unattended-safe:** `verifyValue`+`setValue` в едином bounded 15с-guard на request-потоке (не SWT-UI, без модалок); read-only узел / плохое значение / устаревший кадр → понятный `ToolResult.error`, без зависаний.

## Проверка (живой suspended-сеанс, стенд 2025.2.6)
- `set_variable Сумма 42→100` + строковую → **re-read показал новые значения**;
- **эффект в исполнении:** после `resume` строка `Итого = Сумма * 10` посчиталась **1000** (не 420) — значение реально применилось;
- negatives (не найдена / плохой литерал отклонён 1С-evaluator'ом / stale frameRef) — все actionable и быстрые;
- гонка из аналога (placeholder «вычисление локальных переменных») **не проявилась** — наш `resolvePath` уже ждёт async-загрузку.
- `get_variables`/`evaluate_expression` и прочие пути byte-unchanged; golden добавил только запись `set_variable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
