### PR TITLE
update_database: actionable-хинт для InternalInfo-сбоя EDT + документация длинных прогонов (#258)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/update_database.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/update_database.md
@@ -45,6 +45,24 @@ When the update changes the DB structure (new/changed objects), EDT pops a block
 
 JSON with `project`, `applicationId`, `applicationName`, `updateType` (FULL/INCREMENTAL), `stateBefore`, `stateAfter` and a `message`. `terminatedClient: true` is present ONLY when a running client was actually terminated to free the infobase (absent on a preview, on opt-out, or when no client was running). A successful run reports `stateAfter = UPDATED`. If the application is already BEING_UPDATED the tool returns an error and you should wait.
 
+## Long-running updates and client timeouts
+
+On a large configuration (thousands of objects) `update_database` can run **5–25 minutes**. Many MCP clients apply their own call timeout (e.g. 120 s) well short of that — the client gives up waiting, but that is purely a client-side timeout: it does **not** cancel the underlying EDT update job, which keeps running in EDT to completion (success or failure) regardless of whether anyone is still listening for the response.
+
+If your client times out before the response arrives, do not assume the update failed or retry blindly (a retry while the first update is still running fails with "Application is currently being updated" or races the exclusive lock). Instead, retrieve the real outcome afterwards with `get_mcp_history`:
+
+```
+get_mcp_history(tool="update_database", limit=1)
+```
+
+This returns the recorded call, including its final `status` and `durationMs`, once the update has actually finished — even though the original call's own response was lost to the client-side timeout. Prefer raising the client's call timeout for this tool (well above the 5–25 minute range) over polling `get_mcp_history` in a loop.
+
+## Known EDT limitation: missing InternalInfo node
+
+On some projects the platform's load pipeline rejects the configuration XML that EDT itself generated for the update, with an error mentioning a missing `InternalInfo` node (Russian EDT message: "Отсутствует внутренняя информация (узел InternalInfo) для объекта Configuration"). This is an **EDT-platform pipeline limitation**, not a bug in this tool or in the MCP call — the EDT GUI's "Update database configuration" fails identically on the same project.
+
+Workaround: update via the platform CLI instead — `export_configuration_to_xml` to export the configuration to files, then run `1cv8 DESIGNER /LoadConfigFromFiles <dir> /UpdateDBCfg` — or try a newer EDT release, which may not have the limitation.
+
 ## Gotchas
 
 - With `terminateRunningClients=false`, most failures are the exclusive lock above — terminate the running launch first (the default frees it automatically).

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
@@ -55,6 +55,12 @@ public class UpdateDatabaseTool implements IMcpTool
     /** Output key: application update state before the update. */
     private static final String KEY_STATE_BEFORE = "stateBefore"; //$NON-NLS-1$
 
+    /**
+     * Cap on how many {@link Throwable#getCause()} hops {@link #describeInternalInfoHint} walks,
+     * guarding against a cyclical cause chain.
+     */
+    private static final int MAX_CAUSE_CHAIN_DEPTH = 10;
+
     @Override
     public String getName()
     {
@@ -437,13 +443,20 @@ public class UpdateDatabaseTool implements IMcpTool
      * Builds the JSON for an {@link ApplicationException} failure. The common failure is the
      * exclusive lock: name a 1C client that still holds the infobase (an MCP-owned sibling launch
      * is exempt from the sweep, or a client outlived the terminate window) so the agent can act
-     * instead of seeing a bare failure. Side-effect-free (the error is already logged by the caller).
+     * instead of seeing a bare failure. When the failure matches the known EDT-platform
+     * {@code InternalInfo} pipeline limitation (#258), {@link #describeInternalInfoHint} takes
+     * priority and {@link #describeAuthHint} is suppressed — that failure has nothing to do with
+     * credentials, and appending the auth hint too would mislead the caller. Side-effect-free (the
+     * error is already logged by the caller). Exposed (package-private) so the #258
+     * InternalInfo-vs-auth-hint precedence can be unit-tested directly.
      */
-    private static String buildApplicationErrorResult(ApplicationException e, String projectName,
+    static String buildApplicationErrorResult(ApplicationException e, String projectName,
             String applicationId, boolean terminatedClient)
     {
+        String internalInfoHint = describeInternalInfoHint(e);
+        String hint = internalInfoHint.isEmpty() ? describeAuthHint(e) : internalInfoHint;
         ToolResult errorResult = ToolResult.error("Database update failed: " //$NON-NLS-1$
-            + e.getMessage() + describeInfobaseHolder(applicationId) + describeAuthHint(e));
+            + e.getMessage() + describeInfobaseHolder(applicationId) + hint);
         errorResult.put(McpKeys.APPLICATION_ID, applicationId);
         errorResult.put(McpKeys.PROJECT, projectName);
         if (terminatedClient)
@@ -516,5 +529,48 @@ public class UpdateDatabaseTool implements IMcpTool
         }
         return " If the infobase requires user authentication, set the connection credentials with " //$NON-NLS-1$
             + "set_infobase_credentials (user/password) and retry."; //$NON-NLS-1$
+    }
+
+    /**
+     * Hint appended to the update-failure message when the failure is the known EDT-platform
+     * pipeline limitation (#258): the configuration XML that EDT itself generated for the load is
+     * rejected because the {@code InternalInfo} node is missing (Russian EDT message:
+     * "Отсутствует внутренняя информация (узел InternalInfo) для объекта Configuration"). This is
+     * an EDT-side failure, not something the MCP call causes — the EDT GUI's "Update database
+     * configuration" fails the same way on the same project. Detection walks the WHOLE cause
+     * chain (this exception plus every {@link Throwable#getCause()} below it, depth-capped at
+     * {@link #MAX_CAUSE_CHAIN_DEPTH} to guard against a cycle) looking for a
+     * {@code ConfigurationLoadException} type name or a message containing the language-independent
+     * marker {@code InternalInfo}. Empty when the failure does not match; when it matches, the
+     * caller suppresses {@link #describeAuthHint} (see {@link #buildApplicationErrorResult}) because
+     * this failure has nothing to do with credentials. Exposed (package-private) so the matching
+     * can be unit-tested directly.
+     *
+     * @param e the application exception
+     * @return the InternalInfo hint, or an empty string
+     */
+    static String describeInternalInfoHint(ApplicationException e)
+    {
+        Throwable current = e;
+        int depth = 0;
+        while (current != null && depth < MAX_CAUSE_CHAIN_DEPTH)
+        {
+            String typeName = current.getClass().getSimpleName();
+            String message = String.valueOf(current.getMessage());
+            boolean isConfigLoadFailure = typeName.contains("ConfigurationLoadException") //$NON-NLS-1$
+                || message.contains("InternalInfo"); //$NON-NLS-1$
+            if (isConfigLoadFailure)
+            {
+                return " The platform rejected the configuration XML EDT generated for the load " //$NON-NLS-1$
+                    + "(the InternalInfo node is missing). This is an EDT-side pipeline limitation " //$NON-NLS-1$
+                    + "for this project - the EDT GUI 'Update database configuration' fails the same " //$NON-NLS-1$
+                    + "way; it is not caused by the MCP call. Workarounds: update via the platform " //$NON-NLS-1$
+                    + "CLI (export_configuration_to_xml, then 1cv8 DESIGNER /LoadConfigFromFiles " //$NON-NLS-1$
+                    + "<dir> /UpdateDBCfg), or try a newer EDT release."; //$NON-NLS-1$
+            }
+            current = current.getCause();
+            depth++;
+        }
+        return ""; //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+import com.e1c.g5.dt.applications.ApplicationException;
 
 /**
  * Tests for {@link UpdateDatabaseTool}.
@@ -26,6 +27,11 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
  * returns before any live launch-manager access. This is a destructive tool —
  * the tests only exercise the argument-validation sentinels (which return before
  * any database update); the actual update is covered by the E2E suite.
+ * <p>
+ * Also covers the #258 {@code InternalInfo} error-hint logic (via the package-private
+ * {@link UpdateDatabaseTool#describeInternalInfoHint} and
+ * {@link UpdateDatabaseTool#buildApplicationErrorResult} seams) and the guide's
+ * documentation of the long-running-update / {@code get_mcp_history} workflow.
  */
 public class UpdateDatabaseToolTest
 {
@@ -170,6 +176,133 @@ public class UpdateDatabaseToolTest
             guide.contains("STARTS the standalone server in RUN mode")); //$NON-NLS-1$
         assertTrue("guide must say a subsequent debug launch restarts the server",
             guide.contains("restart that server in DEBUG mode")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testGuideDocumentsLongRunningUpdatesAndHistoryRetrieval()
+    {
+        // #258: large-configuration updates run minutes and often outlast an MCP client's own
+        // call timeout; the guide must point the caller at get_mcp_history to retrieve the real
+        // outcome afterwards, and at the CLI workaround for the InternalInfo pipeline limitation.
+        String guide = new UpdateDatabaseTool().getGuide();
+        assertNotNull(guide);
+        assertTrue("guide must document retrieving the outcome via get_mcp_history", //$NON-NLS-1$
+            guide.contains("get_mcp_history")); //$NON-NLS-1$
+        assertTrue("guide must document the CLI workaround for the InternalInfo limitation", //$NON-NLS-1$
+            guide.contains("LoadConfigFromFiles")); //$NON-NLS-1$
+    }
+
+    // ==================== #258 InternalInfo error hint (package-private surface) ====================
+
+    /**
+     * Mirrors the real EDT cause type reported in #258: its simple name matches the legacy
+     * {@code describeAuthHint} "Synchronization" keyword, so a naive detector would (wrongly)
+     * append the credentials hint to this InternalInfo failure.
+     */
+    private static class InfobaseSynchronizationException extends RuntimeException
+    {
+        private static final long serialVersionUID = 1L;
+
+        InfobaseSynchronizationException(String message)
+        {
+            super(message);
+        }
+    }
+
+    /** Mirrors the type-name-only detection branch of {@code describeInternalInfoHint}. */
+    private static class ConfigurationLoadException extends RuntimeException
+    {
+        private static final long serialVersionUID = 1L;
+
+        ConfigurationLoadException(String message)
+        {
+            super(message);
+        }
+    }
+
+    @Test
+    public void testInternalInfoHintMatchesMarkerInNestedCause()
+    {
+        // The real Russian EDT message reported in #258.
+        Throwable cause = new RuntimeException(
+            "Отсутствует внутренняя информация (узел InternalInfo) для объекта Configuration"); //$NON-NLS-1$
+        ApplicationException e = new ApplicationException("Failed to load configuration", cause); //$NON-NLS-1$
+
+        String hint = UpdateDatabaseTool.describeInternalInfoHint(e);
+
+        assertFalse("hint must be non-empty for the InternalInfo marker", hint.isEmpty()); //$NON-NLS-1$
+        assertTrue("hint must point at the CLI workaround", //$NON-NLS-1$
+            hint.contains("LoadConfigFromFiles")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testInternalInfoHintEmptyForUnrelatedException()
+    {
+        ApplicationException e = new ApplicationException("Unrelated failure", //$NON-NLS-1$
+            new RuntimeException("some other cause")); //$NON-NLS-1$
+
+        String hint = UpdateDatabaseTool.describeInternalInfoHint(e);
+
+        assertEquals("", hint); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testInternalInfoHintMatchesMarkerThreeLevelsDeep()
+    {
+        Throwable level3 = new RuntimeException("InternalInfo node is missing"); //$NON-NLS-1$
+        Throwable level2 = new RuntimeException("wrapping level 2", level3); //$NON-NLS-1$
+        Throwable level1 = new RuntimeException("wrapping level 1", level2); //$NON-NLS-1$
+        ApplicationException e = new ApplicationException("top-level failure", level1); //$NON-NLS-1$
+
+        String hint = UpdateDatabaseTool.describeInternalInfoHint(e);
+
+        assertFalse("hint must match a marker 3 cause-hops deep", hint.isEmpty()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testInternalInfoHintMatchesConfigurationLoadExceptionTypeName()
+    {
+        // The type-name branch: matches even when the message itself carries no marker text.
+        ApplicationException e = new ApplicationException("Load failed", //$NON-NLS-1$
+            new ConfigurationLoadException("generic load failure")); //$NON-NLS-1$
+
+        String hint = UpdateDatabaseTool.describeInternalInfoHint(e);
+
+        assertFalse("hint must match on the ConfigurationLoadException type name", hint.isEmpty()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testInternalInfoHintTakesPriorityOverAuthHintInErrorResult()
+    {
+        // Reproduces #258 problem (1): the cause is an InfobaseSynchronizationException (which
+        // would trip the legacy "Synchronization" auth-hint keyword) AND its message carries the
+        // InternalInfo marker. The final error JSON must carry the InternalInfo hint and must NOT
+        // carry the misleading credentials hint.
+        ApplicationException e = new ApplicationException("Failed to load configuration", //$NON-NLS-1$
+            new InfobaseSynchronizationException("missing InternalInfo node")); //$NON-NLS-1$
+
+        String result =
+            UpdateDatabaseTool.buildApplicationErrorResult(e, "MyProject", "app1", false); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertTrue("result must carry the InternalInfo hint", //$NON-NLS-1$
+            result.contains("LoadConfigFromFiles")); //$NON-NLS-1$
+        assertFalse("result must NOT carry the misleading credentials hint", //$NON-NLS-1$
+            result.contains("set_infobase_credentials")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testAuthHintStillAppliesWhenNoInternalInfoMarker()
+    {
+        // Unchanged today's behaviour: an actual auth/connection/sync failure with no InternalInfo
+        // marker anywhere in the cause chain must still get the credentials hint.
+        ApplicationException e = new ApplicationException("Failed to load configuration", //$NON-NLS-1$
+            new InfobaseSynchronizationException("connection refused")); //$NON-NLS-1$
+
+        String result =
+            UpdateDatabaseTool.buildApplicationErrorResult(e, "MyProject", "app1", false); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertTrue("result must still carry the credentials hint when InternalInfo does not match", //$NON-NLS-1$
+            result.contains("set_infobase_credentials")); //$NON-NLS-1$
     }
 
     // ==================== Argument validation (no live launch manager needed) ====================


### PR DESCRIPTION
## Контекст — #258

`update_database` падает с «Отсутствует внутренняя информация (узел InternalInfo)…». Разбор ([коммент в ишью](https://github.com/DitriXNew/EDT-MCP/issues/258#issuecomment-4952358212)): сбой происходит **внутри конвейера EDT** (`InfobaseSynchronizationManager → importFullXmlToInfobase`) — GUI-кнопка «Обновить конфигурацию БД» падает идентично (воспроизведено самим репортером), т.е. сериализацию плагин не контролирует и «переиспользовать экспортный сериализатор» в этом пути не может.

Но у плагина при этом два реальных дефекта — они здесь и исправлены.

## Что сделано

**1. Убран вводящий в заблуждение хинт.** Детектор auth-проблем матчил `InfobaseSynchronizationException` по подстроке `Synchronization` → к InternalInfo-ошибке приклеивался совет «настройте set_infobase_credentials» (ложный след). Теперь:
- новый `describeInternalInfoHint(e)` — обходит cause-chain (с ограничением глубины), детектит по языконезависимому маркеру `InternalInfo` / типу `ConfigurationLoadException` и возвращает actionable-хинт: это ограничение конвейера EDT (GUI падает так же), рабочий обход — `export_configuration_to_xml` + `1cv8 DESIGNER /LoadConfigFromFiles <dir> /UpdateDBCfg`, попробовать более новую EDT;
- когда хинт сработал — ложный auth-хинт подавляется; без маркера поведение байт-в-байт прежнее.

**2. Задокументирован long-run (пункт D репорта).** В `get_tool_guide('update_database')` добавлены разделы:
- «Long-running updates and client timeouts»: на больших конфигурациях апдейт идёт 5–25 минут; клиентский таймаут MCP **не останавливает** EDT-джоб; фактический итог после таймаута забирается новым инструментом `get_mcp_history(tool="update_database", limit=1)` (вернёт `status` + `durationMs`); рекомендация поднять клиентский таймаут для этого вызова;
- «Known EDT limitation: missing InternalInfo node» — как выглядит сбой и CLI-обход.

**3. Тесты:** +7 headless-тестов (маркер во вложенной причине, цепочка в 3 уровня, матч по имени типа, пустой хинт на нерелевантной ошибке, приоритет/подавление auth-хинта, auth-хинт по-прежнему работает без маркера, покрытие гайда).

## Проверка

- `mvn clean verify` зелёный: **3406 тестов, 0 провалов** (все ратчеты, включая `ToolContractConsistencyTest`/`GuideCoverageTest`).
- Независимое адверсариальное ревью диффа: 10 попыток опровержения (цикл в cause-chain, NPE на null-message, байт-идентичность старого пути, NLS-нумерация, headless-OSGi-безопасность тестов, фактология параметров `get_mcp_history` в гайде) — все REFUTED, вердикт PASS.
- Wire-поверхность (name/description/schemas) не менялась → `tools/list` golden без изменений.

🤖 Generated with [Claude Code](https://claude.com/claude-code)