### PR TITLE
Standalone-сервер на EDT 2026.1: version-tolerant рефлексия (create/delete/чистка реестра) (#273)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ log.log
 
 # Proxy module build output
 proxy/target/
+tests/TestConfiguration/.scannerwork/

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
@@ -139,6 +139,24 @@ public class CreateInfobaseTool implements IMcpTool
     private static final String STANDALONE_SERVER_INFOBASE_CLASS =
         "com.e1c.g5.v8.dt.platform.standaloneserver.wst.core.StandaloneServerInfobase"; //$NON-NLS-1$
 
+    /**
+     * FQN of the create-template file database ({@code FileCreateTemplateDatabase extends FileDatabase
+     * implements ICreateTemplateDatabase}; javap-verified IDENTICAL on EDT 2025.2 and 2026.1, bundle
+     * {@code com.e1c.g5.v8.dt.platform.standaloneserver.core}). Loaded via the LIVE database object's
+     * own classloader (same bundle) — never {@code Class.forName}: this plugin has no dependency on
+     * that bundle. See {@link #ssEnsureCreateTemplateDatabase}.
+     */
+    private static final String CREATE_TEMPLATE_DATABASE_CLASS =
+        "com.e1c.g5.v8.dt.platform.standaloneserver.core.config.FileCreateTemplateDatabase"; //$NON-NLS-1$
+
+    /**
+     * SIMPLE name of the create-template marker interface
+     * ({@code com.e1c.g5.v8.dt.platform.standaloneserver.core.config.ICreateTemplateDatabase}).
+     * {@link #ssIsCreateTemplateDatabase} matches it by simple name so the decision logic is
+     * unit-testable with headless stub interfaces (the platform ships no other type with this name).
+     */
+    private static final String CREATE_TEMPLATE_DATABASE_INTERFACE = "ICreateTemplateDatabase"; //$NON-NLS-1$
+
     /** Symbolic name of the bundle that owns the internal PlatformServicesCore (and its Guice injector). */
     private static final String PLATFORM_SERVICES_CORE_BUNDLE_ID =
         "com._1c.g5.v8.dt.platform.services.core"; //$NON-NLS-1$
@@ -1073,9 +1091,13 @@ public class CreateInfobaseTool implements IMcpTool
     /**
      * Best-effort marks a just-registered {@code StandaloneServerInfobase} module as ALREADY existing
      * for mode='register' — {@code setExist(true)} (mirrors the EDT wizard's existing-infobase branch).
-     * Never called with {@code setCreate(true)}: the served {@code 1Cv8.1CD} already exists on disk, so
-     * no database is materialized. Any reflective failure is logged and swallowed — the WST server
-     * registration already succeeded and must not be failed by a best-effort flag.
+     * Never called with the create-flag setter ({@link #ssSetCreateFlag}): the served {@code 1Cv8.1CD}
+     * already exists on disk, so no database is materialized. {@code setExist} exists only on EDT
+     * 2025.2 — it was REMOVED on 2026.1 with no replacement, so there the reflective {@link #ssInvoke}
+     * call below resolves to a silent no-op (method not found -> returns {@code null}, no exception, no
+     * log) and this method degrades to a harmless no-op. Any OTHER reflective failure (e.g. an actual
+     * invocation error on 2025.2) is logged and swallowed — the WST server registration already
+     * succeeded and must not be failed by a best-effort flag.
      *
      * @param standaloneServerInfobase the module returned by {@link #ssCreateServerWithInfobase}
      */
@@ -1379,12 +1401,22 @@ public class CreateInfobaseTool implements IMcpTool
     /**
      * Physically creates the served file infobase for a standalone server that
      * {@link #ssCreateServerWithInfobase} just registered. That call builds the {@code StandaloneServerInfobase}
-     * with {@code create=false}, so {@code ibcmd infobase create} (which writes {@code 1Cv8.1CD}) never runs and
-     * the server fails to start with "Информационная база не обнаружена". This flips {@code create=true} on the
-     * returned LIVE module — the same flag the EDT new-server wizard sets — and invokes the WST behaviour
-     * delegate's {@code createStandaloneServerInfobase} DIRECTLY (the only place that runs the create, gated by
-     * {@code isCreate()}; verified against EDT 2025.2 bytecode — no start/publish path creates the DB, and
-     * re-adding the module via {@code modifyModules} is blocked by an "already have module" guard).
+     * with the create-new-infobase flag {@code false}, so {@code ibcmd infobase create} (which writes
+     * {@code 1Cv8.1CD}) never runs and the server fails to start with "Информационная база не обнаружена". This
+     * flips that flag to {@code true} on the returned LIVE module — the same flag the EDT new-server wizard sets,
+     * named {@code setCreate} on EDT 2025.2 and renamed (no back-compat alias) to {@code setCreateNewInfobase} on
+     * 2026.1, resolved version-tolerantly by {@link #ssSetCreateFlag} — and invokes the WST behaviour delegate's
+     * {@code createStandaloneServerInfobase} DIRECTLY (the only place that runs the create, gated by the flag's
+     * getter; verified against EDT 2025.2 bytecode — no start/publish path creates the DB, and re-adding the
+     * module via {@code modifyModules} is blocked by an "already have module" guard).
+     *
+     * <p>On 2026.1 there is a SECOND drift layer past the setter rename: {@code createServerWithInfobase}
+     * builds the module config with a PLAIN {@code FileDatabase}, but the behaviour delegate's
+     * {@code createStandaloneServerInfobase} now CASTS the config's database to
+     * {@code ICreateTemplateDatabase} (live error: "FileDatabase cannot be cast to class
+     * ...ICreateTemplateDatabase"). {@link #ssEnsureCreateTemplateDatabase} swaps in a
+     * {@code FileCreateTemplateDatabase} (identical on both versions, harmless on 2025.2 — it IS a
+     * {@code FileDatabase}) before the delegate runs.
      *
      * <p>Runs inside the create Job (with its monitor). Throws on failure so the caller reports an honest
      * error (the server is then registered without a DB; {@code delete_infobase} can clean it up).
@@ -1397,15 +1429,18 @@ public class CreateInfobaseTool implements IMcpTool
             throw new IllegalStateException("createServerWithInfobase returned no infobase handle; " //$NON-NLS-1$
                 + "the served infobase could not be created."); //$NON-NLS-1$
         }
-        // Flip create=true (the flag that gates the physical creation) on the live module. setExist=false
-        // mirrors the EDT wizard's "new infobase" branch and is optional (a no-op if the API lacks it).
-        if (ssMethod(infobase.getClass(), "setCreate", 1) == null) //$NON-NLS-1$
-        {
-            throw new IllegalStateException("StandaloneServerInfobase.setCreate not found — the standalone-" //$NON-NLS-1$
-                + "server API may have changed; the served infobase could not be created."); //$NON-NLS-1$
-        }
-        ssInvoke(infobase, "setCreate", 1, Boolean.TRUE); //$NON-NLS-1$
+        // Flip the create-new-infobase flag to true (the flag that gates the physical creation) on the
+        // live module — version-tolerant name resolution, see ssSetCreateFlag. setExist=false mirrors the
+        // EDT wizard's "new infobase" branch on 2025.2 and stays best-effort/optional: setExist was
+        // REMOVED on 2026.1 with no replacement, and ssInvoke resolves a missing method to a silent
+        // no-op (returns null, no exception, no log) — matching the clean log observed on a live 2026.1
+        // register run.
+        ssSetCreateFlag(infobase, true);
         ssInvoke(infobase, "setExist", 1, Boolean.FALSE); //$NON-NLS-1$
+
+        // 2026.1's behaviour delegate casts the config's database to ICreateTemplateDatabase — make sure
+        // it is one BEFORE invoking the delegate (a no-op when it already is; safe on 2025.2 too).
+        ssEnsureCreateTemplateDatabase(infobase);
 
         // Resolve the WST behaviour delegate for this server and run the (otherwise publish-time) create now.
         Object delegate = ssInvoke(service, "findBehaviourDelegate", 1, server); //$NON-NLS-1$
@@ -1470,6 +1505,186 @@ public class CreateInfobaseTool implements IMcpTool
             }
         }
         return null;
+    }
+
+    /**
+     * First public method on {@code cls} (incl. inherited) matching any of {@code names} (tried in
+     * order) and the given parameter count — a version-tolerant lookup for an API whose method name was
+     * RENAMED across EDT platform versions with no back-compat alias (e.g. {@code setCreate} on 2025.2 /
+     * {@code setCreateNewInfobase} on 2026.1). Returns the first match by name-priority order, or
+     * {@code null} when none of {@code names} resolve. Package-private for direct unit testing with stub
+     * classes exposing one name, the other, or neither.
+     */
+    static Method ssMethodAny(Class<?> cls, int paramCount, String... names)
+    {
+        for (String name : names)
+        {
+            Method m = ssMethod(cls, name, paramCount);
+            if (m != null)
+            {
+                return m;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolves and invokes the version-tolerant "create a new infobase" flag setter on the live
+     * {@code StandaloneServerInfobase} module: {@code setCreate(boolean)} on EDT 2025.2, renamed with no
+     * back-compat alias to {@code setCreateNewInfobase(boolean)} on EDT 2026.1 ({@code isCreate}/
+     * {@code getInfobaseId} renames are the sibling cases of the same 2026.1 API drift — see
+     * {@link StandaloneServerSupport#infobaseIdOf}). Package-private for direct unit testing with stub
+     * classes exposing one name, the other, or neither.
+     *
+     * @param infobase the live {@code StandaloneServerInfobase} module returned by
+     *            {@link #ssCreateServerWithInfobase}
+     * @param value the flag value to set (always {@code true} from {@link #ssMaterializeInfobase})
+     * @throws IllegalStateException when NEITHER setter name resolves — names both tried methods so the
+     *             failure is diagnosable without a javap session
+     */
+    static void ssSetCreateFlag(Object infobase, boolean value) throws Exception
+    {
+        Method setter = ssMethodAny(infobase.getClass(), 1, "setCreate", "setCreateNewInfobase"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (setter == null)
+        {
+            throw new IllegalStateException(
+                "Neither StandaloneServerInfobase.setCreate nor setCreateNewInfobase was found — " //$NON-NLS-1$
+                    + "the standalone-server API may have changed; the served infobase could not be " //$NON-NLS-1$
+                    + "created."); //$NON-NLS-1$
+        }
+        try
+        {
+            setter.invoke(infobase, Boolean.valueOf(value));
+        }
+        catch (java.lang.reflect.InvocationTargetException ite)
+        {
+            Throwable cause = ite.getCause();
+            if (cause instanceof Exception)
+            {
+                throw (Exception)cause;
+            }
+            throw new IllegalStateException(cause != null ? cause : ite);
+        }
+    }
+
+    /**
+     * Ensures the module config's database IS a create-template one before the behaviour delegate runs
+     * the physical create. On EDT 2026.1 {@code createServerWithInfobase} builds the config with a PLAIN
+     * {@code FileDatabase}, but the delegate's {@code createStandaloneServerInfobase} casts the config's
+     * database to {@code ICreateTemplateDatabase} — a live {@code ClassCastException} without this swap.
+     * When needed, a {@code FileCreateTemplateDatabase} (javap-verified identical on 2025.2 and 2026.1;
+     * it {@code extends FileDatabase}, so the swap is harmless on 2025.2 too) is instantiated via the
+     * live database object's OWN classloader (same bundle — never {@code Class.forName}), the directory
+     * is copied across the {@code getConfigDirectory}/{@code getPath} rename
+     * ({@link #ssCopyDatabaseDirectory}), and {@code Config.setDatabase} (present on both versions)
+     * installs it. ONLY the mode='create' materialization path calls this — the register path must
+     * NEVER get a create-template database.
+     *
+     * <p>Decision logic ({@code null} database untouched — the delegate then fails with its own honest
+     * error; already-a-create-template database untouched — the 2025.2-compatible/future-proof path) is
+     * split into the headless-testable {@link #ssIsCreateTemplateDatabase}/{@link #ssCopyDatabaseDirectory};
+     * the bundle class-loading step itself is live-verified only. BEST-EFFORT: any failure is logged and
+     * swallowed — on 2025.2 a plain {@code FileDatabase} still materializes fine (never regress that),
+     * and on 2026.1 the delegate then surfaces its own cast error.
+     *
+     * @param infobase the live {@code StandaloneServerInfobase} module returned by
+     *            {@link #ssCreateServerWithInfobase}
+     */
+    static void ssEnsureCreateTemplateDatabase(Object infobase)
+    {
+        try
+        {
+            Object cfg = ssInvoke(infobase, "getStandaloneServerConfiguration", 0); //$NON-NLS-1$
+            if (cfg == null)
+            {
+                return;
+            }
+            Object db = ssInvoke(cfg, "getDatabase", 0); //$NON-NLS-1$
+            if (db == null)
+            {
+                // Leave as-is: the behaviour delegate fails with its own honest error on a missing DB.
+                return;
+            }
+            if (ssIsCreateTemplateDatabase(db.getClass()))
+            {
+                // Already create-template capable — nothing to do (also future-proof).
+                return;
+            }
+            Class<?> templateClass =
+                db.getClass().getClassLoader().loadClass(CREATE_TEMPLATE_DATABASE_CLASS);
+            Object templateDb = templateClass.getDeclaredConstructor().newInstance();
+            ssCopyDatabaseDirectory(db, templateDb);
+            ssInvoke(cfg, "setDatabase", 1, templateDb); //$NON-NLS-1$
+        }
+        catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+        {
+            Activator.logError("create_infobase: could not swap the standalone-server database to a " //$NON-NLS-1$
+                + "FileCreateTemplateDatabase (best-effort; on 2026.1 the create may fail with an " //$NON-NLS-1$
+                + "ICreateTemplateDatabase cast error)", t); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Whether {@code cls} (or any superclass / (super)interface of it) is the create-template marker
+     * interface {@code ICreateTemplateDatabase} — matched by SIMPLE name (the live FQN is
+     * {@code com.e1c.g5.v8.dt.platform.standaloneserver.core.config.ICreateTemplateDatabase}; the type
+     * is intentionally not imported, so {@code instanceof} is impossible, and the simple-name match
+     * keeps the check unit-testable with stub interfaces). Package-private for direct unit testing.
+     */
+    static boolean ssIsCreateTemplateDatabase(Class<?> cls)
+    {
+        if (cls == null)
+        {
+            return false;
+        }
+        if (cls.isInterface() && CREATE_TEMPLATE_DATABASE_INTERFACE.equals(cls.getSimpleName()))
+        {
+            return true;
+        }
+        for (Class<?> iface : cls.getInterfaces())
+        {
+            if (ssIsCreateTemplateDatabase(iface))
+            {
+                return true;
+            }
+        }
+        return ssIsCreateTemplateDatabase(cls.getSuperclass());
+    }
+
+    /**
+     * Copies the file database's on-disk directory from {@code from} to {@code to}, version-tolerant
+     * across the {@code FileDatabase} 2025.2 -> 2026.1 accessor rename: read via
+     * {@code getConfigDirectory()} (2025.2) OR {@code getPath()} (2026.1), write via
+     * {@code setConfigDirectory(String)} OR {@code setPath(String)} — each side resolved independently
+     * with {@link #ssMethodAny}. A missing accessor on either side, or a {@code null} directory value,
+     * degrades to a no-op (best-effort — the caller already treats the whole swap as best-effort).
+     * Package-private for direct unit testing with stubs exposing either accessor generation.
+     */
+    static void ssCopyDatabaseDirectory(Object from, Object to) throws Exception
+    {
+        Method read = ssMethodAny(from.getClass(), 0, "getConfigDirectory", "getPath"); //$NON-NLS-1$ //$NON-NLS-2$
+        Method write = ssMethodAny(to.getClass(), 1, "setConfigDirectory", "setPath"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (read == null || write == null)
+        {
+            return;
+        }
+        try
+        {
+            Object dir = read.invoke(from);
+            if (dir != null)
+            {
+                write.invoke(to, dir);
+            }
+        }
+        catch (java.lang.reflect.InvocationTargetException ite)
+        {
+            Throwable cause = ite.getCause();
+            if (cause instanceof Exception)
+            {
+                throw (Exception)cause;
+            }
+            throw new IllegalStateException(cause != null ? cause : ite);
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteInfobaseTool.java
@@ -819,6 +819,7 @@ public class DeleteInfobaseTool implements IMcpTool
         // and keeps it off the request thread. ---
         final Object finalService = service;
         final Object finalServer = server;
+        final Object finalModule = deletionCtx.module;
         final String finalInfobaseId = infobaseId;
         final boolean doRegistry = deleteRegistration;
         final AtomicReference<IStatus> jobStatus = new AtomicReference<>();
@@ -839,8 +840,8 @@ public class DeleteInfobaseTool implements IMcpTool
                     // means deleteServer did not run/succeed, so the server still exists.
                     if (s != null && s.isOK() && doRegistry)
                     {
-                        jobCleanup.set(
-                            StandaloneServerSupport.removeFromInfobaseRegistry(finalInfobaseId, monitor));
+                        jobCleanup.set(StandaloneServerSupport.removeFromInfobaseRegistry(finalModule,
+                            finalInfobaseId, monitor));
                     }
                 }
                 catch (Exception e)
@@ -946,9 +947,11 @@ public class DeleteInfobaseTool implements IMcpTool
             return ctx;
         }
 
-        // Capture the infobaseId AND the served-DB directory (database.path) BEFORE deletion — the
-        // module/config is torn down by deleteServer. The infobaseId drives the yaml cleanup; the DB
-        // directory is used only when deleteDatabaseFiles=true (deleteServer itself never deletes it).
+        // Capture the module, its infobaseId AND the served-DB directory (database.path) BEFORE
+        // deletion — the module/config is torn down by deleteServer. The module + infobaseId drive the
+        // yaml cleanup (value-identity first, raw-id key fallback — the map key scheme differs per EDT
+        // version, see StandaloneServerSupport.removeFromInfobaseRegistry); the DB directory is used
+        // only when deleteDatabaseFiles=true (deleteServer itself never deletes it).
         Object module = StandaloneServerSupport.moduleOfApplication(targetApp);
         final String infobaseId = module != null ? StandaloneServerSupport.infobaseIdOf(module) : null;
         final String dbDirStr = module != null ? StandaloneServerSupport.databaseDirOf(module) : null;
@@ -960,6 +963,7 @@ public class DeleteInfobaseTool implements IMcpTool
 
         ctx.service = service;
         ctx.server = server;
+        ctx.module = module;
         ctx.infobaseId = infobaseId;
         ctx.dbDir = dbDir;
         ctx.dbSharedWithOthers = dbSharedWithOthers;
@@ -1059,14 +1063,16 @@ public class DeleteInfobaseTool implements IMcpTool
     }
 
     /**
-     * Holder for {@link #resolveDeletionContext}: the resolved service, WST server,
-     * infobaseId, served-DB directory and shared-files guard, or an {@code error} payload
-     * the caller returns as-is.
+     * Holder for {@link #resolveDeletionContext}: the resolved service, WST server, live
+     * {@code StandaloneServerInfobase} module (the value-identity target of the infobases.yaml
+     * cleanup), infobaseId, served-DB directory and shared-files guard, or an {@code error}
+     * payload the caller returns as-is.
      */
     private static class DeletionContext
     {
         Object service;
         Object server;
+        Object module;
         String infobaseId;
         Path dbDir;
         boolean dbSharedWithOthers;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/StandaloneServerSupport.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/StandaloneServerSupport.java
@@ -11,8 +11,10 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -222,8 +224,17 @@ final class StandaloneServerSupport
     }
 
     /**
-     * Reflective {@code StandaloneServerInfobase.getInfobaseId().toString()} — the key under which the
-     * entry is stored in infobases.yaml. Returns {@code null} on failure.
+     * Reflective infobase-id read, version-tolerant across the {@code StandaloneServerInfobase}
+     * 2025.2 -> 2026.1 API rename — the key under which the entry is stored in infobases.yaml (a raw
+     * id STRING on both shapes):
+     * <ul>
+     *   <li>2025.2: {@code getInfobaseId(): UUID} — read directly, then {@code toString()}'d.</li>
+     *   <li>2026.1: {@code getInfobaseId()} was REMOVED with no replacement; the raw id instead lives
+     *   at {@code getStandaloneServerConfiguration().getInfobase().getId(): String}, resolved
+     *   null-safely at each hop.</li>
+     * </ul>
+     * Returns {@code null} on failure/absence of BOTH shapes, never throwing; an error is logged only
+     * when neither shape resolved (so a single-shape EDT version never logs spuriously).
      */
     static String infobaseIdOf(Object standaloneServerInfobaseModule)
     {
@@ -233,6 +244,19 @@ final class StandaloneServerSupport
                 .invoke(standaloneServerInfobaseModule);
             return id != null ? id.toString() : null;
         }
+        catch (NoSuchMethodException e)
+        {
+            // 2025.2 shape absent -> try the 2026.1 shape (getInfobaseId() was removed with no
+            // direct replacement; the raw id moved under the standalone-server configuration).
+            String id = infobaseIdViaConfiguration(standaloneServerInfobaseModule);
+            if (id == null)
+            {
+                Activator.logError("delete_infobase: could not read standalone-server infobaseId " //$NON-NLS-1$
+                    + "(neither getInfobaseId() nor getStandaloneServerConfiguration()." //$NON-NLS-1$
+                    + "getInfobase().getId() resolved)", null); //$NON-NLS-1$
+            }
+            return id;
+        }
         catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
         {
             Activator.logError("delete_infobase: could not read standalone-server infobaseId", t); //$NON-NLS-1$
@@ -241,9 +265,40 @@ final class StandaloneServerSupport
     }
 
     /**
+     * 2026.1 fallback shape for {@link #infobaseIdOf}:
+     * {@code getStandaloneServerConfiguration().getInfobase().getId(): String}. Null-safe at each hop;
+     * returns {@code null} on any missing hop or reflective failure (never throws — the caller decides
+     * whether to log).
+     */
+    private static String infobaseIdViaConfiguration(Object standaloneServerInfobaseModule)
+    {
+        try
+        {
+            Object cfg = standaloneServerInfobaseModule.getClass()
+                .getMethod("getStandaloneServerConfiguration").invoke(standaloneServerInfobaseModule); //$NON-NLS-1$
+            if (cfg == null)
+            {
+                return null;
+            }
+            Object infobase = cfg.getClass().getMethod("getInfobase").invoke(cfg); //$NON-NLS-1$
+            if (infobase == null)
+            {
+                return null;
+            }
+            Object id = infobase.getClass().getMethod("getId").invoke(infobase); //$NON-NLS-1$
+            return (id instanceof String) ? (String)id : null;
+        }
+        catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+        {
+            return null;
+        }
+    }
+
+    /**
      * Reflective {@code StandaloneServerInfobase.getStandaloneServerConfiguration().getDatabase()} →, for a
-     * FILE-backed standalone server, {@code FileDatabase.getConfigDirectory()} — the on-disk directory of
-     * the served database (= {@code database.path} in config.yaml = the {@code infobaseFile} that was
+     * FILE-backed standalone server, the on-disk directory of the served database — read via
+     * {@code FileDatabase.getConfigDirectory()} (2025.2) or {@code getPath()} (the 2026.1 rename of the
+     * same accessor) — (= {@code database.path} in config.yaml = the {@code infobaseFile} that was
      * passed to {@code create_infobase}). This is SEPARATE from the {@code Серверы/…-config} folder that
      * {@code deleteServer} removes — {@code deleteServer} never deletes the served database, so this is how
      * {@code deleteDatabaseFiles=true} finds the directory to remove. Must be read BEFORE {@code deleteServer}
@@ -266,20 +321,22 @@ final class StandaloneServerSupport
                 return null;
             }
             // A FILE database (and its create-template subclass FileCreateTemplateDatabase) carries the
-            // on-disk directory in getConfigDirectory(); an RDBMS database has neither that method nor a
-            // local directory. Detect the file kind by the PRESENCE of getConfigDirectory() rather than
-            // by the class name: the type is platform-internal and intentionally not imported (no
-            // Require-Bundle), so instanceof is impossible, and a name match would be fragile.
-            Object dir;
-            try // NOSONAR nested try is intentional (distinct resource/exception scopes)
+            // on-disk directory in getConfigDirectory() (2025.2), renamed to getPath() on 2026.1; an
+            // RDBMS database has neither accessor nor a local directory. Detect the file kind by the
+            // PRESENCE of either accessor rather than by the class name: the type is platform-internal
+            // and intentionally not imported (no Require-Bundle), so instanceof is impossible, and a
+            // name match would be fragile.
+            Method dirGetter = findMethod(db.getClass(), "getConfigDirectory", 0); //$NON-NLS-1$
+            if (dirGetter == null)
             {
-                dir = db.getClass().getMethod("getConfigDirectory").invoke(db); //$NON-NLS-1$
+                dirGetter = findMethod(db.getClass(), "getPath", 0); //$NON-NLS-1$
             }
-            catch (NoSuchMethodException e)
+            if (dirGetter == null)
             {
                 // Not a file-backed database — nothing on the local disk to resolve.
                 return null;
             }
+            Object dir = dirGetter.invoke(db);
             return (dir instanceof String) ? (String)dir : null;
         }
         catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
@@ -340,23 +397,40 @@ final class StandaloneServerSupport
      * Best-effort removal of the orphaned infobases.yaml entry that {@code deleteServer} leaves behind
      * (EDT never removes it — a confirmed platform gap). Reflectively reaches the
      * {@code StandaloneServerInfobaseModuleFactoryDelegate} via the WST module-factory registry, removes
-     * the entry from its in-memory {@code modules} map by {@code infobaseId}, and re-serializes the
-     * remaining entries to infobases.yaml exactly as the delegate's own {@code saveModule} does.
+     * the entry from its in-memory {@code modules} map, and re-serializes the remaining entries to
+     * infobases.yaml exactly as the delegate's own {@code saveModule} does.
+     *
+     * <p><strong>Version-proof removal (issue #273):</strong> the delegate's map KEY scheme differs per
+     * EDT version — 2025.2 keys by the raw {@code getInfobaseId().toString()} uuid (proven live when
+     * this cleanup shipped), while 2026.1 keys by {@code StandaloneServerInfobase.getId()}, a PREFIXED
+     * module-id string built over the raw config id — so a key-based remove by the raw id silently
+     * misses on 2026.1. Guessing key schemes per version is fragile; the primary strategy is therefore
+     * removal BY VALUE ({@link #removeModuleEntries}): (1) reference identity with the passed live
+     * {@code module} (the map holds the same instance), (2) reflective {@code getId()} String equality,
+     * (3) only then the raw-id key fallback that preserves the proven 2025.2 behavior even when the
+     * instance differs.
      *
      * <p>NON-FATAL: any failure is logged and ignored — the server itself is already deleted, the app is
      * gone from {@code get_applications}, and the orphan self-heals on the next workbench start (the
      * delegate's {@code initialize()} drops config-less entries from its map).
      *
+     * @param module the live {@code StandaloneServerInfobase} module of the deleted server (from
+     *            {@link #moduleOfApplication}, read BEFORE deletion); may be {@code null}
+     * @param infobaseId the raw infobase id string (from {@link #infobaseIdOf}) — the 2025.2 map key,
+     *            kept as the final fallback; may be {@code null}
      * @return {@link RegistryCleanup#REMOVED} if a stale entry was removed, {@link RegistryCleanup#NOT_PRESENT}
-     *         when there was nothing to clean (no infobaseId / no matching entry), or
-     *         {@link RegistryCleanup#FAILED} on a reflective failure
+     *         when there was nothing to clean (no matching entry), or {@link RegistryCleanup#FAILED} on
+     *         a reflective failure / when both {@code module} and {@code infobaseId} are {@code null}
+     *         (nothing to target)
      */
-    static RegistryCleanup removeFromInfobaseRegistry(String infobaseId, IProgressMonitor monitor)
+    static RegistryCleanup removeFromInfobaseRegistry(Object module, String infobaseId,
+        IProgressMonitor monitor)
     {
-        if (infobaseId == null)
+        if (module == null && infobaseId == null)
         {
-            // We could not read the infobaseId, so we cannot target the entry — report FAILED (honest:
-            // "could not clean, self-heals on restart") rather than implying there was nothing to clean.
+            // We could resolve neither the module nor its raw id, so we cannot target the entry —
+            // report FAILED (honest: "could not clean, self-heals on restart") rather than implying
+            // there was nothing to clean.
             return RegistryCleanup.FAILED;
         }
         try
@@ -410,7 +484,7 @@ final class StandaloneServerSupport
             {
                 return RegistryCleanup.FAILED;
             }
-            if (modules.remove(infobaseId) == null)
+            if (removeModuleEntries(modules, module, infobaseId) == 0)
             {
                 // Already gone (e.g. the delegate's initialize() self-healed it) — not an error.
                 return RegistryCleanup.NOT_PRESENT;
@@ -429,6 +503,91 @@ final class StandaloneServerSupport
             Activator.logError("delete_infobase: best-effort infobases.yaml cleanup failed " //$NON-NLS-1$
                 + "(non-fatal — the server is deleted; the orphan self-heals on restart)", t); //$NON-NLS-1$
             return RegistryCleanup.FAILED;
+        }
+    }
+
+    /**
+     * The map surgery of {@link #removeFromInfobaseRegistry}, extracted as a pure (headless-testable)
+     * decision: removes the deleted server's entry/entries from the delegate's {@code modules} map and
+     * returns how many were removed. Three strategies, tried in order (each only when the previous
+     * removed nothing) because the map's KEY scheme differs per EDT version (2025.2 = raw uuid string,
+     * 2026.1 = the prefixed {@code getId()} module-id string):
+     * <ol>
+     *   <li>VALUE reference identity with {@code module} — version-proof: the live map holds the very
+     *   instance {@link #moduleOfApplication} returned, whatever the key scheme;</li>
+     *   <li>value {@code getId()} String equality with {@code module}'s own reflective {@code getId()}
+     *   — catches a re-created (non-identical) instance for the same module id;</li>
+     *   <li>key-based {@code remove(infobaseId)} — the original raw-id removal, preserving the proven
+     *   2025.2 behavior even when the instance differs and {@code getId()} is unavailable.</li>
+     * </ol>
+     *
+     * @param modules the delegate's live modules map (never {@code null})
+     * @param module the deleted server's module instance; may be {@code null} (strategies 1-2 skipped)
+     * @param infobaseId the raw infobase id (the 2025.2 key); may be {@code null} (strategy 3 skipped)
+     * @return the number of entries removed (0 = nothing matched)
+     */
+    static int removeModuleEntries(Map<Object, Object> modules, Object module, String infobaseId)
+    {
+        int removed = 0;
+        if (module != null)
+        {
+            removed = removeByValue(modules, value -> value == module);
+        }
+        if (removed == 0 && module != null)
+        {
+            String moduleId = idOf(module);
+            if (moduleId != null)
+            {
+                removed = removeByValue(modules, value -> moduleId.equals(idOf(value)));
+            }
+        }
+        if (removed == 0 && infobaseId != null && modules.remove(infobaseId) != null)
+        {
+            removed = 1;
+        }
+        return removed;
+    }
+
+    /** Removes every map entry whose VALUE matches the predicate; returns the removed count. */
+    private static int removeByValue(Map<Object, Object> modules, Predicate<Object> valueMatches)
+    {
+        int removed = 0;
+        for (Iterator<Map.Entry<Object, Object>> it = modules.entrySet().iterator(); it.hasNext();)
+        {
+            if (valueMatches.test(it.next().getValue()))
+            {
+                it.remove();
+                removed++;
+            }
+        }
+        return removed;
+    }
+
+    /**
+     * Reflective {@code getId()} of a registry module as a String (on 2026.1 this is the delegate's
+     * map key — the prefixed module-id). Returns {@code null} when the object is {@code null}, the
+     * method is absent (possible on older versions) or the read fails — the caller then just skips the
+     * id-equality strategy.
+     */
+    private static String idOf(Object module)
+    {
+        if (module == null)
+        {
+            return null;
+        }
+        try
+        {
+            Method m = findMethod(module.getClass(), "getId", 0); //$NON-NLS-1$
+            if (m == null)
+            {
+                return null;
+            }
+            Object id = m.invoke(module);
+            return id != null ? id.toString() : null;
+        }
+        catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+        {
+            return null;
         }
     }
 

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseToolTest.java
@@ -7,9 +7,14 @@
 package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -331,5 +336,346 @@ public class CreateInfobaseToolTest
         assertTrue("error must mention the expected 1Cv8.1CD file", //$NON-NLS-1$
             result.contains("1Cv8.1CD")); //$NON-NLS-1$
         assertTrue("error must steer to mode='create'", result.contains("create")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== #273: version-tolerant create-flag resolution ====================
+    // StandaloneServerInfobase's create-new-infobase flag setter was RENAMED, with no back-compat
+    // alias, between EDT 2025.2 (setCreate) and 2026.1 (setCreateNewInfobase). ssMethodAny/
+    // ssSetCreateFlag resolve it version-tolerantly; both are package-private test seams (mirrors
+    // StandaloneServerSupport's convention of package-visible statics for testability), exercised
+    // here with plain stub classes exposing one name, the other, or neither — no live EDT needed.
+
+    @Test
+    public void testSsMethodAnyResolves2025ShapeWhenOnlySetCreatePresent()
+    {
+        Method m = CreateInfobaseTool.ssMethodAny(StubOnlySetCreate.class, 1, "setCreate", //$NON-NLS-1$
+            "setCreateNewInfobase"); //$NON-NLS-1$
+        assertNotNull("setCreate must resolve when present", m); //$NON-NLS-1$
+        assertEquals("setCreate", m.getName()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsMethodAnyResolves2026ShapeWhenOnlySetCreateNewInfobasePresent()
+    {
+        Method m = CreateInfobaseTool.ssMethodAny(StubOnlySetCreateNewInfobase.class, 1, "setCreate", //$NON-NLS-1$
+            "setCreateNewInfobase"); //$NON-NLS-1$
+        assertNotNull("setCreateNewInfobase must resolve when present", m); //$NON-NLS-1$
+        assertEquals("setCreateNewInfobase", m.getName()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsMethodAnyReturnsNullWhenNeitherNamePresent()
+    {
+        assertNull(CreateInfobaseTool.ssMethodAny(StubNeitherSetter.class, 1, "setCreate", //$NON-NLS-1$
+            "setCreateNewInfobase")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsSetCreateFlagInvokesSetCreateOn2025Shape() throws Exception
+    {
+        StubOnlySetCreate stub = new StubOnlySetCreate();
+        CreateInfobaseTool.ssSetCreateFlag(stub, true);
+        assertTrue("setCreate(true) must have been invoked", stub.created); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsSetCreateFlagInvokesSetCreateNewInfobaseOn2026Shape() throws Exception
+    {
+        StubOnlySetCreateNewInfobase stub = new StubOnlySetCreateNewInfobase();
+        CreateInfobaseTool.ssSetCreateFlag(stub, true);
+        assertTrue("setCreateNewInfobase(true) must have been invoked", stub.created); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsSetCreateFlagThrowsNamingBothTriedMethodsWhenNeitherPresent()
+    {
+        try
+        {
+            CreateInfobaseTool.ssSetCreateFlag(new StubNeitherSetter(), true);
+            fail("must throw when neither setCreate nor setCreateNewInfobase resolves"); //$NON-NLS-1$
+        }
+        catch (Exception e)
+        {
+            assertTrue("failure message must name setCreate", //$NON-NLS-1$
+                e.getMessage().contains("setCreate")); //$NON-NLS-1$
+            assertTrue("failure message must name setCreateNewInfobase", //$NON-NLS-1$
+                e.getMessage().contains("setCreateNewInfobase")); //$NON-NLS-1$
+        }
+    }
+
+    // ==================== #273: create-template database ensure (2026.1 second drift layer) ====================
+    // On 2026.1 the behaviour delegate CASTS the module config's database to ICreateTemplateDatabase,
+    // but createServerWithInfobase builds it with a plain FileDatabase -> live ClassCastException.
+    // ssEnsureCreateTemplateDatabase swaps in a FileCreateTemplateDatabase; the DECISION logic
+    // (needs-replacement check + directory copy across the getConfigDirectory/getPath rename) is
+    // headless-testable below; the bundle class-LOADING step needs the real EDT bundle and stays
+    // live-verified (here it degrades best-effort, which is itself asserted).
+
+    @Test
+    public void testSsIsCreateTemplateDatabaseTrueForDirectImplementor()
+    {
+        assertTrue(CreateInfobaseTool.ssIsCreateTemplateDatabase(StubTemplateCapableDatabase.class));
+    }
+
+    @Test
+    public void testSsIsCreateTemplateDatabaseTrueViaSuperclass()
+    {
+        // The marker interface arrives through the superclass -> the hierarchy walk must find it.
+        assertTrue(CreateInfobaseTool.ssIsCreateTemplateDatabase(StubTemplateCapableSubclass.class));
+    }
+
+    @Test
+    public void testSsIsCreateTemplateDatabaseTrueViaSuperinterface()
+    {
+        // The marker interface arrives as a SUPERinterface of an implemented interface.
+        assertTrue(CreateInfobaseTool.ssIsCreateTemplateDatabase(StubExtendedTemplateDatabase.class));
+    }
+
+    @Test
+    public void testSsIsCreateTemplateDatabaseFalseForPlainClass()
+    {
+        assertFalse(CreateInfobaseTool.ssIsCreateTemplateDatabase(StubFileDatabase2025.class));
+        assertFalse(CreateInfobaseTool.ssIsCreateTemplateDatabase(Object.class));
+    }
+
+    @Test
+    public void testSsIsCreateTemplateDatabaseFalseForNull()
+    {
+        assertFalse(CreateInfobaseTool.ssIsCreateTemplateDatabase(null));
+    }
+
+    @Test
+    public void testSsCopyDatabaseDirectoryFrom2025To2026Shape() throws Exception
+    {
+        // Read via getConfigDirectory (2025.2), write via setPath (2026.1) — the cross-rename copy.
+        StubFileDatabase2025 from = new StubFileDatabase2025("C:/data/ib"); //$NON-NLS-1$
+        StubFileDatabase2026 to = new StubFileDatabase2026(null);
+        CreateInfobaseTool.ssCopyDatabaseDirectory(from, to);
+        assertEquals("C:/data/ib", to.getPath()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsCopyDatabaseDirectoryFrom2026To2025Shape() throws Exception
+    {
+        // Read via getPath (2026.1), write via setConfigDirectory (2025.2).
+        StubFileDatabase2026 from = new StubFileDatabase2026("C:/data/ib2026"); //$NON-NLS-1$
+        StubFileDatabase2025 to = new StubFileDatabase2025(null);
+        CreateInfobaseTool.ssCopyDatabaseDirectory(from, to);
+        assertEquals("C:/data/ib2026", to.getConfigDirectory()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsCopyDatabaseDirectoryNoOpWhenSourceHasNoAccessor() throws Exception
+    {
+        // The source exposes neither getConfigDirectory nor getPath -> no-op, no throw.
+        StubFileDatabase2026 to = new StubFileDatabase2026("keep"); //$NON-NLS-1$
+        CreateInfobaseTool.ssCopyDatabaseDirectory(new Object(), to);
+        assertEquals("keep", to.getPath()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsCopyDatabaseDirectoryNoOpWhenTargetHasNoSetter() throws Exception
+    {
+        // The target exposes neither setConfigDirectory nor setPath -> no-op, no throw.
+        CreateInfobaseTool.ssCopyDatabaseDirectory(new StubFileDatabase2025("C:/data/ib"), //$NON-NLS-1$
+            new Object());
+    }
+
+    @Test
+    public void testSsCopyDatabaseDirectorySkipsNullDirectory() throws Exception
+    {
+        // A null source directory is not written (the target keeps its value).
+        StubFileDatabase2026 to = new StubFileDatabase2026("keep"); //$NON-NLS-1$
+        CreateInfobaseTool.ssCopyDatabaseDirectory(new StubFileDatabase2025(null), to);
+        assertEquals("keep", to.getPath()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsEnsureCreateTemplateDatabaseLeavesTemplateCapableDatabaseUntouched()
+    {
+        // The database already implements an ICreateTemplateDatabase-named interface -> untouched
+        // (the 2025.2-compatible / future-proof path): same instance, setDatabase never called.
+        StubTemplateCapableDatabase db = new StubTemplateCapableDatabase();
+        StubServerConfig cfg = new StubServerConfig(db);
+        CreateInfobaseTool.ssEnsureCreateTemplateDatabase(new StubInfobaseWithConfig(cfg));
+        assertFalse("setDatabase must not be called for a template-capable database", //$NON-NLS-1$
+            cfg.setDatabaseCalled);
+        assertSame(db, cfg.getDatabase());
+    }
+
+    @Test
+    public void testSsEnsureCreateTemplateDatabaseLeavesNullDatabaseAsIs()
+    {
+        // A null database is left as-is (the delegate then fails with its own honest error).
+        StubServerConfig cfg = new StubServerConfig(null);
+        CreateInfobaseTool.ssEnsureCreateTemplateDatabase(new StubInfobaseWithConfig(cfg));
+        assertFalse(cfg.setDatabaseCalled);
+        assertNull(cfg.getDatabase());
+    }
+
+    @Test
+    public void testSsEnsureCreateTemplateDatabaseToleratesNullConfiguration()
+    {
+        // getStandaloneServerConfiguration() returning null must be a silent no-op, never a throw.
+        CreateInfobaseTool.ssEnsureCreateTemplateDatabase(new StubInfobaseWithConfig(null));
+    }
+
+    @Test
+    public void testSsEnsureCreateTemplateDatabaseIsBestEffortWhenBundleClassUnavailable()
+    {
+        // A plain (non-template) database triggers the replacement branch, whose bundle class-load
+        // (FileCreateTemplateDatabase via the db's own classloader) cannot succeed headlessly. The
+        // whole ensure is BEST-EFFORT: no throw, database left unchanged, setDatabase never called
+        // (on 2025.2 a plain FileDatabase still materializes fine — that path must never regress).
+        StubFileDatabase2025 db = new StubFileDatabase2025("C:/data/ib"); //$NON-NLS-1$
+        StubServerConfig cfg = new StubServerConfig(db);
+        CreateInfobaseTool.ssEnsureCreateTemplateDatabase(new StubInfobaseWithConfig(cfg));
+        assertFalse("a failed swap must leave the original database in place", //$NON-NLS-1$
+            cfg.setDatabaseCalled);
+        assertSame(db, cfg.getDatabase());
+    }
+
+    // ==================== Stubs (plain classes ssMethodAny/ssSetCreateFlag introspect) ====================
+
+    /** A 2025.2-shaped {@code StandaloneServerInfobase} stub: only {@code setCreate(boolean)}. */
+    public static final class StubOnlySetCreate
+    {
+        boolean created;
+
+        public void setCreate(boolean value)
+        {
+            created = value;
+        }
+    }
+
+    /** A 2026.1-shaped {@code StandaloneServerInfobase} stub: only {@code setCreateNewInfobase(boolean)}. */
+    public static final class StubOnlySetCreateNewInfobase
+    {
+        boolean created;
+
+        public void setCreateNewInfobase(boolean value)
+        {
+            created = value;
+        }
+    }
+
+    /** A stub exposing NEITHER create-flag setter name (the both-names error path). */
+    public static final class StubNeitherSetter
+    {
+        // deliberately no setCreate / setCreateNewInfobase
+    }
+
+    /**
+     * #273: stands in for the platform's create-template marker interface — matched by SIMPLE name
+     * (the live one is {@code com.e1c...standaloneserver.core.config.ICreateTemplateDatabase}).
+     */
+    public interface ICreateTemplateDatabase
+    {
+        // marker
+    }
+
+    /** #273: an interface EXTENDING the marker (the superinterface-walk branch). */
+    public interface IExtendedTemplateDatabase extends ICreateTemplateDatabase
+    {
+        // marker
+    }
+
+    /** #273: a database that implements the marker interface DIRECTLY (needs no replacement). */
+    public static class StubTemplateCapableDatabase implements ICreateTemplateDatabase
+    {
+        // marker only
+    }
+
+    /** #273: a database inheriting the marker via its SUPERCLASS (the hierarchy-walk branch). */
+    public static final class StubTemplateCapableSubclass extends StubTemplateCapableDatabase
+    {
+        // marker only, via the superclass
+    }
+
+    /** #273: a database reaching the marker via a superINTERFACE of an implemented interface. */
+    public static final class StubExtendedTemplateDatabase implements IExtendedTemplateDatabase
+    {
+        // marker only, via the extended interface
+    }
+
+    /** #273: a 2025.2-shaped plain file database — getConfigDirectory/setConfigDirectory accessors. */
+    public static final class StubFileDatabase2025
+    {
+        private String dir;
+
+        StubFileDatabase2025(String dir)
+        {
+            this.dir = dir;
+        }
+
+        public String getConfigDirectory()
+        {
+            return dir;
+        }
+
+        public void setConfigDirectory(String dir)
+        {
+            this.dir = dir;
+        }
+    }
+
+    /** #273: a 2026.1-shaped plain file database — the accessors were RENAMED to getPath/setPath. */
+    public static final class StubFileDatabase2026
+    {
+        private String path;
+
+        StubFileDatabase2026(String path)
+        {
+            this.path = path;
+        }
+
+        public String getPath()
+        {
+            return path;
+        }
+
+        public void setPath(String path)
+        {
+            this.path = path;
+        }
+    }
+
+    /** #273: the module config stand-in — getDatabase/setDatabase (setDatabase call is recorded). */
+    public static final class StubServerConfig
+    {
+        private Object database;
+        boolean setDatabaseCalled;
+
+        StubServerConfig(Object database)
+        {
+            this.database = database;
+        }
+
+        public Object getDatabase()
+        {
+            return database;
+        }
+
+        public void setDatabase(Object database)
+        {
+            this.database = database;
+            setDatabaseCalled = true;
+        }
+    }
+
+    /** #273: the StandaloneServerInfobase stand-in exposing its module configuration. */
+    public static final class StubInfobaseWithConfig
+    {
+        private final Object configuration;
+
+        StubInfobaseWithConfig(Object configuration)
+        {
+            this.configuration = configuration;
+        }
+
+        public Object getStandaloneServerConfiguration()
+        {
+            return configuration;
+        }
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/StandaloneServerSupportTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/StandaloneServerSupportTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
@@ -95,7 +96,9 @@ public class StandaloneServerSupportTest
     @Test
     public void testInfobaseIdOfReturnsNullWhenMethodAbsent()
     {
-        // An object without getInfobaseId() -> NoSuchMethodException is swallowed -> null.
+        // #273: an object with NEITHER the 2025.2 shape (getInfobaseId()) NOR the 2026.1 fallback
+        // chain (getStandaloneServerConfiguration()) -> both NoSuchMethodExceptions are swallowed ->
+        // null, and the "both shapes missing" error is LOGGED, never thrown.
         assertNull(StandaloneServerSupport.infobaseIdOf(new Object()));
     }
 
@@ -105,6 +108,44 @@ public class StandaloneServerSupportTest
         // A UUID-like non-String id is rendered via toString().
         Object module = new FakeInfobaseModule(Integer.valueOf(7));
         assertEquals("7", StandaloneServerSupport.infobaseIdOf(module)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testInfobaseIdOfReadsUuidViaGetInfobaseId()
+    {
+        // The real 2025.2 shape: getInfobaseId() returns a java.util.UUID -> its toString() is
+        // returned (the raw id string that keys the infobases.yaml registry entry).
+        java.util.UUID uuid = java.util.UUID.randomUUID();
+        Object module = new FakeInfobaseModule(uuid);
+        assertEquals(uuid.toString(), StandaloneServerSupport.infobaseIdOf(module));
+    }
+
+    // ---- #273: 2026.1 fallback shape — getStandaloneServerConfiguration().getInfobase().getId() ----
+
+    @Test
+    public void testInfobaseIdOfFallsBackToConfigurationChainWhenGetInfobaseIdAbsent()
+    {
+        // 2026.1: getInfobaseId() is GONE (no replacement); the raw id lives instead at
+        // getStandaloneServerConfiguration().getInfobase().getId(): String.
+        Object module = new FakeInfobaseModule2026Only(
+            new Fake2026Configuration(new Fake2026Infobase("ib-2026"))); //$NON-NLS-1$
+        assertEquals("ib-2026", StandaloneServerSupport.infobaseIdOf(module)); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testInfobaseIdOfFallbackIsNullSafeWhenConfigurationIsNull()
+    {
+        // getStandaloneServerConfiguration() present but returns null -> null-safe, no NPE.
+        Object module = new FakeInfobaseModule2026Only(null);
+        assertNull(StandaloneServerSupport.infobaseIdOf(module));
+    }
+
+    @Test
+    public void testInfobaseIdOfFallbackIsNullSafeWhenInfobaseIsNull()
+    {
+        // getInfobase() present but returns null -> null-safe, no NPE.
+        Object module = new FakeInfobaseModule2026Only(new Fake2026Configuration(null));
+        assertNull(StandaloneServerSupport.infobaseIdOf(module));
     }
 
     // ==================== databaseDirOf ====================
@@ -137,9 +178,28 @@ public class StandaloneServerSupportTest
     @Test
     public void testDatabaseDirOfReturnsNullForRdbmsDatabaseWithoutConfigDirectory()
     {
-        // An RDBMS database has no getConfigDirectory() -> NoSuchMethodException -> null.
+        // An RDBMS database has NEITHER getConfigDirectory() (2025.2) NOR getPath() (2026.1) -> null.
         Object module = new FakeServerInfobaseModule(
             new FakeConfiguration(new FakeRdbmsDatabase()));
+        assertNull(StandaloneServerSupport.databaseDirOf(module));
+    }
+
+    @Test
+    public void testDatabaseDirOfReadsGetPathOn2026Shape()
+    {
+        // #273: 2026.1 renamed FileDatabase.getConfigDirectory() -> getPath(); the read must accept
+        // either accessor (this is why deleteDatabaseFiles resolved nothing on 2026.1).
+        Object module = new FakeServerInfobaseModule(
+            new FakeConfiguration(new Fake2026PathDatabase("C:/data/ib2026"))); //$NON-NLS-1$
+        assertEquals("C:/data/ib2026", StandaloneServerSupport.databaseDirOf(module)); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testDatabaseDirOfReturnsNullWhenGetPathIsNotAString()
+    {
+        // #273: getPath() exists but returns a non-String -> null (same instanceof guard as 2025.2).
+        Object module = new FakeServerInfobaseModule(
+            new FakeConfiguration(new FakeNonStringPathDatabase()));
         assertNull(StandaloneServerSupport.databaseDirOf(module));
     }
 
@@ -304,11 +364,12 @@ public class StandaloneServerSupportTest
     // ==================== removeFromInfobaseRegistry ====================
 
     @Test
-    public void testRemoveFromInfobaseRegistryNullIdReturnsFailed()
+    public void testRemoveFromInfobaseRegistryNullModuleAndIdReturnsFailed()
     {
-        // PURE branch (no OSGi): a null infobaseId can target no entry -> FAILED (honest, not NOT_PRESENT).
+        // PURE branch (no OSGi): with NEITHER the module NOR the raw id, no entry can be targeted ->
+        // FAILED (honest, not NOT_PRESENT).
         assertSame(RegistryCleanup.FAILED,
-            StandaloneServerSupport.removeFromInfobaseRegistry(null, MONITOR));
+            StandaloneServerSupport.removeFromInfobaseRegistry(null, null, MONITOR));
     }
 
     @Test
@@ -318,8 +379,109 @@ public class StandaloneServerSupportTest
         // runtime the cleanup cannot run: it must return a non-null RegistryCleanup (FAILED) and never
         // throw. (On a real EDT with the feature installed this is where REMOVED/NOT_PRESENT happen.)
         RegistryCleanup result =
-            StandaloneServerSupport.removeFromInfobaseRegistry("some-id", MONITOR); //$NON-NLS-1$
+            StandaloneServerSupport.removeFromInfobaseRegistry(null, "some-id", MONITOR); //$NON-NLS-1$
         assertNotNull(result);
+    }
+
+    @Test
+    public void testRemoveFromInfobaseRegistryWithModuleOnlyDegradesGracefully()
+    {
+        // A module without a raw id (the 2026.1 shape when only the instance is known) must also
+        // degrade gracefully in the headless runtime — non-null result, never a throw.
+        RegistryCleanup result = StandaloneServerSupport.removeFromInfobaseRegistry(
+            new FakeIdModule("prefixed#abc"), null, MONITOR); //$NON-NLS-1$
+        assertNotNull(result);
+    }
+
+    // ==================== removeModuleEntries (#273: the version-proof map surgery) ====================
+    // The delegate's modules-map KEY scheme differs per EDT version: 2025.2 keys by the raw uuid,
+    // 2026.1 by the PREFIXED StandaloneServerInfobase.getId() module-id — so key-based removal by the
+    // raw id silently misses on 2026.1. The extracted seam is tested here strategy by strategy; the
+    // delegate/mapper/location plumbing around it stays live-verified.
+
+    @Test
+    public void testRemoveModuleEntriesByValueIdentity()
+    {
+        // Strategy 1: the map value IS the passed instance — removed regardless of the key scheme
+        // (here the 2026.1-style prefixed key, which the raw id would miss).
+        FakeIdModule module = new FakeIdModule("srv#raw-1"); //$NON-NLS-1$
+        java.util.Map<Object, Object> modules = new java.util.HashMap<>();
+        modules.put("srv#raw-1", module); //$NON-NLS-1$
+        assertEquals(1, StandaloneServerSupport.removeModuleEntries(modules, module, "raw-1")); //$NON-NLS-1$
+        assertTrue(modules.isEmpty());
+    }
+
+    @Test
+    public void testRemoveModuleEntriesIdentityDoesNotTouchOtherEntries()
+    {
+        // Identity removal must be surgical: an unrelated entry (even one with the SAME getId) stays,
+        // because strategy 2 only runs when strategy 1 removed nothing.
+        FakeIdModule module = new FakeIdModule("srv#raw-1"); //$NON-NLS-1$
+        FakeIdModule twin = new FakeIdModule("srv#raw-1"); //$NON-NLS-1$
+        java.util.Map<Object, Object> modules = new java.util.HashMap<>();
+        modules.put("k1", module); //$NON-NLS-1$
+        modules.put("k2", twin); //$NON-NLS-1$
+        assertEquals(1, StandaloneServerSupport.removeModuleEntries(modules, module, null));
+        assertSame(twin, modules.get("k2")); //$NON-NLS-1$
+        assertEquals(1, modules.size());
+    }
+
+    @Test
+    public void testRemoveModuleEntriesByGetIdEquality()
+    {
+        // Strategy 2: a DIFFERENT instance with the SAME getId() (a re-created module) is matched by
+        // reflective getId() String equality when identity misses.
+        java.util.Map<Object, Object> modules = new java.util.HashMap<>();
+        modules.put("srv#raw-2", new FakeIdModule("srv#raw-2")); //$NON-NLS-1$ //$NON-NLS-2$
+        FakeIdModule sameIdOtherInstance = new FakeIdModule("srv#raw-2"); //$NON-NLS-1$
+        assertEquals(1,
+            StandaloneServerSupport.removeModuleEntries(modules, sameIdOtherInstance, null));
+        assertTrue(modules.isEmpty());
+    }
+
+    @Test
+    public void testRemoveModuleEntriesByRawIdKeyFallback()
+    {
+        // Strategy 3: identity and getId both miss (value has no matching id) -> the proven 2025.2
+        // key-based removal by the raw id still fires.
+        java.util.Map<Object, Object> modules = new java.util.HashMap<>();
+        modules.put("raw-3", new Object()); //$NON-NLS-1$
+        assertEquals(1, StandaloneServerSupport.removeModuleEntries(modules,
+            new FakeIdModule("srv#other"), "raw-3")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(modules.isEmpty());
+    }
+
+    @Test
+    public void testRemoveModuleEntriesKeyFallbackWithNullModule()
+    {
+        // module == null (the pre-#273 caller shape): only the key-based strategy applies.
+        java.util.Map<Object, Object> modules = new java.util.HashMap<>();
+        modules.put("raw-4", new Object()); //$NON-NLS-1$
+        assertEquals(1, StandaloneServerSupport.removeModuleEntries(modules, null, "raw-4")); //$NON-NLS-1$
+        assertTrue(modules.isEmpty());
+    }
+
+    @Test
+    public void testRemoveModuleEntriesFullMissReturnsZero()
+    {
+        // No identity, no id equality, no key match -> 0 (the caller maps this to NOT_PRESENT).
+        java.util.Map<Object, Object> modules = new java.util.HashMap<>();
+        modules.put("other-key", new FakeIdModule("srv#other")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(0, StandaloneServerSupport.removeModuleEntries(modules,
+            new FakeIdModule("srv#mine"), "raw-mine")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(1, modules.size());
+    }
+
+    @Test
+    public void testRemoveModuleEntriesToleratesValuesWithoutGetId()
+    {
+        // Strategy 2 must skip values that have no getId() (or are null) without throwing.
+        java.util.Map<Object, Object> modules = new java.util.HashMap<>();
+        modules.put("k1", new Object()); //$NON-NLS-1$
+        modules.put("k2", null); //$NON-NLS-1$
+        assertEquals(0, StandaloneServerSupport.removeModuleEntries(modules,
+            new FakeIdModule("srv#raw-5"), null)); //$NON-NLS-1$
+        assertEquals(2, modules.size());
     }
 
     // ==================== acquireService ====================
@@ -341,6 +503,25 @@ public class StandaloneServerSupportTest
 
     // ==================== Fakes (plain classes the reflective wrappers introspect) ====================
 
+    /**
+     * #273: a registry module with a {@code getId()} — on 2026.1 that PREFIXED module-id string is the
+     * delegate's map key. Used by the {@code removeModuleEntries} strategy tests.
+     */
+    public static final class FakeIdModule
+    {
+        private final String id;
+
+        FakeIdModule(String id)
+        {
+            this.id = id;
+        }
+
+        public String getId()
+        {
+            return id;
+        }
+    }
+
     /** Stands in for {@code StandaloneServerInfobase} for {@code infobaseIdOf}. */
     public static final class FakeInfobaseModule
     {
@@ -352,6 +533,57 @@ public class StandaloneServerSupportTest
         }
 
         public Object getInfobaseId()
+        {
+            return id;
+        }
+    }
+
+    /**
+     * #273: a module exposing ONLY the 2026.1 config-chain fallback for {@code infobaseIdOf} —
+     * deliberately has NO {@code getInfobaseId()}, mirroring EDT 2026.1 where that method was removed.
+     */
+    public static final class FakeInfobaseModule2026Only
+    {
+        private final Object configuration;
+
+        FakeInfobaseModule2026Only(Object configuration)
+        {
+            this.configuration = configuration;
+        }
+
+        public Object getStandaloneServerConfiguration()
+        {
+            return configuration;
+        }
+    }
+
+    /** #273: stands in for the 2026.1 {@code StandaloneServerConfiguration}'s {@code getInfobase()} hop. */
+    public static final class Fake2026Configuration
+    {
+        private final Object infobase;
+
+        Fake2026Configuration(Object infobase)
+        {
+            this.infobase = infobase;
+        }
+
+        public Object getInfobase()
+        {
+            return infobase;
+        }
+    }
+
+    /** #273: stands in for the 2026.1 {@code Infobase}, holding the raw id via {@code getId(): String}. */
+    public static final class Fake2026Infobase
+    {
+        private final String id;
+
+        Fake2026Infobase(String id)
+        {
+            this.id = id;
+        }
+
+        public String getId()
         {
             return id;
         }
@@ -405,10 +637,10 @@ public class StandaloneServerSupportTest
         }
     }
 
-    /** RDBMS database: deliberately has NO getConfigDirectory() method. */
+    /** RDBMS database: deliberately has NEITHER getConfigDirectory() (2025.2) nor getPath() (2026.1). */
     public static final class FakeRdbmsDatabase
     {
-        // no getConfigDirectory()
+        // no getConfigDirectory() / getPath()
     }
 
     /** File-like database whose getConfigDirectory() returns a non-String (the instanceof guard). */
@@ -417,6 +649,31 @@ public class StandaloneServerSupportTest
         public Object getConfigDirectory()
         {
             return new java.io.File("x"); //$NON-NLS-1$
+        }
+    }
+
+    /** #273: a 2026.1-shaped file database — the directory accessor was RENAMED to getPath(). */
+    public static final class Fake2026PathDatabase
+    {
+        private final String path;
+
+        Fake2026PathDatabase(String path)
+        {
+            this.path = path;
+        }
+
+        public String getPath()
+        {
+            return path;
+        }
+    }
+
+    /** #273: a 2026.1-shaped database whose getPath() returns a non-String (the instanceof guard). */
+    public static final class FakeNonStringPathDatabase
+    {
+        public Object getPath()
+        {
+            return new java.io.File("y"); //$NON-NLS-1$
         }
     }
 

--- a/tests/TestConfiguration/.scannerwork/report-task.txt
+++ b/tests/TestConfiguration/.scannerwork/report-task.txt
@@ -1,0 +1,6 @@
+projectKey=TestConfiguration
+serverUrl=http://localhost:9001
+serverVersion=26.7.0.124771
+dashboardUrl=http://localhost:9001/dashboard?id=TestConfiguration
+ceTaskId=4b123390-1b2d-40e0-b5e0-7d92a290d52f
+ceTaskUrl=http://localhost:9001/api/ce/task?id=4b123390-1b2d-40e0-b5e0-7d92a290d52f

--- a/tests/TestConfiguration/.scannerwork/report-task.txt
+++ b/tests/TestConfiguration/.scannerwork/report-task.txt
@@ -1,6 +1,0 @@
-projectKey=TestConfiguration
-serverUrl=http://localhost:9001
-serverVersion=26.7.0.124771
-dashboardUrl=http://localhost:9001/dashboard?id=TestConfiguration
-ceTaskId=4b123390-1b2d-40e0-b5e0-7d92a290d52f
-ceTaskUrl=http://localhost:9001/api/ce/task?id=4b123390-1b2d-40e0-b5e0-7d92a290d52f


### PR DESCRIPTION
Закрывает #273. **Основан на ветке #272** — в дифе видны и его коммиты, после мержа #272 диф схлопнется до одного коммита этого фикса (+коммит-чистка).

## Что сломалось на 2026.1

EDT 2026.1 переименовал/удалил рефлективную поверхность standalone-сервера, javap-верифицированную нами по 2025.2. Три поломки в master (все живо воспроизведены):

1. **`create_infobase` (standaloneServer, mode='create')** — `setCreate` → `setCreateNewInfobase`, а следом второй слой: behaviour-делегат 2026.1 кастует БД конфига к `ICreateTemplateDatabase`, тогда как `createServerWithInfobase` кладёт туда plain `FileDatabase` → живой ClassCastException.
2. **`delete_infobase` / `deleteDatabaseFiles`** — `FileDatabase.getConfigDirectory` → `getPath`: каталог БД молча не резолвился, файлы не удалялись.
3. **Чистка infobases.yaml при delete** — `getInfobaseId()` удалён, и вдобавок карта реестра на 2026.1 ключуется префиксованным `module.getId()` (на 2025.2 — сырой UUID) → сиротская запись оставалась всегда.

## Фикс (всё version-tolerant, оба стенда, без compile-зависимостей)

- `ssSetCreateFlag`/`ssMethodAny`: сеттер create-флага пробует оба имени; если нет ни одного — ошибка называет оба.
- `ssEnsureCreateTemplateDatabase`: перед материализацией БД конфига при необходимости подменяется на рефлективно инстанцированный `FileCreateTemplateDatabase` (класслоадер самого бандла, перенос каталога через оба имени аксессора). Только create-путь; register из #271 её никогда не получает.
- `infobaseIdOf`: фолбэк `getStandaloneServerConfiguration().getInfobase().getId()`.
- `databaseDirOf`: принимает `getConfigDirectory` (2025.2) или `getPath` (2026.1); RDBMS по-прежнему `null`.
- Чистка yaml: удаление **по значению** — identity переданного модуля → равенство `getId()` → легаси-фолбэк по сырому ключу (сохраняет доказанное поведение 2025.2). Схема ключа больше не угадывается.
- `setExist` там, где его нет (2026.1) — тихий best-effort no-op, как и было.

## Проверено

- Unit: **3491/3491** (`CreateInfobaseToolTest` 20→40, `StandaloneServerSupportTest` 28→43 — обе формы API пришиты стабами).
- **Живой стенд EDT 2026.1.1**: полный роундтрип — create пишет `1Cv8.1CD` и отдаёт webUrl; delete удаляет файлы БД **и** запись из infobases.yaml; регрессия register из #272 зелёная.
- Wire не менялся, golden не тронут.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
