### PR TITLE
deploy-update-site: автодеплой после релиза + гонко-устойчивый выбор версии (#265)

### DIFF
--- a/.github/workflows/deploy-update-site.yml
+++ b/.github/workflows/deploy-update-site.yml
@@ -1,12 +1,20 @@
 name: Deploy Update Site
 
 on:
+  # NOTE: `on: release` alone never fires here - the release is published by release.yml
+  # with the standard GITHUB_TOKEN, and GITHUB_TOKEN-generated events do not trigger other
+  # workflows (GitHub's anti-recursion rule). Chain off the Release workflow instead.
   release:
     types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   workflow_dispatch:
 
 jobs:
   deploy:
+    # For the workflow_run chaining, deploy only when the Release run succeeded.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -30,10 +38,21 @@ jobs:
           if [[ "$GITHUB_REF_NAME" == v* ]]; then
             VERSION="${GITHUB_REF_NAME#v}"
           else
-            # workflow_dispatch: use the latest published release tag
-            VERSION=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 1 --json tagName -q '.[0].tagName | ltrimstr("v")')
+            # workflow_dispatch / workflow_run: the latest PUBLISHED release. Use the
+            # releases/latest endpoint (never a draft, no list-ordering ambiguity) and retry:
+            # `gh release list` raced a just-published release once and redeployed the OLD
+            # version (issue #265 - the site served 2.6.1 after the 2.7.1 release).
+            VERSION=""
+            for attempt in 1 2 3 4 5; do
+              VERSION=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" -q '.tag_name | ltrimstr("v")' || true)
+              [[ -n "$VERSION" ]] && break
+              echo "releases/latest not ready (attempt $attempt); retrying in 15s"
+              sleep 15
+            done
+            [[ -n "$VERSION" ]] || { echo "::error::could not resolve the latest published release"; exit 1; }
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Deploying update site for v$VERSION"
 
       - name: Download release artifact
         env:


### PR DESCRIPTION
## Причина #265 (сайт показывает 2.6.1 после релиза 2.7.1)

Разбор лога деплой-прогона от 14.07 18:28 показал две причины:

1. **Автотриггер `on: release [published]` не срабатывает вовсе** — релиз публикуется из `release.yml` стандартным `GITHUB_TOKEN`, а события, порождённые `GITHUB_TOKEN`, не запускают другие workflows (анти-рекурсия GitHub). Поэтому в истории деплоя — только ручные запуски.
2. **Ручной запуск попал в гонку**: он стартовал через 48 секунд после публикации v2.7.1, а `gh release list --limit 1` ещё отдавал v2.6.1 (лаг индексации списка) — воркфлоу «успешно» задеплоил старый сайт (в логе видно `gh release download "v2.6.1"`).

## Фикс

- Добавлен триггер **`workflow_run` на завершение workflow «Release»** (срабатывает и от GITHUB_TOKEN-событий), с гейтом на success — теперь сайт обновляется автоматически после каждого релиза, кнопку жать не нужно.
- Выбор версии в ручном/цепочечном запуске переведён с `gh release list` на **эндпоинт `releases/latest`** (атомарный, никогда не draft) + ретраи с фейлом-громко, + лог «Deploying update site for vX».

## Сейчас (до мержа)

Чтобы сайт обновился прямо сейчас — запусти `Deploy Update Site` вручную ещё раз: гонка давно прошла, `releases/latest` уже отдаёт v2.7.1, задеплоится корректно и на старом коде.

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)
