### PR TITLE
proxy: субкоманды serve/status/stop, конфиг-файл, admin-stop, покрытие, jar в релиз (#253 follow-up)

### DIFF
--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -33,6 +33,19 @@ jobs:
       - name: Maven build
         run: mvn -f proxy/pom.xml clean verify --batch-mode --no-transfer-progress
 
+      - name: Coverage summary
+        run: |
+          {
+            echo "## Proxy coverage"
+            awk -F',' 'NR>1 {missed+=$4; covered+=$5} END {total=missed+covered; pct=(total>0)?(100*covered/total):0; printf "Instruction coverage: %.2f%% (%d/%d)\n", pct, covered, total}' proxy/target/site/jacoco/jacoco.csv
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          name: proxy-coverage
+          path: proxy/target/site/jacoco/
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,13 @@ jobs:
           done
           exit 1
 
+      - name: Build proxy
+        env:
+          MAVEN_OPTS: -Xmx2g
+        run: |
+          mvn -f proxy/pom.xml clean verify --batch-mode --no-transfer-progress
+          cp proxy/target/edt-mcp-proxy-*.jar "edt-mcp-proxy-v${{ steps.version.outputs.version }}.jar"
+
       - name: Package archive
         run: |
           cd mcp/repositories/com.ditrix.edt.mcp.server.repository/target/repository
@@ -73,5 +80,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           name: MCP-EDT v${{ steps.version.outputs.version }}
-          files: MCP-EDT.v*.zip
+          files: |
+            MCP-EDT.v*.zip
+            edt-mcp-proxy-v*.jar
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![GitHub all releases](https://img.shields.io/github/downloads/DitriXNew/EDT-MCP/total)](https://github.com/DitriXNew/EDT-MCP/releases)
 
 [![Build & Unit Tests](https://github.com/DitriXNew/EDT-MCP/actions/workflows/build.yml/badge.svg)](https://github.com/DitriXNew/EDT-MCP/actions/workflows/build.yml)
+[![Proxy](https://github.com/DitriXNew/EDT-MCP/actions/workflows/proxy.yml/badge.svg)](https://github.com/DitriXNew/EDT-MCP/actions/workflows/proxy.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DitriXNew_EDT-MCP&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DitriXNew_EDT-MCP)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=DitriXNew_EDT-MCP&metric=bugs)](https://sonarcloud.io/summary/new_code?id=DitriXNew_EDT-MCP)
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=DitriXNew_EDT-MCP&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=DitriXNew_EDT-MCP)
@@ -351,6 +352,10 @@ Add to `.claude.json` (in Windows `%USERPROFILE%\.claude.json`):
 ```
 
 </details>
+
+## Multi-EDT Proxy
+
+Running more than one EDT instance at once? [`edt-mcp-proxy`](proxy/) is a standalone router that exposes a single, stable MCP endpoint on `:8764` and forwards each call to the right EDT-MCP instance by `projectName`, discovering live instances in the background. It ships as `edt-mcp-proxy-<version>.jar` alongside the plugin archive in every [release](https://github.com/DitriXNew/EDT-MCP/releases). See [proxy/README.md](proxy/README.md) for setup, CLI options and configuration.
 
 ## Available Tools
 

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -38,19 +38,79 @@ Then connect your MCP client (Claude, Copilot, Cursor, ...) to
 `http://127.0.0.1:8764/mcp` — exactly as you would connect it to a single EDT-MCP
 server, just a different port.
 
+## CLI subcommands
+
+Allure-style subcommands (a bare invocation with no subcommand — options only, or
+none at all — is an alias for `serve`, for backward compatibility with the CLI before
+subcommands existed):
+
+```bash
+java -jar edt-mcp-proxy.jar serve                 # server on :8764, scan 8765-8774 (foreground)
+java -jar edt-mcp-proxy.jar serve --port 9000 --scan 8765-8780 --refresh 30 --timeout 300
+java -jar edt-mcp-proxy.jar serve --bind 0.0.0.0  # explicit remote bind (logs a SECURITY warning)
+java -jar edt-mcp-proxy.jar serve --config C:\edt\proxy.properties
+
+java -jar edt-mcp-proxy.jar status                # query a running proxy: live EDT backends,
+java -jar edt-mcp-proxy.jar status --port 9000    #   project map, duplicates, scan range, last refresh
+
+java -jar edt-mcp-proxy.jar stop                  # gracefully stop a running proxy
+java -jar edt-mcp-proxy.jar --help | --version
+```
+
+- **`serve [options]`** — starts the proxy in the foreground (see [Configuration](#configuration)
+  for every option). This is also the implicit behaviour of a bare invocation.
+- **`status [--port N]`** — a CLI *client*: probes the running proxy's `/health` and, when
+  alive, its `router_status` tool (via a minimal MCP handshake), then prints a
+  human-readable table of `port | projects`, followed by duplicate projects, the
+  scan range and the last refresh time. Exits `0` when the proxy answered, `1` with an
+  actionable message when it could not be reached (e.g. nothing is listening on that
+  port yet).
+- **`stop [--port N]`** — asks the running proxy's admin endpoint (`POST
+  /admin/shutdown`, loopback only — see [Security](#security)) to shut down gracefully.
+  Exits `0` when accepted, `1` with an actionable message when the proxy could not be
+  reached.
+- **`--help`** — prints the full usage: every subcommand plus the complete `serve`
+  option/environment-variable reference. **`--version`** — prints the proxy's version
+  (read from the jar manifest's `Implementation-Version`, falling back to `dev` when
+  absent, e.g. running from a development classpath).
+- An unrecognised subcommand prints the usage and exits `2`.
+
 ## Configuration
 
-| CLI flag         | Environment variable    | Default     | Meaning                                    |
-|------------------|-------------------------|-------------|--------------------------------------------|
-| `--port N`       | `EDT_MCP_PROXY_PORT`    | `8764`      | Port the proxy listens on                  |
-| `--scan FROM-TO` | `EDT_MCP_PROXY_SCAN`    | `8765-8774` | Backend port scan range (inclusive)        |
-| `--refresh N`    | `EDT_MCP_PROXY_REFRESH` | `20`        | Periodic registry refresh interval, seconds |
-| `--timeout N`    | `EDT_MCP_PROXY_TIMEOUT` | `300`       | Timeout per forwarded call, seconds        |
-| `--bind HOST`    | `EDT_MCP_PROXY_HOST`    | *(unset)*   | Bind `HOST` instead of loopback only (e.g. `0.0.0.0`) - see [Security](#security) |
+| CLI flag         | Environment variable    | Config file key | Default     | Meaning                                    |
+|------------------|-------------------------|------------------|-------------|--------------------------------------------|
+| `--port N`       | `EDT_MCP_PROXY_PORT`    | `port`           | `8764`      | Port the proxy listens on                  |
+| `--scan FROM-TO` | `EDT_MCP_PROXY_SCAN`    | `scan`           | `8765-8774` | Backend port scan range (inclusive)        |
+| `--refresh N`    | `EDT_MCP_PROXY_REFRESH` | `refresh`        | `20`        | Periodic registry refresh interval, seconds |
+| `--timeout N`    | `EDT_MCP_PROXY_TIMEOUT` | `timeout`        | `300`       | Timeout per forwarded call, seconds        |
+| `--bind HOST`    | `EDT_MCP_PROXY_HOST`    | `bind`           | *(unset)*   | Bind `HOST` instead of loopback only (e.g. `0.0.0.0`) - see [Security](#security) |
 
-Precedence: **CLI flags win over environment variables win over defaults.**
+Precedence: **CLI flags &gt; environment variables &gt; config file &gt; defaults.**
 `--help` prints usage and exits. An invalid value fails startup with an actionable
-error message.
+error message that names the source it came from (a CLI flag, an environment
+variable, or `config file <name>: <key>`).
+
+### Config file
+
+A plain [`java.util.Properties`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Properties.html)
+file with the same five keys as the table above (`port`, `scan`, `refresh`, `timeout`,
+`bind`) — no new dependency, no new format to learn:
+
+```properties
+# edt-mcp-proxy.properties
+port=8764
+scan=8765-8780
+refresh=30
+timeout=300
+bind=0.0.0.0
+```
+
+Point `serve` at it explicitly with `--config <path>`, or drop a file named
+`edt-mcp-proxy.properties` next to the jar (`java -jar` resolves the jar's own
+directory) and it is picked up automatically — no flag needed. The auto-discovered
+file is entirely optional: if it is not there, the proxy just falls back to
+environment variables and defaults. An explicitly named file (`--config`) that
+cannot be found or read fails startup immediately, naming the path.
 
 ## Security
 
@@ -77,6 +137,11 @@ Two further limits guard against resource exhaustion regardless of the bind addr
 - **Session cap** - the proxy tracks at most 10,000 concurrently open client sessions;
   `initialize` past that cap is refused with a JSON-RPC error asking idle sessions to be closed
   (`DELETE /mcp`) first.
+- **Admin endpoint stays loopback-only, always** - `POST /admin/shutdown` (the `stop`
+  subcommand's target) is accepted only when the caller's remote address is loopback,
+  checked on the actual TCP peer address of every request - **regardless of `--bind`**.
+  Even a proxy bound to `0.0.0.0` cannot be remotely shut down; any other HTTP method or a
+  non-loopback caller gets `405`/`403`.
 
 ## How routing works
 
@@ -131,11 +196,12 @@ Two extra tools are injected into `tools/list` (both take no parameters):
 
 ## Endpoints
 
-| Endpoint      | Behaviour                                                                     |
-|---------------|-------------------------------------------------------------------------------|
-| `GET /health` | `200` with `{"status":"ok","role":"proxy","backends":<live count>}`           |
-| `POST /mcp`   | MCP Streamable HTTP, same wire contract as the plugin (SSE `data:` frames, `Mcp-Session-Id` header) |
-| `DELETE /mcp` | Closes the client's session **on the proxy**; backend sessions are untouched  |
+| Endpoint               | Behaviour                                                            |
+|------------------------|-----------------------------------------------------------------------------|
+| `GET /health`          | `200` with `{"status":"ok","role":"proxy","backends":<live count>}`  |
+| `POST /mcp`            | MCP Streamable HTTP, same wire contract as the plugin (SSE `data:` frames, `Mcp-Session-Id` header) |
+| `DELETE /mcp`          | Closes the client's session **on the proxy**; backend sessions are untouched  |
+| `POST /admin/shutdown` | Loopback callers only (regardless of `--bind`, see [Security](#security)): `200 {"status":"stopping"}` then the proxy stops gracefully; non-loopback callers get `403`; any other HTTP method gets `405`. This is the `stop` subcommand's target. |
 
 ## Zero-backend behaviour
 
@@ -157,19 +223,48 @@ If a backend dies mid-call, the proxy refreshes the registry and returns an erro
 the form `backend at :<port> stopped responding; refreshed registry; retry` — simply
 retry the call.
 
-## Running as a service
+## Autostart
 
-### Linux (systemd)
+**Deliberately per-user, never a system-wide Windows service or a system `systemd`
+unit:** a system-wide service runs as a single OS account for *everyone*, but the
+proxy scans *that account's own* localhost ports for EDT instances — on a shared
+host (e.g. an RDP terminal server with several developers logged in at once), each
+user needs their *own* proxy bound to their *own* session, not one shared instance
+fighting over port 8764. Both recipes below start the proxy under the invoking
+user's own account, with no administrator/root privileges required.
 
-`/etc/systemd/system/edt-mcp-proxy.service`:
+### Windows (Task Scheduler, per-user)
+
+Register a logon task for the *current* user (no admin rights needed) with
+`schtasks`:
+
+```powershell
+schtasks /Create /SC ONLOGON /TN edt-mcp-proxy /RL LIMITED /TR "\"C:\Path\To\jdk-17\bin\javaw.exe\" -jar \"C:\Path\To\edt-mcp-proxy.jar\" serve --port 8764 --scan 8765-8774"
+```
+
+- `/SC ONLOGON` runs it every time this user logs on; `/RL LIMITED` runs it with
+  the user's normal (non-elevated) rights, matching the proxy's own
+  loopback-by-default posture.
+- Use `javaw.exe` (not `java.exe`) so no console window lingers.
+- Remove it with `schtasks /Delete /TN edt-mcp-proxy /F`.
+- Equivalently, via the GUI: **Task Scheduler → Create Task…** → trigger **At log
+  on** (current user) → action **Start a program** with `Program: javaw.exe`,
+  `Arguments: -jar C:\Path\To\edt-mcp-proxy.jar serve --port 8764 --scan 8765-8774`.
+- To stop the running instance from a script (e.g. before an update), use the CLI
+  itself: `java -jar edt-mcp-proxy.jar stop`.
+
+### Linux (`systemd --user`)
+
+`~/.config/systemd/user/edt-mcp-proxy.service`:
 
 ```ini
 [Unit]
 Description=EDT MCP Proxy (router for EDT-MCP instances)
-After=network.target
+After=default.target
 
 [Service]
-ExecStart=/usr/bin/java -jar /opt/edt-mcp-proxy/edt-mcp-proxy.jar --port 8764 --scan 8765-8774
+ExecStart=/usr/bin/java -jar %h/edt-mcp-proxy/edt-mcp-proxy.jar serve --port 8764 --scan 8765-8774
+ExecStop=/usr/bin/java -jar %h/edt-mcp-proxy/edt-mcp-proxy.jar stop
 Restart=on-failure
 RestartSec=5
 
@@ -178,25 +273,15 @@ WantedBy=default.target
 ```
 
 ```bash
-sudo systemctl daemon-reload
-sudo systemctl enable --now edt-mcp-proxy
+systemctl --user daemon-reload
+systemctl --user enable --now edt-mcp-proxy
 ```
 
-> Tip: since the proxy scans localhost, run it as the same user that runs EDT (or as a
-> user service via `systemctl --user`) so it lives and dies with your desktop session.
-
-### Windows (Task Scheduler)
-
-Create a per-user task (no admin rights needed): **Task Scheduler → Create Task…** →
-trigger **At log on** → action **Start a program** with
-
-```
-Program:   C:\Path\To\jdk-17\bin\javaw.exe
-Arguments: -jar C:\Path\To\edt-mcp-proxy.jar --port 8764 --scan 8765-8774
-```
-
-Use `javaw.exe` (not `java.exe`) to avoid a lingering console window. Alternatively,
-drop a shortcut with the same command line into `shell:startup`.
+No `sudo` anywhere: `systemctl --user` manages units under the invoking user's own
+session manager, so the proxy starts/stops with that user's login session — exactly
+the per-user model the Windows recipe above gives you too. (If your distribution
+does not start user services without an active login, enable lingering once with
+`loginctl enable-linger $USER`.)
 
 ## Limitations (v1)
 

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -57,9 +57,39 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>com.ditrix.edt.mcp.proxy.Main</mainClass>
+                  <manifestEntries>
+                    <Implementation-Version>${project.version}</Implementation-Version>
+                  </manifestEntries>
                 </transformer>
               </transformers>
               <createDependencyReducedPom>false</createDependencyReducedPom>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.13</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <configuration>
+              <formats>
+                <format>XML</format>
+                <format>HTML</format>
+                <format>CSV</format>
+              </formats>
             </configuration>
           </execution>
         </executions>

--- a/proxy/src/main/java/com/ditrix/edt/mcp/proxy/CliCommands.java
+++ b/proxy/src/main/java/com/ditrix/edt/mcp/proxy/CliCommands.java
@@ -1,0 +1,573 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.proxy;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.logging.Logger;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * Implementations of the proxy's three CLI subcommands ({@code serve}, {@code status},
+ * {@code stop}) plus the {@code --help}/{@code --version} text. {@link Main} only parses the
+ * subcommand name and dispatches here; {@code status}/{@code stop} take an explicit
+ * {@link PrintStream} pair so a test can capture their output without touching
+ * {@link System#out}/{@link System#err} or forking a process.
+ */
+public final class CliCommands
+{
+    private static final Logger LOG = Logger.getLogger(CliCommands.class.getName());
+
+    private static final String OPT_PORT = "--port"; //$NON-NLS-1$
+
+    private static final String HEADER_SESSION_ID = "Mcp-Session-Id"; //$NON-NLS-1$
+    private static final String HEADER_ACCEPT = "Accept"; //$NON-NLS-1$
+    private static final String HEADER_CONTENT_TYPE = "Content-Type"; //$NON-NLS-1$
+    private static final String CONTENT_TYPE_JSON = "application/json"; //$NON-NLS-1$
+
+    private static final String CLIENT_NAME = "edt-mcp-proxy-cli"; //$NON-NLS-1$
+    private static final String CLIENT_VERSION = "1"; //$NON-NLS-1$
+
+    private static final String METHOD_INITIALIZE = "initialize"; //$NON-NLS-1$
+    private static final String METHOD_INITIALIZED_NOTIFICATION = "notifications/initialized"; //$NON-NLS-1$
+    private static final String METHOD_TOOLS_CALL = "tools/call"; //$NON-NLS-1$
+    private static final String TOOL_ROUTER_STATUS = "router_status"; //$NON-NLS-1$
+
+    private static final String KEY_JSONRPC = "jsonrpc"; //$NON-NLS-1$
+    private static final String KEY_ID = "id"; //$NON-NLS-1$
+    private static final String KEY_METHOD = "method"; //$NON-NLS-1$
+    private static final String KEY_PARAMS = "params"; //$NON-NLS-1$
+    private static final String KEY_NAME = "name"; //$NON-NLS-1$
+    private static final String KEY_VERSION = "version"; //$NON-NLS-1$
+    private static final String KEY_ARGUMENTS = "arguments"; //$NON-NLS-1$
+    private static final String KEY_PROTOCOL_VERSION = "protocolVersion"; //$NON-NLS-1$
+    private static final String KEY_CAPABILITIES = "capabilities"; //$NON-NLS-1$
+    private static final String KEY_CLIENT_INFO = "clientInfo"; //$NON-NLS-1$
+    private static final String KEY_RESULT = "result"; //$NON-NLS-1$
+    private static final String KEY_STRUCTURED_CONTENT = "structuredContent"; //$NON-NLS-1$
+    private static final String KEY_PORT = "port"; //$NON-NLS-1$
+    private static final String KEY_PROJECTS = "projects"; //$NON-NLS-1$
+    private static final String KEY_BACKENDS = "backends"; //$NON-NLS-1$
+    private static final String KEY_DUPLICATES = "duplicates"; //$NON-NLS-1$
+    private static final String KEY_SCAN_RANGE = "scanRange"; //$NON-NLS-1$
+    private static final String KEY_LAST_REFRESH_MS = "lastRefreshMs"; //$NON-NLS-1$
+
+    private static final String JSONRPC_VERSION = "2.0"; //$NON-NLS-1$
+
+    /** Connect/response timeout for every status/stop client HTTP call. */
+    private static final int CLIENT_TIMEOUT_SECONDS = 5;
+
+    private static final String NONE = "(none)"; //$NON-NLS-1$
+
+    private CliCommands()
+    {
+        // static entry-point helpers only
+    }
+
+    /**
+     * Implements the {@code serve} subcommand (and the implicit behaviour of a bare invocation):
+     * parses {@link ProxyConfig}, wires the registry/handler/server, performs the initial
+     * synchronous discovery scan, starts the periodic refresh, wires the {@code POST
+     * /admin/shutdown} cleanup callback to the SAME {@link Runnable} installed as the JVM
+     * shutdown hook, and prints the one-line startup banner. Never returns while the proxy is
+     * running - the process stays alive on the HTTP server's non-daemon dispatcher thread.
+     *
+     * @param args the {@code serve} CLI arguments, see {@link ProxyConfig#usage()}
+     */
+    static void serve(String[] args)
+    {
+        ProxyConfig cfg;
+        try
+        {
+            cfg = ProxyConfig.parse(args, System.getenv());
+        }
+        catch (IllegalArgumentException e)
+        {
+            System.err.println("edt-mcp-proxy: " + e.getMessage()); //$NON-NLS-1$
+            System.err.println();
+            System.err.println(ProxyConfig.usage());
+            System.exit(2);
+            return;
+        }
+
+        BackendRegistry registry = new BackendRegistry(cfg);
+        SessionManager sessions = new SessionManager();
+        McpProxyHandler handler = new McpProxyHandler(cfg, registry, sessions);
+        ProxyServer server = new ProxyServer(cfg, registry, handler);
+
+        // Initial discovery so /health and the first requests see the backends immediately.
+        registry.refresh();
+        server.start();
+
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread thread = new Thread(r, "edt-mcp-proxy-refresh"); //$NON-NLS-1$
+            thread.setDaemon(true);
+            return thread;
+        });
+        registry.startPeriodicRefresh(scheduler);
+
+        Runnable shutdown = () -> {
+            LOG.info("Shutting down edt-mcp-proxy"); //$NON-NLS-1$
+            scheduler.shutdownNow();
+            server.stop();
+        };
+        // POST /admin/shutdown (the 'stop' subcommand's target) and a Ctrl+C/SIGTERM shutdown
+        // hook must clean up identically; both invocations are idempotent, so it is harmless if
+        // the hook also fires after an admin-triggered stop already ran it.
+        server.setShutdownCallback(shutdown);
+        Runtime.getRuntime().addShutdownHook(new Thread(shutdown, "edt-mcp-proxy-shutdown")); //$NON-NLS-1$
+
+        // The single startup line goes to stdout by contract (scripts grep for it).
+        System.out.println("edt-mcp-proxy listening on :" + server.getPort() //$NON-NLS-1$
+            + ", scanning " + cfg.scanFrom + "-" + cfg.scanTo); //$NON-NLS-1$ //$NON-NLS-2$
+        LOG.info("Live backends after initial discovery: " + registry.live().size()); //$NON-NLS-1$
+        // The JVM stays alive on the HttpServer's non-daemon dispatcher thread.
+    }
+
+    /**
+     * Implements the {@code status} subcommand: probes a RUNNING proxy's {@code GET /health}
+     * and, when alive, performs a minimal MCP handshake ({@code initialize} +
+     * {@code notifications/initialized}) followed by {@code tools/call router_status}, then
+     * prints a human-readable table of the live backends, their projects, duplicate projects,
+     * the scan range and the last refresh time.
+     *
+     * @param args the {@code status} CLI arguments (only {@code --port N} is supported)
+     * @param out the stream the status table is printed to (normally {@link System#out})
+     * @param err the stream an actionable failure line is printed to (normally {@link System#err})
+     * @return {@code 0} when the proxy answered, {@code 1} when it could not be reached or its
+     *         router status could not be retrieved, {@code 2} on a bad {@code --port} argument
+     */
+    static int status(String[] args, PrintStream out, PrintStream err)
+    {
+        int port;
+        try
+        {
+            port = parsePort(args);
+        }
+        catch (IllegalArgumentException e)
+        {
+            err.println("edt-mcp-proxy: " + e.getMessage()); //$NON-NLS-1$
+            return 2;
+        }
+
+        if (!isHealthy(port))
+        {
+            err.println(unreachableMessage(port));
+            return 1;
+        }
+
+        try
+        {
+            JsonObject structured = fetchRouterStatus(port);
+            if (structured == null)
+            {
+                err.println("edt-mcp-proxy: proxy on :" + port //$NON-NLS-1$
+                    + " is alive but router_status could not be retrieved."); //$NON-NLS-1$
+                return 1;
+            }
+            printStatusTable(out, port, structured);
+            return 0;
+        }
+        catch (IOException e)
+        {
+            err.println(unreachableMessage(port) + " (" + e.getMessage() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+            return 1;
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            err.println(unreachableMessage(port));
+            return 1;
+        }
+    }
+
+    /**
+     * Implements the {@code stop} subcommand: {@code POST}s the running proxy's
+     * {@code /admin/shutdown} endpoint (loopback only - see {@link ProxyServer}; a CLI client
+     * connecting to {@code 127.0.0.1} always qualifies) and reports the result.
+     *
+     * @param args the {@code stop} CLI arguments (only {@code --port N} is supported)
+     * @param out the stream the confirmation is printed to
+     * @param err the stream an actionable failure line is printed to
+     * @return {@code 0} when the shutdown request was accepted, {@code 1} when the proxy could
+     *         not be reached or refused the request, {@code 2} on a bad {@code --port} argument
+     */
+    static int stop(String[] args, PrintStream out, PrintStream err)
+    {
+        int port;
+        try
+        {
+            port = parsePort(args);
+        }
+        catch (IllegalArgumentException e)
+        {
+            err.println("edt-mcp-proxy: " + e.getMessage()); //$NON-NLS-1$
+            return 2;
+        }
+
+        HttpRequest request = HttpRequest.newBuilder(adminShutdownUri(port))
+            .timeout(Duration.ofSeconds(CLIENT_TIMEOUT_SECONDS))
+            .header(HEADER_CONTENT_TYPE, CONTENT_TYPE_JSON)
+            .POST(HttpRequest.BodyPublishers.noBody())
+            .build();
+        try
+        {
+            HttpResponse<String> response = newClient().send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 200)
+            {
+                out.println("edt-mcp-proxy: proxy on :" + port + " is stopping."); //$NON-NLS-1$ //$NON-NLS-2$
+                return 0;
+            }
+            err.println("edt-mcp-proxy: proxy on :" + port + " refused the stop request (HTTP " //$NON-NLS-1$ //$NON-NLS-2$
+                + response.statusCode() + "): " + response.body()); //$NON-NLS-1$
+            return 1;
+        }
+        catch (IOException e)
+        {
+            err.println(unreachableMessage(port) + " (" + e.getMessage() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+            return 1;
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            err.println(unreachableMessage(port));
+            return 1;
+        }
+    }
+
+    /**
+     * Returns the full {@code --help} usage text: the subcommand overview plus the complete
+     * {@code serve} option/env-variable reference ({@link ProxyConfig#usage()}), so one flag
+     * shows everything a user needs (spec section 2: "usage covering all subcommands + options
+     * + env vars").
+     *
+     * @return the multi-line usage text, never {@code null}
+     */
+    static String usage()
+    {
+        String subcommandOverview = String.join(System.lineSeparator(),
+            "edt-mcp-proxy - standalone MCP router for multiple 1C:EDT instances", //$NON-NLS-1$
+            "", //$NON-NLS-1$
+            "Usage:", //$NON-NLS-1$
+            "  java -jar edt-mcp-proxy.jar [serve] [options]  Start the proxy (default subcommand)", //$NON-NLS-1$
+            "  java -jar edt-mcp-proxy.jar status [--port N]  Query a running proxy's router status", //$NON-NLS-1$
+            "  java -jar edt-mcp-proxy.jar stop [--port N]    Stop a running proxy", //$NON-NLS-1$
+            "  java -jar edt-mcp-proxy.jar --help             Print this help and exit", //$NON-NLS-1$
+            "  java -jar edt-mcp-proxy.jar --version          Print the proxy version and exit", //$NON-NLS-1$
+            "", //$NON-NLS-1$
+            "A bare invocation with no subcommand (options only, or none at all) is an alias for", //$NON-NLS-1$
+            "'serve', for backward compatibility with the CLI before subcommands existed.", //$NON-NLS-1$
+            "'status' and 'stop' accept only --port N (default " + ProxyConfig.defaultPort() + ")."); //$NON-NLS-1$ //$NON-NLS-2$
+        return String.join(System.lineSeparator() + System.lineSeparator(), subcommandOverview, ProxyConfig.usage());
+    }
+
+    /**
+     * Returns the {@code --version} output line.
+     *
+     * @return {@code "edt-mcp-proxy "} followed by {@link ProxyVersion#current()}
+     */
+    static String versionLine()
+    {
+        return "edt-mcp-proxy " + ProxyVersion.current(); //$NON-NLS-1$
+    }
+
+    // ------------------------------------------------------------------------------------
+    // status / stop plumbing
+    // ------------------------------------------------------------------------------------
+
+    private static int parsePort(String[] args)
+    {
+        int port = ProxyConfig.defaultPort();
+        if (args != null)
+        {
+            for (int i = 0; i < args.length; i++)
+            {
+                if (OPT_PORT.equals(args[i]))
+                {
+                    if (++i >= args.length)
+                    {
+                        throw new IllegalArgumentException(
+                            "Option '" + OPT_PORT + "' requires a value. Run with --help for usage."); //$NON-NLS-1$ //$NON-NLS-2$
+                    }
+                    port = parsePortValue(args[i]);
+                }
+                else
+                {
+                    throw new IllegalArgumentException("Unknown option '" + args[i] //$NON-NLS-1$
+                        + "'. Only " + OPT_PORT + " is supported here."); //$NON-NLS-1$ //$NON-NLS-2$
+                }
+            }
+        }
+        return port;
+    }
+
+    private static int parsePortValue(String value)
+    {
+        try
+        {
+            return Integer.parseInt(value);
+        }
+        catch (NumberFormatException e)
+        {
+            throw new IllegalArgumentException("Invalid value for " + OPT_PORT + ": '" + value //$NON-NLS-1$ //$NON-NLS-2$
+                + "' - expected an integer."); //$NON-NLS-1$
+        }
+    }
+
+    private static boolean isHealthy(int port)
+    {
+        try
+        {
+            HttpRequest request = HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/health")) //$NON-NLS-1$ //$NON-NLS-2$
+                .timeout(Duration.ofSeconds(CLIENT_TIMEOUT_SECONDS))
+                .GET()
+                .build();
+            HttpResponse<String> response = newClient().send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200)
+            {
+                return false;
+            }
+            JsonObject body = Json.parseObject(response.body());
+            return body != null && "ok".equals(Json.str(body, "status")); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        catch (IOException e)
+        {
+            return false;
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    /**
+     * Performs the minimal MCP handshake against the proxy on {@code port} and calls
+     * {@code router_status}, returning its {@code structuredContent} payload.
+     *
+     * @return the {@code structuredContent} object, or {@code null} when the handshake or the
+     *         call did not yield a usable response
+     */
+    private static JsonObject fetchRouterStatus(int port) throws IOException, InterruptedException
+    {
+        HttpClient client = newClient();
+        URI mcpUri = URI.create("http://127.0.0.1:" + port + "/mcp"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        JsonObject clientInfo = new JsonObject();
+        clientInfo.addProperty(KEY_NAME, CLIENT_NAME);
+        clientInfo.addProperty(KEY_VERSION, CLIENT_VERSION);
+        JsonObject initParams = new JsonObject();
+        initParams.addProperty(KEY_PROTOCOL_VERSION, Backend.PROTOCOL_VERSION);
+        initParams.add(KEY_CAPABILITIES, new JsonObject());
+        initParams.add(KEY_CLIENT_INFO, clientInfo);
+
+        HttpResponse<String> initResponse =
+            post(client, mcpUri, null, jsonRpcRequest(1, METHOD_INITIALIZE, initParams));
+        if (initResponse.statusCode() != 200)
+        {
+            return null;
+        }
+        String sessionId = initResponse.headers().firstValue(HEADER_SESSION_ID).orElse(null);
+        if (sessionId == null)
+        {
+            return null;
+        }
+
+        JsonObject initializedNotification = new JsonObject();
+        initializedNotification.addProperty(KEY_JSONRPC, JSONRPC_VERSION);
+        initializedNotification.addProperty(KEY_METHOD, METHOD_INITIALIZED_NOTIFICATION);
+        post(client, mcpUri, sessionId, initializedNotification);
+
+        JsonObject callParams = new JsonObject();
+        callParams.addProperty(KEY_NAME, TOOL_ROUTER_STATUS);
+        callParams.add(KEY_ARGUMENTS, new JsonObject());
+        HttpResponse<String> statusResponse =
+            post(client, mcpUri, sessionId, jsonRpcRequest(2, METHOD_TOOLS_CALL, callParams));
+        if (statusResponse.statusCode() != 200)
+        {
+            return null;
+        }
+        JsonObject envelope = Json.parseObject(statusResponse.body());
+        JsonObject result = envelope == null ? null : Json.obj(envelope, KEY_RESULT);
+        return result == null ? null : Json.obj(result, KEY_STRUCTURED_CONTENT);
+    }
+
+    private static JsonObject jsonRpcRequest(int id, String method, JsonObject params)
+    {
+        JsonObject request = new JsonObject();
+        request.addProperty(KEY_JSONRPC, JSONRPC_VERSION);
+        request.addProperty(KEY_ID, id);
+        request.addProperty(KEY_METHOD, method);
+        request.add(KEY_PARAMS, params);
+        return request;
+    }
+
+    /**
+     * Posts one JSON-RPC message with {@code Accept: application/json} (so the proxy answers
+     * plain JSON rather than SSE - see {@code McpProxyHandler#sendMcpResponse}), avoiding any
+     * SSE-framing parsing in this small CLI client.
+     */
+    private static HttpResponse<String> post(HttpClient client, URI uri, String sessionId, JsonObject body)
+        throws IOException, InterruptedException
+    {
+        HttpRequest.Builder builder = HttpRequest.newBuilder(uri)
+            .timeout(Duration.ofSeconds(CLIENT_TIMEOUT_SECONDS))
+            .header(HEADER_CONTENT_TYPE, CONTENT_TYPE_JSON)
+            .header(HEADER_ACCEPT, CONTENT_TYPE_JSON)
+            .POST(HttpRequest.BodyPublishers.ofString(Json.compact(body), StandardCharsets.UTF_8));
+        if (sessionId != null)
+        {
+            builder.header(HEADER_SESSION_ID, sessionId);
+        }
+        return client.send(builder.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    }
+
+    private static void printStatusTable(PrintStream out, int queriedPort, JsonObject structured)
+    {
+        JsonArray backends = asArray(structured, KEY_BACKENDS);
+        out.println("edt-mcp-proxy status: reachable on :" + queriedPort //$NON-NLS-1$
+            + " (" + backends.size() + " live backend(s))"); //$NON-NLS-1$ //$NON-NLS-2$
+        out.println();
+        if (backends.isEmpty())
+        {
+            out.println("  (no live EDT-MCP backends)"); //$NON-NLS-1$
+        }
+        else
+        {
+            out.println("  PORT     PROJECTS"); //$NON-NLS-1$
+            for (JsonElement element : backends)
+            {
+                JsonObject backend = element.getAsJsonObject();
+                int backendPort = backend.get(KEY_PORT).getAsInt();
+                out.println("  " + padRight(String.valueOf(backendPort), 8) + " " //$NON-NLS-1$ //$NON-NLS-2$
+                    + joinOrNone(asArray(backend, KEY_PROJECTS)));
+            }
+        }
+        out.println();
+        out.println(formatDuplicates(asObject(structured, KEY_DUPLICATES)));
+        out.println("Scan range: " + stringOrEmpty(structured, KEY_SCAN_RANGE)); //$NON-NLS-1$
+        out.println("Last refresh: " + formatLastRefresh(longOrZero(structured, KEY_LAST_REFRESH_MS))); //$NON-NLS-1$
+    }
+
+    private static String formatDuplicates(JsonObject duplicates)
+    {
+        if (duplicates == null || duplicates.entrySet().isEmpty())
+        {
+            return "Duplicates: none"; //$NON-NLS-1$
+        }
+        StringBuilder sb = new StringBuilder("Duplicates: "); //$NON-NLS-1$
+        boolean first = true;
+        for (Map.Entry<String, JsonElement> entry : duplicates.entrySet())
+        {
+            if (!first)
+            {
+                sb.append("; "); //$NON-NLS-1$
+            }
+            first = false;
+            sb.append(entry.getKey()).append(" -> ").append(joinPorts(entry.getValue().getAsJsonArray())); //$NON-NLS-1$
+        }
+        return sb.toString();
+    }
+
+    private static String joinPorts(JsonArray ports)
+    {
+        List<String> values = new ArrayList<>();
+        for (JsonElement port : ports)
+        {
+            values.add(port.getAsString());
+        }
+        return String.join(", ", values); //$NON-NLS-1$
+    }
+
+    private static String joinOrNone(JsonArray projects)
+    {
+        if (projects.isEmpty())
+        {
+            return NONE;
+        }
+        List<String> names = new ArrayList<>();
+        for (JsonElement project : projects)
+        {
+            names.add(project.getAsString());
+        }
+        return String.join(", ", names); //$NON-NLS-1$
+    }
+
+    private static String formatLastRefresh(long epochMillis)
+    {
+        if (epochMillis <= 0)
+        {
+            return "never"; //$NON-NLS-1$
+        }
+        long ageSeconds = Math.max(0, (System.currentTimeMillis() - epochMillis) / 1000);
+        return ageSeconds + "s ago"; //$NON-NLS-1$
+    }
+
+    private static String padRight(String value, int width)
+    {
+        StringBuilder sb = new StringBuilder(value);
+        while (sb.length() < width)
+        {
+            sb.append(' ');
+        }
+        return sb.toString();
+    }
+
+    private static JsonArray asArray(JsonObject parent, String key)
+    {
+        return parent != null && parent.has(key) && parent.get(key).isJsonArray()
+            ? parent.getAsJsonArray(key) : new JsonArray();
+    }
+
+    private static JsonObject asObject(JsonObject parent, String key)
+    {
+        return parent != null && parent.has(key) && parent.get(key).isJsonObject()
+            ? parent.getAsJsonObject(key) : null;
+    }
+
+    private static String stringOrEmpty(JsonObject parent, String key)
+    {
+        String value = parent == null ? null : Json.str(parent, key);
+        return value == null ? "" : value; //$NON-NLS-1$
+    }
+
+    private static long longOrZero(JsonObject parent, String key)
+    {
+        return parent != null && parent.has(key) && parent.get(key).isJsonPrimitive()
+            ? parent.get(key).getAsLong() : 0L;
+    }
+
+    private static String unreachableMessage(int port)
+    {
+        return "edt-mcp-proxy: no proxy reachable on :" + port //$NON-NLS-1$
+            + ". Is it running? Start it with: java -jar edt-mcp-proxy.jar serve --port " + port; //$NON-NLS-1$
+    }
+
+    private static URI adminShutdownUri(int port)
+    {
+        return URI.create("http://127.0.0.1:" + port + "/admin/shutdown"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    private static HttpClient newClient()
+    {
+        return HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(CLIENT_TIMEOUT_SECONDS)).build();
+    }
+}

--- a/proxy/src/main/java/com/ditrix/edt/mcp/proxy/Main.java
+++ b/proxy/src/main/java/com/ditrix/edt/mcp/proxy/Main.java
@@ -6,24 +6,32 @@
 
 package com.ditrix.edt.mcp.proxy;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.logging.Logger;
+import java.util.Arrays;
 
 /**
  * Command-line entry point of the standalone MCP proxy (issue #253).
  *
- * <p>Wires the components together: parses {@link ProxyConfig} ({@code --help} prints usage and
- * exits 0), builds the {@link BackendRegistry}, {@link SessionManager}, {@link McpProxyHandler}
- * and {@link ProxyServer}, performs an initial backend discovery, starts the periodic registry
- * refresh loop, installs a shutdown hook, and prints one startup line to stdout.
- *
- * <p>The proxy stays alive with zero backends: discovery is periodic and also happens on a
- * routing miss, so backends may come and go while the proxy is running.
+ * <p>Allure-style subcommands, dispatched here and implemented in {@link CliCommands}:
+ * <ul>
+ * <li>{@code serve [options]} - starts the proxy in the foreground. This is also the implicit
+ *     behaviour of a bare invocation (no subcommand, or options only), for backward
+ *     compatibility with the pre-subcommand CLI;</li>
+ * <li>{@code status [--port N]} - queries a RUNNING proxy and prints a human-readable table;</li>
+ * <li>{@code stop [--port N]} - asks a RUNNING proxy to shut down.</li>
+ * </ul>
+ * {@code --help}/{@code -h} and {@code --version} are recognised anywhere in the arguments and
+ * short-circuit dispatch entirely (see {@link CliCommands#usage()} / {@link CliCommands#versionLine()}).
+ * An unrecognised subcommand prints the usage and exits {@code 2}.
  */
 public final class Main
 {
-    private static final Logger LOG = Logger.getLogger(Main.class.getName());
+    private static final String CMD_SERVE = "serve"; //$NON-NLS-1$
+    private static final String CMD_STATUS = "status"; //$NON-NLS-1$
+    private static final String CMD_STOP = "stop"; //$NON-NLS-1$
+    private static final String OPT_HELP_LONG = "--help"; //$NON-NLS-1$
+    private static final String OPT_HELP_SHORT = "-h"; //$NON-NLS-1$
+    private static final String OPT_VERSION = "--version"; //$NON-NLS-1$
+    private static final String OPTION_PREFIX = "--"; //$NON-NLS-1$
 
     private Main()
     {
@@ -31,64 +39,68 @@ public final class Main
     }
 
     /**
-     * Starts the proxy.
+     * Parses the subcommand (defaulting to {@code serve}) and dispatches to {@link CliCommands}.
      *
-     * @param args CLI arguments, see {@link ProxyConfig#usage()}
+     * @param args CLI arguments; see {@link CliCommands#usage()}
      */
     public static void main(String[] args)
     {
-        if (args != null)
-        {
-            for (String arg : args)
-            {
-                if ("--help".equals(arg) || "-h".equals(arg)) //$NON-NLS-1$ //$NON-NLS-2$
-                {
-                    System.out.println(ProxyConfig.usage());
-                    return;
-                }
-            }
-        }
+        String[] safeArgs = args == null ? new String[0] : args;
 
-        ProxyConfig cfg;
-        try
+        if (containsAny(safeArgs, OPT_HELP_LONG, OPT_HELP_SHORT))
         {
-            cfg = ProxyConfig.parse(args, System.getenv());
+            System.out.println(CliCommands.usage());
+            return;
         }
-        catch (IllegalArgumentException e)
+        if (containsAny(safeArgs, OPT_VERSION))
         {
-            System.err.println("edt-mcp-proxy: " + e.getMessage()); //$NON-NLS-1$
-            System.err.println();
-            System.err.println(ProxyConfig.usage());
-            System.exit(2);
+            System.out.println(CliCommands.versionLine());
             return;
         }
 
-        BackendRegistry registry = new BackendRegistry(cfg);
-        SessionManager sessions = new SessionManager();
-        McpProxyHandler handler = new McpProxyHandler(cfg, registry, sessions);
-        ProxyServer server = new ProxyServer(cfg, registry, handler);
+        if (safeArgs.length == 0 || safeArgs[0].startsWith(OPTION_PREFIX))
+        {
+            // No subcommand, or the first token is already an option (e.g. "--port 9000") -
+            // 'serve' is the implicit default, for backward compatibility with the CLI before
+            // subcommands existed.
+            CliCommands.serve(safeArgs);
+            return;
+        }
 
-        // Initial discovery so /health and the first requests see the backends immediately.
-        registry.refresh();
-        server.start();
+        String subcommand = safeArgs[0];
+        String[] rest = Arrays.copyOfRange(safeArgs, 1, safeArgs.length);
+        switch (subcommand)
+        {
+        case CMD_SERVE:
+            CliCommands.serve(rest);
+            break;
+        case CMD_STATUS:
+            System.exit(CliCommands.status(rest, System.out, System.err));
+            break;
+        case CMD_STOP:
+            System.exit(CliCommands.stop(rest, System.out, System.err));
+            break;
+        default:
+            System.err.println("edt-mcp-proxy: unknown subcommand '" + subcommand //$NON-NLS-1$
+                + "'. Run with --help for usage."); //$NON-NLS-1$
+            System.err.println();
+            System.err.println(CliCommands.usage());
+            System.exit(2);
+        }
+    }
 
-        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
-            Thread thread = new Thread(r, "edt-mcp-proxy-refresh"); //$NON-NLS-1$
-            thread.setDaemon(true);
-            return thread;
-        });
-        registry.startPeriodicRefresh(scheduler);
-
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            LOG.info("Shutting down edt-mcp-proxy"); //$NON-NLS-1$
-            scheduler.shutdownNow();
-            server.stop();
-        }, "edt-mcp-proxy-shutdown")); //$NON-NLS-1$
-
-        // The single startup line goes to stdout by contract (scripts grep for it).
-        System.out.println("edt-mcp-proxy listening on :" + server.getPort() //$NON-NLS-1$
-            + ", scanning " + cfg.scanFrom + "-" + cfg.scanTo); //$NON-NLS-1$ //$NON-NLS-2$
-        LOG.info("Live backends after initial discovery: " + registry.live().size()); //$NON-NLS-1$
-        // The JVM stays alive on the HttpServer's non-daemon dispatcher thread.
+    private static boolean containsAny(String[] args, String... needles)
+    {
+        for (String arg : args)
+        {
+            for (String needle : needles)
+            {
+                if (needle.equals(arg))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/proxy/src/main/java/com/ditrix/edt/mcp/proxy/McpProxyHandler.java
+++ b/proxy/src/main/java/com/ditrix/edt/mcp/proxy/McpProxyHandler.java
@@ -73,7 +73,6 @@ public final class McpProxyHandler implements HttpHandler
     private static final String NOTIFICATION_PREFIX = "notifications/"; //$NON-NLS-1$
 
     private static final String SERVER_NAME = "edt-mcp-proxy"; //$NON-NLS-1$
-    private static final String FALLBACK_VERSION = "dev"; //$NON-NLS-1$
 
     private static final int ERROR_INVALID_REQUEST = -32600;
     private static final int ERROR_INTERNAL = -32603;
@@ -627,11 +626,10 @@ public final class McpProxyHandler implements HttpHandler
         return "Backend at :" + port + " stopped responding; refreshed registry; retry."; //$NON-NLS-1$ //$NON-NLS-2$
     }
 
-    /** The proxy's own version, read from the shaded jar's manifest; {@value #FALLBACK_VERSION} outside one. */
+    /** The proxy's own version; see {@link ProxyVersion} for how it is resolved. */
     private static String proxyVersion()
     {
-        String version = McpProxyHandler.class.getPackage().getImplementationVersion();
-        return version != null ? version : FALLBACK_VERSION;
+        return ProxyVersion.current();
     }
 
     private static String buildSimpleError(String message)

--- a/proxy/src/main/java/com/ditrix/edt/mcp/proxy/ProxyConfig.java
+++ b/proxy/src/main/java/com/ditrix/edt/mcp/proxy/ProxyConfig.java
@@ -6,20 +6,40 @@
 
 package com.ditrix.edt.mcp.proxy;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.CodeSource;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * Immutable configuration for the standalone MCP proxy.
  *
- * <p>Values are resolved with the precedence: CLI argument &gt; environment variable &gt; built-in default.
+ * <p>Values are resolved with the precedence: CLI argument &gt; environment variable &gt; config
+ * file &gt; built-in default.
  * Supported CLI options: {@code --port N}, {@code --scan FROM-TO}, {@code --refresh N}, {@code --timeout N},
- * {@code --bind HOST}.
+ * {@code --bind HOST}, {@code --config PATH}.
  * Supported environment variables: {@code EDT_MCP_PROXY_PORT}, {@code EDT_MCP_PROXY_SCAN} (e.g.
  * {@code "8765-8774"}), {@code EDT_MCP_PROXY_REFRESH}, {@code EDT_MCP_PROXY_TIMEOUT},
  * {@code EDT_MCP_PROXY_HOST}.
  *
+ * <p><b>Config file (issue #253 follow-up).</b> A plain {@link Properties} file with the keys
+ * {@code port}, {@code scan}, {@code refresh}, {@code timeout}, {@code bind} (same semantics as
+ * the matching CLI flag/env variable). An explicit {@code --config PATH} names the file
+ * directly and fails fast when it cannot be read; without it, a file named
+ * {@value #AUTO_CONFIG_FILE_NAME} next to the running jar is loaded automatically when present
+ * and silently skipped when it is not (the config file is always optional). The jar's directory
+ * is resolved via this class's {@link CodeSource} - when that cannot be determined (e.g. running
+ * from a test classpath with no jar at all) auto-discovery simply finds nothing.
+ *
  * <p>Any invalid value fails fast with an {@link IllegalArgumentException} carrying an actionable
- * message. The {@code --help} flag is handled by {@link Main} before parsing, not here.
+ * message that names the source it came from (a CLI flag, an env variable, or {@code "config
+ * file &lt;name&gt;: &lt;key&gt;"}). The {@code --help} flag is handled by {@link Main} /
+ * {@link CliCommands} before parsing, not here.
  *
  * <p>An inverted scan range ({@code FROM > TO}) is accepted and means an <b>empty</b> scan range:
  * no backend ports are probed and the proxy starts (and stays alive) with zero backends.
@@ -58,6 +78,16 @@ public final class ProxyConfig
     private static final String OPT_REFRESH = "--refresh"; //$NON-NLS-1$
     private static final String OPT_TIMEOUT = "--timeout"; //$NON-NLS-1$
     private static final String OPT_BIND = "--bind"; //$NON-NLS-1$
+    private static final String OPT_CONFIG = "--config"; //$NON-NLS-1$
+
+    private static final String PROP_PORT = "port"; //$NON-NLS-1$
+    private static final String PROP_SCAN = "scan"; //$NON-NLS-1$
+    private static final String PROP_REFRESH = "refresh"; //$NON-NLS-1$
+    private static final String PROP_TIMEOUT = "timeout"; //$NON-NLS-1$
+    private static final String PROP_BIND = "bind"; //$NON-NLS-1$
+
+    /** Name of the config file auto-discovered next to the running jar when {@code --config} is absent. */
+    private static final String AUTO_CONFIG_FILE_NAME = "edt-mcp-proxy.properties"; //$NON-NLS-1$
 
     private static final int DEFAULT_PORT = 8764;
     private static final int DEFAULT_SCAN_FROM = 8765;
@@ -127,6 +157,39 @@ public final class ProxyConfig
         boolean allowRemote = false;
         String bindHost = null;
 
+        // Layer 1 (lowest precedence after the built-in defaults above): the config file,
+        // either --config PATH or the auto-discovered file next to the jar.
+        ConfigFileSource configFile = loadConfigFileSource(args);
+        String fileValue = trimmedOrNull(configFile.properties.getProperty(PROP_PORT));
+        if (fileValue != null)
+        {
+            port = parseListenPort(configFileSource(configFile.label, PROP_PORT), fileValue);
+        }
+        fileValue = trimmedOrNull(configFile.properties.getProperty(PROP_SCAN));
+        if (fileValue != null)
+        {
+            int[] range = parseScanRange(configFileSource(configFile.label, PROP_SCAN), fileValue);
+            scanFrom = range[0];
+            scanTo = range[1];
+        }
+        fileValue = trimmedOrNull(configFile.properties.getProperty(PROP_REFRESH));
+        if (fileValue != null)
+        {
+            refreshSeconds = parsePositive(configFileSource(configFile.label, PROP_REFRESH), fileValue);
+        }
+        fileValue = trimmedOrNull(configFile.properties.getProperty(PROP_TIMEOUT));
+        if (fileValue != null)
+        {
+            backendTimeoutSeconds = parsePositive(configFileSource(configFile.label, PROP_TIMEOUT), fileValue);
+        }
+        fileValue = trimmedOrNull(configFile.properties.getProperty(PROP_BIND));
+        if (fileValue != null)
+        {
+            bindHost = parseHost(configFileSource(configFile.label, PROP_BIND), fileValue);
+            allowRemote = true;
+        }
+
+        // Layer 2: environment variables (win over the config file, lose to the CLI below).
         if (env != null)
         {
             String value = trimmedOrNull(env.get(ENV_PORT));
@@ -159,6 +222,7 @@ public final class ProxyConfig
             }
         }
 
+        // Layer 3 (highest precedence): CLI arguments.
         if (args != null)
         {
             for (int i = 0; i < args.length; i++)
@@ -184,6 +248,11 @@ public final class ProxyConfig
                     bindHost = parseHost(OPT_BIND, optionValue(OPT_BIND, args, ++i));
                     allowRemote = true;
                     break;
+                case OPT_CONFIG:
+                    // The path was already consumed by loadConfigFileSource() above; just skip
+                    // its value here so it is not mistaken for an unknown option.
+                    optionValue(OPT_CONFIG, args, ++i);
+                    break;
                 default:
                     throw new IllegalArgumentException(
                         "Unknown option '" + option + "'. Run with --help for the supported options."); //$NON-NLS-1$ //$NON-NLS-2$
@@ -192,6 +261,17 @@ public final class ProxyConfig
         }
 
         return new ProxyConfig(port, scanFrom, scanTo, refreshSeconds, backendTimeoutSeconds, allowRemote, bindHost);
+    }
+
+    /**
+     * Returns the default proxy listen port, for CLI subcommands ({@code status}/{@code stop})
+     * that talk to an already-running proxy without going through full {@link #parse} resolution.
+     *
+     * @return the default port ({@value #DEFAULT_PORT})
+     */
+    public static int defaultPort()
+    {
+        return DEFAULT_PORT;
     }
 
     /**
@@ -204,7 +284,7 @@ public final class ProxyConfig
         return String.join(System.lineSeparator(),
             "edt-mcp-proxy - standalone MCP router for multiple 1C:EDT instances", //$NON-NLS-1$
             "", //$NON-NLS-1$
-            "Usage: java -jar edt-mcp-proxy.jar [options]", //$NON-NLS-1$
+            "Usage: java -jar edt-mcp-proxy.jar serve [options]", //$NON-NLS-1$
             "", //$NON-NLS-1$
             "Options:", //$NON-NLS-1$
             "  --port N        HTTP port to listen on (default 8764, 0 = ephemeral)", //$NON-NLS-1$
@@ -214,9 +294,14 @@ public final class ProxyConfig
             "  --bind HOST     Bind HOST instead of loopback only (e.g. 0.0.0.0 for all interfaces).", //$NON-NLS-1$
             "                  WARNING: v1 has no authentication - this exposes every routed EDT", //$NON-NLS-1$
             "                  tool, including arbitrary BSL, to anyone who can reach the port.", //$NON-NLS-1$
+            "  --config PATH   Load port/scan/refresh/timeout/bind from a java.util.Properties", //$NON-NLS-1$
+            "                  file (keys: port, scan, refresh, timeout, bind). Without this flag,", //$NON-NLS-1$
+            "                  a file named " + AUTO_CONFIG_FILE_NAME + " next to the running jar is used if present.", //$NON-NLS-1$ //$NON-NLS-2$
             "  --help          Print this help and exit", //$NON-NLS-1$
             "", //$NON-NLS-1$
-            "Environment variables (CLI options take precedence):", //$NON-NLS-1$
+            "Precedence: CLI options > environment variables > config file > defaults.", //$NON-NLS-1$
+            "", //$NON-NLS-1$
+            "Environment variables:", //$NON-NLS-1$
             "  EDT_MCP_PROXY_PORT, EDT_MCP_PROXY_SCAN (FROM-TO),", //$NON-NLS-1$
             "  EDT_MCP_PROXY_REFRESH, EDT_MCP_PROXY_TIMEOUT, EDT_MCP_PROXY_HOST"); //$NON-NLS-1$
     }
@@ -308,6 +393,146 @@ public final class ProxyConfig
         {
             throw new IllegalArgumentException("Invalid value for " + source + ": '" + value //$NON-NLS-1$ //$NON-NLS-2$
                 + "' - expected an integer."); //$NON-NLS-1$
+        }
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Config file (issue #253 follow-up, spec section 3).
+    // ------------------------------------------------------------------------------------
+
+    /**
+     * Resolves the config-file layer: an explicit {@code --config PATH} wins and fails fast when
+     * unreadable (the caller asked for it by name); otherwise a {@value #AUTO_CONFIG_FILE_NAME}
+     * file next to the running jar is used when present, and silently skipped when it is not (or
+     * when the jar directory cannot be determined at all) - the config file is always optional
+     * unless named explicitly.
+     *
+     * @param args the CLI arguments (scanned only for {@code --config}), may be {@code null}
+     * @return the resolved (possibly empty) properties plus the label used in diagnostics
+     */
+    private static ConfigFileSource loadConfigFileSource(String[] args)
+    {
+        String explicitPath = findConfigOption(args);
+        if (explicitPath != null)
+        {
+            return new ConfigFileSource(loadPropertiesFile(explicitPath, true), explicitPath);
+        }
+
+        Path autoPath = discoverConfigFileNextToJar();
+        if (autoPath == null)
+        {
+            return new ConfigFileSource(new Properties(), AUTO_CONFIG_FILE_NAME);
+        }
+        return new ConfigFileSource(loadPropertiesFile(autoPath.toString(), false), AUTO_CONFIG_FILE_NAME);
+    }
+
+    /**
+     * Scans {@code args} for {@code --config PATH}, without validating any other option (the
+     * main CLI loop in {@link #parse} does that afterwards).
+     *
+     * @param args the CLI arguments, may be {@code null}
+     * @return the path given after {@code --config}, or {@code null} when the flag is absent
+     * @throws IllegalArgumentException when {@code --config} is the last argument with no value
+     */
+    private static String findConfigOption(String[] args)
+    {
+        if (args == null)
+        {
+            return null;
+        }
+        for (int i = 0; i < args.length; i++)
+        {
+            if (OPT_CONFIG.equals(args[i]))
+            {
+                if (i + 1 >= args.length)
+                {
+                    throw new IllegalArgumentException(
+                        "Option '" + OPT_CONFIG + "' requires a value. Run with --help for usage."); //$NON-NLS-1$ //$NON-NLS-2$
+                }
+                return args[i + 1];
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the directory of the running jar via this class's {@link CodeSource} and
+     * appends {@value #AUTO_CONFIG_FILE_NAME}. Package-private so a unit test can call it
+     * directly and prove it never throws (only returns {@code null}) even when no usable jar
+     * location exists, e.g. running from a test classpath directory instead of a packaged jar.
+     *
+     * @return the candidate config file path, or {@code null} when the jar directory cannot be
+     *         determined
+     */
+    static Path discoverConfigFileNextToJar()
+    {
+        try
+        {
+            CodeSource codeSource = ProxyConfig.class.getProtectionDomain().getCodeSource();
+            if (codeSource == null || codeSource.getLocation() == null)
+            {
+                return null;
+            }
+            Path location = Paths.get(codeSource.getLocation().toURI());
+            Path jarDir = Files.isDirectory(location) ? location : location.getParent();
+            return jarDir == null ? null : jarDir.resolve(AUTO_CONFIG_FILE_NAME);
+        }
+        catch (URISyntaxException | IllegalArgumentException | SecurityException e)
+        {
+            // No usable jar location - auto-discovery simply finds nothing; the config file is
+            // always optional when it was not named explicitly via --config.
+            return null;
+        }
+    }
+
+    /**
+     * Loads a {@link Properties} file from disk.
+     *
+     * @param path the file path, as given by the caller (used verbatim in diagnostics)
+     * @param required when {@code true}, a missing/unreadable file fails fast; when
+     *            {@code false} it is treated as an empty file (auto-discovery)
+     * @return the loaded properties, or empty when {@code !required} and the file is absent
+     * @throws IllegalArgumentException when {@code required} and the file cannot be read/parsed
+     */
+    private static Properties loadPropertiesFile(String path, boolean required)
+    {
+        Properties properties = new Properties();
+        Path file = Paths.get(path);
+        if (!Files.isReadable(file))
+        {
+            if (required)
+            {
+                throw new IllegalArgumentException("Config file '" + path + "' not found or not readable."); //$NON-NLS-1$ //$NON-NLS-2$
+            }
+            return properties;
+        }
+        try (InputStream in = Files.newInputStream(file))
+        {
+            properties.load(in);
+        }
+        catch (IOException e)
+        {
+            throw new IllegalArgumentException("Failed to read config file '" + path + "': " + e.getMessage(), e); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return properties;
+    }
+
+    /** Builds the diagnostic "source" label for a config-file-sourced value, e.g. {@code "config file edt-mcp-proxy.properties: scan"}. */
+    private static String configFileSource(String label, String key)
+    {
+        return "config file " + label + ": " + key; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /** The config-file layer's resolved properties plus the label used to name it in diagnostics. */
+    private static final class ConfigFileSource
+    {
+        final Properties properties;
+        final String label;
+
+        ConfigFileSource(Properties properties, String label)
+        {
+            this.properties = properties;
+            this.label = label;
         }
     }
 }

--- a/proxy/src/main/java/com/ditrix/edt/mcp/proxy/ProxyServer.java
+++ b/proxy/src/main/java/com/ditrix/edt/mcp/proxy/ProxyServer.java
@@ -21,7 +21,7 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 
 /**
- * Owns the proxy's {@link HttpServer}: binds the configured port and wires the two contexts.
+ * Owns the proxy's {@link HttpServer}: binds the configured port and wires the three contexts.
  *
  * <ul>
  * <li>{@code GET /health} - liveness probe answered here:
@@ -29,6 +29,11 @@ import com.sun.net.httpserver.HttpServer;
  *     of live backends in the registry.</li>
  * <li>{@code /mcp} - the MCP Streamable HTTP endpoint, delegated entirely to
  *     {@link McpProxyHandler}.</li>
+ * <li>{@code POST /admin/shutdown} - the {@code stop} CLI subcommand's target (issue #253
+ *     follow-up, spec section 7): gracefully stops the proxy. Accepted ONLY from a loopback
+ *     remote address, REGARDLESS of {@code cfg.allowRemote}/{@code --bind} - the admin surface
+ *     is never exposed remotely even when the MCP traffic itself is. See
+ *     {@link #handleAdminShutdown} and {@link #setShutdownCallback}.</li>
  * </ul>
  *
  * <p><b>Bind address.</b> {@link #start()} binds loopback only unless {@code cfg.allowRemote}
@@ -42,6 +47,8 @@ public final class ProxyServer
 
     private static final String CONTENT_TYPE = "Content-Type"; //$NON-NLS-1$
     private static final String APPLICATION_JSON = "application/json"; //$NON-NLS-1$
+    private static final String HTTP_METHOD_POST = "POST"; //$NON-NLS-1$
+    private static final String CONTEXT_ADMIN_SHUTDOWN = "/admin/shutdown"; //$NON-NLS-1$
 
     private final ProxyConfig cfg;
     private final BackendRegistry registry;
@@ -49,6 +56,16 @@ public final class ProxyServer
 
     private HttpServer httpServer;
     private ExecutorService executor;
+
+    /**
+     * Cleanup run once {@code POST /admin/shutdown} has been accepted and its response flushed;
+     * wired by {@code Main}/{@code CliCommands} to the exact same cleanup a Ctrl+C/SIGTERM
+     * shutdown hook runs (stop the periodic-refresh scheduler, then this server). {@code null}
+     * (the default, e.g. in a test that never calls {@link #setShutdownCallback}) falls back to
+     * calling {@link #stop()} directly, so the endpoint is still self-sufficient without a caller
+     * that owns extra resources to clean up.
+     */
+    private volatile Runnable shutdownCallback;
 
     /**
      * Creates the server (does not bind yet - call {@link #start()}).
@@ -104,6 +121,7 @@ public final class ProxyServer
         httpServer.setExecutor(executor);
         httpServer.createContext("/health", this::handleHealth); //$NON-NLS-1$
         httpServer.createContext("/mcp", handler); //$NON-NLS-1$
+        httpServer.createContext(CONTEXT_ADMIN_SHUTDOWN, this::handleAdminShutdown);
         httpServer.start();
         LOG.info("Proxy HTTP server binding to " //$NON-NLS-1$
             + (cfg.allowRemote ? "remote (" + cfg.bindHost + ")" : "loopback only") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
@@ -132,6 +150,21 @@ public final class ProxyServer
             executor.shutdownNow();
             executor = null;
         }
+    }
+
+    /**
+     * Installs the cleanup {@code POST /admin/shutdown} runs once its response has been flushed
+     * to the client, instead of the plain {@link #stop()} fallback. The caller (normally
+     * {@code CliCommands.serve}) should pass the SAME {@link Runnable} it installs as its JVM
+     * shutdown hook, so a Ctrl+C/SIGTERM and an admin-triggered stop clean up identically
+     * (stop the periodic-refresh scheduler, then this server); both paths are idempotent, so it
+     * is harmless if the shutdown hook also fires afterwards.
+     *
+     * @param callback the shutdown cleanup to run; {@code null} restores the {@link #stop()} fallback
+     */
+    public void setShutdownCallback(Runnable callback)
+    {
+        this.shutdownCallback = callback;
     }
 
     /**
@@ -172,6 +205,88 @@ public final class ProxyServer
         {
             exchange.close();
         }
+    }
+
+    /**
+     * Serves {@code POST /admin/shutdown} (issue #253 follow-up, spec section 7/8): the {@code
+     * stop} CLI subcommand's target. Accepted ONLY when {@link #isLoopbackRequest} is {@code
+     * true} for the exchange's remote address - REGARDLESS of {@code cfg.allowRemote}/{@code
+     * --bind} - answering {@code 403} otherwise; any HTTP method other than {@code POST}
+     * answers {@code 405}. On acceptance the {@code 200 {"status":"stopping"}} response is sent
+     * and the exchange closed FIRST, so it reaches the client, and only THEN is the actual stop
+     * triggered on a separate thread (see {@link #triggerShutdown()}) - stopping this server
+     * from within one of its own dispatcher threads before the response is flushed would race
+     * the client seeing a reply at all.
+     */
+    private void handleAdminShutdown(HttpExchange exchange) throws IOException
+    {
+        boolean accepted = false;
+        try
+        {
+            if (!HTTP_METHOD_POST.equals(exchange.getRequestMethod()))
+            {
+                sendJson(exchange, 405, "{\"error\":\"Method not allowed\"}"); //$NON-NLS-1$
+                return;
+            }
+            if (!isLoopbackRequest(exchange.getRemoteAddress()))
+            {
+                LOG.warning("Rejected " + CONTEXT_ADMIN_SHUTDOWN + " from non-loopback address " //$NON-NLS-1$ //$NON-NLS-2$
+                    + exchange.getRemoteAddress());
+                sendJson(exchange, 403,
+                    "{\"error\":\"Forbidden - " + CONTEXT_ADMIN_SHUTDOWN + " accepts loopback callers only\"}"); //$NON-NLS-1$ //$NON-NLS-2$
+                return;
+            }
+            LOG.info("Accepted " + CONTEXT_ADMIN_SHUTDOWN + " from " + exchange.getRemoteAddress()); //$NON-NLS-1$ //$NON-NLS-2$
+            sendJson(exchange, 200, "{\"status\":\"stopping\"}"); //$NON-NLS-1$
+            accepted = true;
+        }
+        finally
+        {
+            exchange.close();
+        }
+        if (accepted)
+        {
+            triggerShutdown();
+        }
+    }
+
+    /**
+     * Tells whether an HTTP exchange's remote address is loopback - the ONLY address class
+     * {@code POST /admin/shutdown} accepts, regardless of {@code cfg.allowRemote}/{@code --bind}.
+     * Package-private and static (no exchange/socket needed) so a unit test can exercise both
+     * branches directly: faking a genuinely non-loopback remote peer in-process is impractical,
+     * so the 403 branch is proven on this helper instead of over a real socket.
+     *
+     * @param remote the exchange's remote socket address; {@code null} is treated as non-loopback
+     * @return {@code true} only when the remote address is present and loopback
+     */
+    static boolean isLoopbackRequest(InetSocketAddress remote)
+    {
+        return remote != null && remote.getAddress() != null && remote.getAddress().isLoopbackAddress();
+    }
+
+    /**
+     * Runs the shutdown cleanup on a fresh daemon thread, off the HTTP dispatcher thread that
+     * just answered {@code POST /admin/shutdown}, so stopping this server's {@link HttpServer}
+     * never races the response it just sent. Uses {@link #shutdownCallback} when set (installed
+     * by the caller that also owns e.g. the periodic-refresh scheduler); falls back to
+     * {@link #stop()} so the endpoint is self-sufficient even without one.
+     */
+    private void triggerShutdown()
+    {
+        Thread shutdownThread = new Thread(() -> {
+            Runnable callback = shutdownCallback;
+            if (callback != null)
+            {
+                callback.run();
+            }
+            else
+            {
+                stop();
+            }
+        }, "edt-mcp-proxy-admin-shutdown"); //$NON-NLS-1$
+        shutdownThread.setDaemon(true);
+        shutdownThread.start();
     }
 
     private static void sendJson(HttpExchange exchange, int status, String body) throws IOException

--- a/proxy/src/main/java/com/ditrix/edt/mcp/proxy/ProxyVersion.java
+++ b/proxy/src/main/java/com/ditrix/edt/mcp/proxy/ProxyVersion.java
@@ -1,0 +1,44 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.proxy;
+
+/**
+ * The proxy's own version string, shared by everything that needs to report it: the MCP
+ * {@code initialize} response ({@code McpProxyHandler}) and the {@code --version} CLI flag
+ * ({@code CliCommands}).
+ *
+ * <p>Read from the running jar's manifest {@code Implementation-Version} entry, same as any
+ * other {@code Package#getImplementationVersion()} lookup. Today's {@code proxy/pom.xml} does
+ * not populate that entry (no {@code addDefaultImplementationEntries} / explicit manifest
+ * entry is configured), so {@link #FALLBACK_VERSION} is what {@code --version} currently
+ * reports even from the packaged shaded jar; wiring the manifest entry is a build-config change
+ * outside this class's scope. Either way, the lookup degrades to {@link #FALLBACK_VERSION}
+ * whenever the entry is absent - including when running from a test/IDE classpath with no jar
+ * at all.
+ */
+public final class ProxyVersion
+{
+    private static final String FALLBACK_VERSION = "dev"; //$NON-NLS-1$
+
+    private ProxyVersion()
+    {
+        // utility class
+    }
+
+    /**
+     * Returns the proxy's version.
+     *
+     * @return the {@code Implementation-Version} manifest entry of the jar this class was
+     *         loaded from, or {@value #FALLBACK_VERSION} when there is none (not running from a
+     *         packaged jar)
+     */
+    public static String current()
+    {
+        String version = ProxyVersion.class.getPackage().getImplementationVersion();
+        return version != null ? version : FALLBACK_VERSION;
+    }
+}

--- a/proxy/src/test/java/com/ditrix/edt/mcp/proxy/AdminShutdownIT.java
+++ b/proxy/src/test/java/com/ditrix/edt/mcp/proxy/AdminShutdownIT.java
@@ -1,0 +1,106 @@
+/**
+ * MCP Server for EDT - Proxy Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.proxy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import com.ditrix.edt.mcp.proxy.ProxyRoutingIT.ProxyFixture;
+
+/**
+ * Direct wire-level coverage of {@code POST /admin/shutdown} (issue #253 follow-up, spec
+ * section 7/8): accepted from a loopback caller - the ONLY remote address this in-process
+ * harness can exercise; a genuinely non-loopback remote peer cannot be faked without a real
+ * second host, so the {@code 403} branch is instead unit-tested directly on the address-check
+ * helper in {@link ProxyServerTest} - rejected for any HTTP method other than {@code POST}, and
+ * proven to actually stop the server afterwards.
+ */
+public class AdminShutdownIT
+{
+    /** Hard cap per test so a transport hang fails fast instead of wedging the build. */
+    @Rule
+    public final Timeout globalTimeout = Timeout.seconds(60);
+
+    private static final Duration CLIENT_TIMEOUT = Duration.ofSeconds(5);
+
+    /**
+     * A {@code POST} from loopback must be accepted ({@code 200 {"status":"stopping"}}) and the
+     * proxy must actually stop shortly afterwards.
+     */
+    @Test
+    public void testPostFromLoopbackStopsTheProxy() throws Exception
+    {
+        int deadPort = ProxyRoutingIT.reserveFreePorts(1)[0]; // no backend needed for this scenario
+        ProxyFixture proxy = new ProxyFixture(deadPort, deadPort);
+        proxy.start();
+        int proxyPort = proxy.port();
+        HttpClient client = HttpClient.newBuilder().connectTimeout(CLIENT_TIMEOUT).build();
+
+        HttpResponse<String> response = client.send(
+            HttpRequest.newBuilder(adminShutdownUri(proxyPort))
+                .timeout(CLIENT_TIMEOUT)
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, response.statusCode());
+        assertTrue("the response must report the proxy is stopping: " + response.body(), //$NON-NLS-1$
+            response.body().contains("stopping")); //$NON-NLS-1$
+
+        ProxyRoutingIT.awaitHealthUnreachable(proxyPort, 10_000);
+    }
+
+    /**
+     * Any HTTP method other than {@code POST} must be rejected with {@code 405}, without
+     * stopping the proxy.
+     */
+    @Test
+    public void testGetMethodRejectedWith405AndProxyStaysUp() throws Exception
+    {
+        int deadPort = ProxyRoutingIT.reserveFreePorts(1)[0];
+        ProxyFixture proxy = new ProxyFixture(deadPort, deadPort);
+        proxy.start();
+        try
+        {
+            HttpClient client = HttpClient.newBuilder().connectTimeout(CLIENT_TIMEOUT).build();
+
+            HttpResponse<String> response = client.send(
+                HttpRequest.newBuilder(adminShutdownUri(proxy.port())).timeout(CLIENT_TIMEOUT).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+
+            assertEquals(405, response.statusCode());
+
+            // The proxy must still be answering - a rejected GET must not have stopped it.
+            HttpResponse<String> health = client.send(
+                HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + proxy.port() + "/health")) //$NON-NLS-1$ //$NON-NLS-2$
+                    .timeout(CLIENT_TIMEOUT)
+                    .GET()
+                    .build(),
+                HttpResponse.BodyHandlers.ofString());
+            assertEquals(200, health.statusCode());
+        }
+        finally
+        {
+            proxy.stop();
+        }
+    }
+
+    private static URI adminShutdownUri(int port)
+    {
+        return URI.create("http://127.0.0.1:" + port + "/admin/shutdown"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+}

--- a/proxy/src/test/java/com/ditrix/edt/mcp/proxy/CliCommandsTest.java
+++ b/proxy/src/test/java/com/ditrix/edt/mcp/proxy/CliCommandsTest.java
@@ -1,0 +1,151 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.proxy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link CliCommands} that need no network: the subcommand-aware {@code --help}
+ * usage text, the {@code --version} line, and {@code status}/{@code stop} argument validation
+ * (bad {@code --port} values exit {@code 2} before any HTTP call is attempted). The reachable/
+ * unreachable-proxy behaviour of {@code status}/{@code stop} is covered end-to-end by
+ * {@link CliIT} instead.
+ */
+public class CliCommandsTest
+{
+    @Test
+    public void testUsageMentionsAllThreeSubcommands()
+    {
+        String usage = CliCommands.usage();
+
+        assertTrue(usage.contains("serve")); //$NON-NLS-1$
+        assertTrue(usage.contains("status")); //$NON-NLS-1$
+        assertTrue(usage.contains("stop")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testUsageMentionsHelpAndVersionFlags()
+    {
+        String usage = CliCommands.usage();
+
+        assertTrue(usage.contains("--help")); //$NON-NLS-1$
+        assertTrue(usage.contains("--version")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testUsageMentionsEveryServeOptionAndEnvVariable()
+    {
+        // usage() embeds ProxyConfig.usage() so --help shows subcommands + options + env vars
+        // in one place (spec section 2).
+        String usage = CliCommands.usage();
+
+        assertTrue(usage.contains("--port")); //$NON-NLS-1$
+        assertTrue(usage.contains("--scan")); //$NON-NLS-1$
+        assertTrue(usage.contains("--refresh")); //$NON-NLS-1$
+        assertTrue(usage.contains("--timeout")); //$NON-NLS-1$
+        assertTrue(usage.contains("--bind")); //$NON-NLS-1$
+        assertTrue(usage.contains("--config")); //$NON-NLS-1$
+        assertTrue(usage.contains(ProxyConfig.ENV_PORT));
+        assertTrue(usage.contains(ProxyConfig.ENV_SCAN));
+        assertTrue(usage.contains(ProxyConfig.ENV_REFRESH));
+        assertTrue(usage.contains(ProxyConfig.ENV_TIMEOUT));
+        assertTrue(usage.contains(ProxyConfig.ENV_HOST));
+    }
+
+    @Test
+    public void testVersionLineIncludesProxyNameAndAVersion()
+    {
+        String line = CliCommands.versionLine();
+
+        assertTrue("version line must identify the proxy: " + line, line.startsWith("edt-mcp-proxy ")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("version line must carry a non-empty version after the name: " + line, //$NON-NLS-1$
+            line.length() > "edt-mcp-proxy ".length()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStatusRejectsUnknownOptionWithExitCodeTwo()
+    {
+        Captured captured = runStatus("--bogus", "1"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertEquals(2, captured.exitCode);
+        assertTrue("message should name the bad option: " + captured.err, captured.err.contains("--bogus")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testStatusRequiresAPortValue()
+    {
+        Captured captured = runStatus("--port"); //$NON-NLS-1$
+
+        assertEquals(2, captured.exitCode);
+        assertTrue(captured.err.contains("requires a value")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStatusRejectsANonNumericPort()
+    {
+        Captured captured = runStatus("--port", "not-a-port"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertEquals(2, captured.exitCode);
+        assertTrue(captured.err.contains("not-a-port")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStopRejectsUnknownOptionWithExitCodeTwo()
+    {
+        Captured captured = runStop("--bogus", "1"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertEquals(2, captured.exitCode);
+        assertTrue("message should name the bad option: " + captured.err, captured.err.contains("--bogus")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    private static Captured runStatus(String... args)
+    {
+        ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
+        ByteArrayOutputStream errBytes = new ByteArrayOutputStream();
+        int exitCode;
+        try (PrintStream out = new PrintStream(outBytes, true, StandardCharsets.UTF_8);
+            PrintStream err = new PrintStream(errBytes, true, StandardCharsets.UTF_8))
+        {
+            exitCode = CliCommands.status(args, out, err);
+        }
+        return new Captured(exitCode, outBytes.toString(StandardCharsets.UTF_8), errBytes.toString(StandardCharsets.UTF_8));
+    }
+
+    private static Captured runStop(String... args)
+    {
+        ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
+        ByteArrayOutputStream errBytes = new ByteArrayOutputStream();
+        int exitCode;
+        try (PrintStream out = new PrintStream(outBytes, true, StandardCharsets.UTF_8);
+            PrintStream err = new PrintStream(errBytes, true, StandardCharsets.UTF_8))
+        {
+            exitCode = CliCommands.stop(args, out, err);
+        }
+        return new Captured(exitCode, outBytes.toString(StandardCharsets.UTF_8), errBytes.toString(StandardCharsets.UTF_8));
+    }
+
+    private static final class Captured
+    {
+        final int exitCode;
+        final String out;
+        final String err;
+
+        Captured(int exitCode, String out, String err)
+        {
+            this.exitCode = exitCode;
+            this.out = out;
+            this.err = err;
+        }
+    }
+}

--- a/proxy/src/test/java/com/ditrix/edt/mcp/proxy/CliIT.java
+++ b/proxy/src/test/java/com/ditrix/edt/mcp/proxy/CliIT.java
@@ -1,0 +1,166 @@
+/**
+ * MCP Server for EDT - Proxy Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.proxy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import com.ditrix.edt.mcp.proxy.ProxyRoutingIT.ProxyFixture;
+
+/**
+ * End-to-end coverage of the CLI subcommands added by the issue #253 follow-up spec: {@code
+ * status} and {@code stop} run against a REAL in-process proxy (the same {@link ProxyFixture}
+ * the routing ITs use) by calling the exact package-private static methods {@link Main}
+ * dispatches to ({@link CliCommands#status} / {@link CliCommands#stop}), capturing their output
+ * instead of touching {@link System#out}/{@link System#err} or forking a process.
+ */
+public class CliIT
+{
+    /** Hard cap per test so a transport hang fails fast instead of wedging the build. */
+    @Rule
+    public final Timeout globalTimeout = Timeout.seconds(60);
+
+    private static final String STATUS_PROJECT = "StatusProject"; //$NON-NLS-1$
+
+    private FakeBackend backend;
+    private ProxyFixture proxy;
+
+    /** Stops the proxy and whatever backend a scenario started. */
+    @After
+    public void tearDown()
+    {
+        if (proxy != null)
+        {
+            proxy.stop();
+        }
+        ProxyRoutingIT.stopQuietly(backend);
+    }
+
+    /**
+     * {@code status} against a proxy with one live backend must print a table naming that
+     * backend's port and the project it serves, and exit {@code 0}.
+     */
+    @Test
+    public void testStatusPrintsBackendPortAndProject() throws Exception
+    {
+        int[] ports = ProxyRoutingIT.reserveFreePorts(1);
+        backend = new FakeBackend(ports[0], List.of(STATUS_PROJECT));
+        backend.start();
+        proxy = new ProxyFixture(ports[0], ports[0]);
+        proxy.start();
+
+        Captured captured = runCommand((out, err) -> CliCommands.status(
+            new String[] { "--port", String.valueOf(proxy.port()) }, out, err)); //$NON-NLS-1$
+
+        assertEquals("status must exit 0 when the proxy is reachable: " + captured.err, //$NON-NLS-1$
+            0, captured.exitCode);
+        assertTrue("status table must mention the backend port: " + captured.out, //$NON-NLS-1$
+            captured.out.contains(String.valueOf(ports[0])));
+        assertTrue("status table must mention the project it serves: " + captured.out, //$NON-NLS-1$
+            captured.out.contains(STATUS_PROJECT));
+    }
+
+    /**
+     * {@code status} against a port nothing listens on must exit {@code 1} with an actionable
+     * message naming that port.
+     */
+    @Test
+    public void testStatusUnreachableExitsOneWithActionableMessage() throws Exception
+    {
+        int deadPort = ProxyRoutingIT.reserveFreePorts(1)[0]; // reserved then released - nothing listens
+
+        Captured captured = runCommand(
+            (out, err) -> CliCommands.status(new String[] { "--port", String.valueOf(deadPort) }, out, err)); //$NON-NLS-1$
+
+        assertEquals(1, captured.exitCode);
+        assertTrue("the unreachable message must name the port: " + captured.err, //$NON-NLS-1$
+            captured.err.contains(String.valueOf(deadPort)));
+    }
+
+    /**
+     * {@code stop} against a running proxy must be accepted (exit {@code 0}) and the proxy must
+     * actually stop shortly afterwards (its {@code /health} stops answering).
+     */
+    @Test
+    public void testStopActuallyStopsTheProxy() throws Exception
+    {
+        int deadPort = ProxyRoutingIT.reserveFreePorts(1)[0]; // no backend needed for this scenario
+        proxy = new ProxyFixture(deadPort, deadPort);
+        proxy.start();
+        int proxyPort = proxy.port();
+
+        Captured captured = runCommand(
+            (out, err) -> CliCommands.stop(new String[] { "--port", String.valueOf(proxyPort) }, out, err)); //$NON-NLS-1$
+
+        assertEquals("stop must exit 0 when accepted: " + captured.err, 0, captured.exitCode); //$NON-NLS-1$
+        assertTrue("stop must confirm the port it stopped: " + captured.out, //$NON-NLS-1$
+            captured.out.contains(String.valueOf(proxyPort)));
+
+        ProxyRoutingIT.awaitHealthUnreachable(proxyPort, 10_000);
+    }
+
+    /**
+     * {@code stop} against a port nothing listens on must exit {@code 1} with an actionable
+     * message naming that port.
+     */
+    @Test
+    public void testStopUnreachableExitsOneWithActionableMessage() throws Exception
+    {
+        int deadPort = ProxyRoutingIT.reserveFreePorts(1)[0];
+
+        Captured captured = runCommand(
+            (out, err) -> CliCommands.stop(new String[] { "--port", String.valueOf(deadPort) }, out, err)); //$NON-NLS-1$
+
+        assertEquals(1, captured.exitCode);
+        assertTrue("the unreachable message must name the port: " + captured.err, //$NON-NLS-1$
+            captured.err.contains(String.valueOf(deadPort)));
+    }
+
+    /** Runs a {@code (PrintStream, PrintStream) -> int} CLI command, capturing stdout/stderr as strings. */
+    private static Captured runCommand(CliInvocation invocation)
+    {
+        ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
+        ByteArrayOutputStream errBytes = new ByteArrayOutputStream();
+        int exitCode;
+        try (PrintStream out = new PrintStream(outBytes, true, StandardCharsets.UTF_8);
+            PrintStream err = new PrintStream(errBytes, true, StandardCharsets.UTF_8))
+        {
+            exitCode = invocation.run(out, err);
+        }
+        return new Captured(exitCode, outBytes.toString(StandardCharsets.UTF_8), errBytes.toString(StandardCharsets.UTF_8));
+    }
+
+    @FunctionalInterface
+    private interface CliInvocation
+    {
+        int run(PrintStream out, PrintStream err);
+    }
+
+    private static final class Captured
+    {
+        final int exitCode;
+        final String out;
+        final String err;
+
+        Captured(int exitCode, String out, String err)
+        {
+            this.exitCode = exitCode;
+            this.out = out;
+            this.err = err;
+        }
+    }
+}

--- a/proxy/src/test/java/com/ditrix/edt/mcp/proxy/ProxyConfigTest.java
+++ b/proxy/src/test/java/com/ditrix/edt/mcp/proxy/ProxyConfigTest.java
@@ -12,9 +12,15 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Map;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * Unit tests for {@link ProxyConfig}: defaults, CLI parsing, env parsing, precedence
@@ -23,6 +29,9 @@ import org.junit.Test;
 public class ProxyConfigTest
 {
     private static final String[] NO_ARGS = new String[0];
+
+    @Rule
+    public final TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Test
     public void testDefaults()
@@ -327,11 +336,165 @@ public class ProxyConfigTest
         assertTrue(usage.contains("--refresh"));
         assertTrue(usage.contains("--timeout"));
         assertTrue(usage.contains("--bind"));
+        assertTrue(usage.contains("--config"));
         assertTrue(usage.contains("--help"));
         assertTrue(usage.contains(ProxyConfig.ENV_PORT));
         assertTrue(usage.contains(ProxyConfig.ENV_SCAN));
         assertTrue(usage.contains(ProxyConfig.ENV_REFRESH));
         assertTrue(usage.contains(ProxyConfig.ENV_TIMEOUT));
         assertTrue(usage.contains(ProxyConfig.ENV_HOST));
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Config file (issue #253 follow-up, spec section 3).
+    // ------------------------------------------------------------------------------------
+
+    @Test
+    public void testConfigFileSuppliesAllFiveKeys() throws IOException
+    {
+        Path file = writeConfigFile(
+            "port=9200",
+            "scan=9201-9210",
+            "refresh=15",
+            "timeout=90",
+            "bind=0.0.0.0");
+
+        ProxyConfig cfg = ProxyConfig.parse(new String[] { "--config", file.toString() }, Map.of());
+
+        assertEquals(9200, cfg.port);
+        assertEquals(9201, cfg.scanFrom);
+        assertEquals(9210, cfg.scanTo);
+        assertEquals(15, cfg.refreshSeconds);
+        assertEquals(90, cfg.backendTimeoutSeconds);
+        assertTrue("bind in the config file must opt into allowRemote", cfg.allowRemote);
+        assertEquals("0.0.0.0", cfg.bindHost);
+    }
+
+    @Test
+    public void testConfigFileOnlyAppliesWhenNeitherCliNorEnvOverride() throws IOException
+    {
+        Path file = writeConfigFile("port=9200");
+
+        ProxyConfig cfg = ProxyConfig.parse(new String[] { "--config", file.toString() }, Map.of());
+
+        assertEquals("the config-file value applies when nothing else says otherwise", 9200, cfg.port);
+        // Every other field still falls back to the built-in default.
+        assertEquals(8765, cfg.scanFrom);
+        assertEquals(8774, cfg.scanTo);
+        assertEquals(20, cfg.refreshSeconds);
+        assertEquals(300, cfg.backendTimeoutSeconds);
+    }
+
+    @Test
+    public void testEnvBeatsConfigFile() throws IOException
+    {
+        Path file = writeConfigFile("port=9200");
+        Map<String, String> env = Map.of(ProxyConfig.ENV_PORT, "9300");
+
+        ProxyConfig cfg = ProxyConfig.parse(new String[] { "--config", file.toString() }, env);
+
+        assertEquals("env must win over the config file", 9300, cfg.port);
+    }
+
+    @Test
+    public void testCliBeatsEnvBeatsConfigFile() throws IOException
+    {
+        Path file = writeConfigFile("port=9200");
+        Map<String, String> env = Map.of(ProxyConfig.ENV_PORT, "9300");
+        String[] args = { "--config", file.toString(), "--port", "9400" };
+
+        ProxyConfig cfg = ProxyConfig.parse(args, env);
+
+        assertEquals("CLI must win over both env and the config file", 9400, cfg.port);
+    }
+
+    @Test
+    public void testInvalidConfigFileValueNamesTheSourceFileAndKey() throws IOException
+    {
+        // No dash: fails the FROM-TO shape check itself instead of being parsed as a range
+        // whose FROM half is the reported bad token (matching parseScanRange's own behaviour).
+        Path file = writeConfigFile("scan=oops");
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> ProxyConfig.parse(new String[] { "--config", file.toString() }, Map.of()));
+
+        assertTrue("message should name the config file: " + e.getMessage(),
+            e.getMessage().contains("config file"));
+        assertTrue("message should name the file path: " + e.getMessage(),
+            e.getMessage().contains(file.toString()));
+        assertTrue("message should name the bad key: " + e.getMessage(), e.getMessage().contains("scan"));
+        assertTrue("message should name the bad value: " + e.getMessage(), e.getMessage().contains("oops"));
+    }
+
+    @Test
+    public void testMissingExplicitConfigFileFailsFastNamingThePath()
+    {
+        String missingPath = tempFolder.getRoot().toPath().resolve("does-not-exist.properties").toString();
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> ProxyConfig.parse(new String[] { "--config", missingPath }, Map.of()));
+
+        assertTrue("message should name the missing path: " + e.getMessage(), e.getMessage().contains(missingPath));
+    }
+
+    @Test
+    public void testConfigOptionRequiresAValue()
+    {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> ProxyConfig.parse(new String[] { "--config" }, Map.of()));
+
+        assertTrue(e.getMessage().contains("--config"));
+        assertTrue(e.getMessage().contains("requires a value"));
+    }
+
+    @Test
+    public void testBlankConfigFilePropertyIgnored() throws IOException
+    {
+        Path file = writeConfigFile("port=   ");
+
+        ProxyConfig cfg = ProxyConfig.parse(new String[] { "--config", file.toString() }, Map.of());
+
+        assertEquals("a blank property value must be treated as absent, falling back to the default",
+            8764, cfg.port);
+    }
+
+    @Test
+    public void testAutoDiscoverySkippedCleanlyWhenNoMatchingFileExists()
+    {
+        // No --config given and (in the test/build environment) no edt-mcp-proxy.properties
+        // sits next to the test classes - auto-discovery must find nothing and simply fall
+        // back to the built-in defaults, never throwing.
+        ProxyConfig cfg = ProxyConfig.parse(NO_ARGS, Map.of());
+
+        assertEquals(8764, cfg.port);
+        assertEquals(8765, cfg.scanFrom);
+        assertEquals(8774, cfg.scanTo);
+    }
+
+    @Test
+    public void testJarDirDiscoveryHelperNeverThrows()
+    {
+        // Package-private test seam: under Surefire the code source is a directory (not a
+        // packaged jar), and in other class-loading environments it can be entirely absent
+        // (CodeSource == null / getLocation() == null) - either way this must degrade to a
+        // Path or null, never an exception (the "no jar dir" contract from the follow-up spec).
+        Path discovered = ProxyConfig.discoverConfigFileNextToJar();
+
+        if (discovered != null)
+        {
+            assertTrue("a discovered path must point at the auto-discovery file name: " + discovered,
+                discovered.toString().endsWith("edt-mcp-proxy.properties"));
+        }
+    }
+
+    /**
+     * Writes a {@code java.util.Properties}-format file with the given raw {@code key=value}
+     * lines into the JUnit temp folder.
+     */
+    private Path writeConfigFile(String... lines) throws IOException
+    {
+        Path file = tempFolder.newFile("edt-mcp-proxy-test.properties").toPath();
+        Files.write(file, Arrays.asList(lines));
+        return file;
     }
 }

--- a/proxy/src/test/java/com/ditrix/edt/mcp/proxy/ProxyRoutingIT.java
+++ b/proxy/src/test/java/com/ditrix/edt/mcp/proxy/ProxyRoutingIT.java
@@ -345,6 +345,39 @@ public class ProxyRoutingIT
     }
 
     /**
+     * Polls {@code GET /health} on {@code port} until it stops answering (an {@link IOException}
+     * on the connection attempt) or {@code timeoutMillis} elapses, whichever comes first. Used by
+     * the {@code stop}/{@code POST /admin/shutdown} tests ({@code CliIT}, {@code AdminShutdownIT})
+     * to observe the proxy actually stopping asynchronously (the response to the shutdown request
+     * is sent before the server itself stops - see {@code ProxyServer#triggerShutdown}).
+     *
+     * @param port the port to poll
+     * @param timeoutMillis how long to wait before giving up
+     * @throws AssertionError when the port still answers after the timeout
+     */
+    static void awaitHealthUnreachable(int port, long timeoutMillis) throws InterruptedException
+    {
+        HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
+        URI uri = URI.create("http://127.0.0.1:" + port + "/health"); //$NON-NLS-1$ //$NON-NLS-2$
+        long deadline = System.currentTimeMillis() + timeoutMillis;
+        while (System.currentTimeMillis() < deadline)
+        {
+            try
+            {
+                client.send(HttpRequest.newBuilder(uri).timeout(Duration.ofSeconds(1)).GET().build(),
+                    HttpResponse.BodyHandlers.discarding());
+                Thread.sleep(200);
+            }
+            catch (IOException expected)
+            {
+                return;
+            }
+        }
+        throw new AssertionError("port :" + port + " kept answering /health past the " + timeoutMillis //$NON-NLS-1$ //$NON-NLS-2$
+            + "ms timeout"); //$NON-NLS-1$
+    }
+
+    /**
      * Stops a backend, tolerating {@code null} and an already-stopped server (a test may
      * stop a backend mid-scenario; teardown must still be safe).
      *

--- a/proxy/src/test/java/com/ditrix/edt/mcp/proxy/ProxyServerTest.java
+++ b/proxy/src/test/java/com/ditrix/edt/mcp/proxy/ProxyServerTest.java
@@ -1,0 +1,56 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.proxy;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ProxyServer#isLoopbackRequest}: the address-check helper behind
+ * {@code POST /admin/shutdown}'s loopback-only guard (issue #253 follow-up, spec section 7/8).
+ * A genuinely non-loopback remote socket cannot be faked in an in-process integration test (see
+ * {@link AdminShutdownIT} for the loopback-accepted wire behaviour), so the {@code 403} branch
+ * is proven directly on this helper instead.
+ */
+public class ProxyServerTest
+{
+    @Test
+    public void testNullRemoteAddressIsNotLoopback()
+    {
+        assertFalse(ProxyServer.isLoopbackRequest(null));
+    }
+
+    @Test
+    public void testLoopbackIpv4AddressIsAccepted()
+    {
+        InetSocketAddress loopback = new InetSocketAddress(InetAddress.getLoopbackAddress(), 54321);
+
+        assertTrue(ProxyServer.isLoopbackRequest(loopback));
+    }
+
+    @Test
+    public void testExplicit127AddressIsAccepted() throws UnknownHostException
+    {
+        InetAddress explicitLoopback = InetAddress.getByAddress(new byte[] { 127, 0, 0, 1 });
+
+        assertTrue(ProxyServer.isLoopbackRequest(new InetSocketAddress(explicitLoopback, 1)));
+    }
+
+    @Test
+    public void testNonLoopbackAddressIsRejected() throws UnknownHostException
+    {
+        InetAddress remote = InetAddress.getByAddress(new byte[] { 8, 8, 8, 8 });
+
+        assertFalse(ProxyServer.isLoopbackRequest(new InetSocketAddress(remote, 54321)));
+    }
+}


### PR DESCRIPTION
## Что это

Follow-up к #260: реализация всех оставшихся 🔧-пунктов согласованного там ТЗ (§2, §3, §7, §10). Код прокси-ядра (маршрутизация/discovery/сессии) не менялся.

## Сделано

**§2 — CLI-субкоманды (стиль Allure):**
- `serve` — запуск сервера (умолчание: голый запуск без субкоманды = `serve`, обратная совместимость);
- `status [--port N]` — опрос работающего прокси: таблица «порт | проекты», дубликаты, диапазон скана; код возврата 0/1 для скриптов;
- `stop [--port N]` — корректная остановка через admin-эндпоинт;
- `--help` / `--version` (версия теперь штампуется в манифест fat-jar).

**§3 — конфиг-файл:** `--config <path>` (обычный properties: port/scan/refresh/timeout/bind) + автопоиск `edt-mcp-proxy.properties` рядом с jar. Приоритет: CLI > env > файл > умолчания; невалидное значение называет свой источник.

**§7 — жизненный цикл:** `POST /admin/shutdown` — принимается **только с loopback-адреса** независимо от `--bind` (сначала ответ, потом graceful-остановка сервера и планировщика). README прокси: автозапуск **per-user** — `schtasks /SC ONLOGON` (Windows) и `systemd --user` (Linux), с пояснением почему не служба.

**§10 — CI/поставка:**
- JaCoCo в `proxy/pom.xml`; Proxy-CI печатает сводку покрытия в summary и выкладывает отчёт артефактом (замер на текущем коде: **83% инструкций**);
- **`release.yml` теперь собирает прокси и кладёт `edt-mcp-proxy-v<версия>.jar` ассетом рядом с zip плагина** — в v2.7.1 jar не попал именно из-за этого, со следующего тега попадёт;
- бейдж «Proxy» + короткий раздел Multi-EDT Proxy в корневом README.

## Проверка

- **138 тестов** (было 110, +28: диспетчер субкоманд, приоритеты с конфиг-файлом, loopback-гейт admin-эндпоинта, живой CLI-цикл serve→status→stop), все зелёные.
- Смок собранного jar: `--version` → `edt-mcp-proxy 0.1.0-SNAPSHOT`, `--help`, полный цикл `serve` → `status` (таблица бекендов) → `stop` (процесс реально гаснет).
- YAML обоих workflow провалидирован; glob релиз-ассета не захватывает `original-*.jar`.

SonarCloud-врезку покрытия сознательно не делал: прокси вне Tycho-реактора, а цепочка coverage.yml (workflow_run) хрупкая — если хочешь видеть прокси в Sonar, лучше отдельным решением (могу предложить варианты).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
