### PR TITLE
Диалог подтверждения деструктивных операций ограничен 120 с — MCP-вызов больше не висит бессрочно (#277)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ log.log
 
 # Proxy module build output
 proxy/target/
+tests/TestConfiguration/.scannerwork/

--- a/README.md
+++ b/README.md
@@ -615,6 +615,13 @@ it overrides the preference and lets every gated operation proceed without a dia
 e2e suite uses). When there is no active workbench window (a headless server), the gate never blocks
 either. The dialog only ever appears on a live UI session at the *Ask* level.
 
+**The prompt is time-bounded.** A confirmation dialog waits at most **120 seconds** for a human to
+answer (below common MCP client request budgets, so a caller gets an actionable error instead of its
+own transport timing out first). If nobody answers in time, the operation auto-rejects — nothing is
+changed — with an error naming the tool, the 120 s budget, and the three ways to proceed: allow the
+tool via Preferences (*Allow all* or per-tool), set `EDT_MCP_DESTRUCTIVE_CONSENT=allow` for unattended
+runs, or re-run the call and answer the dialog promptly.
+
 ### Infobase authentication dialog
 
 When a target infobase has a **user list**, connecting to it during `update_database` or `debug_launch`

--- a/docs/tools/create_infobase.md
+++ b/docs/tools/create_infobase.md
@@ -1,6 +1,6 @@
 # create_infobase
 
-Create a new FILE infobase (1C database) OR register an existing one, and bind it to a configuration project so it appears in get_applications. mode='create' (default) makes a new database (requires a registered 1C platform runtime); mode='register' adds an already-existing infobase at the given path without launching the platform. applicationKind='infobase' (default) makes a plain file infobase; applicationKind='standaloneServer' creates (or, with mode='register', wraps an EXISTING file infobase with) an autonomous (standalone) server that also exposes a web URL for HTTP testing (requires a registered 1C standalone-server runtime, platform >= 8.3.23). FILE type only (server/web rejected). Runs in a background Job (up to 120 s). Full parameters and examples: call get_tool_guide('create_infobase').
+Create a new FILE infobase (1C database) OR register an existing one, and bind it to a configuration project so it appears in get_applications. mode='create' (default) makes a new database (requires a registered 1C platform runtime); mode='register' adds an already-existing infobase at the given path without launching the platform. applicationKind='infobase' (default) makes a plain file infobase; applicationKind='standaloneServer' creates (or, with mode='register', wraps an EXISTING file infobase with) an autonomous (standalone) server that also exposes a web URL for HTTP testing (requires a registered 1C standalone-server runtime, platform >= 8.3.23). FILE type only (server/web rejected). Runs in a background Job (up to 120 s). user/password/access store connection credentials for applicationKind='infobase', and for applicationKind='standaloneServer' with mode='register' — rejected for a newly created standalone server (mode='create'). Full parameters and examples: call get_tool_guide('create_infobase').
 
 ## Parameters
 | Parameter | Required | Type | Description |
@@ -12,9 +12,9 @@ Create a new FILE infobase (1C database) OR register an existing one, and bind i
 | platform | — | string | 1C platform version mask to use for creation (e.g. '8.3.25'). If omitted, EDT resolves the best available installed version automatically. |
 | setDefault | — | boolean | Set the new infobase as the default application for the project after creation (default false). |
 | applicationKind | — | string (one of: infobase, standaloneServer) | 'infobase' (default) = a plain file infobase via the configurator; 'standaloneServer' = an autonomous (standalone) server that creates and serves a new file infobase and exposes a web URL for HTTP testing (requires a registered 1C standalone-server runtime, platform >= 8.3.23). With mode='register' the server instead wraps an EXISTING file infobase (a 1Cv8.1CD must be present at infobaseFile) rather than creating a new one. The web port is auto-allocated by EDT and reported back as 'port'/'webUrl' in the result. |
-| user | — | string | Infobase connection user to store so update_database / debug_launch can authenticate the update agent (issue #194). Selects an EXISTING user; most useful with mode='register' (the existing base already has users). Omit to store no credentials. |
-| password | — | string | Password for 'user'. Optional; default empty (demo bases use an empty password). |
-| access | — | string (one of: INFOBASE, OS) | Authentication kind for the stored credentials: 'INFOBASE' (default, 1C user auth) or 'OS'. Credentials are stored when ANY of user/password/access is given; access='OS' on its own stores OS-authentication settings (no 1C user/password). Applies only to applicationKind='infobase' (a file infobase). |
+| user | — | string | Infobase connection user to store so update_database / debug_launch can authenticate the update agent (issue #194). Selects an EXISTING user; most useful with mode='register' (the existing base already has users). Omit to store no credentials. Accepted for applicationKind='infobase', and for applicationKind='standaloneServer' with mode='register'; rejected for a newly created standalone server (mode='create'). |
+| password | — | string | Password for 'user'. Optional; default empty (demo bases use an empty password). Same applicationKind/mode restriction as 'user' (issue #275). |
+| access | — | string (one of: INFOBASE, OS) | Authentication kind for the stored credentials: 'INFOBASE' (default, 1C user auth) or 'OS'. Credentials are stored when ANY of user/password/access is given; access='OS' on its own stores OS-authentication settings (no 1C user/password). Applies to applicationKind='infobase' (a file infobase), and to applicationKind='standaloneServer' with mode='register'; rejected for a newly created standalone server (mode='create'). |
 
 ## Guide
 Creates a new FILE infobase (1C:Enterprise database) OR registers an existing one, and binds it to a configuration project so it appears in `get_applications` as an application of type `com.e1c.g5.dt.applications.type.infobase`. This mirrors the two choices of the EDT "new infobase" dialog: make a new database, or use a database that already exists on disk.
@@ -50,7 +50,17 @@ On success the result's `action` is **`registered`** (not `created`), and the `m
 #    -> action="registered"; webUrl/port point at the running server; the existing 1Cv8.1CD is reused as-is.
 ```
 
-Note: the `user`/`password`/`access` connection-credential parameters remain **rejected** for `applicationKind='standaloneServer'` in either mode (a standalone server manages its own infobase and authentication) — this behavior is unchanged.
+### Connection credentials for a standalone server (`mode='register'` only, issue #275)
+
+The `user`/`password`/`access` connection-credential parameters (see "Parameter details" below) are now **accepted** for `applicationKind='standaloneServer'` **with `mode='register'`** — the wrapped infobase already exists and already has users, so storing credentials is meaningful. They are still **rejected** for `applicationKind='standaloneServer'` with `mode='create'` (a brand-new server has no infobase reference to store them against yet — omit them or add the credentials afterwards with `set_infobase_credentials` once the base has users).
+
+Credentials for a registered standalone server are stored against the **application EDT's own launch path resolves** (`ServerApplicationBehaviourDelegate` adapts the `wst-server` application/module to an `InfobaseReference` via `org.eclipse.core.runtime.Adapters`), so they authenticate the SAME update agent a later `debug_launch`/`update_database` starts.
+
+```
+# Register a standalone server over an EXISTING infobase AND store credentials for its 'Admin' user:
+1. create_infobase  projectName="MyProject"  infobaseFile="C:\infobases\ExistingApp"  applicationKind="standaloneServer"  mode="register"  user="Admin"  password="secret"
+#    -> action="registered"; the message confirms the credentials were stored (or, non-fatally, a WARNING if storage failed).
+```
 
 ### Prerequisites and result
 
@@ -82,7 +92,7 @@ Note: the `user`/`password`/`access` connection-credential parameters remain **r
 - **infobaseName** (optional): display name for the infobase in the EDT Infobases view. If omitted, a name is auto-generated.
 - **platform** (optional, `create` only): 1C platform version mask (e.g. `8.3.25`). If omitted, EDT resolves the best available installed version automatically.
 - **setDefault** (boolean, default false): set the infobase as the default application for the project afterwards.
-- **user** / **password** / **access** (optional, #194): store **infobase connection credentials** so a later `update_database` / `debug_launch` can authenticate the update agent against a base with a user list. `access` is `INFOBASE` (default, 1C user auth) or `OS`. Most useful with `mode='register'` (the existing base already has users); for a `mode='create'` base there are no users yet, so the credentials authenticate only once a matching user is added. Use `set_infobase_credentials` to change them later.
+- **user** / **password** / **access** (optional, #194; standalone-server support #275): store **infobase connection credentials** so a later `update_database` / `debug_launch` can authenticate the update agent against a base with a user list. `access` is `INFOBASE` (default, 1C user auth) or `OS`. Accepted for `applicationKind='infobase'` (any mode), and for `applicationKind='standaloneServer'` with `mode='register'` — **rejected** for `applicationKind='standaloneServer'` with `mode='create'` (a brand-new server has no infobase reference to store them against yet). Most useful with `mode='register'` (the existing base already has users); for a `mode='create'` file infobase there are no users yet, so the credentials authenticate only once a matching user is added. Use `set_infobase_credentials` to change them later.
 - **applicationKind** (optional, `infobase` | `standaloneServer`, default `infobase`): see "Application kind" above. The standalone-server path takes no port/publication input — EDT auto-allocates the web port and reports it back as `port`/`webUrl`.
 
 ## Result

--- a/docs/tools/set_infobase_credentials.md
+++ b/docs/tools/set_infobase_credentials.md
@@ -1,6 +1,6 @@
 # set_infobase_credentials
 
-Store infobase connection credentials (user/password) so update_database and debug_launch can authenticate the update agent on an infobase that has a user list (issue #194). Selects an EXISTING infobase user (does not create users); an empty password is valid (demo bases). Target by launchConfigurationName (preferred) or projectName + applicationId (from get_applications). Full parameters and examples: call get_tool_guide('set_infobase_credentials').
+Store infobase connection credentials (user/password) so update_database and debug_launch can authenticate the update agent on an infobase that has a user list (issue #194) — also for a standalone-server application wrapping an already-registered infobase (issue #275). Selects an EXISTING infobase user (does not create users); an empty password is valid (demo bases). Target by launchConfigurationName (preferred) or projectName + applicationId (from get_applications). Full parameters and examples: call get_tool_guide('set_infobase_credentials').
 
 ## Parameters
 | Parameter | Required | Type | Description |
@@ -14,6 +14,8 @@ Store infobase connection credentials (user/password) so update_database and deb
 
 ## Guide
 Stores the **infobase connection credentials** (user / password) EDT uses to authenticate the 1C designer agent that runs the pre-launch DB update for `update_database` and `debug_launch`. Needed when the target infobase has a **user list** (issue #194): without stored credentials the agent is started without the infobase user, fails to authenticate, and the platform pops a blocking "Configure Infobase access Settings" dialog that hangs an unattended call.
+
+**Also works for a standalone server (issue #275):** the target application does not have to be a plain file/server infobase (`IInfobaseApplication`) — a `standaloneServer` (`wst-server`) application that wraps an already-registered infobase is supported too. EDT's own launch path for such an application resolves the infobase to authenticate against by ADAPTING the application (or its module) to an `InfobaseReference` (`org.eclipse.core.runtime.Adapters`); this tool stores credentials against that SAME adapted reference, so a later `debug_launch`/`update_database` on the server authenticates with them. An application that is neither an infobase nor an adaptable standalone server is rejected with an actionable error naming the application id.
 
 ## What these credentials are (and are not)
 
@@ -63,7 +65,7 @@ While an MCP tool is in flight (plus a short grace window for the asynchronous r
 ## Gotchas
 
 - **The user must exist in the infobase.** Storing credentials for a user that does not exist makes the next connect fail authentication (while a tool is running the MCP server auto-cancels the resulting dialog — see the auto-cancel note above — and the operation fails fast with a hint back to this tool). Add the user first, then set credentials.
-- **`create_infobase` can store credentials too** (its `user`/`password`/`access` parameters) — handy with `mode='register'` (the existing base already has users). For a brand-new `mode='create'` base there are no users yet, so set credentials only after adding a matching user.
+- **`create_infobase` can store credentials too** (its `user`/`password`/`access` parameters) — handy with `mode='register'` (the existing base already has users), including `applicationKind='standaloneServer'` + `mode='register'` (issue #275). For a brand-new `mode='create'` base (file infobase or standalone server) there are no users yet, so set credentials only after adding a matching user — `create_infobase` rejects credentials up front for a newly created standalone server.
 - **Wrong password / wrong user** → `update_database`/`debug_launch` fail fast with "the infobase requires authentication — set the connection credentials with set_infobase_credentials" instead of hanging.
 - These are connection credentials, not a permission grant: the user's rights inside the infobase are unchanged.
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/create_infobase.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/create_infobase.md
@@ -31,7 +31,17 @@ On success the result's `action` is **`registered`** (not `created`), and the `m
 #    -> action="registered"; webUrl/port point at the running server; the existing 1Cv8.1CD is reused as-is.
 ```
 
-Note: the `user`/`password`/`access` connection-credential parameters remain **rejected** for `applicationKind='standaloneServer'` in either mode (a standalone server manages its own infobase and authentication) — this behavior is unchanged.
+### Connection credentials for a standalone server (`mode='register'` only, issue #275)
+
+The `user`/`password`/`access` connection-credential parameters (see "Parameter details" below) are now **accepted** for `applicationKind='standaloneServer'` **with `mode='register'`** — the wrapped infobase already exists and already has users, so storing credentials is meaningful. They are still **rejected** for `applicationKind='standaloneServer'` with `mode='create'` (a brand-new server has no infobase reference to store them against yet — omit them or add the credentials afterwards with `set_infobase_credentials` once the base has users).
+
+Credentials for a registered standalone server are stored against the **application EDT's own launch path resolves** (`ServerApplicationBehaviourDelegate` adapts the `wst-server` application/module to an `InfobaseReference` via `org.eclipse.core.runtime.Adapters`), so they authenticate the SAME update agent a later `debug_launch`/`update_database` starts.
+
+```
+# Register a standalone server over an EXISTING infobase AND store credentials for its 'Admin' user:
+1. create_infobase  projectName="MyProject"  infobaseFile="C:\infobases\ExistingApp"  applicationKind="standaloneServer"  mode="register"  user="Admin"  password="secret"
+#    -> action="registered"; the message confirms the credentials were stored (or, non-fatally, a WARNING if storage failed).
+```
 
 ### Prerequisites and result
 
@@ -63,7 +73,7 @@ Note: the `user`/`password`/`access` connection-credential parameters remain **r
 - **infobaseName** (optional): display name for the infobase in the EDT Infobases view. If omitted, a name is auto-generated.
 - **platform** (optional, `create` only): 1C platform version mask (e.g. `8.3.25`). If omitted, EDT resolves the best available installed version automatically.
 - **setDefault** (boolean, default false): set the infobase as the default application for the project afterwards.
-- **user** / **password** / **access** (optional, #194): store **infobase connection credentials** so a later `update_database` / `debug_launch` can authenticate the update agent against a base with a user list. `access` is `INFOBASE` (default, 1C user auth) or `OS`. Most useful with `mode='register'` (the existing base already has users); for a `mode='create'` base there are no users yet, so the credentials authenticate only once a matching user is added. Use `set_infobase_credentials` to change them later.
+- **user** / **password** / **access** (optional, #194; standalone-server support #275): store **infobase connection credentials** so a later `update_database` / `debug_launch` can authenticate the update agent against a base with a user list. `access` is `INFOBASE` (default, 1C user auth) or `OS`. Accepted for `applicationKind='infobase'` (any mode), and for `applicationKind='standaloneServer'` with `mode='register'` — **rejected** for `applicationKind='standaloneServer'` with `mode='create'` (a brand-new server has no infobase reference to store them against yet). Most useful with `mode='register'` (the existing base already has users); for a `mode='create'` file infobase there are no users yet, so the credentials authenticate only once a matching user is added. Use `set_infobase_credentials` to change them later.
 - **applicationKind** (optional, `infobase` | `standaloneServer`, default `infobase`): see "Application kind" above. The standalone-server path takes no port/publication input — EDT auto-allocates the web port and reports it back as `port`/`webUrl`.
 
 ## Result

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/set_infobase_credentials.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/set_infobase_credentials.md
@@ -1,5 +1,7 @@
 Stores the **infobase connection credentials** (user / password) EDT uses to authenticate the 1C designer agent that runs the pre-launch DB update for `update_database` and `debug_launch`. Needed when the target infobase has a **user list** (issue #194): without stored credentials the agent is started without the infobase user, fails to authenticate, and the platform pops a blocking "Configure Infobase access Settings" dialog that hangs an unattended call.
 
+**Also works for a standalone server (issue #275):** the target application does not have to be a plain file/server infobase (`IInfobaseApplication`) — a `standaloneServer` (`wst-server`) application that wraps an already-registered infobase is supported too. EDT's own launch path for such an application resolves the infobase to authenticate against by ADAPTING the application (or its module) to an `InfobaseReference` (`org.eclipse.core.runtime.Adapters`); this tool stores credentials against that SAME adapted reference, so a later `debug_launch`/`update_database` on the server authenticates with them. An application that is neither an infobase nor an adaptable standalone server is rejected with an actionable error naming the application id.
+
 ## What these credentials are (and are not)
 
 - They select an **EXISTING** infobase user to connect AS — they do **NOT** create infobase users. The user must already exist in the infobase (added via the configurator's Administration → Users, or BSL `ПользователиИнформационнойБазы`).
@@ -48,6 +50,6 @@ While an MCP tool is in flight (plus a short grace window for the asynchronous r
 ## Gotchas
 
 - **The user must exist in the infobase.** Storing credentials for a user that does not exist makes the next connect fail authentication (while a tool is running the MCP server auto-cancels the resulting dialog — see the auto-cancel note above — and the operation fails fast with a hint back to this tool). Add the user first, then set credentials.
-- **`create_infobase` can store credentials too** (its `user`/`password`/`access` parameters) — handy with `mode='register'` (the existing base already has users). For a brand-new `mode='create'` base there are no users yet, so set credentials only after adding a matching user.
+- **`create_infobase` can store credentials too** (its `user`/`password`/`access` parameters) — handy with `mode='register'` (the existing base already has users), including `applicationKind='standaloneServer'` + `mode='register'` (issue #275). For a brand-new `mode='create'` base (file infobase or standalone server) there are no users yet, so set credentials only after adding a matching user — `create_infobase` rejects credentials up front for a newly created standalone server.
 - **Wrong password / wrong user** → `update_database`/`debug_launch` fail fast with "the infobase requires authentication — set the connection credentials with set_infobase_credentials" instead of hanging.
 - These are connection credentials, not a permission grant: the user's rights inside the infobase are unchanged.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
@@ -183,7 +183,10 @@ public class CreateInfobaseTool implements IMcpTool
             + "file infobase with) an autonomous (standalone) server that also exposes a web URL for " //$NON-NLS-1$
             + "HTTP testing (requires a registered 1C standalone-server runtime, " //$NON-NLS-1$
             + "platform >= 8.3.23). FILE type only (server/web rejected). Runs in a background Job " //$NON-NLS-1$
-            + "(up to 120 s). Full parameters and examples: call get_tool_guide('create_infobase')."; //$NON-NLS-1$
+            + "(up to 120 s). user/password/access store connection credentials for " //$NON-NLS-1$
+            + "applicationKind='infobase', and for applicationKind='standaloneServer' with " //$NON-NLS-1$
+            + "mode='register' — rejected for a newly created standalone server " //$NON-NLS-1$
+            + "(mode='create'). Full parameters and examples: call get_tool_guide('create_infobase')."; //$NON-NLS-1$
     }
 
     @Override
@@ -224,14 +227,20 @@ public class CreateInfobaseTool implements IMcpTool
             .stringProperty(KEY_USER,
                 "Infobase connection user to store so update_database / debug_launch can authenticate " //$NON-NLS-1$
                 + "the update agent (issue #194). Selects an EXISTING user; most useful with " //$NON-NLS-1$
-                + "mode='register' (the existing base already has users). Omit to store no credentials.") //$NON-NLS-1$
+                + "mode='register' (the existing base already has users). Omit to store no credentials. " //$NON-NLS-1$
+                + "Accepted for applicationKind='infobase', and for applicationKind='standaloneServer' " //$NON-NLS-1$
+                + "with mode='register'; rejected for a newly created standalone server " //$NON-NLS-1$
+                + "(mode='create').") //$NON-NLS-1$
             .stringProperty("password", //$NON-NLS-1$
-                "Password for 'user'. Optional; default empty (demo bases use an empty password).") //$NON-NLS-1$
+                "Password for 'user'. Optional; default empty (demo bases use an empty password). " //$NON-NLS-1$
+                + "Same applicationKind/mode restriction as 'user'.") //$NON-NLS-1$
             .enumProperty(KEY_ACCESS,
                 "Authentication kind for the stored credentials: 'INFOBASE' (default, 1C user auth) " //$NON-NLS-1$
                 + "or 'OS'. Credentials are stored when ANY of user/password/access is given; " //$NON-NLS-1$
                 + "access='OS' on its own stores OS-authentication settings (no 1C user/password). " //$NON-NLS-1$
-                + "Applies only to applicationKind='infobase' (a file infobase).", //$NON-NLS-1$
+                + "Applies to applicationKind='infobase' (a file infobase), and to " //$NON-NLS-1$
+                + "applicationKind='standaloneServer' with mode='register'; rejected for " //$NON-NLS-1$
+                + "a newly created standalone server (mode='create').", //$NON-NLS-1$
                 "INFOBASE", "OS") //$NON-NLS-1$ //$NON-NLS-2$
             .build();
     }
@@ -322,23 +331,32 @@ public class CreateInfobaseTool implements IMcpTool
         }
         boolean standaloneServer = kind.value;
 
-        // Credentials (#194) target a FILE infobase's access settings; the standalone-server path
-        // manages its own infobase/auth and would silently drop them. Reject up front (before any
-        // workspace/service access) rather than no-op so the caller is not misled.
-        if (standaloneServer && credentials.any())
-        {
-            return ToolResult.error("user/password/access are supported only with " //$NON-NLS-1$
-                + "applicationKind='infobase' (a file infobase). A standalone server manages its " //$NON-NLS-1$
-                + "own infobase and authentication — omit these parameters.").toJson(); //$NON-NLS-1$
-        }
-
-        // Validate mode (default 'create').
+        // Validate mode (default 'create'). Parsed BEFORE the credentials guard below (issue #275
+        // needs to know register to decide whether standaloneServer+credentials is allowed).
         FlagResult mode = parseMode(modeStr);
         if (mode.error != null)
         {
             return mode.error;
         }
         boolean register = mode.value;
+
+        // Credentials (#194) always apply to a FILE infobase's access settings. A newly created
+        // standalone server (mode='create') has no existing infobase reference to store them
+        // against at this point and would silently drop them — reject up front (before any
+        // workspace/service access) rather than no-op. mode='register' wraps an EXISTING file
+        // infobase that already has users, so credentials DO apply there (issue #275): the
+        // read-back wst-server application is adapted to an InfobaseReference via the widened
+        // InfobaseAccessSupport.storeCredentials(IApplication, ...), which is exactly what EDT's
+        // own launch path (ServerApplicationBehaviourDelegate) resolves against later.
+        if (standaloneServer && !register && credentials.any())
+        {
+            return ToolResult.error("user/password/access are supported only with " //$NON-NLS-1$
+                + "applicationKind='infobase' (a file infobase), or with applicationKind=" //$NON-NLS-1$
+                + "'standaloneServer' AND mode='register' (a standalone server wrapping an existing, " //$NON-NLS-1$
+                + "already-registered infobase). A newly created standalone server " //$NON-NLS-1$
+                + "(mode='create') has no existing infobase users yet — omit these parameters or " //$NON-NLS-1$
+                + "use mode='register'.").toJson(); //$NON-NLS-1$
+        }
 
         // Validate and normalize the infobase path early (before acquiring services)
         Path infobaseDir;
@@ -376,9 +394,10 @@ public class CreateInfobaseTool implements IMcpTool
         {
             // mode='create' creates and serves a NEW infobase; mode='register' wraps an EXISTING file
             // infobase (1Cv8.1CD already on disk) with a standalone server — same registration, minus
-            // the database materialization.
+            // the database materialization. credentials (issue #275) are only ever non-empty here
+            // when register==true — the guard above already rejected mode='create'+credentials.
             return createStandaloneServer(projectName, infobaseDir, infobaseName, platform,
-                setDefault, register);
+                setDefault, register, credentials);
         }
 
         return createInfobase(projectName, infobaseDir, infobaseName, platform, setDefault, register,
@@ -952,10 +971,14 @@ public class CreateInfobaseTool implements IMcpTool
      * @param setDefault set the new server as the project's default application after creation
      * @param register {@code true} to wrap an EXISTING file infobase (mode='register'); {@code false} to
      *            create and serve a new one (mode='create')
+     * @param credentials connection credentials to store against the read-back wst-server application
+     *            (issue #275); non-empty only when {@code register} is {@code true} — {@link #execute}
+     *            already rejects credentials with mode='create'
      * @return the tool result JSON
      */
     private String createStandaloneServer(String projectName, Path infobaseDir,
-            String infobaseName, String platform, boolean setDefault, boolean register)
+            String infobaseName, String platform, boolean setDefault, boolean register,
+            Credentials credentials)
     {
         // --- 1-2. Resolve project + services --- (register-path validation ran in execute() already)
         StandaloneContext sctx = resolveStandaloneContext(projectName);
@@ -1085,7 +1108,7 @@ public class CreateInfobaseTool implements IMcpTool
 
         // --- 9. Read back applications and return ---
         ResultContext rc = new ResultContext(projectName, infobaseDir, effectiveName, appManager, project);
-        return buildStandaloneServerResult(rc, actualPort, webUrl, setDefault, register);
+        return buildStandaloneServerResult(rc, actualPort, webUrl, setDefault, register, credentials);
     }
 
     /**
@@ -1868,7 +1891,7 @@ public class CreateInfobaseTool implements IMcpTool
      * the file path to absorb the provision-delegate listener race.
      */
     private static String buildStandaloneServerResult(ResultContext rc, int actualPort, String webUrl,
-            boolean setDefault, boolean register)
+            boolean setDefault, boolean register, Credentials credentials)
     {
         // Read back the applications (bounded re-poll) and locate the just-created wst-server.
         ServerReadBack readBack =
@@ -1905,6 +1928,13 @@ public class CreateInfobaseTool implements IMcpTool
             }
         }
 
+        // Optionally store infobase connection credentials (issue #275): standaloneServer +
+        // mode='register' ONLY — execute() already rejects credentials with mode='create'. Targets
+        // the READ-BACK wst-server IApplication (not the FILE ibRef built earlier for the create
+        // call) — InfobaseAccessSupport.storeCredentials(IApplication, ...) adapts IT to the
+        // InfobaseReference that EDT's own launch path (ServerApplicationBehaviourDelegate) resolves.
+        String credNote = register ? storeStandaloneCredentialsIfRequested(newApp, credentials) : null;
+
         ToolResult result = ToolResult.success()
             .put(McpKeys.ACTION, register ? "registered" : "created") //$NON-NLS-1$ //$NON-NLS-2$
             .put(KEY_APPLICATION_KIND, KIND_STANDALONE_SERVER)
@@ -1928,10 +1958,50 @@ public class CreateInfobaseTool implements IMcpTool
             result.put(McpKeys.APPLICATION_ID, newAppId);
         }
 
+        String combinedNote = (setDefaultNote != null ? setDefaultNote : "") //$NON-NLS-1$
+            + (credNote != null ? credNote : ""); //$NON-NLS-1$
         result.put(McpKeys.MESSAGE, buildStandaloneServerMessage(rc.projectName, rc.infobaseDir,
-            rc.infobaseName, actualPort, webUrl, setDefaultNote, register));
+            rc.infobaseName, actualPort, webUrl, combinedNote.isEmpty() ? null : combinedNote, register));
 
         return result.toJson();
+    }
+
+    /**
+     * Stores infobase connection credentials against the READ-BACK wst-server application (issue
+     * #275) when the caller supplied any of {@code user}/{@code password}/{@code access}, returning
+     * a note to append to the result message — a success note, a non-fatal WARNING when the store
+     * failed (or the application was not visible yet within the read-back poll budget), or
+     * {@code null} when no credentials were requested. Credential storage never fails the
+     * standalone-server registration itself (the server is already registered and bound). Mirrors
+     * {@link #storeCredentialsIfRequested(InfobaseReference, Credentials, boolean)}, the plain
+     * file-infobase equivalent.
+     *
+     * @param application the read-back wst-server application ({@code null} if not found within the
+     *            poll budget)
+     * @param credentials the requested connection credentials (any field may be {@code null}/empty)
+     * @return a message note, or {@code null} when no credentials were requested
+     */
+    private static String storeStandaloneCredentialsIfRequested(IApplication application,
+            Credentials credentials)
+    {
+        if (!credentials.any())
+        {
+            return null;
+        }
+        if (application == null)
+        {
+            return " WARNING: connection credentials were NOT stored: the new standalone-server " //$NON-NLS-1$
+                + "application was not visible yet within the read-back poll budget - retry with " //$NON-NLS-1$
+                + "set_infobase_credentials once it appears in get_applications."; //$NON-NLS-1$
+        }
+        String error = InfobaseAccessSupport.storeCredentials(application, credentials.user, credentials.password,
+            InfobaseAccessSupport.parseAccess(credentials.access));
+        if (error != null)
+        {
+            return " WARNING: connection credentials were NOT stored: " + error; //$NON-NLS-1$
+        }
+        return " Stored connection credentials for user '" + (credentials.user == null ? "" : credentials.user) //$NON-NLS-1$ //$NON-NLS-2$
+            + "' (change them later with set_infobase_credentials)."; //$NON-NLS-1$
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
@@ -139,6 +139,24 @@ public class CreateInfobaseTool implements IMcpTool
     private static final String STANDALONE_SERVER_INFOBASE_CLASS =
         "com.e1c.g5.v8.dt.platform.standaloneserver.wst.core.StandaloneServerInfobase"; //$NON-NLS-1$
 
+    /**
+     * FQN of the create-template file database ({@code FileCreateTemplateDatabase extends FileDatabase
+     * implements ICreateTemplateDatabase}; javap-verified IDENTICAL on EDT 2025.2 and 2026.1, bundle
+     * {@code com.e1c.g5.v8.dt.platform.standaloneserver.core}). Loaded via the LIVE database object's
+     * own classloader (same bundle) — never {@code Class.forName}: this plugin has no dependency on
+     * that bundle. See {@link #ssEnsureCreateTemplateDatabase}.
+     */
+    private static final String CREATE_TEMPLATE_DATABASE_CLASS =
+        "com.e1c.g5.v8.dt.platform.standaloneserver.core.config.FileCreateTemplateDatabase"; //$NON-NLS-1$
+
+    /**
+     * SIMPLE name of the create-template marker interface
+     * ({@code com.e1c.g5.v8.dt.platform.standaloneserver.core.config.ICreateTemplateDatabase}).
+     * {@link #ssIsCreateTemplateDatabase} matches it by simple name so the decision logic is
+     * unit-testable with headless stub interfaces (the platform ships no other type with this name).
+     */
+    private static final String CREATE_TEMPLATE_DATABASE_INTERFACE = "ICreateTemplateDatabase"; //$NON-NLS-1$
+
     /** Symbolic name of the bundle that owns the internal PlatformServicesCore (and its Guice injector). */
     private static final String PLATFORM_SERVICES_CORE_BUNDLE_ID =
         "com._1c.g5.v8.dt.platform.services.core"; //$NON-NLS-1$
@@ -1073,9 +1091,13 @@ public class CreateInfobaseTool implements IMcpTool
     /**
      * Best-effort marks a just-registered {@code StandaloneServerInfobase} module as ALREADY existing
      * for mode='register' — {@code setExist(true)} (mirrors the EDT wizard's existing-infobase branch).
-     * Never called with {@code setCreate(true)}: the served {@code 1Cv8.1CD} already exists on disk, so
-     * no database is materialized. Any reflective failure is logged and swallowed — the WST server
-     * registration already succeeded and must not be failed by a best-effort flag.
+     * Never called with the create-flag setter ({@link #ssSetCreateFlag}): the served {@code 1Cv8.1CD}
+     * already exists on disk, so no database is materialized. {@code setExist} exists only on EDT
+     * 2025.2 — it was REMOVED on 2026.1 with no replacement, so there the reflective {@link #ssInvoke}
+     * call below resolves to a silent no-op (method not found -> returns {@code null}, no exception, no
+     * log) and this method degrades to a harmless no-op. Any OTHER reflective failure (e.g. an actual
+     * invocation error on 2025.2) is logged and swallowed — the WST server registration already
+     * succeeded and must not be failed by a best-effort flag.
      *
      * @param standaloneServerInfobase the module returned by {@link #ssCreateServerWithInfobase}
      */
@@ -1379,12 +1401,22 @@ public class CreateInfobaseTool implements IMcpTool
     /**
      * Physically creates the served file infobase for a standalone server that
      * {@link #ssCreateServerWithInfobase} just registered. That call builds the {@code StandaloneServerInfobase}
-     * with {@code create=false}, so {@code ibcmd infobase create} (which writes {@code 1Cv8.1CD}) never runs and
-     * the server fails to start with "Информационная база не обнаружена". This flips {@code create=true} on the
-     * returned LIVE module — the same flag the EDT new-server wizard sets — and invokes the WST behaviour
-     * delegate's {@code createStandaloneServerInfobase} DIRECTLY (the only place that runs the create, gated by
-     * {@code isCreate()}; verified against EDT 2025.2 bytecode — no start/publish path creates the DB, and
-     * re-adding the module via {@code modifyModules} is blocked by an "already have module" guard).
+     * with the create-new-infobase flag {@code false}, so {@code ibcmd infobase create} (which writes
+     * {@code 1Cv8.1CD}) never runs and the server fails to start with "Информационная база не обнаружена". This
+     * flips that flag to {@code true} on the returned LIVE module — the same flag the EDT new-server wizard sets,
+     * named {@code setCreate} on EDT 2025.2 and renamed (no back-compat alias) to {@code setCreateNewInfobase} on
+     * 2026.1, resolved version-tolerantly by {@link #ssSetCreateFlag} — and invokes the WST behaviour delegate's
+     * {@code createStandaloneServerInfobase} DIRECTLY (the only place that runs the create, gated by the flag's
+     * getter; verified against EDT 2025.2 bytecode — no start/publish path creates the DB, and re-adding the
+     * module via {@code modifyModules} is blocked by an "already have module" guard).
+     *
+     * <p>On 2026.1 there is a SECOND drift layer past the setter rename: {@code createServerWithInfobase}
+     * builds the module config with a PLAIN {@code FileDatabase}, but the behaviour delegate's
+     * {@code createStandaloneServerInfobase} now CASTS the config's database to
+     * {@code ICreateTemplateDatabase} (live error: "FileDatabase cannot be cast to class
+     * ...ICreateTemplateDatabase"). {@link #ssEnsureCreateTemplateDatabase} swaps in a
+     * {@code FileCreateTemplateDatabase} (identical on both versions, harmless on 2025.2 — it IS a
+     * {@code FileDatabase}) before the delegate runs.
      *
      * <p>Runs inside the create Job (with its monitor). Throws on failure so the caller reports an honest
      * error (the server is then registered without a DB; {@code delete_infobase} can clean it up).
@@ -1397,15 +1429,18 @@ public class CreateInfobaseTool implements IMcpTool
             throw new IllegalStateException("createServerWithInfobase returned no infobase handle; " //$NON-NLS-1$
                 + "the served infobase could not be created."); //$NON-NLS-1$
         }
-        // Flip create=true (the flag that gates the physical creation) on the live module. setExist=false
-        // mirrors the EDT wizard's "new infobase" branch and is optional (a no-op if the API lacks it).
-        if (ssMethod(infobase.getClass(), "setCreate", 1) == null) //$NON-NLS-1$
-        {
-            throw new IllegalStateException("StandaloneServerInfobase.setCreate not found — the standalone-" //$NON-NLS-1$
-                + "server API may have changed; the served infobase could not be created."); //$NON-NLS-1$
-        }
-        ssInvoke(infobase, "setCreate", 1, Boolean.TRUE); //$NON-NLS-1$
+        // Flip the create-new-infobase flag to true (the flag that gates the physical creation) on the
+        // live module — version-tolerant name resolution, see ssSetCreateFlag. setExist=false mirrors the
+        // EDT wizard's "new infobase" branch on 2025.2 and stays best-effort/optional: setExist was
+        // REMOVED on 2026.1 with no replacement, and ssInvoke resolves a missing method to a silent
+        // no-op (returns null, no exception, no log) — matching the clean log observed on a live 2026.1
+        // register run.
+        ssSetCreateFlag(infobase, true);
         ssInvoke(infobase, "setExist", 1, Boolean.FALSE); //$NON-NLS-1$
+
+        // 2026.1's behaviour delegate casts the config's database to ICreateTemplateDatabase — make sure
+        // it is one BEFORE invoking the delegate (a no-op when it already is; safe on 2025.2 too).
+        ssEnsureCreateTemplateDatabase(infobase);
 
         // Resolve the WST behaviour delegate for this server and run the (otherwise publish-time) create now.
         Object delegate = ssInvoke(service, "findBehaviourDelegate", 1, server); //$NON-NLS-1$
@@ -1470,6 +1505,186 @@ public class CreateInfobaseTool implements IMcpTool
             }
         }
         return null;
+    }
+
+    /**
+     * First public method on {@code cls} (incl. inherited) matching any of {@code names} (tried in
+     * order) and the given parameter count — a version-tolerant lookup for an API whose method name was
+     * RENAMED across EDT platform versions with no back-compat alias (e.g. {@code setCreate} on 2025.2 /
+     * {@code setCreateNewInfobase} on 2026.1). Returns the first match by name-priority order, or
+     * {@code null} when none of {@code names} resolve. Package-private for direct unit testing with stub
+     * classes exposing one name, the other, or neither.
+     */
+    static Method ssMethodAny(Class<?> cls, int paramCount, String... names)
+    {
+        for (String name : names)
+        {
+            Method m = ssMethod(cls, name, paramCount);
+            if (m != null)
+            {
+                return m;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolves and invokes the version-tolerant "create a new infobase" flag setter on the live
+     * {@code StandaloneServerInfobase} module: {@code setCreate(boolean)} on EDT 2025.2, renamed with no
+     * back-compat alias to {@code setCreateNewInfobase(boolean)} on EDT 2026.1 ({@code isCreate}/
+     * {@code getInfobaseId} renames are the sibling cases of the same 2026.1 API drift — see
+     * {@link StandaloneServerSupport#infobaseIdOf}). Package-private for direct unit testing with stub
+     * classes exposing one name, the other, or neither.
+     *
+     * @param infobase the live {@code StandaloneServerInfobase} module returned by
+     *            {@link #ssCreateServerWithInfobase}
+     * @param value the flag value to set (always {@code true} from {@link #ssMaterializeInfobase})
+     * @throws IllegalStateException when NEITHER setter name resolves — names both tried methods so the
+     *             failure is diagnosable without a javap session
+     */
+    static void ssSetCreateFlag(Object infobase, boolean value) throws Exception
+    {
+        Method setter = ssMethodAny(infobase.getClass(), 1, "setCreate", "setCreateNewInfobase"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (setter == null)
+        {
+            throw new IllegalStateException(
+                "Neither StandaloneServerInfobase.setCreate nor setCreateNewInfobase was found — " //$NON-NLS-1$
+                    + "the standalone-server API may have changed; the served infobase could not be " //$NON-NLS-1$
+                    + "created."); //$NON-NLS-1$
+        }
+        try
+        {
+            setter.invoke(infobase, Boolean.valueOf(value));
+        }
+        catch (java.lang.reflect.InvocationTargetException ite)
+        {
+            Throwable cause = ite.getCause();
+            if (cause instanceof Exception)
+            {
+                throw (Exception)cause;
+            }
+            throw new IllegalStateException(cause != null ? cause : ite);
+        }
+    }
+
+    /**
+     * Ensures the module config's database IS a create-template one before the behaviour delegate runs
+     * the physical create. On EDT 2026.1 {@code createServerWithInfobase} builds the config with a PLAIN
+     * {@code FileDatabase}, but the delegate's {@code createStandaloneServerInfobase} casts the config's
+     * database to {@code ICreateTemplateDatabase} — a live {@code ClassCastException} without this swap.
+     * When needed, a {@code FileCreateTemplateDatabase} (javap-verified identical on 2025.2 and 2026.1;
+     * it {@code extends FileDatabase}, so the swap is harmless on 2025.2 too) is instantiated via the
+     * live database object's OWN classloader (same bundle — never {@code Class.forName}), the directory
+     * is copied across the {@code getConfigDirectory}/{@code getPath} rename
+     * ({@link #ssCopyDatabaseDirectory}), and {@code Config.setDatabase} (present on both versions)
+     * installs it. ONLY the mode='create' materialization path calls this — the register path must
+     * NEVER get a create-template database.
+     *
+     * <p>Decision logic ({@code null} database untouched — the delegate then fails with its own honest
+     * error; already-a-create-template database untouched — the 2025.2-compatible/future-proof path) is
+     * split into the headless-testable {@link #ssIsCreateTemplateDatabase}/{@link #ssCopyDatabaseDirectory};
+     * the bundle class-loading step itself is live-verified only. BEST-EFFORT: any failure is logged and
+     * swallowed — on 2025.2 a plain {@code FileDatabase} still materializes fine (never regress that),
+     * and on 2026.1 the delegate then surfaces its own cast error.
+     *
+     * @param infobase the live {@code StandaloneServerInfobase} module returned by
+     *            {@link #ssCreateServerWithInfobase}
+     */
+    static void ssEnsureCreateTemplateDatabase(Object infobase)
+    {
+        try
+        {
+            Object cfg = ssInvoke(infobase, "getStandaloneServerConfiguration", 0); //$NON-NLS-1$
+            if (cfg == null)
+            {
+                return;
+            }
+            Object db = ssInvoke(cfg, "getDatabase", 0); //$NON-NLS-1$
+            if (db == null)
+            {
+                // Leave as-is: the behaviour delegate fails with its own honest error on a missing DB.
+                return;
+            }
+            if (ssIsCreateTemplateDatabase(db.getClass()))
+            {
+                // Already create-template capable — nothing to do (also future-proof).
+                return;
+            }
+            Class<?> templateClass =
+                db.getClass().getClassLoader().loadClass(CREATE_TEMPLATE_DATABASE_CLASS);
+            Object templateDb = templateClass.getDeclaredConstructor().newInstance();
+            ssCopyDatabaseDirectory(db, templateDb);
+            ssInvoke(cfg, "setDatabase", 1, templateDb); //$NON-NLS-1$
+        }
+        catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+        {
+            Activator.logError("create_infobase: could not swap the standalone-server database to a " //$NON-NLS-1$
+                + "FileCreateTemplateDatabase (best-effort; on 2026.1 the create may fail with an " //$NON-NLS-1$
+                + "ICreateTemplateDatabase cast error)", t); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Whether {@code cls} (or any superclass / (super)interface of it) is the create-template marker
+     * interface {@code ICreateTemplateDatabase} — matched by SIMPLE name (the live FQN is
+     * {@code com.e1c.g5.v8.dt.platform.standaloneserver.core.config.ICreateTemplateDatabase}; the type
+     * is intentionally not imported, so {@code instanceof} is impossible, and the simple-name match
+     * keeps the check unit-testable with stub interfaces). Package-private for direct unit testing.
+     */
+    static boolean ssIsCreateTemplateDatabase(Class<?> cls)
+    {
+        if (cls == null)
+        {
+            return false;
+        }
+        if (cls.isInterface() && CREATE_TEMPLATE_DATABASE_INTERFACE.equals(cls.getSimpleName()))
+        {
+            return true;
+        }
+        for (Class<?> iface : cls.getInterfaces())
+        {
+            if (ssIsCreateTemplateDatabase(iface))
+            {
+                return true;
+            }
+        }
+        return ssIsCreateTemplateDatabase(cls.getSuperclass());
+    }
+
+    /**
+     * Copies the file database's on-disk directory from {@code from} to {@code to}, version-tolerant
+     * across the {@code FileDatabase} 2025.2 -> 2026.1 accessor rename: read via
+     * {@code getConfigDirectory()} (2025.2) OR {@code getPath()} (2026.1), write via
+     * {@code setConfigDirectory(String)} OR {@code setPath(String)} — each side resolved independently
+     * with {@link #ssMethodAny}. A missing accessor on either side, or a {@code null} directory value,
+     * degrades to a no-op (best-effort — the caller already treats the whole swap as best-effort).
+     * Package-private for direct unit testing with stubs exposing either accessor generation.
+     */
+    static void ssCopyDatabaseDirectory(Object from, Object to) throws Exception
+    {
+        Method read = ssMethodAny(from.getClass(), 0, "getConfigDirectory", "getPath"); //$NON-NLS-1$ //$NON-NLS-2$
+        Method write = ssMethodAny(to.getClass(), 1, "setConfigDirectory", "setPath"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (read == null || write == null)
+        {
+            return;
+        }
+        try
+        {
+            Object dir = read.invoke(from);
+            if (dir != null)
+            {
+                write.invoke(to, dir);
+            }
+        }
+        catch (java.lang.reflect.InvocationTargetException ite)
+        {
+            Throwable cause = ite.getCause();
+            if (cause instanceof Exception)
+            {
+                throw (Exception)cause;
+            }
+            throw new IllegalStateException(cause != null ? cause : ite);
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteInfobaseTool.java
@@ -413,22 +413,25 @@ public class DeleteInfobaseTool implements IMcpTool
     /**
      * Destructive-operation consent gate shared by both deletion paths (file infobase + standalone
      * server): builds a {@link ConsentPreview} naming the single target and asks
-     * {@link DestructiveConsentGate}. Returns the ready {@code "Operation declined by user"} error JSON
-     * on REJECT (the caller returns it and mutates nothing), or {@code null} on ALLOW to continue.
-     * Headless / env-bypass / non-ASK never block. This is the LAST check before the deletion.
+     * {@link DestructiveConsentGate}. Returns the ready error JSON on a non-ALLOW verdict (REJECT: the
+     * human declined; TIMEOUT: nobody answered within the gate's bounded wait — see
+     * {@link DestructiveConsentGate#consentDeniedMessage}) — the caller returns it and mutates nothing
+     * — or {@code null} on ALLOW to continue. Headless / env-bypass / non-ASK never block. This is the
+     * LAST check before the deletion.
      *
      * @param targetName the resolved infobase / server display name (the single top-name)
      * @param subtitle a human-readable description of what will be removed
-     * @return the decline error JSON on REJECT, or {@code null} on ALLOW
+     * @return the decline/timeout error JSON on a non-ALLOW verdict, or {@code null} on ALLOW
      */
     private static String checkDestructiveConsent(String targetName, String subtitle)
     {
         ConsentPreview preview = new ConsentPreview("Delete infobase", subtitle, 1, //$NON-NLS-1$
             java.util.Collections.singletonList(targetName));
-        if (DestructiveConsentGate.getInstance().requireConsent(NAME, preview)
-            == DestructiveConsentGate.ConsentDecision.REJECT)
+        DestructiveConsentGate.ConsentDecision consentDecision =
+            DestructiveConsentGate.getInstance().requireConsent(NAME, preview);
+        if (consentDecision != DestructiveConsentGate.ConsentDecision.ALLOW)
         {
-            return ToolResult.error("Operation declined by user").toJson(); //$NON-NLS-1$
+            return ToolResult.error(DestructiveConsentGate.consentDeniedMessage(consentDecision, NAME)).toJson();
         }
         return null;
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteInfobaseTool.java
@@ -819,6 +819,7 @@ public class DeleteInfobaseTool implements IMcpTool
         // and keeps it off the request thread. ---
         final Object finalService = service;
         final Object finalServer = server;
+        final Object finalModule = deletionCtx.module;
         final String finalInfobaseId = infobaseId;
         final boolean doRegistry = deleteRegistration;
         final AtomicReference<IStatus> jobStatus = new AtomicReference<>();
@@ -839,8 +840,8 @@ public class DeleteInfobaseTool implements IMcpTool
                     // means deleteServer did not run/succeed, so the server still exists.
                     if (s != null && s.isOK() && doRegistry)
                     {
-                        jobCleanup.set(
-                            StandaloneServerSupport.removeFromInfobaseRegistry(finalInfobaseId, monitor));
+                        jobCleanup.set(StandaloneServerSupport.removeFromInfobaseRegistry(finalModule,
+                            finalInfobaseId, monitor));
                     }
                 }
                 catch (Exception e)
@@ -946,9 +947,11 @@ public class DeleteInfobaseTool implements IMcpTool
             return ctx;
         }
 
-        // Capture the infobaseId AND the served-DB directory (database.path) BEFORE deletion — the
-        // module/config is torn down by deleteServer. The infobaseId drives the yaml cleanup; the DB
-        // directory is used only when deleteDatabaseFiles=true (deleteServer itself never deletes it).
+        // Capture the module, its infobaseId AND the served-DB directory (database.path) BEFORE
+        // deletion — the module/config is torn down by deleteServer. The module + infobaseId drive the
+        // yaml cleanup (value-identity first, raw-id key fallback — the map key scheme differs per EDT
+        // version, see StandaloneServerSupport.removeFromInfobaseRegistry); the DB directory is used
+        // only when deleteDatabaseFiles=true (deleteServer itself never deletes it).
         Object module = StandaloneServerSupport.moduleOfApplication(targetApp);
         final String infobaseId = module != null ? StandaloneServerSupport.infobaseIdOf(module) : null;
         final String dbDirStr = module != null ? StandaloneServerSupport.databaseDirOf(module) : null;
@@ -960,6 +963,7 @@ public class DeleteInfobaseTool implements IMcpTool
 
         ctx.service = service;
         ctx.server = server;
+        ctx.module = module;
         ctx.infobaseId = infobaseId;
         ctx.dbDir = dbDir;
         ctx.dbSharedWithOthers = dbSharedWithOthers;
@@ -1059,14 +1063,16 @@ public class DeleteInfobaseTool implements IMcpTool
     }
 
     /**
-     * Holder for {@link #resolveDeletionContext}: the resolved service, WST server,
-     * infobaseId, served-DB directory and shared-files guard, or an {@code error} payload
-     * the caller returns as-is.
+     * Holder for {@link #resolveDeletionContext}: the resolved service, WST server, live
+     * {@code StandaloneServerInfobase} module (the value-identity target of the infobases.yaml
+     * cleanup), infobaseId, served-DB directory and shared-files guard, or an {@code error}
+     * payload the caller returns as-is.
      */
     private static class DeletionContext
     {
         Object service;
         Object server;
+        Object module;
         String infobaseId;
         Path dbDir;
         boolean dbSharedWithOthers;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
@@ -303,10 +303,11 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         ConsentPreview preview = new ConsentPreview(
             "Delete metadata node", //$NON-NLS-1$
             subtitle, 1, Collections.singletonList(fqn));
-        if (DestructiveConsentGate.getInstance().requireConsent(NAME, preview)
-            == DestructiveConsentGate.ConsentDecision.REJECT)
+        DestructiveConsentGate.ConsentDecision consentDecision =
+            DestructiveConsentGate.getInstance().requireConsent(NAME, preview);
+        if (consentDecision != DestructiveConsentGate.ConsentDecision.ALLOW)
         {
-            return ToolResult.error("Operation declined by user").toJson(); //$NON-NLS-1$
+            return ToolResult.error(DestructiveConsentGate.consentDeniedMessage(consentDecision, NAME)).toJson();
         }
 
         try

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteProjectTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteProjectTool.java
@@ -138,10 +138,11 @@ public class DeleteProjectTool implements IMcpTool
                 : "This removes project '" + projectName //$NON-NLS-1$
                     + "' from the workspace (files kept on disk).", //$NON-NLS-1$
             1, java.util.Collections.singletonList(projectName));
-        if (DestructiveConsentGate.getInstance().requireConsent(NAME, preview)
-            == DestructiveConsentGate.ConsentDecision.REJECT)
+        DestructiveConsentGate.ConsentDecision consentDecision =
+            DestructiveConsentGate.getInstance().requireConsent(NAME, preview);
+        if (consentDecision != DestructiveConsentGate.ConsentDecision.ALLOW)
         {
-            return ToolResult.error("Operation declined by user").toJson(); //$NON-NLS-1$
+            return ToolResult.error(DestructiveConsentGate.consentDeniedMessage(consentDecision, NAME)).toJson();
         }
 
         try

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -1955,8 +1955,9 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
      *
      * <p>The gate itself decides whether to block on a UI dialog (env / headless / preference-driven — see
      * {@link DestructiveConsentGate}); this method just supplies the object FQN + the retyped features as
-     * the preview. Returns a ready JSON error ({@code "Operation declined by user"}) when the human
-     * REJECTS - the caller returns it and mutates NOTHING - or {@code null} to proceed.</p>
+     * the preview. Returns a ready JSON error when the human REJECTS, or when nobody answers within the
+     * gate's bounded wait (TIMEOUT — see {@link DestructiveConsentGate#consentDeniedMessage}) - the
+     * caller returns it and mutates NOTHING - or {@code null} to proceed.</p>
      */
     private static String consentForTypeChanges(String normFqn, List<PreparedChange> changes)
     {
@@ -1976,9 +1977,10 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             "Change the data type of " + normFqn, //$NON-NLS-1$
             "Retyping stored data can drop existing values on the next database update.", //$NON-NLS-1$
             retyped.size(), retyped);
-        if (DestructiveConsentGate.getInstance().requireConsent(NAME, preview) == ConsentDecision.REJECT)
+        ConsentDecision consentDecision = DestructiveConsentGate.getInstance().requireConsent(NAME, preview);
+        if (consentDecision != ConsentDecision.ALLOW)
         {
-            return ToolResult.error("Operation declined by user").toJson(); //$NON-NLS-1$
+            return ToolResult.error(DestructiveConsentGate.consentDeniedMessage(consentDecision, NAME)).toJson();
         }
         return null;
     }
@@ -1988,8 +1990,9 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
      * when it retypes a form ATTRIBUTE (a {@code type} / {@code valueType} property on an Attribute ref).
      * Scoped to the ATTRIBUTE kind (like the dynamic-list-query branch) so a decoration's benign enum
      * {@code type} never prompts, and run here - not inside the tx callback - because the gate may block
-     * on a UI dialog and a transaction must not be held open across it. Returns a ready JSON error
-     * ({@code "Operation declined by user"}) on REJECT, or {@code null} to proceed.
+     * on a UI dialog and a transaction must not be held open across it. Returns a ready JSON error on
+     * REJECT or TIMEOUT (see {@link DestructiveConsentGate#consentDeniedMessage}), or {@code null} to
+     * proceed.
      */
     private static String consentForFormTypeChange(String normFqn, FormElementWriter.FormMemberRef ref,
         List<JsonObject> properties)
@@ -2016,9 +2019,10 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             "Change the data type of " + normFqn, //$NON-NLS-1$
             "Retyping a form attribute can drop stored values on the next database update.", //$NON-NLS-1$
             1, java.util.Collections.singletonList(PROP_VALUE_TYPE));
-        if (DestructiveConsentGate.getInstance().requireConsent(NAME, preview) == ConsentDecision.REJECT)
+        ConsentDecision consentDecision = DestructiveConsentGate.getInstance().requireConsent(NAME, preview);
+        if (consentDecision != ConsentDecision.ALLOW)
         {
-            return ToolResult.error("Operation declined by user").toJson(); //$NON-NLS-1$
+            return ToolResult.error(DestructiveConsentGate.consentDeniedMessage(consentDecision, NAME)).toJson();
         }
         return null;
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetInfobaseCredentialsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetInfobaseCredentialsTool.java
@@ -37,7 +37,8 @@ import com.e1c.g5.dt.applications.IApplicationManager;
  * Stores the <em>infobase connection credentials</em> (user/password) EDT uses
  * to authenticate the designer agent for {@code update_database} and
  * {@code debug_launch} against an infobase that requires user authentication
- * (issue #194).
+ * (issue #194) — including a standalone-server ({@code wst-server}) application
+ * wrapping an already-registered infobase (issue #275).
  *
  * <p>Without stored credentials the update agent is started without the infobase
  * user and fails to authenticate, popping a blocking "Configure Infobase access
@@ -49,13 +50,14 @@ import com.e1c.g5.dt.applications.IApplicationManager;
  * empty {@code password} is valid.
  *
  * <p><strong>Unattended-safety:</strong> the model work (resolve application -&gt;
- * {@code IInfobaseApplication.getInfobase()} -&gt; {@code IInfobaseAccessManager.updateSettings}
- * -&gt; read-back display name) runs in a bounded background Eclipse Job joined with a short
- * {@link #CREDENTIALS_TIMEOUT_SECONDS}-second timeout — never on the UI thread. Resolving an
- * application can provoke EDT's background application-update-state recompute, which can loop
- * for a long time on an unbounded worker thread; the bounded Job guarantees the call returns.
- * The credentials are recorded as a success the instant {@code updateSettings} commits (before
- * the cosmetic name read-back), so a timeout AFTER the commit still reports success.
+ * {@link InfobaseAccessSupport#storeCredentials(IApplication, String, String, InfobaseAccess)}
+ * -&gt; {@code IInfobaseAccessManager.updateSettings} -&gt; read-back display name) runs in a
+ * bounded background Eclipse Job joined with a short {@link #CREDENTIALS_TIMEOUT_SECONDS}-second
+ * timeout — never on the UI thread. Resolving an application can provoke EDT's background
+ * application-update-state recompute, which can loop for a long time on an unbounded worker
+ * thread; the bounded Job guarantees the call returns. The credentials are recorded as a success
+ * the instant {@code updateSettings} commits (before the cosmetic name read-back), so a timeout
+ * AFTER the commit still reports success.
  */
 public class SetInfobaseCredentialsTool implements IMcpTool
 {
@@ -84,9 +86,11 @@ public class SetInfobaseCredentialsTool implements IMcpTool
     {
         return "Store infobase connection credentials (user/password) so update_database and " //$NON-NLS-1$
             + "debug_launch can authenticate the update agent on an infobase that has a user list " //$NON-NLS-1$
-            + "(issue #194). Selects an EXISTING infobase user (does not create users); an empty " //$NON-NLS-1$
-            + "password is valid (demo bases). Target by launchConfigurationName (preferred) or " //$NON-NLS-1$
-            + "projectName + applicationId (from get_applications). " //$NON-NLS-1$
+            + "(issue #194) — also for a standalone-server application wrapping an already-" //$NON-NLS-1$
+            + "registered infobase (issue #275). Selects an EXISTING infobase user (does not " //$NON-NLS-1$
+            + "create users); an empty password is valid (demo bases). Target by " //$NON-NLS-1$
+            + "launchConfigurationName (preferred) or projectName + applicationId (from " //$NON-NLS-1$
+            + "get_applications). " //$NON-NLS-1$
             + "Full parameters and examples: call get_tool_guide('set_infobase_credentials')."; //$NON-NLS-1$
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/StandaloneServerSupport.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/StandaloneServerSupport.java
@@ -11,8 +11,10 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -222,8 +224,17 @@ final class StandaloneServerSupport
     }
 
     /**
-     * Reflective {@code StandaloneServerInfobase.getInfobaseId().toString()} — the key under which the
-     * entry is stored in infobases.yaml. Returns {@code null} on failure.
+     * Reflective infobase-id read, version-tolerant across the {@code StandaloneServerInfobase}
+     * 2025.2 -> 2026.1 API rename — the key under which the entry is stored in infobases.yaml (a raw
+     * id STRING on both shapes):
+     * <ul>
+     *   <li>2025.2: {@code getInfobaseId(): UUID} — read directly, then {@code toString()}'d.</li>
+     *   <li>2026.1: {@code getInfobaseId()} was REMOVED with no replacement; the raw id instead lives
+     *   at {@code getStandaloneServerConfiguration().getInfobase().getId(): String}, resolved
+     *   null-safely at each hop.</li>
+     * </ul>
+     * Returns {@code null} on failure/absence of BOTH shapes, never throwing; an error is logged only
+     * when neither shape resolved (so a single-shape EDT version never logs spuriously).
      */
     static String infobaseIdOf(Object standaloneServerInfobaseModule)
     {
@@ -233,6 +244,19 @@ final class StandaloneServerSupport
                 .invoke(standaloneServerInfobaseModule);
             return id != null ? id.toString() : null;
         }
+        catch (NoSuchMethodException e)
+        {
+            // 2025.2 shape absent -> try the 2026.1 shape (getInfobaseId() was removed with no
+            // direct replacement; the raw id moved under the standalone-server configuration).
+            String id = infobaseIdViaConfiguration(standaloneServerInfobaseModule);
+            if (id == null)
+            {
+                Activator.logError("delete_infobase: could not read standalone-server infobaseId " //$NON-NLS-1$
+                    + "(neither getInfobaseId() nor getStandaloneServerConfiguration()." //$NON-NLS-1$
+                    + "getInfobase().getId() resolved)", null); //$NON-NLS-1$
+            }
+            return id;
+        }
         catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
         {
             Activator.logError("delete_infobase: could not read standalone-server infobaseId", t); //$NON-NLS-1$
@@ -241,9 +265,40 @@ final class StandaloneServerSupport
     }
 
     /**
+     * 2026.1 fallback shape for {@link #infobaseIdOf}:
+     * {@code getStandaloneServerConfiguration().getInfobase().getId(): String}. Null-safe at each hop;
+     * returns {@code null} on any missing hop or reflective failure (never throws — the caller decides
+     * whether to log).
+     */
+    private static String infobaseIdViaConfiguration(Object standaloneServerInfobaseModule)
+    {
+        try
+        {
+            Object cfg = standaloneServerInfobaseModule.getClass()
+                .getMethod("getStandaloneServerConfiguration").invoke(standaloneServerInfobaseModule); //$NON-NLS-1$
+            if (cfg == null)
+            {
+                return null;
+            }
+            Object infobase = cfg.getClass().getMethod("getInfobase").invoke(cfg); //$NON-NLS-1$
+            if (infobase == null)
+            {
+                return null;
+            }
+            Object id = infobase.getClass().getMethod("getId").invoke(infobase); //$NON-NLS-1$
+            return (id instanceof String) ? (String)id : null;
+        }
+        catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+        {
+            return null;
+        }
+    }
+
+    /**
      * Reflective {@code StandaloneServerInfobase.getStandaloneServerConfiguration().getDatabase()} →, for a
-     * FILE-backed standalone server, {@code FileDatabase.getConfigDirectory()} — the on-disk directory of
-     * the served database (= {@code database.path} in config.yaml = the {@code infobaseFile} that was
+     * FILE-backed standalone server, the on-disk directory of the served database — read via
+     * {@code FileDatabase.getConfigDirectory()} (2025.2) or {@code getPath()} (the 2026.1 rename of the
+     * same accessor) — (= {@code database.path} in config.yaml = the {@code infobaseFile} that was
      * passed to {@code create_infobase}). This is SEPARATE from the {@code Серверы/…-config} folder that
      * {@code deleteServer} removes — {@code deleteServer} never deletes the served database, so this is how
      * {@code deleteDatabaseFiles=true} finds the directory to remove. Must be read BEFORE {@code deleteServer}
@@ -266,20 +321,22 @@ final class StandaloneServerSupport
                 return null;
             }
             // A FILE database (and its create-template subclass FileCreateTemplateDatabase) carries the
-            // on-disk directory in getConfigDirectory(); an RDBMS database has neither that method nor a
-            // local directory. Detect the file kind by the PRESENCE of getConfigDirectory() rather than
-            // by the class name: the type is platform-internal and intentionally not imported (no
-            // Require-Bundle), so instanceof is impossible, and a name match would be fragile.
-            Object dir;
-            try // NOSONAR nested try is intentional (distinct resource/exception scopes)
+            // on-disk directory in getConfigDirectory() (2025.2), renamed to getPath() on 2026.1; an
+            // RDBMS database has neither accessor nor a local directory. Detect the file kind by the
+            // PRESENCE of either accessor rather than by the class name: the type is platform-internal
+            // and intentionally not imported (no Require-Bundle), so instanceof is impossible, and a
+            // name match would be fragile.
+            Method dirGetter = findMethod(db.getClass(), "getConfigDirectory", 0); //$NON-NLS-1$
+            if (dirGetter == null)
             {
-                dir = db.getClass().getMethod("getConfigDirectory").invoke(db); //$NON-NLS-1$
+                dirGetter = findMethod(db.getClass(), "getPath", 0); //$NON-NLS-1$
             }
-            catch (NoSuchMethodException e)
+            if (dirGetter == null)
             {
                 // Not a file-backed database — nothing on the local disk to resolve.
                 return null;
             }
+            Object dir = dirGetter.invoke(db);
             return (dir instanceof String) ? (String)dir : null;
         }
         catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
@@ -340,23 +397,40 @@ final class StandaloneServerSupport
      * Best-effort removal of the orphaned infobases.yaml entry that {@code deleteServer} leaves behind
      * (EDT never removes it — a confirmed platform gap). Reflectively reaches the
      * {@code StandaloneServerInfobaseModuleFactoryDelegate} via the WST module-factory registry, removes
-     * the entry from its in-memory {@code modules} map by {@code infobaseId}, and re-serializes the
-     * remaining entries to infobases.yaml exactly as the delegate's own {@code saveModule} does.
+     * the entry from its in-memory {@code modules} map, and re-serializes the remaining entries to
+     * infobases.yaml exactly as the delegate's own {@code saveModule} does.
+     *
+     * <p><strong>Version-proof removal (issue #273):</strong> the delegate's map KEY scheme differs per
+     * EDT version — 2025.2 keys by the raw {@code getInfobaseId().toString()} uuid (proven live when
+     * this cleanup shipped), while 2026.1 keys by {@code StandaloneServerInfobase.getId()}, a PREFIXED
+     * module-id string built over the raw config id — so a key-based remove by the raw id silently
+     * misses on 2026.1. Guessing key schemes per version is fragile; the primary strategy is therefore
+     * removal BY VALUE ({@link #removeModuleEntries}): (1) reference identity with the passed live
+     * {@code module} (the map holds the same instance), (2) reflective {@code getId()} String equality,
+     * (3) only then the raw-id key fallback that preserves the proven 2025.2 behavior even when the
+     * instance differs.
      *
      * <p>NON-FATAL: any failure is logged and ignored — the server itself is already deleted, the app is
      * gone from {@code get_applications}, and the orphan self-heals on the next workbench start (the
      * delegate's {@code initialize()} drops config-less entries from its map).
      *
+     * @param module the live {@code StandaloneServerInfobase} module of the deleted server (from
+     *            {@link #moduleOfApplication}, read BEFORE deletion); may be {@code null}
+     * @param infobaseId the raw infobase id string (from {@link #infobaseIdOf}) — the 2025.2 map key,
+     *            kept as the final fallback; may be {@code null}
      * @return {@link RegistryCleanup#REMOVED} if a stale entry was removed, {@link RegistryCleanup#NOT_PRESENT}
-     *         when there was nothing to clean (no infobaseId / no matching entry), or
-     *         {@link RegistryCleanup#FAILED} on a reflective failure
+     *         when there was nothing to clean (no matching entry), or {@link RegistryCleanup#FAILED} on
+     *         a reflective failure / when both {@code module} and {@code infobaseId} are {@code null}
+     *         (nothing to target)
      */
-    static RegistryCleanup removeFromInfobaseRegistry(String infobaseId, IProgressMonitor monitor)
+    static RegistryCleanup removeFromInfobaseRegistry(Object module, String infobaseId,
+        IProgressMonitor monitor)
     {
-        if (infobaseId == null)
+        if (module == null && infobaseId == null)
         {
-            // We could not read the infobaseId, so we cannot target the entry — report FAILED (honest:
-            // "could not clean, self-heals on restart") rather than implying there was nothing to clean.
+            // We could resolve neither the module nor its raw id, so we cannot target the entry —
+            // report FAILED (honest: "could not clean, self-heals on restart") rather than implying
+            // there was nothing to clean.
             return RegistryCleanup.FAILED;
         }
         try
@@ -410,7 +484,7 @@ final class StandaloneServerSupport
             {
                 return RegistryCleanup.FAILED;
             }
-            if (modules.remove(infobaseId) == null)
+            if (removeModuleEntries(modules, module, infobaseId) == 0)
             {
                 // Already gone (e.g. the delegate's initialize() self-healed it) — not an error.
                 return RegistryCleanup.NOT_PRESENT;
@@ -429,6 +503,91 @@ final class StandaloneServerSupport
             Activator.logError("delete_infobase: best-effort infobases.yaml cleanup failed " //$NON-NLS-1$
                 + "(non-fatal — the server is deleted; the orphan self-heals on restart)", t); //$NON-NLS-1$
             return RegistryCleanup.FAILED;
+        }
+    }
+
+    /**
+     * The map surgery of {@link #removeFromInfobaseRegistry}, extracted as a pure (headless-testable)
+     * decision: removes the deleted server's entry/entries from the delegate's {@code modules} map and
+     * returns how many were removed. Three strategies, tried in order (each only when the previous
+     * removed nothing) because the map's KEY scheme differs per EDT version (2025.2 = raw uuid string,
+     * 2026.1 = the prefixed {@code getId()} module-id string):
+     * <ol>
+     *   <li>VALUE reference identity with {@code module} — version-proof: the live map holds the very
+     *   instance {@link #moduleOfApplication} returned, whatever the key scheme;</li>
+     *   <li>value {@code getId()} String equality with {@code module}'s own reflective {@code getId()}
+     *   — catches a re-created (non-identical) instance for the same module id;</li>
+     *   <li>key-based {@code remove(infobaseId)} — the original raw-id removal, preserving the proven
+     *   2025.2 behavior even when the instance differs and {@code getId()} is unavailable.</li>
+     * </ol>
+     *
+     * @param modules the delegate's live modules map (never {@code null})
+     * @param module the deleted server's module instance; may be {@code null} (strategies 1-2 skipped)
+     * @param infobaseId the raw infobase id (the 2025.2 key); may be {@code null} (strategy 3 skipped)
+     * @return the number of entries removed (0 = nothing matched)
+     */
+    static int removeModuleEntries(Map<Object, Object> modules, Object module, String infobaseId)
+    {
+        int removed = 0;
+        if (module != null)
+        {
+            removed = removeByValue(modules, value -> value == module);
+        }
+        if (removed == 0 && module != null)
+        {
+            String moduleId = idOf(module);
+            if (moduleId != null)
+            {
+                removed = removeByValue(modules, value -> moduleId.equals(idOf(value)));
+            }
+        }
+        if (removed == 0 && infobaseId != null && modules.remove(infobaseId) != null)
+        {
+            removed = 1;
+        }
+        return removed;
+    }
+
+    /** Removes every map entry whose VALUE matches the predicate; returns the removed count. */
+    private static int removeByValue(Map<Object, Object> modules, Predicate<Object> valueMatches)
+    {
+        int removed = 0;
+        for (Iterator<Map.Entry<Object, Object>> it = modules.entrySet().iterator(); it.hasNext();)
+        {
+            if (valueMatches.test(it.next().getValue()))
+            {
+                it.remove();
+                removed++;
+            }
+        }
+        return removed;
+    }
+
+    /**
+     * Reflective {@code getId()} of a registry module as a String (on 2026.1 this is the delegate's
+     * map key — the prefixed module-id). Returns {@code null} when the object is {@code null}, the
+     * method is absent (possible on older versions) or the read fails — the caller then just skips the
+     * id-equality strategy.
+     */
+    private static String idOf(Object module)
+    {
+        if (module == null)
+        {
+            return null;
+        }
+        try
+        {
+            Method m = findMethod(module.getClass(), "getId", 0); //$NON-NLS-1$
+            if (m == null)
+            {
+                return null;
+            }
+            Object id = m.invoke(module);
+            return id != null ? id.toString() : null;
+        }
+        catch (Throwable t) // NOSONAR deliberate catch-all at a reflective/best-effort boundary
+        {
+            return null;
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
@@ -301,10 +301,11 @@ public class UpdateDatabaseTool implements IMcpTool
                     + " configuration update to the database of application '" + application.getName() //$NON-NLS-1$
                     + "' (project " + projectName + "). This mutates the infobase and is irreversible.", //$NON-NLS-1$ //$NON-NLS-2$
                 1, java.util.Collections.singletonList(application.getName()));
-            if (DestructiveConsentGate.getInstance().requireConsent(NAME, consentPreview)
-                == DestructiveConsentGate.ConsentDecision.REJECT)
+            DestructiveConsentGate.ConsentDecision consentDecision =
+                DestructiveConsentGate.getInstance().requireConsent(NAME, consentPreview);
+            if (consentDecision != DestructiveConsentGate.ConsentDecision.ALLOW)
             {
-                return ToolResult.error("Operation declined by user").toJson(); //$NON-NLS-1$
+                return ToolResult.error(DestructiveConsentGate.consentDeniedMessage(consentDecision, NAME)).toJson();
             }
 
             // Create execution context with the active Shell so EDT can parent

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/rename/MetadataRenameService.java
@@ -1692,10 +1692,13 @@ public class MetadataRenameService
         // DestructiveConsentGate.GATED_TOOLS, asserted by DestructiveConsentGateTest) rather than
         // read from RenameMetadataObjectTool.NAME, so this domain service in tools.rename does not
         // take a reverse dependency on the tool adapter in tools.impl.
-        if (DestructiveConsentGate.getInstance().requireConsent("rename_metadata_object", preview) //$NON-NLS-1$
-            == DestructiveConsentGate.ConsentDecision.REJECT)
+        DestructiveConsentGate.ConsentDecision consentDecision =
+            DestructiveConsentGate.getInstance().requireConsent("rename_metadata_object", preview); //$NON-NLS-1$
+        if (consentDecision != DestructiveConsentGate.ConsentDecision.ALLOW)
         {
-            return ToolResult.error("Operation declined by user").toJson(); //$NON-NLS-1$
+            return ToolResult.error(
+                DestructiveConsentGate.consentDeniedMessage(consentDecision, "rename_metadata_object")) //$NON-NLS-1$
+                .toJson();
         }
 
         // Apply disableIndices by traversing items and their native changes

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGate.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGate.java
@@ -8,7 +8,9 @@ package com.ditrix.edt.mcp.server.utils;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.swt.SWTException;
@@ -17,6 +19,7 @@ import org.eclipse.swt.widgets.Shell;
 
 import com.ditrix.edt.mcp.server.Activator;
 import com.ditrix.edt.mcp.server.preferences.ConsentSettingsService;
+import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.ui.DestructiveConsentDialog;
 
 /**
@@ -45,18 +48,34 @@ import com.ditrix.edt.mcp.server.ui.DestructiveConsentDialog;
  *       {@code ALLOW_ALL} → allow; {@code PER_TOOL} + the tool is in the allow-set →
  *       allow; otherwise ({@code ASK_ALWAYS}, or {@code PER_TOOL} + not allowed) →
  *       prompt.</li>
- *   <li><b>Dialog</b>: open {@link DestructiveConsentDialog} and BLOCK. Allow = OK,
- *       Reject = CANCEL, "Allow for session" adds the tool to the session set. When
- *       already on the UI thread ({@code Display.getCurrent() != null}) open directly;
- *       otherwise {@code display.syncExec} capturing the choice in an
- *       {@link AtomicInteger} (the {@code AbstractMetadataWriteTool} syncExec idiom).</li>
+ *   <li><b>Dialog</b>: open {@link DestructiveConsentDialog}, time-bounded to
+ *       {@link #CONSENT_PROMPT_TIMEOUT_SECONDS} on BOTH threading paths. Allow = OK,
+ *       Reject = CANCEL, "Allow for session" adds the tool to the session set.
+ *       Already on the UI thread ({@code Display.getCurrent() != null}) — the NORMAL
+ *       path for the gated tools whose whole {@code execute()} is marshalled onto the
+ *       UI thread before the gate is ever reached ({@code delete_metadata} /
+ *       {@code modify_metadata} via {@code AbstractMetadataWriteTool}'s
+ *       {@code syncExec}, {@code rename_metadata_object} via its own) — the dialog
+ *       opens directly and a pre-scheduled {@link Display#timerExec} closer fires
+ *       inside {@code open()}'s nested event loop to auto-close it on timeout
+ *       ({@link #promptOnUiThread}). Otherwise (an MCP worker thread —
+ *       {@code delete_project} / {@code delete_infobase} / {@code update_database}
+ *       call the gate straight from the worker) the dialog is opened via
+ *       {@code display.asyncExec} (NOT {@code syncExec}, so the UI thread is never
+ *       blocked waiting on the worker) and the worker awaits a decision up to the
+ *       timeout ({@link #promptWithTimeout}). Both paths race through the same
+ *       decide-once {@link ConsentArbiter}: whichever side decides first wins; on a
+ *       timeout win the verdict is {@link ConsentDecision#TIMEOUT} and the dialog
+ *       shell is closed (best-effort) so it does not linger.</li>
  * </ol>
  *
- * <p><b>Invariant:</b> the gate NEVER blocks in a headless / env-bypass / non-ASK
- * (level-2/session/per-tool-allowed) path; it {@code syncExec}s ONLY with a live
- * display and a live shell; it does not deadlock when already on the UI thread; and
- * a {@link ConsentDecision#REJECT} mutates nothing (it only returns the decision, and
- * the caller turns it into an error).
+ * <p><b>Invariant:</b> the gate NEVER blocks indefinitely in EITHER dialog path — it
+ * waits at most {@link #CONSENT_PROMPT_TIMEOUT_SECONDS} (issue #277); it NEVER blocks
+ * at all in a headless / env-bypass / non-ASK (level-2/session/per-tool-allowed)
+ * path; it does not deadlock when already on the UI thread; and a non-
+ * {@link ConsentDecision#ALLOW} verdict ({@link ConsentDecision#REJECT} or
+ * {@link ConsentDecision#TIMEOUT}) mutates nothing (it only returns the decision, and
+ * the caller turns it into an error via {@link #consentDeniedMessage(ConsentDecision, String)}).
  */
 public final class DestructiveConsentGate // NOSONAR intentional singleton (Eclipse service / getInstance); a single instance is by design
 {
@@ -71,6 +90,19 @@ public final class DestructiveConsentGate // NOSONAR intentional singleton (Ecli
 
     /** The env value that forces allow. */
     private static final String ENV_VALUE_ALLOW = "allow"; //$NON-NLS-1$
+
+    /**
+     * How long the gate waits for a human to answer the consent dialog before
+     * auto-rejecting with {@link ConsentDecision#TIMEOUT} — on both prompt paths (the
+     * worker's latch await in {@link #promptWithTimeout} and the {@code timerExec}
+     * closer in {@link #promptOnUiThread}). Chosen below common MCP client request
+     * budgets (many default around 300 s) so the caller gets an actionable timeout
+     * error instead of its OWN transport timing out first, while still long enough
+     * for a human actually at the keyboard to read the preview and click a button.
+     * See issue #277: before this bound, an unanswered dialog blocked the MCP call
+     * indefinitely.
+     */
+    static final int CONSENT_PROMPT_TIMEOUT_SECONDS = 120;
 
     /**
      * Custom JFace button id for the dialog's "Allow for session" button (mirrors
@@ -127,7 +159,16 @@ public final class DestructiveConsentGate // NOSONAR intentional singleton (Ecli
         /** Proceed with the mutation. */
         ALLOW,
         /** The user declined — the caller returns an error and mutates nothing. */
-        REJECT
+        REJECT,
+        /**
+         * Nobody answered the dialog within
+         * {@link DestructiveConsentGate#CONSENT_PROMPT_TIMEOUT_SECONDS} — a
+         * REJECT-like verdict (the caller returns an error and mutates nothing) but
+         * with its own actionable error text built by
+         * {@link DestructiveConsentGate#consentDeniedMessage(ConsentDecision, String)},
+         * distinct from a human's explicit {@link #REJECT}.
+         */
+        TIMEOUT
     }
 
     /**
@@ -188,6 +229,37 @@ public final class DestructiveConsentGate // NOSONAR intentional singleton (Ecli
     }
 
     /**
+     * Builds the {@link ToolResult#error(String)} text for a non-{@link ConsentDecision#ALLOW}
+     * verdict from {@link #requireConsent}. Called at each gated tool's confirm-point in
+     * place of the previously-inlined literal, so both texts live in one place:
+     * {@link ConsentDecision#REJECT} keeps the original, unchanged
+     * {@code "Operation declined by user"} text; {@link ConsentDecision#TIMEOUT} gets
+     * its own actionable text naming the tool, the {@link #CONSENT_PROMPT_TIMEOUT_SECONDS}
+     * budget and the three remedies (allow via Preferences, the
+     * {@link #ENV_DESTRUCTIVE_CONSENT} launch bypass, or re-running and answering
+     * promptly) so an unattended caller can self-diagnose instead of retrying blind
+     * against the same wall.
+     *
+     * @param decision the verdict from {@link #requireConsent}; must not be
+     *            {@link ConsentDecision#ALLOW}
+     * @param toolName the gated tool's name, echoed into the {@code TIMEOUT} text
+     * @return the ready {@link ToolResult#error(String)} message text
+     */
+    public static String consentDeniedMessage(ConsentDecision decision, String toolName)
+    {
+        if (decision == ConsentDecision.TIMEOUT)
+        {
+            return "Destructive operation '" + toolName + "' was not confirmed within " //$NON-NLS-1$ //$NON-NLS-2$
+                + CONSENT_PROMPT_TIMEOUT_SECONDS + " s at the EDT workbench, so it was auto-rejected " //$NON-NLS-1$
+                + "and nothing was changed. To proceed: (1) Preferences -> MCP Server -> Destructive " //$NON-NLS-1$
+                + "operations, set 'Allow all' or allow '" + toolName + "' per-tool; (2) set " //$NON-NLS-1$ //$NON-NLS-2$
+                + ENV_DESTRUCTIVE_CONSENT + "=allow on the EDT process at launch for unattended runs; " //$NON-NLS-1$
+                + "or (3) re-run the call and answer the confirmation dialog promptly."; //$NON-NLS-1$
+        }
+        return "Operation declined by user"; //$NON-NLS-1$
+    }
+
+    /**
      * The pure decision core (steps 3-5): given the already-resolved session-allow
      * flag, the preference {@link ConsentSettingsService.Level} and the per-tool
      * allow flag, decides whether to allow outright or to prompt. Contains NO SWT and
@@ -244,59 +316,259 @@ public final class DestructiveConsentGate // NOSONAR intentional singleton (Ecli
     }
 
     /**
-     * Opens {@link DestructiveConsentDialog} on the live UI session and blocks until
-     * the user answers. Runs directly when already on the UI thread; otherwise
-     * {@code display.syncExec} captures the raw button id in an {@link AtomicInteger}
-     * (the {@code AbstractMetadataWriteTool} syncExec idiom), so the MCP worker thread
-     * blocks exactly until the human responds. Maps the button id to a decision and,
-     * for "Allow for session", records the tool in {@link #sessionAllow}.
+     * Opens {@link DestructiveConsentDialog} on the live UI session, time-bounded on
+     * BOTH threading paths (issue #277):
+     * <ul>
+     *   <li><b>already on the UI thread</b> — the NORMAL path for
+     *       {@code delete_metadata}, {@code modify_metadata} and
+     *       {@code rename_metadata_object}, whose whole {@code execute()} is
+     *       marshalled onto the UI thread ({@code AbstractMetadataWriteTool}'s
+     *       {@code syncExec} / {@code RenameMetadataObjectTool}'s own) before the
+     *       gate is ever reached, NOT just a safety net — which is exactly why it
+     *       needs its own bound: there is no separate worker thread to time out
+     *       against, so {@link #promptOnUiThread} bounds it with a
+     *       {@link Display#timerExec} closer instead;</li>
+     *   <li><b>a worker thread</b> — {@code delete_project} / {@code delete_infobase}
+     *       / {@code update_database} call the gate straight from the MCP worker —
+     *       bounded by {@link #promptWithTimeout}'s latch await.</li>
+     * </ul>
      */
     private ConsentDecision promptForConsent(String toolName, ConsentPreview preview, Display display,
         Shell shell)
     {
-        final AtomicInteger returnCode = new AtomicInteger(IDialogConstants.CANCEL_ID);
-        Runnable openDialog = () -> {
-            DestructiveConsentDialog dialog = new DestructiveConsentDialog(shell, toolName, preview);
-            returnCode.set(dialog.open());
-        };
         if (Display.getCurrent() != null)
         {
-            openDialog.run();
-        }
-        else
-        {
-            // Shutdown race: the display was live when requireConsent checked it, but the workbench
-            // can close before this syncExec runs. A disposed display makes syncExec throw
-            // SWTException; rather than fail a destructive tool with that, fall back to the documented
-            // headless ALLOW (mirrors the neighbouring SWT auto-confirmer). See #222 review.
-            if (display.isDisposed())
-            {
-                return allowOnDisposedDisplay(toolName);
-            }
-            try
-            {
-                display.syncExec(openDialog);
-            }
-            catch (SWTException e) // NOSONAR a workbench shutdown mid-call disposes the display -> allow (headless fallback), never fail the tool
-            {
-                return allowOnDisposedDisplay(toolName);
-            }
+            return promptOnUiThread(toolName, preview, display, shell);
         }
 
-        int code = returnCode.get();
-        if (code == ALLOW_FOR_SESSION_ID)
+        // Shutdown race: the display was live when requireConsent checked it, but the workbench can
+        // close before asyncExec runs. A disposed display makes asyncExec throw SWTException; rather
+        // than fail a destructive tool with that, fall back to the documented headless ALLOW (mirrors
+        // the neighbouring SWT auto-confirmer). See #222 review.
+        if (display.isDisposed())
+        {
+            return allowOnDisposedDisplay(toolName);
+        }
+        return promptWithTimeout(toolName, preview, display, shell);
+    }
+
+    /**
+     * The bounded UI-thread prompt (issue #277): schedules a {@link Display#timerExec}
+     * closer for {@link #CONSENT_PROMPT_TIMEOUT_SECONDS} BEFORE opening the dialog,
+     * then opens it and blocks in {@code open()}'s nested {@code readAndDispatch}
+     * loop. That nested loop DOES dispatch {@code timerExec} runnables, so the closer
+     * fires INSIDE {@code open()}: it publishes {@link ConsentDecision#TIMEOUT}
+     * through the decide-once {@link ConsentArbiter} (a no-op if the human already
+     * answered) and closes the dialog shell, which unblocks {@code open()}.
+     *
+     * <p>NB: a forced {@code Dialog.close()} does NOT set a CANCEL return code —
+     * JFace {@code Window.returnCode} defaults to {@code OK} — so the post-open code
+     * must NOT trust the return code alone. It maps the outcome through the arbiter
+     * instead: {@link #recordDialogAnswer} submits the code-derived candidate, which
+     * LOSES to an already-published TIMEOUT (and still records a late "Allow for
+     * session"); the arbiter's decision is what is returned.
+     *
+     * <p>When the human answers first, the still-pending closer is cancelled by
+     * re-scheduling it with a negative delay ({@code timerExec(-1, closer)} — SWT's
+     * documented cancel idiom). If the closer already fired, that call is a harmless
+     * no-op, and the arbiter guard makes a late closer harmless in every other
+     * interleaving too — the cancel is an optimisation, not a correctness need.
+     */
+    private ConsentDecision promptOnUiThread(String toolName, ConsentPreview preview, Display display,
+        Shell shell)
+    {
+        ConsentArbiter arbiter = new ConsentArbiter();
+        DestructiveConsentDialog dialog = new DestructiveConsentDialog(shell, toolName, preview);
+        Runnable closer = () -> {
+            if (arbiter.tryDecide(ConsentDecision.TIMEOUT))
+            {
+                logTimeoutWin(toolName);
+                closeOnUiThread(dialog);
+            }
+        };
+        display.timerExec((int)TimeUnit.SECONDS.toMillis(CONSENT_PROMPT_TIMEOUT_SECONDS), closer);
+        int code = dialog.open();
+        // Cancel the closer if it is still pending (negative delay = SWT's cancel idiom);
+        // harmless when it already fired or the display is shutting down.
+        try
+        {
+            display.timerExec(-1, closer);
+        }
+        catch (SWTException e) // NOSONAR display disposed while the dialog was up -> nothing left to cancel
+        {
+            // No-op: the workbench is shutting down; the arbiter guard already covers the late closer.
+        }
+        recordDialogAnswer(arbiter, toolName, code);
+        return arbiter.peek();
+    }
+
+    /**
+     * The bounded-wait MCP-worker path (issue #277): opens {@link DestructiveConsentDialog}
+     * via {@code display.asyncExec} (never {@code syncExec} — the UI thread must stay
+     * free to keep pumping its event loop while this thread waits) and blocks the
+     * CALLING (worker) thread on a {@link ConsentArbiter} for at most
+     * {@link #CONSENT_PROMPT_TIMEOUT_SECONDS}. The dialog's eventual answer (UI thread,
+     * inside the async runnable, mapped by {@link #recordDialogAnswer}) and this
+     * method's timeout (worker thread) race to decide first via
+     * {@link ConsentArbiter#tryDecide}; whichever side wins is final, the other is
+     * ignored — EXCEPT "Allow for session", which {@link #recordDialogAnswer} records
+     * into {@link #sessionAllow} unconditionally, even when the dialog answers after
+     * the timeout already won (a human who eventually clicks it should not be
+     * re-prompted on the next call). On a worker-side timeout win, the dialog shell is
+     * closed best-effort so it does not linger answering nobody.
+     */
+    private ConsentDecision promptWithTimeout(String toolName, ConsentPreview preview, Display display,
+        Shell shell)
+    {
+        ConsentArbiter arbiter = new ConsentArbiter();
+        AtomicReference<DestructiveConsentDialog> dialogRef = new AtomicReference<>();
+        Runnable openDialog = () -> {
+            if (shell.isDisposed())
+            {
+                return;
+            }
+            DestructiveConsentDialog dialog = new DestructiveConsentDialog(shell, toolName, preview);
+            // create() BEFORE open() so dialogRef is populated before open()'s blocking nested event
+            // loop starts — a close request queued while that loop is pumping is what lets the
+            // worker's timeout close the shell (see closeDialogIfOpen).
+            dialog.create();
+            dialogRef.set(dialog);
+            int code = dialog.open();
+            recordDialogAnswer(arbiter, toolName, code);
+        };
+        try
+        {
+            display.asyncExec(openDialog);
+        }
+        catch (SWTException e) // NOSONAR display disposed in the gap between the check above and this call -> allow (headless fallback)
+        {
+            return allowOnDisposedDisplay(toolName);
+        }
+
+        boolean decidedInTime;
+        try
+        {
+            decidedInTime = arbiter.await(CONSENT_PROMPT_TIMEOUT_SECONDS);
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            decidedInTime = false;
+        }
+        if (decidedInTime)
+        {
+            return arbiter.peek();
+        }
+
+        // The wait elapsed with no answer recorded yet. Publish the timeout verdict; tryDecide is a
+        // CAS, so if the dialog answers in this same instant exactly one side wins.
+        if (arbiter.tryDecide(ConsentDecision.TIMEOUT))
+        {
+            logTimeoutWin(toolName);
+            closeDialogIfOpen(display, dialogRef.get());
+            return ConsentDecision.TIMEOUT;
+        }
+        // Lost the race: the dialog answered right as the wait elapsed.
+        return arbiter.peek();
+    }
+
+    /**
+     * The single post-dialog mapper for BOTH prompt paths (worker-thread
+     * {@link #promptWithTimeout} and UI-thread {@link #promptOnUiThread}): maps the
+     * JFace button {@code code} to a candidate decision and submits it to
+     * {@code arbiter}. "Allow for session" is recorded into {@link #sessionAllow}
+     * UNCONDITIONALLY — even when {@code arbiter.tryDecide} loses (the timeout
+     * already won) — so a human who eventually clicks it is not re-prompted on the
+     * next call. Takes no SWT types, so this exact behaviour (particularly the
+     * unconditional session recording and the candidate losing to an
+     * already-published TIMEOUT) is headlessly unit-testable without a live
+     * {@link Display}.
+     *
+     * @param arbiter the race arbiter for this dialog invocation
+     * @param toolName the gated tool's name, for logging/session-recording
+     * @param code the JFace button id the dialog closed with (NB: after a forced
+     *            timeout close this is JFace's default {@code OK} — the arbiter, not
+     *            the code, carries the real verdict)
+     */
+    void recordDialogAnswer(ConsentArbiter arbiter, String toolName, int code)
+    {
+        boolean sessionButton = code == ALLOW_FOR_SESSION_ID;
+        ConsentDecision candidate =
+            sessionButton || code == IDialogConstants.OK_ID ? ConsentDecision.ALLOW : ConsentDecision.REJECT;
+        if (sessionButton)
         {
             sessionAllow.add(toolName);
             Activator.logInfo("Destructive-consent gate: user allowed '" + toolName //$NON-NLS-1$
                 + "' for the rest of this EDT session."); //$NON-NLS-1$
-            return ConsentDecision.ALLOW;
         }
-        if (code == IDialogConstants.OK_ID)
+        if (arbiter.tryDecide(candidate) && candidate == ConsentDecision.REJECT)
         {
-            return ConsentDecision.ALLOW;
+            Activator.logInfo("Destructive-consent gate: user declined '" + toolName + "'."); //$NON-NLS-1$ //$NON-NLS-2$
         }
-        Activator.logInfo("Destructive-consent gate: user declined '" + toolName + "'."); //$NON-NLS-1$ //$NON-NLS-2$
-        return ConsentDecision.REJECT;
+    }
+
+    /**
+     * Best-effort close of a timed-out dialog from the WORKER thread: asks the UI
+     * thread (via {@code asyncExec}, never blocking the caller) to run
+     * {@link #closeOnUiThread(DestructiveConsentDialog)}. Never throws — a workbench
+     * shutdown racing this close is not a reason to fail the timeout verdict that
+     * already won.
+     *
+     * @param display the workbench display
+     * @param dialog the dialog instance captured by {@link #promptWithTimeout}, or
+     *            {@code null} if the async open never ran
+     */
+    private static void closeDialogIfOpen(Display display, DestructiveConsentDialog dialog)
+    {
+        if (dialog == null)
+        {
+            return;
+        }
+        try
+        {
+            display.asyncExec(() -> closeOnUiThread(dialog));
+        }
+        catch (SWTException e) // NOSONAR display disposed meanwhile -> nothing left to close
+        {
+            // No-op: the workbench is shutting down, so the shell is gone regardless.
+        }
+    }
+
+    /**
+     * Closes the dialog if its shell is still open. MUST run on the UI thread (called
+     * directly by {@link #promptOnUiThread}'s timer closer, and inside
+     * {@link #closeDialogIfOpen}'s {@code asyncExec} for the worker path). Guards
+     * every disposal step and never throws — closing an already-decided timed-out
+     * dialog is best-effort only.
+     *
+     * @param dialog the dialog to close (never {@code null})
+     */
+    private static void closeOnUiThread(DestructiveConsentDialog dialog)
+    {
+        try
+        {
+            Shell dialogShell = dialog.getShell();
+            if (dialogShell != null && !dialogShell.isDisposed())
+            {
+                dialog.close();
+            }
+        }
+        catch (SWTException e) // NOSONAR best-effort close of an already-decided timeout; never fail
+        {
+            Activator.logInfo(
+                "Destructive-consent gate: could not close the timed-out dialog shell (already closing)."); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Logs the timeout-win line shared by both prompt paths.
+     *
+     * @param toolName the gated tool that timed out
+     */
+    private static void logTimeoutWin(String toolName)
+    {
+        Activator.logInfo("Destructive-consent gate: '" + toolName + "' timed out after " //$NON-NLS-1$ //$NON-NLS-2$
+            + CONSENT_PROMPT_TIMEOUT_SECONDS + " s waiting for a human to confirm; auto-rejecting."); //$NON-NLS-1$
     }
 
     /**
@@ -347,5 +619,66 @@ public final class DestructiveConsentGate // NOSONAR intentional singleton (Ecli
     void clearSessionAllow()
     {
         sessionAllow.clear();
+    }
+
+    /**
+     * The decide-once arbiter shared by both prompt paths: the dialog's eventual
+     * answer races the timeout to decide the verdict for one dialog invocation. On
+     * the worker path ({@link #promptWithTimeout}) the two sides run on different
+     * threads (dialog on UI, timeout on the worker); on the UI-thread path
+     * ({@link #promptOnUiThread}) both run sequentially on the UI thread (the
+     * {@code timerExec} closer fires inside {@code open()}'s nested event loop).
+     * Either way, whichever side calls {@link #tryDecide} FIRST wins — its value
+     * becomes the permanent decision, and every later call (from either side, in
+     * either order) is a no-op. Package-private, holds no SWT or gate state, so the
+     * race itself is unit-testable headlessly without a live {@link Display}.
+     */
+    static final class ConsentArbiter
+    {
+        private final AtomicReference<ConsentDecision> decision = new AtomicReference<>();
+
+        private final CountDownLatch latch = new CountDownLatch(1);
+
+        /**
+         * Attempts to record the final decision. The first call across both threads
+         * wins and releases {@link #await(long)}; every subsequent call is a no-op.
+         *
+         * @param candidate the decision this side wants to record (never {@code null})
+         * @return {@code true} if this call won the race and set the decision,
+         *         {@code false} if another call already decided first
+         */
+        boolean tryDecide(ConsentDecision candidate)
+        {
+            boolean won = decision.compareAndSet(null, candidate);
+            if (won)
+            {
+                latch.countDown();
+            }
+            return won;
+        }
+
+        /**
+         * @return the recorded decision, or {@code null} if {@link #tryDecide} has not
+         *         been called (successfully) yet
+         */
+        ConsentDecision peek()
+        {
+            return decision.get();
+        }
+
+        /**
+         * Blocks the calling thread until a decision is recorded or the timeout
+         * elapses, whichever comes first.
+         *
+         * @param timeoutSeconds how long to wait, in seconds
+         * @return {@code true} if a decision was recorded before the timeout elapsed,
+         *         {@code false} if the wait timed out with no decision yet
+         * @throws InterruptedException if the calling thread is interrupted while
+         *             waiting
+         */
+        boolean await(long timeoutSeconds) throws InterruptedException
+        {
+            return latch.await(timeoutSeconds, TimeUnit.SECONDS);
+        }
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/InfobaseAccessSupport.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/InfobaseAccessSupport.java
@@ -8,6 +8,7 @@ package com.ditrix.edt.mcp.server.utils;
 
 import java.lang.reflect.Method;
 
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.Platform;
 import org.osgi.framework.Bundle;
 
@@ -91,40 +92,125 @@ public final class InfobaseAccessSupport
     }
 
     /**
-     * Stores the infobase connection credentials for an application's infobase.
+     * Stores the infobase connection credentials for an application.
      *
-     * @param application the target application (must be an {@link IInfobaseApplication})
+     * <p>Two shapes are supported:
+     * <ul>
+     *   <li>an {@link IInfobaseApplication} (a file/server infobase) — the direct fast path, via
+     *   its own {@link IInfobaseApplication#getInfobase()} (unchanged since issue #194);</li>
+     *   <li><b>issue #275:</b> any OTHER application that ADAPTS to an {@link InfobaseReference} —
+     *   most notably a standalone-server ({@code wst-server}) application wrapping a registered
+     *   infobase ({@code create_infobase}'s {@code applicationKind='standaloneServer'} +
+     *   {@code mode='register'}). EDT's own launch path for such an application
+     *   ({@code ServerApplicationBehaviourDelegate}) resolves the infobase to authenticate against
+     *   via {@code org.eclipse.core.runtime.Adapters.adapt(<the application/module>,
+     *   InfobaseReference.class)} — the platform's internal (unexported)
+     *   {@code StandaloneServerAdapterFactory} adapts a {@code StandaloneServerInfobase} module (or
+     *   the application itself) into a WEB {@link InfobaseReference} keyed by the config's
+     *   {@code Infobase.getId()}. Storing credentials against THAT SAME adapted reference is
+     *   exactly what the launch resolves later, so this method tries the adapter on the
+     *   application first, then — if that misses — on its module (see
+     *   {@link #moduleOfApplication(IApplication)}, a small local mirror of
+     *   {@code StandaloneServerSupport.moduleOfApplication}; that class is package-private in
+     *   {@code tools.impl}, so it is mirrored here rather than widened just for this one call).</li>
+     * </ul>
+     *
+     * @param application the target application
      * @param user the infobase user name (empty allowed — demo bases use an empty password user)
      * @param password the infobase user password (empty allowed)
      * @param access the access kind (INFOBASE = 1C user auth, OS = OS auth)
      * @return {@code null} on success, otherwise an actionable error message describing why the
-     *         credentials could not be stored (not an infobase application, infobase unresolved,
-     *         access manager unavailable, or the {@code updateSettings} call failed)
+     *         credentials could not be stored (no infobase reference could be resolved for this
+     *         application, access manager unavailable, or the {@code updateSettings} call failed)
      */
     public static String storeCredentials(IApplication application, String user, String password,
             InfobaseAccess access)
     {
-        if (!(application instanceof IInfobaseApplication))
+        if (application instanceof IInfobaseApplication)
         {
-            return "Application '" + application.getId() //$NON-NLS-1$
-                + "' is not a file/server infobase application — credentials apply only to infobases."; //$NON-NLS-1$
+            InfobaseReference ref;
+            try
+            {
+                ref = ((IInfobaseApplication)application).getInfobase();
+            }
+            catch (Exception e) // NOSONAR EDT model access — report verbatim, never crash the tool
+            {
+                Activator.logError("set credentials: getInfobase() failed for " + application.getId(), e); //$NON-NLS-1$
+                return "Could not resolve the infobase for application '" + application.getId() + "': " //$NON-NLS-1$ //$NON-NLS-2$
+                    + e.getMessage();
+            }
+            if (ref == null)
+            {
+                return "Could not resolve the infobase for application '" + application.getId() + "'."; //$NON-NLS-1$ //$NON-NLS-2$
+            }
+            return storeCredentials(ref, user, password, access);
         }
-        InfobaseReference ref;
+
+        // Not an IInfobaseApplication (issue #275): try the SAME adapter path EDT's own launch
+        // uses — first the application itself, then (if that misses) its module — before giving up.
+        InfobaseReference adapted = adaptToInfobaseReference(application);
+        if (adapted == null)
+        {
+            Object module = moduleOfApplication(application);
+            if (module != null)
+            {
+                adapted = adaptToInfobaseReference(module);
+            }
+        }
+        if (adapted != null)
+        {
+            return storeCredentials(adapted, user, password, access);
+        }
+
+        return "Application '" + application.getId() //$NON-NLS-1$
+            + "' exposes no infobase reference — credentials apply to infobases and to standalone " //$NON-NLS-1$
+            + "servers wrapping a registered infobase (issue #275); this application is neither."; //$NON-NLS-1$
+    }
+
+    /**
+     * Adapts {@code adaptable} (an {@link IApplication} or one of its modules) to an
+     * {@link InfobaseReference} via {@link Adapters#adapt(Object, Class)}, the same mechanism
+     * EDT's {@code ServerApplicationBehaviourDelegate} launch path uses to resolve the infobase to
+     * authenticate against (issue #275). Never throws — a probe failure (no adapter registered, or
+     * any adapter-manager error) degrades to {@code null}, which the caller treats as "no match".
+     *
+     * @param adaptable the object to adapt (application or module); may be {@code null}
+     * @return the adapted {@link InfobaseReference}, or {@code null} when none adapts
+     */
+    private static InfobaseReference adaptToInfobaseReference(Object adaptable)
+    {
         try
         {
-            ref = ((IInfobaseApplication)application).getInfobase();
+            return Adapters.adapt(adaptable, InfobaseReference.class);
         }
-        catch (Exception e) // NOSONAR EDT model access — report verbatim, never crash the tool
+        catch (Exception e) // NOSONAR the adapter-registry probe must never crash the tool
         {
-            Activator.logError("set credentials: getInfobase() failed for " + application.getId(), e); //$NON-NLS-1$
-            return "Could not resolve the infobase for application '" + application.getId() + "': " //$NON-NLS-1$ //$NON-NLS-2$
-                + e.getMessage();
+            return null;
         }
-        if (ref == null)
+    }
+
+    /**
+     * Reflective {@code IServerApplication.getModule()} — a small local mirror of
+     * {@code StandaloneServerSupport.moduleOfApplication} (tools.impl). That class (and the
+     * method) is package-private there; rather than widening its visibility for this one call
+     * (issue #275), the same tiny reflective probe is duplicated here. Returns {@code null} on any
+     * failure — in particular for a plain {@link IInfobaseApplication} (already handled by the fast
+     * path above) or any other application with no {@code getModule()}.
+     *
+     * @param application the target application
+     * @return the module object (typically a {@code StandaloneServerInfobase}), or {@code null}
+     */
+    static Object moduleOfApplication(IApplication application)
+    {
+        try
         {
-            return "Could not resolve the infobase for application '" + application.getId() + "'."; //$NON-NLS-1$ //$NON-NLS-2$
+            Method m = application.getClass().getMethod("getModule"); //$NON-NLS-1$
+            return m.invoke(application);
         }
-        return storeCredentials(ref, user, password, access);
+        catch (Exception e) // NOSONAR reflective probe — an application with no module returns null here
+        {
+            return null;
+        }
     }
 
     /**

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseToolTest.java
@@ -282,8 +282,10 @@ public class CreateInfobaseToolTest
     @Test
     public void testStandaloneServerWithCredentialsIsError()
     {
-        // Credentials apply only to a file infobase; pairing them with standaloneServer is rejected
-        // (not silently dropped). Validated before any platform/service lookup (headless-safe).
+        // #275: credentials remain rejected for a newly created standalone server (mode='create',
+        // the default) — pairing them with standaloneServer+create is rejected (not silently
+        // dropped). Validated before any platform/service lookup (headless-safe). The message must
+        // steer to BOTH supported alternatives: applicationKind='infobase', or mode='register'.
         Map<String, String> params = new HashMap<>();
         params.put("projectName", "AnyProject"); //$NON-NLS-1$ //$NON-NLS-2$
         params.put("infobaseFile", "C:/infobases/Any"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -291,10 +293,36 @@ public class CreateInfobaseToolTest
         params.put("user", "Admin"); //$NON-NLS-1$ //$NON-NLS-2$
         String result = new CreateInfobaseTool().execute(params);
         assertNotNull(result);
-        assertTrue("credentials with standaloneServer must be an error", //$NON-NLS-1$
+        assertTrue("credentials with standaloneServer+create must be an error", //$NON-NLS-1$
             result.contains("\"success\":false")); //$NON-NLS-1$
         assertTrue("error must steer to applicationKind='infobase'", //$NON-NLS-1$
             result.contains("infobase")); //$NON-NLS-1$
+        assertTrue("error must steer to mode='register' as the supported standalone-server alternative", //$NON-NLS-1$
+            result.contains("register")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStandaloneServerRegisterWithCredentialsPassesValidation()
+    {
+        // #275: standaloneServer + mode='register' + credentials must NOT be rejected by the
+        // credentials guard (that guard now fires only for standaloneServer+create). Execution
+        // proceeds into the register-path validation instead, which fails on the missing 1Cv8.1CD at
+        // this fake path — proving the credentials guard let it through rather than blocking it.
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "AnyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("infobaseFile", "C:/infobases/edt_mcp_no_such_ib_zzz2"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("applicationKind", "standaloneServer"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("mode", "register"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("user", "Admin"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("password", "secret"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new CreateInfobaseTool().execute(params);
+        assertNotNull(result);
+        assertTrue("must still be an error (no 1Cv8.1CD at the fake path)", //$NON-NLS-1$
+            result.contains("\"success\":false")); //$NON-NLS-1$
+        assertTrue("must NOT be the credentials-rejected error", //$NON-NLS-1$
+            !result.contains("are supported only with")); //$NON-NLS-1$
+        assertTrue("must be the register-path 'no file infobase found' error instead", //$NON-NLS-1$
+            result.contains("1Cv8.1CD")); //$NON-NLS-1$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseToolTest.java
@@ -7,9 +7,14 @@
 package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -331,5 +336,346 @@ public class CreateInfobaseToolTest
         assertTrue("error must mention the expected 1Cv8.1CD file", //$NON-NLS-1$
             result.contains("1Cv8.1CD")); //$NON-NLS-1$
         assertTrue("error must steer to mode='create'", result.contains("create")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== #273: version-tolerant create-flag resolution ====================
+    // StandaloneServerInfobase's create-new-infobase flag setter was RENAMED, with no back-compat
+    // alias, between EDT 2025.2 (setCreate) and 2026.1 (setCreateNewInfobase). ssMethodAny/
+    // ssSetCreateFlag resolve it version-tolerantly; both are package-private test seams (mirrors
+    // StandaloneServerSupport's convention of package-visible statics for testability), exercised
+    // here with plain stub classes exposing one name, the other, or neither — no live EDT needed.
+
+    @Test
+    public void testSsMethodAnyResolves2025ShapeWhenOnlySetCreatePresent()
+    {
+        Method m = CreateInfobaseTool.ssMethodAny(StubOnlySetCreate.class, 1, "setCreate", //$NON-NLS-1$
+            "setCreateNewInfobase"); //$NON-NLS-1$
+        assertNotNull("setCreate must resolve when present", m); //$NON-NLS-1$
+        assertEquals("setCreate", m.getName()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsMethodAnyResolves2026ShapeWhenOnlySetCreateNewInfobasePresent()
+    {
+        Method m = CreateInfobaseTool.ssMethodAny(StubOnlySetCreateNewInfobase.class, 1, "setCreate", //$NON-NLS-1$
+            "setCreateNewInfobase"); //$NON-NLS-1$
+        assertNotNull("setCreateNewInfobase must resolve when present", m); //$NON-NLS-1$
+        assertEquals("setCreateNewInfobase", m.getName()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsMethodAnyReturnsNullWhenNeitherNamePresent()
+    {
+        assertNull(CreateInfobaseTool.ssMethodAny(StubNeitherSetter.class, 1, "setCreate", //$NON-NLS-1$
+            "setCreateNewInfobase")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsSetCreateFlagInvokesSetCreateOn2025Shape() throws Exception
+    {
+        StubOnlySetCreate stub = new StubOnlySetCreate();
+        CreateInfobaseTool.ssSetCreateFlag(stub, true);
+        assertTrue("setCreate(true) must have been invoked", stub.created); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsSetCreateFlagInvokesSetCreateNewInfobaseOn2026Shape() throws Exception
+    {
+        StubOnlySetCreateNewInfobase stub = new StubOnlySetCreateNewInfobase();
+        CreateInfobaseTool.ssSetCreateFlag(stub, true);
+        assertTrue("setCreateNewInfobase(true) must have been invoked", stub.created); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsSetCreateFlagThrowsNamingBothTriedMethodsWhenNeitherPresent()
+    {
+        try
+        {
+            CreateInfobaseTool.ssSetCreateFlag(new StubNeitherSetter(), true);
+            fail("must throw when neither setCreate nor setCreateNewInfobase resolves"); //$NON-NLS-1$
+        }
+        catch (Exception e)
+        {
+            assertTrue("failure message must name setCreate", //$NON-NLS-1$
+                e.getMessage().contains("setCreate")); //$NON-NLS-1$
+            assertTrue("failure message must name setCreateNewInfobase", //$NON-NLS-1$
+                e.getMessage().contains("setCreateNewInfobase")); //$NON-NLS-1$
+        }
+    }
+
+    // ==================== #273: create-template database ensure (2026.1 second drift layer) ====================
+    // On 2026.1 the behaviour delegate CASTS the module config's database to ICreateTemplateDatabase,
+    // but createServerWithInfobase builds it with a plain FileDatabase -> live ClassCastException.
+    // ssEnsureCreateTemplateDatabase swaps in a FileCreateTemplateDatabase; the DECISION logic
+    // (needs-replacement check + directory copy across the getConfigDirectory/getPath rename) is
+    // headless-testable below; the bundle class-LOADING step needs the real EDT bundle and stays
+    // live-verified (here it degrades best-effort, which is itself asserted).
+
+    @Test
+    public void testSsIsCreateTemplateDatabaseTrueForDirectImplementor()
+    {
+        assertTrue(CreateInfobaseTool.ssIsCreateTemplateDatabase(StubTemplateCapableDatabase.class));
+    }
+
+    @Test
+    public void testSsIsCreateTemplateDatabaseTrueViaSuperclass()
+    {
+        // The marker interface arrives through the superclass -> the hierarchy walk must find it.
+        assertTrue(CreateInfobaseTool.ssIsCreateTemplateDatabase(StubTemplateCapableSubclass.class));
+    }
+
+    @Test
+    public void testSsIsCreateTemplateDatabaseTrueViaSuperinterface()
+    {
+        // The marker interface arrives as a SUPERinterface of an implemented interface.
+        assertTrue(CreateInfobaseTool.ssIsCreateTemplateDatabase(StubExtendedTemplateDatabase.class));
+    }
+
+    @Test
+    public void testSsIsCreateTemplateDatabaseFalseForPlainClass()
+    {
+        assertFalse(CreateInfobaseTool.ssIsCreateTemplateDatabase(StubFileDatabase2025.class));
+        assertFalse(CreateInfobaseTool.ssIsCreateTemplateDatabase(Object.class));
+    }
+
+    @Test
+    public void testSsIsCreateTemplateDatabaseFalseForNull()
+    {
+        assertFalse(CreateInfobaseTool.ssIsCreateTemplateDatabase(null));
+    }
+
+    @Test
+    public void testSsCopyDatabaseDirectoryFrom2025To2026Shape() throws Exception
+    {
+        // Read via getConfigDirectory (2025.2), write via setPath (2026.1) — the cross-rename copy.
+        StubFileDatabase2025 from = new StubFileDatabase2025("C:/data/ib"); //$NON-NLS-1$
+        StubFileDatabase2026 to = new StubFileDatabase2026(null);
+        CreateInfobaseTool.ssCopyDatabaseDirectory(from, to);
+        assertEquals("C:/data/ib", to.getPath()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsCopyDatabaseDirectoryFrom2026To2025Shape() throws Exception
+    {
+        // Read via getPath (2026.1), write via setConfigDirectory (2025.2).
+        StubFileDatabase2026 from = new StubFileDatabase2026("C:/data/ib2026"); //$NON-NLS-1$
+        StubFileDatabase2025 to = new StubFileDatabase2025(null);
+        CreateInfobaseTool.ssCopyDatabaseDirectory(from, to);
+        assertEquals("C:/data/ib2026", to.getConfigDirectory()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsCopyDatabaseDirectoryNoOpWhenSourceHasNoAccessor() throws Exception
+    {
+        // The source exposes neither getConfigDirectory nor getPath -> no-op, no throw.
+        StubFileDatabase2026 to = new StubFileDatabase2026("keep"); //$NON-NLS-1$
+        CreateInfobaseTool.ssCopyDatabaseDirectory(new Object(), to);
+        assertEquals("keep", to.getPath()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsCopyDatabaseDirectoryNoOpWhenTargetHasNoSetter() throws Exception
+    {
+        // The target exposes neither setConfigDirectory nor setPath -> no-op, no throw.
+        CreateInfobaseTool.ssCopyDatabaseDirectory(new StubFileDatabase2025("C:/data/ib"), //$NON-NLS-1$
+            new Object());
+    }
+
+    @Test
+    public void testSsCopyDatabaseDirectorySkipsNullDirectory() throws Exception
+    {
+        // A null source directory is not written (the target keeps its value).
+        StubFileDatabase2026 to = new StubFileDatabase2026("keep"); //$NON-NLS-1$
+        CreateInfobaseTool.ssCopyDatabaseDirectory(new StubFileDatabase2025(null), to);
+        assertEquals("keep", to.getPath()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSsEnsureCreateTemplateDatabaseLeavesTemplateCapableDatabaseUntouched()
+    {
+        // The database already implements an ICreateTemplateDatabase-named interface -> untouched
+        // (the 2025.2-compatible / future-proof path): same instance, setDatabase never called.
+        StubTemplateCapableDatabase db = new StubTemplateCapableDatabase();
+        StubServerConfig cfg = new StubServerConfig(db);
+        CreateInfobaseTool.ssEnsureCreateTemplateDatabase(new StubInfobaseWithConfig(cfg));
+        assertFalse("setDatabase must not be called for a template-capable database", //$NON-NLS-1$
+            cfg.setDatabaseCalled);
+        assertSame(db, cfg.getDatabase());
+    }
+
+    @Test
+    public void testSsEnsureCreateTemplateDatabaseLeavesNullDatabaseAsIs()
+    {
+        // A null database is left as-is (the delegate then fails with its own honest error).
+        StubServerConfig cfg = new StubServerConfig(null);
+        CreateInfobaseTool.ssEnsureCreateTemplateDatabase(new StubInfobaseWithConfig(cfg));
+        assertFalse(cfg.setDatabaseCalled);
+        assertNull(cfg.getDatabase());
+    }
+
+    @Test
+    public void testSsEnsureCreateTemplateDatabaseToleratesNullConfiguration()
+    {
+        // getStandaloneServerConfiguration() returning null must be a silent no-op, never a throw.
+        CreateInfobaseTool.ssEnsureCreateTemplateDatabase(new StubInfobaseWithConfig(null));
+    }
+
+    @Test
+    public void testSsEnsureCreateTemplateDatabaseIsBestEffortWhenBundleClassUnavailable()
+    {
+        // A plain (non-template) database triggers the replacement branch, whose bundle class-load
+        // (FileCreateTemplateDatabase via the db's own classloader) cannot succeed headlessly. The
+        // whole ensure is BEST-EFFORT: no throw, database left unchanged, setDatabase never called
+        // (on 2025.2 a plain FileDatabase still materializes fine — that path must never regress).
+        StubFileDatabase2025 db = new StubFileDatabase2025("C:/data/ib"); //$NON-NLS-1$
+        StubServerConfig cfg = new StubServerConfig(db);
+        CreateInfobaseTool.ssEnsureCreateTemplateDatabase(new StubInfobaseWithConfig(cfg));
+        assertFalse("a failed swap must leave the original database in place", //$NON-NLS-1$
+            cfg.setDatabaseCalled);
+        assertSame(db, cfg.getDatabase());
+    }
+
+    // ==================== Stubs (plain classes ssMethodAny/ssSetCreateFlag introspect) ====================
+
+    /** A 2025.2-shaped {@code StandaloneServerInfobase} stub: only {@code setCreate(boolean)}. */
+    public static final class StubOnlySetCreate
+    {
+        boolean created;
+
+        public void setCreate(boolean value)
+        {
+            created = value;
+        }
+    }
+
+    /** A 2026.1-shaped {@code StandaloneServerInfobase} stub: only {@code setCreateNewInfobase(boolean)}. */
+    public static final class StubOnlySetCreateNewInfobase
+    {
+        boolean created;
+
+        public void setCreateNewInfobase(boolean value)
+        {
+            created = value;
+        }
+    }
+
+    /** A stub exposing NEITHER create-flag setter name (the both-names error path). */
+    public static final class StubNeitherSetter
+    {
+        // deliberately no setCreate / setCreateNewInfobase
+    }
+
+    /**
+     * #273: stands in for the platform's create-template marker interface — matched by SIMPLE name
+     * (the live one is {@code com.e1c...standaloneserver.core.config.ICreateTemplateDatabase}).
+     */
+    public interface ICreateTemplateDatabase
+    {
+        // marker
+    }
+
+    /** #273: an interface EXTENDING the marker (the superinterface-walk branch). */
+    public interface IExtendedTemplateDatabase extends ICreateTemplateDatabase
+    {
+        // marker
+    }
+
+    /** #273: a database that implements the marker interface DIRECTLY (needs no replacement). */
+    public static class StubTemplateCapableDatabase implements ICreateTemplateDatabase
+    {
+        // marker only
+    }
+
+    /** #273: a database inheriting the marker via its SUPERCLASS (the hierarchy-walk branch). */
+    public static final class StubTemplateCapableSubclass extends StubTemplateCapableDatabase
+    {
+        // marker only, via the superclass
+    }
+
+    /** #273: a database reaching the marker via a superINTERFACE of an implemented interface. */
+    public static final class StubExtendedTemplateDatabase implements IExtendedTemplateDatabase
+    {
+        // marker only, via the extended interface
+    }
+
+    /** #273: a 2025.2-shaped plain file database — getConfigDirectory/setConfigDirectory accessors. */
+    public static final class StubFileDatabase2025
+    {
+        private String dir;
+
+        StubFileDatabase2025(String dir)
+        {
+            this.dir = dir;
+        }
+
+        public String getConfigDirectory()
+        {
+            return dir;
+        }
+
+        public void setConfigDirectory(String dir)
+        {
+            this.dir = dir;
+        }
+    }
+
+    /** #273: a 2026.1-shaped plain file database — the accessors were RENAMED to getPath/setPath. */
+    public static final class StubFileDatabase2026
+    {
+        private String path;
+
+        StubFileDatabase2026(String path)
+        {
+            this.path = path;
+        }
+
+        public String getPath()
+        {
+            return path;
+        }
+
+        public void setPath(String path)
+        {
+            this.path = path;
+        }
+    }
+
+    /** #273: the module config stand-in — getDatabase/setDatabase (setDatabase call is recorded). */
+    public static final class StubServerConfig
+    {
+        private Object database;
+        boolean setDatabaseCalled;
+
+        StubServerConfig(Object database)
+        {
+            this.database = database;
+        }
+
+        public Object getDatabase()
+        {
+            return database;
+        }
+
+        public void setDatabase(Object database)
+        {
+            this.database = database;
+            setDatabaseCalled = true;
+        }
+    }
+
+    /** #273: the StandaloneServerInfobase stand-in exposing its module configuration. */
+    public static final class StubInfobaseWithConfig
+    {
+        private final Object configuration;
+
+        StubInfobaseWithConfig(Object configuration)
+        {
+            this.configuration = configuration;
+        }
+
+        public Object getStandaloneServerConfiguration()
+        {
+            return configuration;
+        }
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/StandaloneServerSupportTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/StandaloneServerSupportTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
@@ -95,7 +96,9 @@ public class StandaloneServerSupportTest
     @Test
     public void testInfobaseIdOfReturnsNullWhenMethodAbsent()
     {
-        // An object without getInfobaseId() -> NoSuchMethodException is swallowed -> null.
+        // #273: an object with NEITHER the 2025.2 shape (getInfobaseId()) NOR the 2026.1 fallback
+        // chain (getStandaloneServerConfiguration()) -> both NoSuchMethodExceptions are swallowed ->
+        // null, and the "both shapes missing" error is LOGGED, never thrown.
         assertNull(StandaloneServerSupport.infobaseIdOf(new Object()));
     }
 
@@ -105,6 +108,44 @@ public class StandaloneServerSupportTest
         // A UUID-like non-String id is rendered via toString().
         Object module = new FakeInfobaseModule(Integer.valueOf(7));
         assertEquals("7", StandaloneServerSupport.infobaseIdOf(module)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testInfobaseIdOfReadsUuidViaGetInfobaseId()
+    {
+        // The real 2025.2 shape: getInfobaseId() returns a java.util.UUID -> its toString() is
+        // returned (the raw id string that keys the infobases.yaml registry entry).
+        java.util.UUID uuid = java.util.UUID.randomUUID();
+        Object module = new FakeInfobaseModule(uuid);
+        assertEquals(uuid.toString(), StandaloneServerSupport.infobaseIdOf(module));
+    }
+
+    // ---- #273: 2026.1 fallback shape — getStandaloneServerConfiguration().getInfobase().getId() ----
+
+    @Test
+    public void testInfobaseIdOfFallsBackToConfigurationChainWhenGetInfobaseIdAbsent()
+    {
+        // 2026.1: getInfobaseId() is GONE (no replacement); the raw id lives instead at
+        // getStandaloneServerConfiguration().getInfobase().getId(): String.
+        Object module = new FakeInfobaseModule2026Only(
+            new Fake2026Configuration(new Fake2026Infobase("ib-2026"))); //$NON-NLS-1$
+        assertEquals("ib-2026", StandaloneServerSupport.infobaseIdOf(module)); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testInfobaseIdOfFallbackIsNullSafeWhenConfigurationIsNull()
+    {
+        // getStandaloneServerConfiguration() present but returns null -> null-safe, no NPE.
+        Object module = new FakeInfobaseModule2026Only(null);
+        assertNull(StandaloneServerSupport.infobaseIdOf(module));
+    }
+
+    @Test
+    public void testInfobaseIdOfFallbackIsNullSafeWhenInfobaseIsNull()
+    {
+        // getInfobase() present but returns null -> null-safe, no NPE.
+        Object module = new FakeInfobaseModule2026Only(new Fake2026Configuration(null));
+        assertNull(StandaloneServerSupport.infobaseIdOf(module));
     }
 
     // ==================== databaseDirOf ====================
@@ -137,9 +178,28 @@ public class StandaloneServerSupportTest
     @Test
     public void testDatabaseDirOfReturnsNullForRdbmsDatabaseWithoutConfigDirectory()
     {
-        // An RDBMS database has no getConfigDirectory() -> NoSuchMethodException -> null.
+        // An RDBMS database has NEITHER getConfigDirectory() (2025.2) NOR getPath() (2026.1) -> null.
         Object module = new FakeServerInfobaseModule(
             new FakeConfiguration(new FakeRdbmsDatabase()));
+        assertNull(StandaloneServerSupport.databaseDirOf(module));
+    }
+
+    @Test
+    public void testDatabaseDirOfReadsGetPathOn2026Shape()
+    {
+        // #273: 2026.1 renamed FileDatabase.getConfigDirectory() -> getPath(); the read must accept
+        // either accessor (this is why deleteDatabaseFiles resolved nothing on 2026.1).
+        Object module = new FakeServerInfobaseModule(
+            new FakeConfiguration(new Fake2026PathDatabase("C:/data/ib2026"))); //$NON-NLS-1$
+        assertEquals("C:/data/ib2026", StandaloneServerSupport.databaseDirOf(module)); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testDatabaseDirOfReturnsNullWhenGetPathIsNotAString()
+    {
+        // #273: getPath() exists but returns a non-String -> null (same instanceof guard as 2025.2).
+        Object module = new FakeServerInfobaseModule(
+            new FakeConfiguration(new FakeNonStringPathDatabase()));
         assertNull(StandaloneServerSupport.databaseDirOf(module));
     }
 
@@ -304,11 +364,12 @@ public class StandaloneServerSupportTest
     // ==================== removeFromInfobaseRegistry ====================
 
     @Test
-    public void testRemoveFromInfobaseRegistryNullIdReturnsFailed()
+    public void testRemoveFromInfobaseRegistryNullModuleAndIdReturnsFailed()
     {
-        // PURE branch (no OSGi): a null infobaseId can target no entry -> FAILED (honest, not NOT_PRESENT).
+        // PURE branch (no OSGi): with NEITHER the module NOR the raw id, no entry can be targeted ->
+        // FAILED (honest, not NOT_PRESENT).
         assertSame(RegistryCleanup.FAILED,
-            StandaloneServerSupport.removeFromInfobaseRegistry(null, MONITOR));
+            StandaloneServerSupport.removeFromInfobaseRegistry(null, null, MONITOR));
     }
 
     @Test
@@ -318,8 +379,109 @@ public class StandaloneServerSupportTest
         // runtime the cleanup cannot run: it must return a non-null RegistryCleanup (FAILED) and never
         // throw. (On a real EDT with the feature installed this is where REMOVED/NOT_PRESENT happen.)
         RegistryCleanup result =
-            StandaloneServerSupport.removeFromInfobaseRegistry("some-id", MONITOR); //$NON-NLS-1$
+            StandaloneServerSupport.removeFromInfobaseRegistry(null, "some-id", MONITOR); //$NON-NLS-1$
         assertNotNull(result);
+    }
+
+    @Test
+    public void testRemoveFromInfobaseRegistryWithModuleOnlyDegradesGracefully()
+    {
+        // A module without a raw id (the 2026.1 shape when only the instance is known) must also
+        // degrade gracefully in the headless runtime — non-null result, never a throw.
+        RegistryCleanup result = StandaloneServerSupport.removeFromInfobaseRegistry(
+            new FakeIdModule("prefixed#abc"), null, MONITOR); //$NON-NLS-1$
+        assertNotNull(result);
+    }
+
+    // ==================== removeModuleEntries (#273: the version-proof map surgery) ====================
+    // The delegate's modules-map KEY scheme differs per EDT version: 2025.2 keys by the raw uuid,
+    // 2026.1 by the PREFIXED StandaloneServerInfobase.getId() module-id — so key-based removal by the
+    // raw id silently misses on 2026.1. The extracted seam is tested here strategy by strategy; the
+    // delegate/mapper/location plumbing around it stays live-verified.
+
+    @Test
+    public void testRemoveModuleEntriesByValueIdentity()
+    {
+        // Strategy 1: the map value IS the passed instance — removed regardless of the key scheme
+        // (here the 2026.1-style prefixed key, which the raw id would miss).
+        FakeIdModule module = new FakeIdModule("srv#raw-1"); //$NON-NLS-1$
+        java.util.Map<Object, Object> modules = new java.util.HashMap<>();
+        modules.put("srv#raw-1", module); //$NON-NLS-1$
+        assertEquals(1, StandaloneServerSupport.removeModuleEntries(modules, module, "raw-1")); //$NON-NLS-1$
+        assertTrue(modules.isEmpty());
+    }
+
+    @Test
+    public void testRemoveModuleEntriesIdentityDoesNotTouchOtherEntries()
+    {
+        // Identity removal must be surgical: an unrelated entry (even one with the SAME getId) stays,
+        // because strategy 2 only runs when strategy 1 removed nothing.
+        FakeIdModule module = new FakeIdModule("srv#raw-1"); //$NON-NLS-1$
+        FakeIdModule twin = new FakeIdModule("srv#raw-1"); //$NON-NLS-1$
+        java.util.Map<Object, Object> modules = new java.util.HashMap<>();
+        modules.put("k1", module); //$NON-NLS-1$
+        modules.put("k2", twin); //$NON-NLS-1$
+        assertEquals(1, StandaloneServerSupport.removeModuleEntries(modules, module, null));
+        assertSame(twin, modules.get("k2")); //$NON-NLS-1$
+        assertEquals(1, modules.size());
+    }
+
+    @Test
+    public void testRemoveModuleEntriesByGetIdEquality()
+    {
+        // Strategy 2: a DIFFERENT instance with the SAME getId() (a re-created module) is matched by
+        // reflective getId() String equality when identity misses.
+        java.util.Map<Object, Object> modules = new java.util.HashMap<>();
+        modules.put("srv#raw-2", new FakeIdModule("srv#raw-2")); //$NON-NLS-1$ //$NON-NLS-2$
+        FakeIdModule sameIdOtherInstance = new FakeIdModule("srv#raw-2"); //$NON-NLS-1$
+        assertEquals(1,
+            StandaloneServerSupport.removeModuleEntries(modules, sameIdOtherInstance, null));
+        assertTrue(modules.isEmpty());
+    }
+
+    @Test
+    public void testRemoveModuleEntriesByRawIdKeyFallback()
+    {
+        // Strategy 3: identity and getId both miss (value has no matching id) -> the proven 2025.2
+        // key-based removal by the raw id still fires.
+        java.util.Map<Object, Object> modules = new java.util.HashMap<>();
+        modules.put("raw-3", new Object()); //$NON-NLS-1$
+        assertEquals(1, StandaloneServerSupport.removeModuleEntries(modules,
+            new FakeIdModule("srv#other"), "raw-3")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(modules.isEmpty());
+    }
+
+    @Test
+    public void testRemoveModuleEntriesKeyFallbackWithNullModule()
+    {
+        // module == null (the pre-#273 caller shape): only the key-based strategy applies.
+        java.util.Map<Object, Object> modules = new java.util.HashMap<>();
+        modules.put("raw-4", new Object()); //$NON-NLS-1$
+        assertEquals(1, StandaloneServerSupport.removeModuleEntries(modules, null, "raw-4")); //$NON-NLS-1$
+        assertTrue(modules.isEmpty());
+    }
+
+    @Test
+    public void testRemoveModuleEntriesFullMissReturnsZero()
+    {
+        // No identity, no id equality, no key match -> 0 (the caller maps this to NOT_PRESENT).
+        java.util.Map<Object, Object> modules = new java.util.HashMap<>();
+        modules.put("other-key", new FakeIdModule("srv#other")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(0, StandaloneServerSupport.removeModuleEntries(modules,
+            new FakeIdModule("srv#mine"), "raw-mine")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(1, modules.size());
+    }
+
+    @Test
+    public void testRemoveModuleEntriesToleratesValuesWithoutGetId()
+    {
+        // Strategy 2 must skip values that have no getId() (or are null) without throwing.
+        java.util.Map<Object, Object> modules = new java.util.HashMap<>();
+        modules.put("k1", new Object()); //$NON-NLS-1$
+        modules.put("k2", null); //$NON-NLS-1$
+        assertEquals(0, StandaloneServerSupport.removeModuleEntries(modules,
+            new FakeIdModule("srv#raw-5"), null)); //$NON-NLS-1$
+        assertEquals(2, modules.size());
     }
 
     // ==================== acquireService ====================
@@ -341,6 +503,25 @@ public class StandaloneServerSupportTest
 
     // ==================== Fakes (plain classes the reflective wrappers introspect) ====================
 
+    /**
+     * #273: a registry module with a {@code getId()} — on 2026.1 that PREFIXED module-id string is the
+     * delegate's map key. Used by the {@code removeModuleEntries} strategy tests.
+     */
+    public static final class FakeIdModule
+    {
+        private final String id;
+
+        FakeIdModule(String id)
+        {
+            this.id = id;
+        }
+
+        public String getId()
+        {
+            return id;
+        }
+    }
+
     /** Stands in for {@code StandaloneServerInfobase} for {@code infobaseIdOf}. */
     public static final class FakeInfobaseModule
     {
@@ -352,6 +533,57 @@ public class StandaloneServerSupportTest
         }
 
         public Object getInfobaseId()
+        {
+            return id;
+        }
+    }
+
+    /**
+     * #273: a module exposing ONLY the 2026.1 config-chain fallback for {@code infobaseIdOf} —
+     * deliberately has NO {@code getInfobaseId()}, mirroring EDT 2026.1 where that method was removed.
+     */
+    public static final class FakeInfobaseModule2026Only
+    {
+        private final Object configuration;
+
+        FakeInfobaseModule2026Only(Object configuration)
+        {
+            this.configuration = configuration;
+        }
+
+        public Object getStandaloneServerConfiguration()
+        {
+            return configuration;
+        }
+    }
+
+    /** #273: stands in for the 2026.1 {@code StandaloneServerConfiguration}'s {@code getInfobase()} hop. */
+    public static final class Fake2026Configuration
+    {
+        private final Object infobase;
+
+        Fake2026Configuration(Object infobase)
+        {
+            this.infobase = infobase;
+        }
+
+        public Object getInfobase()
+        {
+            return infobase;
+        }
+    }
+
+    /** #273: stands in for the 2026.1 {@code Infobase}, holding the raw id via {@code getId(): String}. */
+    public static final class Fake2026Infobase
+    {
+        private final String id;
+
+        Fake2026Infobase(String id)
+        {
+            this.id = id;
+        }
+
+        public String getId()
         {
             return id;
         }
@@ -405,10 +637,10 @@ public class StandaloneServerSupportTest
         }
     }
 
-    /** RDBMS database: deliberately has NO getConfigDirectory() method. */
+    /** RDBMS database: deliberately has NEITHER getConfigDirectory() (2025.2) nor getPath() (2026.1). */
     public static final class FakeRdbmsDatabase
     {
-        // no getConfigDirectory()
+        // no getConfigDirectory() / getPath()
     }
 
     /** File-like database whose getConfigDirectory() returns a non-String (the instanceof guard). */
@@ -417,6 +649,31 @@ public class StandaloneServerSupportTest
         public Object getConfigDirectory()
         {
             return new java.io.File("x"); //$NON-NLS-1$
+        }
+    }
+
+    /** #273: a 2026.1-shaped file database — the directory accessor was RENAMED to getPath(). */
+    public static final class Fake2026PathDatabase
+    {
+        private final String path;
+
+        Fake2026PathDatabase(String path)
+        {
+            this.path = path;
+        }
+
+        public String getPath()
+        {
+            return path;
+        }
+    }
+
+    /** #273: a 2026.1-shaped database whose getPath() returns a non-String (the instanceof guard). */
+    public static final class FakeNonStringPathDatabase
+    {
+        public Object getPath()
+        {
+            return new java.io.File("y"); //$NON-NLS-1$
         }
     }
 

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGateTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGateTest.java
@@ -10,13 +10,17 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import static org.junit.Assert.assertNull;
+
 import java.util.Set;
 
+import org.eclipse.jface.dialogs.IDialogConstants;
 import org.junit.After;
 import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.preferences.ConsentSettingsService;
 import com.ditrix.edt.mcp.server.protocol.ToolAnnotationClassifier;
+import com.ditrix.edt.mcp.server.utils.DestructiveConsentGate.ConsentArbiter;
 import com.ditrix.edt.mcp.server.utils.DestructiveConsentGate.ConsentDecision;
 import com.ditrix.edt.mcp.server.utils.DestructiveConsentGate.Outcome;
 
@@ -201,5 +205,159 @@ public class DestructiveConsentGateTest
                 ToolAnnotationClassifier.classify("delete_launch_config").getDestructiveHint())); //$NON-NLS-1$
         assertFalse("delete_launch_config must NOT be gated", //$NON-NLS-1$
             DestructiveConsentGate.GATED_TOOLS.contains("delete_launch_config")); //$NON-NLS-1$
+    }
+
+    // =====================================================================
+    // Issue #277 — the bounded-wait ConsentArbiter (first-wins, both orders)
+    // =====================================================================
+
+    @Test
+    public void arbiterFirstDecisionWinsWhenTheRealAnswerComesFirst() throws InterruptedException
+    {
+        ConsentArbiter arbiter = new ConsentArbiter();
+        assertTrue("the first tryDecide call must win the race", //$NON-NLS-1$
+            arbiter.tryDecide(ConsentDecision.ALLOW));
+        assertFalse("a later tryDecide call must be ignored (already decided)", //$NON-NLS-1$
+            arbiter.tryDecide(ConsentDecision.TIMEOUT));
+        assertEquals("the winning decision must stick", ConsentDecision.ALLOW, arbiter.peek()); //$NON-NLS-1$
+        assertTrue("await must observe the already-recorded decision without waiting", //$NON-NLS-1$
+            arbiter.await(0));
+    }
+
+    @Test
+    public void arbiterFirstDecisionWinsWhenTheTimeoutComesFirst() throws InterruptedException
+    {
+        ConsentArbiter arbiter = new ConsentArbiter();
+        assertTrue("the worker's timeout must win when it decides first", //$NON-NLS-1$
+            arbiter.tryDecide(ConsentDecision.TIMEOUT));
+        assertFalse("a late dialog answer arriving after the timeout must be ignored", //$NON-NLS-1$
+            arbiter.tryDecide(ConsentDecision.REJECT));
+        assertEquals("TIMEOUT must stick, not the late REJECT", //$NON-NLS-1$
+            ConsentDecision.TIMEOUT, arbiter.peek());
+    }
+
+    @Test
+    public void arbiterAwaitTimesOutWhenNobodyHasDecidedYet() throws InterruptedException
+    {
+        ConsentArbiter arbiter = new ConsentArbiter();
+        assertFalse("await must time out (return false) with no decision recorded", //$NON-NLS-1$
+            arbiter.await(0));
+        assertNull("peek must stay null until a decision is recorded", arbiter.peek()); //$NON-NLS-1$
+    }
+
+    // =====================================================================
+    // Issue #277 — recordDialogAnswer: late "Allow for session" is remembered
+    // =====================================================================
+
+    @Test
+    public void lateAllowForSessionIsRecordedEvenAfterTheTimeoutWonTheRace()
+    {
+        DestructiveConsentGate gate = DestructiveConsentGate.getInstance();
+        ConsentArbiter arbiter = new ConsentArbiter();
+        // The worker's timeout already won the race before the human's answer arrives.
+        assertTrue(arbiter.tryDecide(ConsentDecision.TIMEOUT));
+
+        gate.recordDialogAnswer(arbiter, TOOL, DestructiveConsentGate.ALLOW_FOR_SESSION_ID);
+
+        assertEquals("a late answer must NOT overturn the already-decided TIMEOUT", //$NON-NLS-1$
+            ConsentDecision.TIMEOUT, arbiter.peek());
+        assertTrue("a late 'Allow for session' must still be recorded so the tool is not " //$NON-NLS-1$
+            + "re-prompted next time", gate.isSessionAllowed(TOOL)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void dialogAnswerInTimeWinsTheArbiterAndTheLateTimeoutIsIgnored()
+    {
+        ConsentArbiter arbiter = new ConsentArbiter();
+        DestructiveConsentGate.getInstance().recordDialogAnswer(arbiter, TOOL, IDialogConstants.OK_ID);
+
+        assertEquals(ConsentDecision.ALLOW, arbiter.peek());
+        assertFalse("the worker's timeout must lose once the dialog already answered", //$NON-NLS-1$
+            arbiter.tryDecide(ConsentDecision.TIMEOUT));
+        assertEquals(ConsentDecision.ALLOW, arbiter.peek());
+    }
+
+    @Test
+    public void recordDialogAnswerMapsRejectAndDoesNotTouchSessionAllow()
+    {
+        DestructiveConsentGate gate = DestructiveConsentGate.getInstance();
+        ConsentArbiter arbiter = new ConsentArbiter();
+
+        gate.recordDialogAnswer(arbiter, TOOL, IDialogConstants.CANCEL_ID);
+
+        assertEquals(ConsentDecision.REJECT, arbiter.peek());
+        assertFalse("a plain Reject must not add the tool to the session-allow set", //$NON-NLS-1$
+            gate.isSessionAllowed(TOOL));
+    }
+
+    // =====================================================================
+    // Issue #277 — the UI-thread (timerExec) path orderings through the same seams
+    // =====================================================================
+
+    @Test
+    public void uiThreadTimerWinMapsToTimeoutDespiteTheDefaultOkReturnCode()
+    {
+        // The UI-thread path's timeout sequence: the timerExec closer wins (TIMEOUT)
+        // and force-closes the dialog. A forced Dialog.close() does NOT set a CANCEL
+        // return code — JFace Window.returnCode defaults to OK — so open() hands the
+        // post-open mapping an OK code. The arbiter, not the code, must carry the
+        // verdict: the OK-derived ALLOW candidate loses and nothing enters the
+        // session set.
+        DestructiveConsentGate gate = DestructiveConsentGate.getInstance();
+        ConsentArbiter arbiter = new ConsentArbiter();
+        assertTrue("the timer closer must win when nobody answered yet", //$NON-NLS-1$
+            arbiter.tryDecide(ConsentDecision.TIMEOUT));
+
+        gate.recordDialogAnswer(arbiter, TOOL, IDialogConstants.OK_ID);
+
+        assertEquals("the default-OK code after a forced close must NOT overturn TIMEOUT", //$NON-NLS-1$
+            ConsentDecision.TIMEOUT, arbiter.peek());
+        assertFalse("a forced close must not session-allow the tool", //$NON-NLS-1$
+            gate.isSessionAllowed(TOOL));
+    }
+
+    @Test
+    public void uiThreadHumanRejectFirstBeatsTheLateTimer()
+    {
+        // The UI-thread path's human-first sequence: the human answers Reject inside
+        // open(), the answer is mapped first, and the (cancelled-or-late) timer
+        // closer must be a harmless no-op.
+        DestructiveConsentGate gate = DestructiveConsentGate.getInstance();
+        ConsentArbiter arbiter = new ConsentArbiter();
+
+        gate.recordDialogAnswer(arbiter, TOOL, IDialogConstants.CANCEL_ID);
+
+        assertEquals(ConsentDecision.REJECT, arbiter.peek());
+        assertFalse("a late timer closer must lose to the human's answer", //$NON-NLS-1$
+            arbiter.tryDecide(ConsentDecision.TIMEOUT));
+        assertEquals("REJECT must stick, not the late TIMEOUT", //$NON-NLS-1$
+            ConsentDecision.REJECT, arbiter.peek());
+    }
+
+    // =====================================================================
+    // Issue #277 — consentDeniedMessage: REJECT text unchanged, TIMEOUT text actionable
+    // =====================================================================
+
+    @Test
+    public void consentDeniedMessageKeepsTheOriginalRejectText()
+    {
+        assertEquals("Operation declined by user", //$NON-NLS-1$
+            DestructiveConsentGate.consentDeniedMessage(ConsentDecision.REJECT, TOOL));
+    }
+
+    @Test
+    public void consentDeniedMessageForTimeoutNamesToolSecondsAndAllThreeRemedies()
+    {
+        String message = DestructiveConsentGate.consentDeniedMessage(ConsentDecision.TIMEOUT, TOOL);
+
+        assertTrue("must name the tool", message.contains(TOOL)); //$NON-NLS-1$
+        assertTrue("must mention the timeout seconds", //$NON-NLS-1$
+            message.contains("120")); //$NON-NLS-1$
+        assertTrue("must mention the Preferences remedy", //$NON-NLS-1$
+            message.contains("Preferences")); //$NON-NLS-1$
+        assertTrue("must mention the env-bypass remedy", //$NON-NLS-1$
+            message.contains("EDT_MCP_DESTRUCTIVE_CONSENT")); //$NON-NLS-1$
+        assertTrue("must mention re-running / answering promptly as the third remedy", //$NON-NLS-1$
+            message.contains("re-run")); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/InfobaseAccessSupportTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/InfobaseAccessSupportTest.java
@@ -9,16 +9,23 @@ package com.ditrix.edt.mcp.server.utils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import org.junit.Test;
 
 import com._1c.g5.v8.dt.platform.services.model.InfobaseAccess;
+import com.e1c.g5.dt.applications.IApplication;
 
 /**
  * Tests for {@link InfobaseAccessSupport#parseAccess(String)} — the access-kind argument parser
- * (#194). The store/read path (Guice injector -&gt; {@code IInfobaseAccessManager} -&gt;
- * {@code updateSettings}) needs a live EDT and is verified on the e2e stand.
+ * (#194) — and for the {@link InfobaseAccessSupport#storeCredentials(IApplication, String, String,
+ * InfobaseAccess)} adapter-fallback decision added by issue #275. The full store/read path (Guice
+ * injector -&gt; {@code IInfobaseAccessManager} -&gt; {@code updateSettings}) needs a live EDT and
+ * is verified on the e2e stand.
  */
 public class InfobaseAccessSupportTest
 {
@@ -64,5 +71,57 @@ public class InfobaseAccessSupportTest
         assertTrue("error must name the bad value", err.contains("OOPS")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("error must list the allowed kinds", //$NON-NLS-1$
             err.contains("INFOBASE") && err.contains("OS")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== #275: storeCredentials(IApplication) adapter fallback ====================
+    // A non-IInfobaseApplication (e.g. a wst-server standalone-server application) must be adapted
+    // to an InfobaseReference — first the application itself, then its module (moduleOfApplication)
+    // — before being rejected. In this headless unit JVM no adapter factory is registered (no OSGi
+    // platform running), so Adapters.adapt always misses; this exercises the adapter-miss rejection
+    // path with its new, more actionable wording. The success path (adapter hits, updateSettings
+    // commits) needs a live EDT and is verified on the e2e stand.
+
+    @Test
+    public void testStoreCredentialsForNonInfobaseApplicationWithNoAdapterRejectsActionably()
+    {
+        // A stub application that is NOT an IInfobaseApplication and exposes no getModule() (so the
+        // module-fallback probe also misses) — mirrors a wst-server application in an environment
+        // where Adapters.adapt cannot resolve it (no StandaloneServerAdapterFactory registered).
+        IApplication app = mock(IApplication.class);
+        when(app.getId()).thenReturn("wst-app-1"); //$NON-NLS-1$
+
+        String error = InfobaseAccessSupport.storeCredentials(app, "Admin", "", InfobaseAccess.INFOBASE); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertNotNull("must reject when neither the app nor its module adapts to an InfobaseReference", //$NON-NLS-1$
+            error);
+        assertTrue("error must name the application id", error.contains("wst-app-1")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("error must mention infobases", error.toLowerCase().contains("infobase")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("error must mention standalone servers", error.toLowerCase().contains("standalone")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testModuleOfApplicationReturnsNullWhenNoGetModuleMethod()
+    {
+        // A plain IApplication (no getModule()) — the reflective probe must degrade to null, not throw.
+        IApplication app = mock(IApplication.class);
+        assertNull(InfobaseAccessSupport.moduleOfApplication(app));
+    }
+
+    @Test
+    public void testModuleOfApplicationInvokesGetModuleWhenPresent()
+    {
+        // A stub exposing getModule() (mirrors a wst-server IServerApplication) — the reflective
+        // probe must find and invoke it, returning the module verbatim.
+        IApplication app = mock(IApplication.class, withSettings().extraInterfaces(StubModuleAccessor.class));
+        Object module = new Object();
+        when(((StubModuleAccessor)app).getModule()).thenReturn(module);
+
+        assertSame(module, InfobaseAccessSupport.moduleOfApplication(app));
+    }
+
+    /** Stands in for {@code IServerApplication}'s {@code getModule()} accessor (not on {@link IApplication}). */
+    public interface StubModuleAccessor
+    {
+        Object getModule();
     }
 }

--- a/tests/TestConfiguration/.scannerwork/report-task.txt
+++ b/tests/TestConfiguration/.scannerwork/report-task.txt
@@ -1,0 +1,6 @@
+projectKey=TestConfiguration
+serverUrl=http://localhost:9001
+serverVersion=26.7.0.124771
+dashboardUrl=http://localhost:9001/dashboard?id=TestConfiguration
+ceTaskId=4b123390-1b2d-40e0-b5e0-7d92a290d52f
+ceTaskUrl=http://localhost:9001/api/ce/task?id=4b123390-1b2d-40e0-b5e0-7d92a290d52f

--- a/tests/TestConfiguration/.scannerwork/report-task.txt
+++ b/tests/TestConfiguration/.scannerwork/report-task.txt
@@ -1,6 +1,0 @@
-projectKey=TestConfiguration
-serverUrl=http://localhost:9001
-serverVersion=26.7.0.124771
-dashboardUrl=http://localhost:9001/dashboard?id=TestConfiguration
-ceTaskId=4b123390-1b2d-40e0-b5e0-7d92a290d52f
-ceTaskUrl=http://localhost:9001/api/ce/task?id=4b123390-1b2d-40e0-b5e0-7d92a290d52f

--- a/tests/e2e/tools/test_create_infobase.py
+++ b/tests/e2e/tools/test_create_infobase.py
@@ -169,6 +169,26 @@ def test_no_platform_runtime_errors_actionably():
 
 
 @e2e_test(tool="create_infobase", kind="action")
+def test_standalone_create_with_credentials_errors_steering_to_register():
+    """#275 negative (CI-safe): applicationKind='standaloneServer' with the default mode='create'
+    plus any of user/password/access must still be rejected -- a brand-new standalone server has no
+    existing infobase reference to store credentials against yet. Unlike the OLD blanket rejection
+    (any standaloneServer + credentials), the error must now steer to BOTH supported alternatives:
+    applicationKind='infobase', or applicationKind='standaloneServer' + mode='register' (which DOES
+    accept credentials -- see test_live_standalone_register_over_existing_infobase below). Validated
+    before any platform/service lookup (headless-safe)."""
+    r = call("create_infobase",
+             {"projectName": PROJECT,
+              "infobaseFile": "C:\\infobases\\ci_probe_credentials_test",
+              "applicationKind": "standaloneServer",
+              "user": "Admin"})
+    err = assert_error(r, "standaloneServer+create with credentials")
+    assert_error_quality(err, names=["infobase"], suggests=["register"],
+                         ctx="standaloneServer+create+credentials must steer to mode='register'")
+    assert_no_diff("a rejected call must not touch the fixture")
+
+
+@e2e_test(tool="create_infobase", kind="action")
 def test_standalone_register_without_database_errors_naming_path():
     """#271 negative (CI-safe): applicationKind='standaloneServer' + mode='register' pointed at a
     directory that holds NO 1Cv8.1CD must fail FAST — before any platform/standalone-runtime lookup —
@@ -300,6 +320,10 @@ def test_live_standalone_register_over_existing_infobase():
     1. Creates a plain FILE infobase (mode='create') at a temp directory — this writes the 1Cv8.1CD.
     2. Registers a standalone server OVER that SAME directory (mode='register'); the existing database
        must be reused (no new DB materialized), so action=='registered' and webUrl/port are reported.
+       #275: also passes user/password -- standaloneServer+register is the ONE standalone-server
+       combination that accepts connection credentials -- and asserts the result acknowledges they
+       were stored (the message notes it; storing does not require the user to actually exist in the
+       infobase, only actual authentication would).
     3. Verifies get_applications lists a wst-server application for the directory.
     4. Cleans up: delete the standalone-server registration (keeping the database), then delete the
        plain infobase registration, then the temp directory.
@@ -317,13 +341,17 @@ def test_live_standalone_register_over_existing_infobase():
         assert os.path.isfile(os.path.join(_SRV_IB_DIR, "1Cv8.1CD")), \
             "the seed step must write a 1Cv8.1CD into %s" % _SRV_IB_DIR
 
-        # 2. Register a standalone server OVER the existing infobase.
+        # 2. Register a standalone server OVER the existing infobase, ALSO passing connection
+        #    credentials (#275): standaloneServer+register is the one standalone-server combination
+        #    that accepts them.
         r_reg = call("create_infobase",
                      {"projectName": PROJECT,
                       "infobaseFile": _SRV_IB_DIR,
                       "infobaseName": _SRV_IB_NAME,
                       "applicationKind": "standaloneServer",
-                      "mode": "register"})
+                      "mode": "register",
+                      "user": "Admin",
+                      "password": ""})
         assert_ok(r_reg, "standalone register over existing infobase")
         sc = r_reg.structured
         assert isinstance(sc, dict), "structured must be a dict: %r" % sc
@@ -336,6 +364,12 @@ def test_live_standalone_register_over_existing_infobase():
         # The existing database must still be on disk (register must not have removed/rewritten it).
         assert os.path.isfile(os.path.join(_SRV_IB_DIR, "1Cv8.1CD")), \
             "the existing 1Cv8.1CD must remain after register: %s" % _SRV_IB_DIR
+        # #275: the result must acknowledge the stored connection credentials (a success note, or --
+        # non-fatally -- a WARNING naming why storage failed; either way NOT silently dropped).
+        message = sc.get("message") or ""
+        assert ("stored connection credentials" in message.lower()
+                or "connection credentials were not stored" in message.lower()), \
+            "message must acknowledge the credentials request (stored or an explicit WARNING): %r" % sc
 
         # 3. Verify a wst-server application now exists for the directory.
         r_apps = call("get_applications", {"projectName": PROJECT})

--- a/tests/e2e/tools/test_set_infobase_credentials.py
+++ b/tests/e2e/tools/test_set_infobase_credentials.py
@@ -42,17 +42,27 @@ NOTE: the tool writes EDT's per-infobase access settings (secure storage), never
 TestConfiguration source files — every call leaves the project tree clean: assert_no_diff().
 """
 
+import os
+import shutil
+import tempfile
+
 from harness import (
     call,
+    assert_ok,
     assert_error,
     assert_error_quality,
     assert_no_diff,
+    requires_live_infobase,
     e2e_test,
     PROJECT,
 )
 
 NONEXISTENT_PROJECT = "NoSuchProject_sic_zzz"
 NONEXISTENT_APP_ID = "no_such_app_sic_zzz"
+
+# #275: temp dir / name for the live "target a standalone-server application directly" round-trip.
+_SRV_IB_DIR = os.path.join(tempfile.gettempdir(), "edt_sic_standalone_e2e")
+_SRV_IB_NAME = "SicStandalone_e2e"
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -104,3 +114,70 @@ def test_nonexistent_application_id_errors_with_hint():
     assert_error_quality(err, names=[NONEXISTENT_APP_ID], suggests=["get_applications"],
                          ctx="nonexistent applicationId is named with get_applications hint")
     assert_no_diff("a rejected call must not touch the fixture")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# LIVE ROUND-TRIP (Tier-2 -- gated behind EDT_MCP_LIVE_INFOBASE=1)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _ensure_standalone_absent():
+    """Best-effort pre/post clean: remove any leftover wst-server AND plain infobase registration
+    from a prior crashed run, then the temp directory. Ignores the results."""
+    call("delete_infobase",
+         {"projectName": PROJECT, "infobaseName": _SRV_IB_NAME,
+          "deleteRegistration": True, "confirm": True})
+    call("delete_infobase",
+         {"projectName": PROJECT, "infobaseName": _SRV_IB_NAME,
+          "deleteRegistration": True, "confirm": True})
+    shutil.rmtree(_SRV_IB_DIR, ignore_errors=True)
+
+
+@e2e_test(tool="set_infobase_credentials", kind="action")
+def test_live_standalone_server_application_id_roundtrip():
+    """#275 happy path (Tier-2 / live-gated): set_infobase_credentials now accepts a standalone-
+    server (wst-server) applicationId directly, not just a plain file/server infobase -- the
+    widened InfobaseAccessSupport.storeCredentials(IApplication, ...) adapts the wst-server
+    application to the InfobaseReference EDT's own launch path resolves against.
+
+    On the headless CI fixture there is NO wst-server application (TestConfiguration only has the
+    plain infobase used by the other tools' fixtures), so a CI-safe rejection-wording assert here
+    would be indistinguishable from the existing 'nonexistent applicationId' matrix above -- it is
+    therefore LIVE-GATED instead: it seeds a real standalone server (create_infobase
+    applicationKind='standaloneServer' mode='register' over an existing infobase) and targets it
+    directly.
+
+    REQUIRES: EDT_MCP_LIVE_INFOBASE=1 (a live EDT stand with both a 1C platform runtime and a
+    standalone-server runtime registered, and TestConfiguration open)."""
+    requires_live_infobase("set_infobase_credentials standalone-server applicationId round-trip")
+
+    _ensure_standalone_absent()
+    try:
+        # Seed: a plain FILE infobase, then a standalone server registered over it (no credentials
+        # here -- this test exercises set_infobase_credentials targeting the app directly).
+        r_seed = call("create_infobase",
+                      {"projectName": PROJECT, "infobaseFile": _SRV_IB_DIR,
+                       "infobaseName": _SRV_IB_NAME})
+        assert_ok(r_seed, "seed plain infobase for the standalone-server credentials round-trip")
+
+        r_reg = call("create_infobase",
+                     {"projectName": PROJECT, "infobaseFile": _SRV_IB_DIR,
+                      "infobaseName": _SRV_IB_NAME, "applicationKind": "standaloneServer",
+                      "mode": "register"})
+        assert_ok(r_reg, "register standalone server for the credentials round-trip")
+        app_id = r_reg.structured.get("applicationId")
+        assert app_id, "register result must carry an applicationId: %r" % r_reg.structured
+
+        # Target the wst-server application DIRECTLY with set_infobase_credentials (#275) -- this is
+        # the tool under test, not create_infobase's own credentials parameters.
+        r = call("set_infobase_credentials",
+                 {"projectName": PROJECT, "applicationId": app_id, "user": "Admin", "password": ""})
+        assert_ok(r, "set_infobase_credentials against a wst-server application")
+        sc = r.structured
+        assert isinstance(sc, dict), "structured must be a dict: %r" % sc
+        assert sc.get("applicationId") == app_id, "applicationId must be echoed: %r" % sc
+        assert sc.get("user") == "Admin", "stored user must be echoed: %r" % sc
+        assert sc.get("access") == "INFOBASE", "default access must be echoed: %r" % sc
+    finally:
+        _ensure_standalone_absent()
+
+    assert_no_diff("the round-trip must not touch the committed fixture (TestConfiguration)")

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -190,11 +190,11 @@
       "openWorldHint": false,
       "readOnlyHint": false
     },
-    "description": "Create a new FILE infobase (1C database) OR register an existing one, and bind it to a configuration project so it appears in get_applications. mode='create' (default) makes a new database (requires a registered 1C platform runtime); mode='register' adds an already-existing infobase at the given path without launching the platform. applicationKind='infobase' (default) makes a plain file infobase; applicationKind='standaloneServer' creates (or, with mode='register', wraps an EXISTING file infobase with) an autonomous (standalone) server that also exposes a web URL for HTTP testing (requires a registered 1C standalone-server runtime, platform >= 8.3.23). FILE type only (server/web rejected). Runs in a background Job (up to 120 s). Full parameters and examples: call get_tool_guide('create_infobase').",
+    "description": "Create a new FILE infobase (1C database) OR register an existing one, and bind it to a configuration project so it appears in get_applications. mode='create' (default) makes a new database (requires a registered 1C platform runtime); mode='register' adds an already-existing infobase at the given path without launching the platform. applicationKind='infobase' (default) makes a plain file infobase; applicationKind='standaloneServer' creates (or, with mode='register', wraps an EXISTING file infobase with) an autonomous (standalone) server that also exposes a web URL for HTTP testing (requires a registered 1C standalone-server runtime, platform >= 8.3.23). FILE type only (server/web rejected). Runs in a background Job (up to 120 s). user/password/access store connection credentials for applicationKind='infobase', and for applicationKind='standaloneServer' with mode='register' — rejected for a newly created standalone server (mode='create'). Full parameters and examples: call get_tool_guide('create_infobase').",
     "inputSchema": {
       "properties": {
         "access": {
-          "description": "Authentication kind for the stored credentials: 'INFOBASE' (default, 1C user auth) or 'OS'. Credentials are stored when ANY of user/password/access is given; access='OS' on its own stores OS-authentication settings (no 1C user/password). Applies only to applicationKind='infobase' (a file infobase).",
+          "description": "Authentication kind for the stored credentials: 'INFOBASE' (default, 1C user auth) or 'OS'. Credentials are stored when ANY of user/password/access is given; access='OS' on its own stores OS-authentication settings (no 1C user/password). Applies to applicationKind='infobase' (a file infobase), and to applicationKind='standaloneServer' with mode='register'; rejected for a newly created standalone server (mode='create').",
           "enum": [
             "INFOBASE",
             "OS"
@@ -226,7 +226,7 @@
           "type": "string"
         },
         "password": {
-          "description": "Password for 'user'. Optional; default empty (demo bases use an empty password).",
+          "description": "Password for 'user'. Optional; default empty (demo bases use an empty password). Same applicationKind/mode restriction as 'user'.",
           "type": "string"
         },
         "platform": {
@@ -242,7 +242,7 @@
           "type": "boolean"
         },
         "user": {
-          "description": "Infobase connection user to store so update_database / debug_launch can authenticate the update agent (issue #194). Selects an EXISTING user; most useful with mode='register' (the existing base already has users). Omit to store no credentials.",
+          "description": "Infobase connection user to store so update_database / debug_launch can authenticate the update agent (issue #194). Selects an EXISTING user; most useful with mode='register' (the existing base already has users). Omit to store no credentials. Accepted for applicationKind='infobase', and for applicationKind='standaloneServer' with mode='register'; rejected for a newly created standalone server (mode='create').",
           "type": "string"
         }
       },
@@ -3919,7 +3919,7 @@
       "openWorldHint": false,
       "readOnlyHint": false
     },
-    "description": "Store infobase connection credentials (user/password) so update_database and debug_launch can authenticate the update agent on an infobase that has a user list (issue #194). Selects an EXISTING infobase user (does not create users); an empty password is valid (demo bases). Target by launchConfigurationName (preferred) or projectName + applicationId (from get_applications). Full parameters and examples: call get_tool_guide('set_infobase_credentials').",
+    "description": "Store infobase connection credentials (user/password) so update_database and debug_launch can authenticate the update agent on an infobase that has a user list (issue #194) — also for a standalone-server application wrapping an already-registered infobase (issue #275). Selects an EXISTING infobase user (does not create users); an empty password is valid (demo bases). Target by launchConfigurationName (preferred) or projectName + applicationId (from get_applications). Full parameters and examples: call get_tool_guide('set_infobase_credentials').",
     "inputSchema": {
       "properties": {
         "access": {


### PR DESCRIPTION
Закрывает #277. **Основан на ветке #276** (цепочка #272 → #274 → #276 → этот PR; по мере мержа дифы схлопываются).

## Пере-диагноз

Заявленный в issue «долгий stopServer» оказался ни при чём: Job удаления standalone-сервера **уже** ограничен 120 секундами с честной ошибкой. Настоящий источник «>300 с без ответа» — **диалог подтверждения деструктивной операции** (#215): на ASK-уровне он блокировал MCP-вызов **бессрочно**, пока человек не нажмёт кнопку. На необслуживаемом GUI-стенде (Xvfb — display живой, диалог открывается) любой деструктивный вызов переживал любой клиентский таймаут молча; репортёрское удаление реально завершилось — после позднего подтверждения. Это нарушало наш же принцип unattended-safety: у каждого диалога должен быть программный выход, таймаут → ошибка.

## Фикс

Гейт теперь ждёт ответа максимум **120 с** (ниже типовых клиентских бюджетов в 300 с) на **обоих** потоковых путях:

- **воркер-поток** (`delete_project` / `delete_infobase` / `update_database`): диалог открывается через `asyncExec`, воркер ждёт защёлку с таймаутом;
- **UI-поток** — и это не экзотика, а штатный путь `delete_metadata` / `modify_metadata` / `rename_metadata_object`, чей `execute()` целиком маршалится на UI-поток до гейта: заранее взведённый `Display.timerExec`-клозер срабатывает внутри вложенного event-loop модального `open()` и закрывает диалог (при ответе человека таймер снимается идиомой `timerExec(-1)`).

Оба пути идут через decide-once арбитр «первый победил». Таймаут — новый REJECT-подобный вердикт `TIMEOUT` со своей внятной ошибкой: имя инструмента, лимит и три рецепта (Preferences → Destructive operations → Allow all / per-tool; `EDT_MCP_DESTRUCTIVE_CONSENT=allow` при запуске EDT; повторить вызов и подтвердить). Поздний клик «Allow for session» всё равно запоминается. Отдельно пришита юнитом SWT-подлянка: принудительный `close()` возвращает **OK** (дефолт JFace) — без арбитра таймаут молча превращался бы в «разрешить».

Тексты REJECT-ошибки байт-в-байт прежние; схем/описаний не трогали → **golden не менялся**.

## Проверено

- Unit: **3505/3505** (`DestructiveConsentGateTest` 23/23: гонки арбитра в обоих порядках, late-session-allow, OK-default gotcha, тексты).
- **Живой стенд EDT 2026.1 без env-байпаса** (сценарий репортёра): `delete_metadata` (UI-путь) и `delete_project` (воркер-путь) — оба вернули таймаут-ошибку **ровно на 120-й секунде**, мутаций нет (объект и проект целы, проверено читающими инструментами).
- README-раздел про consent дополнен описанием таймаута.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
