### PR TITLE
Прокси: не регистрировать сам себя (и другой прокси) как бэкенд — чинит красный CI-бейдж Proxy

### DIFF
--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -16,6 +16,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Insurance against a wedged test run: fail visibly in minutes instead of a
+    # runner-killing hang (a healthy build takes ~1.5 min).
+    timeout-minutes: 15
     permissions:
       contents: read
 

--- a/proxy/src/main/java/com/ditrix/edt/mcp/proxy/Backend.java
+++ b/proxy/src/main/java/com/ditrix/edt/mcp/proxy/Backend.java
@@ -97,8 +97,14 @@ public final class Backend
      * The plugin's health handler always answers HTTP 200 and distinguishes readiness in
      * the {@code status} field ({@code ok} / {@code starting} / {@code degraded}), so the
      * probe requires BOTH a 200 status AND {@code "status":"ok"} in the JSON body.
+     * <p>
+     * A healthy responder that declares {@code "role":"proxy"} is REJECTED: that is another
+     * edt-mcp-proxy - or this very proxy, when its own port falls inside the scan range.
+     * Registering a proxy as a backend makes every forwarded request re-enter a proxy and
+     * recurse without bound, exhausting memory or the request pool.
      *
-     * @return {@code true} when the backend answered 200 with {@code status == "ok"}
+     * @return {@code true} when the backend answered 200 with {@code status == "ok"} and is
+     *         not itself a proxy
      */
     public boolean probeHealth()
     {
@@ -114,7 +120,8 @@ public final class Backend
                 return false;
             }
             JsonObject body = Json.parseObject(response.body());
-            return body != null && "ok".equals(Json.str(body, "status")); //$NON-NLS-1$ //$NON-NLS-2$
+            return body != null && "ok".equals(Json.str(body, "status")) //$NON-NLS-1$ //$NON-NLS-2$
+                && !"proxy".equals(Json.str(body, "role")); //$NON-NLS-1$ //$NON-NLS-2$
         }
         catch (IOException e)
         {

--- a/proxy/src/test/java/com/ditrix/edt/mcp/proxy/ZeroBackendAndDupIT.java
+++ b/proxy/src/test/java/com/ditrix/edt/mcp/proxy/ZeroBackendAndDupIT.java
@@ -121,6 +121,40 @@ public class ZeroBackendAndDupIT
     }
 
     /**
+     * A scanned port that answers {@code /health} but declares {@code "role":"proxy"} —
+     * another edt-mcp-proxy, or this very proxy when its own (ephemeral) port lands inside
+     * the scan range — must NOT be registered as a backend: forwarding to a proxy re-enters
+     * a proxy and recurses without bound (the CI-runner-killing runaway this guards
+     * against). The registry must stay EMPTY instead.
+     */
+    @Test
+    public void testProxyRoleResponderInScanRangeIsNotRegisteredAsBackend() throws Exception
+    {
+        int[] deadPorts = reserveFreePorts(2);
+        ProxyFixture inner = new ProxyFixture(deadPorts[0], deadPorts[1]);
+        inner.start();
+        try
+        {
+            // The outer proxy's scan range covers EXACTLY the inner proxy - the deterministic
+            // version of the flaky self-discovery (own ephemeral port inside a wide range).
+            proxy = new ProxyFixture(inner.port(), inner.port());
+            proxy.start();
+            McpTestClient client = new McpTestClient(proxy.port());
+            client.handshake();
+
+            JsonObject status = client.callTool(TOOL_ROUTER_STATUS, new JsonObject());
+            assertFalse("router_status must succeed: " + status, isToolError(status)); //$NON-NLS-1$
+            JsonObject structured = structuredContent(status);
+            assertEquals("a proxy-role /health responder must never be registered as a backend: " //$NON-NLS-1$
+                + structured, 0, structured.getAsJsonArray("backends").size()); //$NON-NLS-1$
+        }
+        finally
+        {
+            inner.stop();
+        }
+    }
+
+    /**
      * Two backends both serving the same project: a call routed by that project name must
      * be refused with the duplicate error naming BOTH owning ports (the proxy must never
      * silently pick one).


### PR DESCRIPTION
Чинит красный бейдж **Proxy** в README: workflow `proxy.yml` на master умирает с «Out of memory» / зависанием раннера.

## Диагноз (пойман с поличным)

Прокси **обнаруживает сам себя как бэкенд**. В интеграционных тестах скан-диапазон — это интервал между двумя случайными эфемерными портами, а собственный порт прокси (bind 0) иногда попадает внутрь. Тогда:

1. Скан находит на этом порту живой `/health` со `status:"ok"` → регистрирует прокси как «EDT-бэкенд» (лог из CI: `Live EDT backends changed: [] -> [39247]`, где 39247 — порт самого прокси).
2. Любой следующий форвард уходит в самого себя → каждый хоп порождает новый серверный поток (пул безлимитный) и новый вложенный запрос → **бесконечная HTTP-рекурсия**.
3. Два наблюдаемых исхода — оба воспроизведены: быстрое выедание памяти (~150 МБ/2с, раннер убит через ~30 с, аннотация «Out of memory») либо многоминутное зависание на пуле потоков (прогон висел 45 минут).

Замер на матрице из 8 одинаковых прогонов с memory-вотчдогом: **2 OOM + 4 зависания + 2 успеха** — то есть флак с вероятностью ~75%, зелёные прогоны были везением. Свидетельства: [лог вотчдога с моментом самообнаружения](https://github.com/Jimmo910/EDT-MCP/actions/runs/29441641062).

Это не только тестовая проблема: в проде прокси на дефолтном :8764 со сканом 8765–8774 безопасен случайно — пользователь, поставивший порт прокси внутрь скан-диапазона, получил бы ту же рекурсию вживую.

## Фикс

- **`Backend.probeHealth`** теперь отвергает здорового ответчика с `"role":"proxy"` в `/health` (наш собственный маркер, который прокси и так отдаёт с #260). Закрывает и само-обнаружение на любом порту, и цепочку «прокси за прокси» — без протаскивания фактического порта в реестр.
- **Регрессионный тест** (`ZeroBackendAndDupIT`): детерминированная версия флака — второй прокси, чей скан-диапазон накрывает ровно порт первого; реестр обязан остаться пустым.
- **`proxy.yml`**: `timeout-minutes: 15` — будущее зависание станет видимым красным за минуты, а не 6-часовым зомби.

## Проверено

- Локально `mvn -f proxy/pom.xml clean verify` ×3 — 139/139 зелёные (138 + новый регрессионный).
- Без фикса новый тест детерминированно ловит само-регистрацию; с фиксом реестр пуст.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
