### PR TITLE
Quality Gate: фикс security-false-positive + рост юнит-покрытия нового кода (#171)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListGitBranchesTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ListGitBranchesTool.java
@@ -158,7 +158,8 @@ public class ListGitBranchesTool implements IMcpTool
         return md.toString();
     }
 
-    private String renderBranchTable(List<Ref> refs, String fullBranch, boolean detached)
+    /** Package-visible (not private) so it is directly unit-testable with hand-built {@link Ref}s. */
+    static String renderBranchTable(List<Ref> refs, String fullBranch, boolean detached)
     {
         StringBuilder md = new StringBuilder();
         md.append("| Branch | Type | Current |\n"); //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SwitchGitBranchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SwitchGitBranchTool.java
@@ -352,7 +352,8 @@ public class SwitchGitBranchTool implements IMcpTool
         }
     }
 
-    private static String joinBounded(List<String> paths)
+    /** Package-visible (not private) so it is directly unit-testable. */
+    static String joinBounded(List<String> paths)
     {
         if (paths == null || paths.isEmpty())
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/InfobaseAuthDialogSuppressor.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/InfobaseAuthDialogSuppressor.java
@@ -121,7 +121,10 @@ public final class InfobaseAuthDialogSuppressor
      * {@code project.build.sourceEncoding=UTF-8} and {@code <encoding>UTF-8</encoding>}, so it
      * compiles identically (CLAUDE.md rule #7 allows justified Cyrillic in matched string literals).
      */
-    static final String AUTH_DIALOG_TITLE_PREFIX_RU =
+    // NOSONAR S6418 false positive: a localized UI dialog TITLE the code matches (a Russian
+    // sentence EDT shows), NOT a secret - the "AUTH" in the constant name trips the
+    // hard-coded-credential heuristic.
+    static final String AUTH_DIALOG_TITLE_PREFIX_RU = // NOSONAR
         "Сконфигурируйте" //$NON-NLS-1$
             + " доступ к инфо" //$NON-NLS-1$
             + "рмационной базе"; //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/git/GitCheckoutSupport.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/git/GitCheckoutSupport.java
@@ -92,6 +92,18 @@ public final class GitCheckoutSupport
         }
 
         /**
+         * Package-private test-only factory: builds a {@link CheckoutOutcome} directly, bypassing
+         * {@link GitCheckoutSupport#checkout(IProject, Repository, String)}'s live background {@link Job},
+         * so the pure accessors are unit-testable (issue #171 coverage). No behaviour change - mirrors the
+         * private constructor exactly.
+         */
+        static CheckoutOutcome forTest(CheckoutResult result, String refreshWarning, boolean timedOut,
+            boolean interrupted, Exception jobError)
+        {
+            return new CheckoutOutcome(result, refreshWarning, timedOut, interrupted, jobError);
+        }
+
+        /**
          * @return {@code true} when the Job ran to completion (the checkout may still have a
          *         non-OK {@link CheckoutResult} - that is a normal outcome, not this flag)
          */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/git/GitRepositoryResolver.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/git/GitRepositoryResolver.java
@@ -63,6 +63,18 @@ public final class GitRepositoryResolver
             this.errorJson = errorJson;
         }
 
+        /**
+         * Package-private test-only factory: builds a {@link Resolution} directly, bypassing
+         * {@link #resolve(String)}'s {@code ProjectContext}/EDT-workspace dependency, so the pure
+         * accessors and {@link #closeIfOwned()} are unit-testable against a real (non-EDT) JGit
+         * {@link Repository} (issue #171 coverage). No behaviour change - mirrors the private
+         * constructor exactly.
+         */
+        static Resolution forTest(IProject project, Repository repository, boolean owned, String errorJson)
+        {
+            return new Resolution(project, repository, owned, errorJson);
+        }
+
         /** @return {@code true} when the repository resolved (no error). */
         public boolean ok()
         {
@@ -174,16 +186,9 @@ public final class GitRepositoryResolver
         {
             return null;
         }
-        File projectDir = project.getLocation().toFile();
         try
         {
-            FileRepositoryBuilder builder = new FileRepositoryBuilder().findGitDir(projectDir);
-            if (builder.getGitDir() == null)
-            {
-                // No .git directory found anywhere up the tree - not a git working tree.
-                return null;
-            }
-            return builder.build();
+            return discoverFromDirectory(project.getLocation().toFile());
         }
         catch (IOException | IllegalArgumentException e)
         {
@@ -191,6 +196,29 @@ public final class GitRepositoryResolver
                 + project.getName() + "'", e); //$NON-NLS-1$
             return null;
         }
+    }
+
+    /**
+     * Pure JGit {@code .git} directory discovery from a filesystem location, with NO {@code IProject}/EDT
+     * dependency - the mechanics behind {@link #discoverRepository}, extracted so it is directly
+     * unit-testable against a real temp git repository (issue #171 coverage). Package-visible for exactly
+     * that reason; no behaviour change - {@link #discoverRepository} still catches and logs exactly as
+     * before, just one level up.
+     *
+     * @param dir the filesystem directory to search upward from
+     * @return the discovered, caller-owned repository, or {@code null} when no {@code .git} directory is
+     *         found anywhere up the tree
+     * @throws IOException propagated from {@link FileRepositoryBuilder#build()}
+     */
+    static Repository discoverFromDirectory(File dir) throws IOException
+    {
+        FileRepositoryBuilder builder = new FileRepositoryBuilder().findGitDir(dir);
+        if (builder.getGitDir() == null)
+        {
+            // No .git directory found anywhere up the tree - not a git working tree.
+            return null;
+        }
+        return builder.build();
     }
 
     private static Resolution failed(String errorJson)

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ListGitBranchesToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ListGitBranchesToolTest.java
@@ -10,12 +10,19 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectIdRef;
+import org.eclipse.jgit.lib.Ref;
 import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+import com.ditrix.edt.mcp.server.utils.MarkdownUtils;
 
 /**
  * Tests for {@link ListGitBranchesTool}.
@@ -24,10 +31,20 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
  * guards that fire BEFORE any repository access. The real read path (resolving a
  * repository, listing branches, reading infobase bindings) needs a live EDT
  * workspace with a real git working tree and is covered by the e2e suite.
+ * <p>
+ * {@link ListGitBranchesTool#renderBranchTable} - the pure ref-name-shortening/current-branch-marking
+ * table renderer - is covered directly below against hand-built {@link Ref}s
+ * ({@link ObjectIdRef.Unpeeled}, a real public JGit type - NOT a mock; the object id itself is
+ * irrelevant to this renderer, only {@link Ref#getName()} is read).
  */
 public class ListGitBranchesToolTest
 {
     private static final String NONEXISTENT_PROJECT = "NoSuchProject_lgb_zzz"; //$NON-NLS-1$
+
+    private static Ref ref(String name)
+    {
+        return new ObjectIdRef.Unpeeled(Ref.Storage.LOOSE, name, ObjectId.zeroId());
+    }
 
     @Test
     public void testName()
@@ -108,5 +125,56 @@ public class ListGitBranchesToolTest
             || result.contains("\"error\"")); //$NON-NLS-1$
         assertTrue("error must name the bad project", result.contains(NONEXISTENT_PROJECT)); //$NON-NLS-1$
         assertTrue("error must steer to list_projects", result.contains("list_projects")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== renderBranchTable: pure ref-name shortening / current-branch marking ====================
+
+    @Test
+    public void testRenderBranchTableEmptyRefsShowsNoBranchesFound()
+    {
+        String table = ListGitBranchesTool.renderBranchTable(Collections.emptyList(), null, true);
+        assertTrue(table.contains("*No branches found.*")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRenderBranchTableMarksTheCurrentLocalBranch()
+    {
+        List<Ref> refs = Arrays.asList(ref("refs/heads/main"), ref("refs/heads/feature/x")); //$NON-NLS-1$ //$NON-NLS-2$
+        String table = ListGitBranchesTool.renderBranchTable(refs, "refs/heads/main", false); //$NON-NLS-1$
+
+        assertTrue("the current local branch's row must be marked Yes", //$NON-NLS-1$
+            table.contains(MarkdownUtils.tableRow("main", "local", "Yes"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        assertTrue("a non-current local branch's Current cell must be empty", //$NON-NLS-1$
+            table.contains(MarkdownUtils.tableRow("feature/x", "local", ""))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    @Test
+    public void testRenderBranchTableDetachedHeadNeverMarksAnyRowCurrent()
+    {
+        // detached=true: even though the ref name equals fullBranch, isCurrent must stay false - the
+        // detached-HEAD short SHA is reported separately above the table, not via this row flag.
+        List<Ref> refs = Collections.singletonList(ref("refs/heads/main")); //$NON-NLS-1$
+        String table = ListGitBranchesTool.renderBranchTable(refs, "refs/heads/main", true); //$NON-NLS-1$
+
+        assertTrue(table.contains(MarkdownUtils.tableRow("main", "local", ""))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    @Test
+    public void testRenderBranchTableShortensRemoteTrackingRefs()
+    {
+        List<Ref> refs = Collections.singletonList(ref("refs/remotes/origin/main")); //$NON-NLS-1$
+        String table = ListGitBranchesTool.renderBranchTable(refs, null, true);
+
+        assertTrue(table.contains(MarkdownUtils.tableRow("origin/main", "remote", ""))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    @Test
+    public void testRenderBranchTableFallsBackToOtherForANonBranchRef()
+    {
+        // A tag (or any ref outside refs/heads//refs/remotes) keeps its FULL name and is typed "other".
+        List<Ref> refs = Collections.singletonList(ref("refs/tags/v1")); //$NON-NLS-1$
+        String table = ListGitBranchesTool.renderBranchTable(refs, null, true);
+
+        assertTrue(table.contains(MarkdownUtils.tableRow("refs/tags/v1", "other", ""))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/SetBranchInfobaseToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/SetBranchInfobaseToolTest.java
@@ -7,6 +7,7 @@
 package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -167,5 +168,70 @@ public class SetBranchInfobaseToolTest
             || result.contains("\"error\"")); //$NON-NLS-1$
         assertTrue("error must name the bad project", result.contains(NONEXISTENT_PROJECT)); //$NON-NLS-1$
         assertTrue("error must steer to list_projects", result.contains("list_projects")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== validateAction: every value that must PASS the pure guard ====================
+    //
+    // The "bogus" case above covers the guard's rejection branch; these cover every acceptance branch
+    // (null / empty / 'attach' case-insensitively / 'detach') by observing that each one reaches PAST the
+    // action guard to project resolution instead of being rejected as an invalid action - reachable
+    // headlessly, no live service needed, same technique the existing pre-check tests already use.
+
+    @Test
+    public void testMissingActionDefaultsToAttachAndReachesProjectResolution()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", NONEXISTENT_PROJECT); //$NON-NLS-1$
+        params.put("branch", "feature/x"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("applicationId", "app1"); //$NON-NLS-1$ //$NON-NLS-2$
+        // action omitted entirely.
+        String result = new SetBranchInfobaseTool().execute(params);
+        assertTrue("must reject with an error", result.contains("\"success\":false") //$NON-NLS-1$ //$NON-NLS-2$
+            || result.contains("\"error\"")); //$NON-NLS-1$
+        assertFalse("a missing action must NOT be rejected as invalid", //$NON-NLS-1$
+            result.contains("Invalid action")); //$NON-NLS-1$
+        assertTrue("the guard must pass through to project resolution", //$NON-NLS-1$
+            result.contains(NONEXISTENT_PROJECT));
+    }
+
+    @Test
+    public void testEmptyActionDefaultsToAttachAndReachesProjectResolution()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", NONEXISTENT_PROJECT); //$NON-NLS-1$
+        params.put("branch", "feature/x"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("applicationId", "app1"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("action", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new SetBranchInfobaseTool().execute(params);
+        assertFalse("an empty action must NOT be rejected as invalid", //$NON-NLS-1$
+            result.contains("Invalid action")); //$NON-NLS-1$
+        assertTrue(result.contains(NONEXISTENT_PROJECT));
+    }
+
+    @Test
+    public void testAttachActionIsAcceptedCaseInsensitively()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", NONEXISTENT_PROJECT); //$NON-NLS-1$
+        params.put("branch", "feature/x"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("applicationId", "app1"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("action", "ATTACH"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new SetBranchInfobaseTool().execute(params);
+        assertFalse("'ATTACH' (any case) must NOT be rejected as invalid", //$NON-NLS-1$
+            result.contains("Invalid action")); //$NON-NLS-1$
+        assertTrue(result.contains(NONEXISTENT_PROJECT));
+    }
+
+    @Test
+    public void testDetachActionIsAccepted()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", NONEXISTENT_PROJECT); //$NON-NLS-1$
+        params.put("branch", "feature/x"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("applicationId", "app1"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("action", "detach"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new SetBranchInfobaseTool().execute(params);
+        assertFalse("'detach' must NOT be rejected as invalid", result.contains("Invalid action")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(result.contains(NONEXISTENT_PROJECT));
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/SwitchGitBranchToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/SwitchGitBranchToolTest.java
@@ -11,7 +11,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
@@ -137,5 +141,57 @@ public class SwitchGitBranchToolTest
         assertTrue("error must name the bad project", result.contains(NONEXISTENT_PROJECT)); //$NON-NLS-1$
         assertTrue("error must steer to list_projects", result.contains("list_projects")); //$NON-NLS-1$ //$NON-NLS-2$
         assertFalse("a rejected call must not claim success", result.contains("\"success\":true")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== joinBounded: pure list-to-string joiner (used in error messages) ====================
+
+    @Test
+    public void testJoinBoundedNullIsNone()
+    {
+        assertEquals("(none)", SwitchGitBranchTool.joinBounded(null)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testJoinBoundedEmptyIsNone()
+    {
+        assertEquals("(none)", SwitchGitBranchTool.joinBounded(Collections.emptyList())); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testJoinBoundedJoinsAllPathsWhenUnderTheCap()
+    {
+        assertEquals("a, b, c", SwitchGitBranchTool.joinBounded(Arrays.asList("a", "b", "c"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+    }
+
+    @Test
+    public void testJoinBoundedCapsAtTwentyAndReportsTheRemainderCount()
+    {
+        List<String> paths = new ArrayList<>();
+        for (int i = 1; i <= 25; i++)
+        {
+            paths.add("path" + i); //$NON-NLS-1$
+        }
+
+        String joined = SwitchGitBranchTool.joinBounded(paths);
+
+        assertTrue("the first path must be listed", joined.startsWith("path1, path2")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("exactly the first 20 paths must be listed", joined.contains("path20")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("the 21st path exceeds the cap and must NOT be listed", joined.contains("path21")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the remainder count must be reported", joined.endsWith(" ...and 5 more")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testJoinBoundedExactlyAtTheCapReportsNoRemainder()
+    {
+        List<String> paths = new ArrayList<>();
+        for (int i = 1; i <= 20; i++)
+        {
+            paths.add("path" + i); //$NON-NLS-1$
+        }
+
+        String joined = SwitchGitBranchTool.joinBounded(paths);
+
+        assertTrue(joined.contains("path20")); //$NON-NLS-1$
+        assertFalse("exactly 20 paths need no '...and N more' suffix", joined.contains("...and")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/DcsStructureReaderTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/DcsStructureReaderTest.java
@@ -28,18 +28,32 @@ import org.junit.Test;
 import com._1c.g5.v8.dt.dcs.model.core.DataCompositionField;
 import com._1c.g5.v8.dt.dcs.model.core.DataCompositionParameterUse;
 import com._1c.g5.v8.dt.dcs.model.core.DcsFactory;
+import com._1c.g5.v8.dt.dcs.model.core.DesignTimeValue;
+import com._1c.g5.v8.dt.dcs.model.core.DesignTimeValueValue;
+import com._1c.g5.v8.dt.dcs.model.core.LocalString;
 import com._1c.g5.v8.dt.dcs.model.core.Presentation;
 import com._1c.g5.v8.dt.dcs.model.schema.DataCompositionSchema;
 import com._1c.g5.v8.dt.dcs.model.schema.DataCompositionSchemaCalculatedField;
 import com._1c.g5.v8.dt.dcs.model.schema.DataCompositionSchemaDataSetField;
+import com._1c.g5.v8.dt.dcs.model.schema.DataCompositionSchemaDataSetFieldFolder;
 import com._1c.g5.v8.dt.dcs.model.schema.DataCompositionSchemaDataSetObject;
 import com._1c.g5.v8.dt.dcs.model.schema.DataCompositionSchemaDataSetQuery;
+import com._1c.g5.v8.dt.dcs.model.schema.DataCompositionSchemaDataSetUnion;
+import com._1c.g5.v8.dt.dcs.model.schema.DataCompositionSchemaNestedDataSet;
 import com._1c.g5.v8.dt.dcs.model.schema.DataCompositionSchemaParameter;
 import com._1c.g5.v8.dt.dcs.model.schema.DataCompositionSchemaTotalField;
+import com._1c.g5.v8.dt.mcore.BooleanValue;
+import com._1c.g5.v8.dt.mcore.DateValue;
+import com._1c.g5.v8.dt.mcore.EnumValue;
 import com._1c.g5.v8.dt.mcore.McoreFactory;
 import com._1c.g5.v8.dt.mcore.NumberValue;
+import com._1c.g5.v8.dt.mcore.ReferenceValue;
+import com._1c.g5.v8.dt.mcore.StringValue;
 import com._1c.g5.v8.dt.mcore.Type;
 import com._1c.g5.v8.dt.mcore.TypeDescription;
+import com._1c.g5.v8.dt.mcore.TypeSet;
+import com._1c.g5.v8.dt.mcore.TypeValue;
+import com._1c.g5.v8.dt.mcore.UndefinedValue;
 
 /**
  * Tests {@link DcsStructureReader}: the pure Markdown renderer for a {@link DataCompositionSchema} content.
@@ -157,6 +171,86 @@ public class DcsStructureReaderTest
         assertTrue(rendered.contains("**Object:** Catalog.Goods")); //$NON-NLS-1$
     }
 
+    @Test
+    public void testObjectDataSetRendersDataSourceWhenPresent()
+    {
+        DataCompositionSchema schema = newSchema();
+        DataCompositionSchemaDataSetObject dataSet =
+            com._1c.g5.v8.dt.dcs.model.schema.DcsFactory.eINSTANCE.createDataCompositionSchemaDataSetObject();
+        dataSet.setName("Obj2"); //$NON-NLS-1$
+        dataSet.setObjectName("Catalog.Warehouses"); //$NON-NLS-1$
+        dataSet.setDataSource("Local2"); //$NON-NLS-1$
+        schema.getDataSets().add(dataSet);
+
+        String rendered = DcsStructureReader.render("CommonTemplate.Obj2", schema, "en"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("an object data set's own data source must be present", //$NON-NLS-1$
+            rendered.contains("**Data source:** Local2")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testUnionDataSetRendersUnionOfNestedNames()
+    {
+        DataCompositionSchema schema = newSchema();
+        DataCompositionSchemaDataSetUnion union =
+            com._1c.g5.v8.dt.dcs.model.schema.DcsFactory.eINSTANCE.createDataCompositionSchemaDataSetUnion();
+        union.setName("Combined"); //$NON-NLS-1$
+
+        DataCompositionSchemaDataSetObject first =
+            com._1c.g5.v8.dt.dcs.model.schema.DcsFactory.eINSTANCE.createDataCompositionSchemaDataSetObject();
+        first.setName("Sales"); //$NON-NLS-1$
+        DataCompositionSchemaDataSetObject second =
+            com._1c.g5.v8.dt.dcs.model.schema.DcsFactory.eINSTANCE.createDataCompositionSchemaDataSetObject();
+        second.setName("Returns"); //$NON-NLS-1$
+        union.getItems().add(first);
+        union.getItems().add(second);
+        schema.getDataSets().add(union);
+
+        String rendered = DcsStructureReader.render("Report.X.Template.Main", schema, "en"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the union's own kind/name subsection must be present", //$NON-NLS-1$
+            rendered.contains("### Combined (union)")); //$NON-NLS-1$
+        assertTrue("the union's nested item names must be joined", //$NON-NLS-1$
+            rendered.contains("**Union of:** Sales, Returns")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testDataSetFieldFolderRendersAsAFolderRow()
+    {
+        DataCompositionSchema schema = newSchema();
+        DataCompositionSchemaDataSetQuery dataSet =
+            com._1c.g5.v8.dt.dcs.model.schema.DcsFactory.eINSTANCE.createDataCompositionSchemaDataSetQuery();
+        dataSet.setName("Sales"); //$NON-NLS-1$
+        DataCompositionSchemaDataSetFieldFolder folder = com._1c.g5.v8.dt.dcs.model.schema.DcsFactory.eINSTANCE
+            .createDataCompositionSchemaDataSetFieldFolder();
+        folder.setDataPath("Group"); //$NON-NLS-1$
+        folder.setTitle(title("Group title")); //$NON-NLS-1$
+        dataSet.getFields().add(folder);
+        schema.getDataSets().add(dataSet);
+
+        String rendered = DcsStructureReader.render("Report.X.Template.Main", schema, "en"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the folder's data path must be present", rendered.contains("Group")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the folder's title must be present", rendered.contains("Group title")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a folder field must be marked as such", rendered.contains("(folder)")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testDataSetFieldOfUnrecognizedKindFallsBackToEClassName()
+    {
+        DataCompositionSchema schema = newSchema();
+        DataCompositionSchemaDataSetQuery dataSet =
+            com._1c.g5.v8.dt.dcs.model.schema.DcsFactory.eINSTANCE.createDataCompositionSchemaDataSetQuery();
+        dataSet.setName("Sales"); //$NON-NLS-1$
+        // DataCompositionSchemaNestedDataSet is a THIRD DataSetField subinterface (besides Field/Folder) -
+        // it hits the reader's defensive "else" row (data path/field/title columns empty, EClass name only).
+        DataCompositionSchemaNestedDataSet nested = com._1c.g5.v8.dt.dcs.model.schema.DcsFactory.eINSTANCE
+            .createDataCompositionSchemaNestedDataSet();
+        dataSet.getFields().add(nested);
+        schema.getDataSets().add(dataSet);
+
+        String rendered = DcsStructureReader.render("Report.X.Template.Main", schema, "en"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("an unrecognized DataSetField kind must fall back to its EClass simple name", //$NON-NLS-1$
+            rendered.contains("DataCompositionSchemaNestedDataSet")); //$NON-NLS-1$
+    }
+
     // ==================== calculated fields / total fields ====================
 
     @Test
@@ -227,6 +321,93 @@ public class DcsStructureReaderTest
             rendered.contains(DataCompositionParameterUse.AUTO.getName()));
     }
 
+    @Test
+    public void testParameterDefaultValuesCoverEveryDescribeValueKind()
+    {
+        // One parameter with one default value of every mcore Value kind describeValue/describeSimpleValue/
+        // describeTypedValue dispatch on, plus one kind NONE of them recognize (the eClass-name fallback) -
+        // joinValues comma-joins them all into a single table cell, so one render covers every branch.
+        DataCompositionSchema schema = newSchema();
+        DataCompositionSchemaParameter parameter = com._1c.g5.v8.dt.dcs.model.schema.DcsFactory.eINSTANCE
+            .createDataCompositionSchemaParameter();
+        parameter.setName("Mixed"); //$NON-NLS-1$
+
+        StringValue stringValue = McoreFactory.eINSTANCE.createStringValue();
+        stringValue.setValue("Hello"); //$NON-NLS-1$
+        parameter.getValues().add(stringValue);
+
+        BooleanValue booleanValue = McoreFactory.eINSTANCE.createBooleanValue();
+        booleanValue.setValue(true);
+        parameter.getValues().add(booleanValue);
+
+        DateValue dateValue = McoreFactory.eINSTANCE.createDateValue();
+        com._1c.g5.v8.dt.mcore.util.Date rawDate = new com._1c.g5.v8.dt.mcore.util.Date(2024, 1, 1, 0, 0, 0);
+        dateValue.setValue(rawDate);
+        parameter.getValues().add(dateValue);
+
+        EnumValue enumValue = McoreFactory.eINSTANCE.createEnumValue();
+        enumValue.setValue(DataCompositionParameterUse.AUTO);
+        parameter.getValues().add(enumValue);
+
+        TypeValue typeValue = McoreFactory.eINSTANCE.createTypeValue();
+        Type numberType = McoreFactory.eINSTANCE.createType();
+        numberType.setName("Number"); //$NON-NLS-1$
+        typeValue.setValue(numberType);
+        parameter.getValues().add(typeValue);
+
+        ReferenceValue referenceValue = McoreFactory.eINSTANCE.createReferenceValue();
+        LocalString referenceTarget = DcsFactory.eINSTANCE.createLocalString();
+        referenceValue.setValue(referenceTarget);
+        parameter.getValues().add(referenceValue);
+
+        DesignTimeValue designTimeValue = DcsFactory.eINSTANCE.createDesignTimeValue();
+        designTimeValue.setValue("MyDesignTimeExpr"); //$NON-NLS-1$
+        DesignTimeValueValue designTimeValueValue = DcsFactory.eINSTANCE.createDesignTimeValueValue();
+        designTimeValueValue.setValue(designTimeValue);
+        parameter.getValues().add(designTimeValueValue);
+
+        UndefinedValue undefinedValue = McoreFactory.eINSTANCE.createUndefinedValue();
+        parameter.getValues().add(undefinedValue);
+
+        schema.getParameters().add(parameter);
+
+        String rendered = DcsStructureReader.render("Report.X.Template.Main", schema, "en"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a StringValue must render quoted", rendered.contains("\"Hello\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a BooleanValue must render its literal", rendered.contains("true")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a DateValue must render the mcore Date's raw toString()", //$NON-NLS-1$
+            rendered.contains(rawDate.toString()));
+        assertTrue("an EnumValue must render its literal name", //$NON-NLS-1$
+            rendered.contains(DataCompositionParameterUse.AUTO.getName()));
+        assertTrue("a TypeValue must render the resolved type name", rendered.contains("Number")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a ReferenceValue must render the referenced object's toString()", //$NON-NLS-1$
+            rendered.contains(referenceTarget.toString()));
+        assertTrue("a DesignTimeValueValue must render its raw text", //$NON-NLS-1$
+            rendered.contains("MyDesignTimeExpr")); //$NON-NLS-1$
+        assertTrue("an unrecognized Value kind must fall back to its EClass simple name", //$NON-NLS-1$
+            rendered.contains("UndefinedValue")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testParameterValueTypeFallsBackToEClassNameForANonTypeTypeItem()
+    {
+        // TypeSet is a TypeItem that is NOT a Type - typeItemName() must fall back to its EClass simple
+        // name rather than a (nonexistent) getName() call.
+        DataCompositionSchema schema = newSchema();
+        DataCompositionSchemaParameter parameter = com._1c.g5.v8.dt.dcs.model.schema.DcsFactory.eINSTANCE
+            .createDataCompositionSchemaParameter();
+        parameter.setName("SetParam"); //$NON-NLS-1$
+
+        TypeDescription valueType = McoreFactory.eINSTANCE.createTypeDescription();
+        TypeSet typeSet = McoreFactory.eINSTANCE.createTypeSet();
+        valueType.getTypes().add(typeSet);
+        parameter.setValueType(valueType);
+        schema.getParameters().add(parameter);
+
+        String rendered = DcsStructureReader.render("Report.X.Template.Main", schema, "en"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a non-Type TypeItem must fall back to its EClass simple name", //$NON-NLS-1$
+            rendered.contains("TypeSet")); //$NON-NLS-1$
+    }
+
     // ==================== default settings: selection / filter (incl. group) / order ====================
     //
     // com._1c.g5.v8.dt.dcs.model.settings is access-restricted (see the class javadoc), so these exercise
@@ -257,6 +438,53 @@ public class DcsStructureReaderTest
         assertTrue(DcsStructureReader.renderSelection(null, "en").isEmpty()); //$NON-NLS-1$
         EObject emptySelection = SETTINGS_MODEL.newContainer(SETTINGS_MODEL.selectedFields);
         assertTrue(DcsStructureReader.renderSelection(emptySelection, "en").isEmpty()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRenderSelectionFlagsADisabledField()
+    {
+        EObject selectedField = SETTINGS_MODEL.newItem(SETTINGS_MODEL.selectedField);
+        selectedField.eSet(SETTINGS_MODEL.selectedField.getEStructuralFeature("field"), field("Description")); //$NON-NLS-1$ //$NON-NLS-2$
+        selectedField.eSet(SETTINGS_MODEL.selectedField.getEStructuralFeature("use"), Boolean.FALSE); //$NON-NLS-1$
+
+        EObject selection = SETTINGS_MODEL.newContainer(SETTINGS_MODEL.selectedFields);
+        SETTINGS_MODEL.addItem(selection, selectedField);
+
+        String rendered = DcsStructureReader.renderSelection(selection, "en"); //$NON-NLS-1$
+        assertTrue("a disabled selected field must be flagged", rendered.contains("[not used]")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testRenderSelectionRendersAGroupWithNestedChildren()
+    {
+        EObject child = SETTINGS_MODEL.newItem(SETTINGS_MODEL.selectedField);
+        child.eSet(SETTINGS_MODEL.selectedField.getEStructuralFeature("field"), field("Description")); //$NON-NLS-1$ //$NON-NLS-2$
+        child.eSet(SETTINGS_MODEL.selectedField.getEStructuralFeature("use"), Boolean.TRUE); //$NON-NLS-1$
+
+        EObject group = SETTINGS_MODEL.newItem(SETTINGS_MODEL.selectedFieldGroup);
+        group.eSet(SETTINGS_MODEL.selectedFieldGroup.getEStructuralFeature("field"), field("GroupField")); //$NON-NLS-1$ //$NON-NLS-2$
+        group.eSet(SETTINGS_MODEL.selectedFieldGroup.getEStructuralFeature("use"), Boolean.TRUE); //$NON-NLS-1$
+        SETTINGS_MODEL.addTo(group, "items", child); //$NON-NLS-1$
+
+        EObject selection = SETTINGS_MODEL.newContainer(SETTINGS_MODEL.selectedFields);
+        SETTINGS_MODEL.addItem(selection, group);
+
+        String rendered = DcsStructureReader.renderSelection(selection, "en"); //$NON-NLS-1$
+        assertTrue("the group's own field must be present", rendered.contains("GroupField")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a group item must be marked as such", rendered.contains("(group)")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the nested child must be rendered too", rendered.contains("Description")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testRenderSelectionRendersTheAutoFieldsMarker()
+    {
+        EObject auto = SETTINGS_MODEL.newItem(SETTINGS_MODEL.autoSelectedField);
+        EObject selection = SETTINGS_MODEL.newContainer(SETTINGS_MODEL.selectedFields);
+        SETTINGS_MODEL.addItem(selection, auto);
+
+        String rendered = DcsStructureReader.renderSelection(selection, "en"); //$NON-NLS-1$
+        assertTrue("a DataCompositionAuto* item must render the auto-fields marker", //$NON-NLS-1$
+            rendered.contains("_(auto fields)_")); //$NON-NLS-1$
     }
 
     @Test
@@ -301,6 +529,34 @@ public class DcsStructureReaderTest
         assertTrue(DcsStructureReader.renderFilter(SETTINGS_MODEL.newContainer(SETTINGS_MODEL.filter)).isEmpty());
     }
 
+    // NOTE (SKIPPED sub-branch, honestly documented rather than forced): appendFilterItem's
+    // "groupType.isEmpty() ? "group" : ..." bare-label fallback (reached when enumFeature() returns "")
+    // is NOT reachable through this dynamic fixture: an unset EMF EEnum-typed attribute does not resolve
+    // to null/absent - it defaults to the enum's own lowest-value LITERAL (verified empirically; e.g. an
+    // untouched "groupType" here still reads back as AND_GROUP, not "") - so an empty result would need
+    // either an EEnum with literally zero literals (which cannot share groupTypeEnum without breaking
+    // testRenderFilterConditionAndNestedGroup's AND_GROUP assertions) or the real restricted settings
+    // type's actual (unknown) unset behaviour. Not forced with fixture surgery; left uncovered.
+
+    @Test
+    public void testRenderFilterConditionWithoutARightHandValue()
+    {
+        // "right" is intentionally left EMPTY (a many-valued reference feature genuinely reads back as an
+        // empty list when untouched, unlike a single-valued enum/boolean attribute - see the NOTE above) -
+        // the optional trailing right-hand value must simply be omitted, not rendered as empty junk.
+        EObject condition = SETTINGS_MODEL.newItem(SETTINGS_MODEL.filterItem);
+        condition.eSet(SETTINGS_MODEL.filterItem.getEStructuralFeature("left"), field("Quantity")); //$NON-NLS-1$ //$NON-NLS-2$
+        SETTINGS_MODEL.setEnum(condition, SETTINGS_MODEL.filterItem, "comparisonType", "GREATER"); //$NON-NLS-1$ //$NON-NLS-2$
+        condition.eSet(SETTINGS_MODEL.filterItem.getEStructuralFeature("use"), Boolean.TRUE); //$NON-NLS-1$
+
+        EObject filter = SETTINGS_MODEL.newContainer(SETTINGS_MODEL.filter);
+        SETTINGS_MODEL.addTo(filter, "items", condition); //$NON-NLS-1$
+
+        String rendered = DcsStructureReader.renderFilter(filter);
+        assertTrue("with no right-hand value the line must end right after the comparison literal", //$NON-NLS-1$
+            rendered.contains("- Quantity GREATER\n")); //$NON-NLS-1$
+    }
+
     @Test
     public void testRenderOrderListsFieldDirectionAndUse()
     {
@@ -326,6 +582,34 @@ public class DcsStructureReaderTest
         assertTrue(DcsStructureReader.renderOrder(SETTINGS_MODEL.newContainer(SETTINGS_MODEL.order)).isEmpty());
     }
 
+    @Test
+    public void testRenderOrderFlagsADisabledItem()
+    {
+        EObject orderItem = SETTINGS_MODEL.newItem(SETTINGS_MODEL.orderItem);
+        orderItem.eSet(SETTINGS_MODEL.orderItem.getEStructuralFeature("field"), field("Description")); //$NON-NLS-1$ //$NON-NLS-2$
+        SETTINGS_MODEL.setEnum(orderItem, SETTINGS_MODEL.orderItem, "orderType", "DESC"); //$NON-NLS-1$ //$NON-NLS-2$
+        orderItem.eSet(SETTINGS_MODEL.orderItem.getEStructuralFeature("use"), Boolean.FALSE); //$NON-NLS-1$
+
+        EObject order = SETTINGS_MODEL.newContainer(SETTINGS_MODEL.order);
+        SETTINGS_MODEL.addTo(order, "items", orderItem); //$NON-NLS-1$
+
+        String rendered = DcsStructureReader.renderOrder(order);
+        assertTrue(rendered.contains("DESC")); //$NON-NLS-1$
+        assertTrue("a disabled order item must be flagged", rendered.contains("[not used]")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testRenderOrderRendersTheAutoOrderMarker()
+    {
+        EObject auto = SETTINGS_MODEL.newItem(SETTINGS_MODEL.autoOrderItem);
+        EObject order = SETTINGS_MODEL.newContainer(SETTINGS_MODEL.order);
+        SETTINGS_MODEL.addTo(order, "items", auto); //$NON-NLS-1$
+
+        String rendered = DcsStructureReader.renderOrder(order);
+        assertTrue("a DataCompositionAuto* item must render the auto-order marker", //$NON-NLS-1$
+            rendered.contains("_(auto order)_")); //$NON-NLS-1$
+    }
+
     // ==================== dynamic EMF fixture for the access-restricted "settings" subtree ====================
 
     private static final SettingsLikeModel SETTINGS_MODEL = new SettingsLikeModel();
@@ -344,11 +628,14 @@ public class DcsStructureReaderTest
     {
         final EClass selectedFields;
         final EClass selectedField;
+        final EClass selectedFieldGroup;
+        final EClass autoSelectedField;
         final EClass filter;
         final EClass filterItem;
         final EClass filterItemGroup;
         final EClass order;
         final EClass orderItem;
+        final EClass autoOrderItem;
 
         SettingsLikeModel()
         {
@@ -369,6 +656,16 @@ public class DcsStructureReaderTest
 
             selectedFields = newEClass(factory, "DataCompositionSelectedFields"); //$NON-NLS-1$
             manyObjectRef(factory, selectedFields, "items"); //$NON-NLS-1$
+
+            selectedFieldGroup = newEClass(factory, "DataCompositionSelectedFieldGroup"); //$NON-NLS-1$
+            objectRef(factory, selectedFieldGroup, "field"); //$NON-NLS-1$
+            manyObjectRef(factory, selectedFieldGroup, "items"); //$NON-NLS-1$
+            boolAttr(factory, selectedFieldGroup, "use"); //$NON-NLS-1$
+
+            // Name only matters: isAutoItem() dispatches purely on the "DataCompositionAuto" EClass-name
+            // prefix, so these two carry no features at all.
+            autoSelectedField = newEClass(factory, "DataCompositionAutoSelectedField"); //$NON-NLS-1$
+            autoOrderItem = newEClass(factory, "DataCompositionAutoOrderItem"); //$NON-NLS-1$
 
             filterItem = newEClass(factory, "DataCompositionFilterItem"); //$NON-NLS-1$
             objectRef(factory, filterItem, "left"); //$NON-NLS-1$
@@ -397,10 +694,13 @@ public class DcsStructureReaderTest
             pkg.getEClassifiers().add(sortDirectionEnum);
             pkg.getEClassifiers().add(selectedField);
             pkg.getEClassifiers().add(selectedFields);
+            pkg.getEClassifiers().add(selectedFieldGroup);
+            pkg.getEClassifiers().add(autoSelectedField);
             pkg.getEClassifiers().add(filterItem);
             pkg.getEClassifiers().add(filterItemGroup);
             pkg.getEClassifiers().add(filter);
             pkg.getEClassifiers().add(orderItem);
+            pkg.getEClassifiers().add(autoOrderItem);
             pkg.getEClassifiers().add(order);
         }
 

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/git/GitCheckoutSupportTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/git/GitCheckoutSupportTest.java
@@ -1,0 +1,87 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils.git;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.jgit.api.CheckoutResult;
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.utils.git.GitCheckoutSupport.CheckoutOutcome;
+
+/**
+ * Tests {@link CheckoutOutcome}: the pure value object carrying a bounded checkout's result. Built
+ * directly via the package-private test factory {@link CheckoutOutcome#forTest} (added for exactly this
+ * purpose - issue #171 coverage), bypassing {@link GitCheckoutSupport#checkout} entirely, so NO {@link
+ * org.eclipse.core.runtime.jobs.Job} and NO live checkout is ever run here - only the accessor/derived-flag
+ * logic on already-built outcomes.
+ */
+public class GitCheckoutSupportTest
+{
+    @Test
+    public void testRanToCompletionOutcomeExposesResultAndOptionalRefreshWarning()
+    {
+        CheckoutOutcome outcome =
+            CheckoutOutcome.forTest(CheckoutResult.NOT_TRIED_RESULT, "workspace refresh failed", false, false, null); //$NON-NLS-1$
+
+        assertTrue("a normal outcome ran to completion", outcome.ranToCompletion()); //$NON-NLS-1$
+        assertSame("the result must round-trip unchanged", CheckoutResult.NOT_TRIED_RESULT, outcome.result()); //$NON-NLS-1$
+        assertEquals("workspace refresh failed", outcome.refreshWarning()); //$NON-NLS-1$
+        assertFalse(outcome.timedOut());
+        assertFalse(outcome.interrupted());
+        assertNull(outcome.jobError());
+    }
+
+    @Test
+    public void testRanToCompletionOutcomeWithNoRefreshWarningIsNull()
+    {
+        CheckoutOutcome outcome = CheckoutOutcome.forTest(CheckoutResult.ERROR_RESULT, null, false, false, null);
+
+        assertTrue(outcome.ranToCompletion());
+        assertSame(CheckoutResult.ERROR_RESULT, outcome.result());
+        assertNull("no refresh warning means no refresh failure occurred", outcome.refreshWarning()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testTimedOutOutcomeDidNotRunToCompletionAndCarriesNoResult()
+    {
+        CheckoutOutcome outcome = CheckoutOutcome.forTest(null, null, true, false, null);
+
+        assertFalse("a timed-out Job never ran to completion", outcome.ranToCompletion()); //$NON-NLS-1$
+        assertTrue(outcome.timedOut());
+        assertFalse(outcome.interrupted());
+        assertNull(outcome.jobError());
+        assertNull("no CheckoutResult is available when the Job timed out", outcome.result()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testInterruptedOutcomeDidNotRunToCompletion()
+    {
+        CheckoutOutcome outcome = CheckoutOutcome.forTest(null, null, false, true, null);
+
+        assertFalse("an interrupted wait never ran to completion", outcome.ranToCompletion()); //$NON-NLS-1$
+        assertFalse(outcome.timedOut());
+        assertTrue(outcome.interrupted());
+        assertNull(outcome.jobError());
+    }
+
+    @Test
+    public void testJobErrorOutcomeDidNotRunToCompletionAndCarriesTheException()
+    {
+        Exception boom = new IllegalStateException("checkout blew up"); //$NON-NLS-1$
+        CheckoutOutcome outcome = CheckoutOutcome.forTest(null, null, false, false, boom);
+
+        assertFalse("a Job that threw never ran to completion", outcome.ranToCompletion()); //$NON-NLS-1$
+        assertFalse(outcome.timedOut());
+        assertFalse(outcome.interrupted());
+        assertSame("the thrown exception must round-trip unchanged", boom, outcome.jobError()); //$NON-NLS-1$
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/git/GitRepositoryResolverTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/git/GitRepositoryResolverTest.java
@@ -1,0 +1,207 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils.git;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Repository;
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.utils.git.GitRepositoryResolver.Resolution;
+
+/**
+ * Tests {@link GitRepositoryResolver}: the pure {@link Resolution} value object (built via the
+ * package-private test factory {@link Resolution#forTest}, added for exactly this purpose - issue #171
+ * coverage - since {@link GitRepositoryResolver#resolve(String)} itself needs a live EDT workspace/
+ * {@code ProjectContext} and is covered by the e2e suite) and {@link GitRepositoryResolver#discoverFromDirectory}
+ * (the pure-JGit {@code .git} discovery step, also extracted as a package-private seam so it is directly
+ * testable against a REAL temp git repository - no mocking of JGit/EGit/EDT anywhere here).
+ */
+public class GitRepositoryResolverTest
+{
+    // ==================== Resolution: pure accessors ====================
+
+    @Test
+    public void testSuccessfulResolutionAccessors()
+    {
+        Resolution resolution = Resolution.forTest(null, null, false, null);
+
+        assertTrue("no errorJson means ok()", resolution.ok()); //$NON-NLS-1$
+        assertNull(resolution.errorJson());
+    }
+
+    @Test
+    public void testFailedResolutionAccessors()
+    {
+        String errorJson = "{\"success\":false,\"error\":\"boom\"}"; //$NON-NLS-1$
+        Resolution resolution = Resolution.forTest(null, null, false, errorJson);
+
+        assertFalse("an errorJson means NOT ok()", resolution.ok()); //$NON-NLS-1$
+        assertEquals(errorJson, resolution.errorJson());
+        assertNull("a failed resolution carries no project", resolution.project()); //$NON-NLS-1$
+        assertNull("a failed resolution carries no repository", resolution.repository()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRepositoryAccessorRoundTrips() throws Exception
+    {
+        File repoDir = Files.createTempDirectory("resolver-accessor").toFile(); //$NON-NLS-1$
+        try (Repository repo = Git.init().setDirectory(repoDir).call().getRepository())
+        {
+            Resolution resolution = Resolution.forTest(null, repo, false, null);
+            assertTrue(resolution.ok());
+            assertEquals("the repository must round-trip unchanged", repo, resolution.repository()); //$NON-NLS-1$
+        }
+        finally
+        {
+            deleteRecursively(repoDir);
+        }
+    }
+
+    // ==================== Resolution.closeIfOwned(): owned vs borrowed ====================
+
+    @Test
+    public void testCloseIfOwnedClosesAnOwnedRepository() throws Exception
+    {
+        File repoDir = Files.createTempDirectory("resolver-owned").toFile(); //$NON-NLS-1$
+        try
+        {
+            Repository repo = Git.init().setDirectory(repoDir).call().getRepository();
+            assertEquals("a freshly-opened repository starts with a use count of 1", 1, useCount(repo)); //$NON-NLS-1$
+
+            Resolution.forTest(null, repo, true, null).closeIfOwned();
+
+            assertEquals("closeIfOwned(owned=true) must call Repository.close()", 0, useCount(repo)); //$NON-NLS-1$
+        }
+        finally
+        {
+            deleteRecursively(repoDir);
+        }
+    }
+
+    @Test
+    public void testCloseIfOwnedLeavesABorrowedRepositoryOpen() throws Exception
+    {
+        File repoDir = Files.createTempDirectory("resolver-borrowed").toFile(); //$NON-NLS-1$
+        try (Repository repo = Git.init().setDirectory(repoDir).call().getRepository())
+        {
+            assertEquals(1, useCount(repo));
+
+            Resolution.forTest(null, repo, false, null).closeIfOwned();
+
+            assertEquals("closeIfOwned(owned=false) must NOT close an EGit-borrowed repository", 1, //$NON-NLS-1$
+                useCount(repo));
+        }
+        finally
+        {
+            deleteRecursively(repoDir);
+        }
+    }
+
+    @Test
+    public void testCloseIfOwnedIsANoOpWhenRepositoryIsNull()
+    {
+        // Must not throw (an error Resolution carries owned=false/repository=null; a successful one
+        // could in principle be owned=true with a still-null repository - either way, no NPE).
+        Resolution.forTest(null, null, true, null).closeIfOwned();
+        Resolution.forTest(null, null, false, null).closeIfOwned();
+    }
+
+    @Test
+    public void testCloseIfOwnedOnAnErrorResolutionIsANoOp()
+    {
+        Resolution.forTest(null, null, false, "{\"success\":false}").closeIfOwned(); //$NON-NLS-1$
+    }
+
+    // ==================== discoverFromDirectory: pure JGit .git discovery ====================
+
+    @Test
+    public void testDiscoverFromDirectoryFindsGitDirWalkingUpFromANestedSubdirectory() throws Exception
+    {
+        File repoRoot = Files.createTempDirectory("resolver-discover").toFile(); //$NON-NLS-1$
+        try
+        {
+            Git.init().setDirectory(repoRoot).call().close();
+            File nested = new File(repoRoot, "src/Catalogs/Foo"); //$NON-NLS-1$
+            assertTrue(nested.mkdirs());
+
+            try (Repository discovered = GitRepositoryResolver.discoverFromDirectory(nested))
+            {
+                assertNotNull("a .git directory exists up the tree - it must be found", discovered); //$NON-NLS-1$
+                assertEquals(new File(repoRoot, ".git").getCanonicalFile(), //$NON-NLS-1$
+                    discovered.getDirectory().getCanonicalFile());
+            }
+        }
+        finally
+        {
+            deleteRecursively(repoRoot);
+        }
+    }
+
+    @Test
+    public void testDiscoverFromDirectoryReturnsNullWhenNoGitDirExistsAnywhereUpTheTree() throws Exception
+    {
+        File notARepo = Files.createTempDirectory("resolver-no-repo").toFile(); //$NON-NLS-1$
+        try
+        {
+            // NOTE: this only proves the "not found starting from here" branch; findGitDir also walks
+            // PAST notARepo toward the filesystem root, so this assertion assumes no ancestor of the
+            // system temp directory is itself a git working tree (true for every CI/dev sandbox).
+            Repository discovered = GitRepositoryResolver.discoverFromDirectory(notARepo);
+            assertNull(discovered);
+        }
+        finally
+        {
+            deleteRecursively(notARepo);
+        }
+    }
+
+    // ==================== test helpers ====================
+
+    /**
+     * Reads {@link Repository}'s private {@code useCnt} reference-count field via reflection - the only
+     * way to observe whether {@link Repository#close()} actually ran without mocking JGit: a freshly
+     * opened (non-cached) repository starts at 1, and drops to 0 the moment {@code close()} is called.
+     * This is JGit-internal (not public API), but it is read-only introspection of a REAL, live
+     * {@link Repository} - not a mock - so it stays honest to the "no mocking JGit" rule while still
+     * proving {@link Resolution#closeIfOwned()}'s behaviour.
+     */
+    private static int useCount(Repository repo) throws ReflectiveOperationException
+    {
+        Field field = Repository.class.getDeclaredField("useCnt"); //$NON-NLS-1$
+        field.setAccessible(true);
+        return ((AtomicInteger)field.get(repo)).get();
+    }
+
+    /** Recursively deletes a temp directory tree (best-effort test cleanup). */
+    private static void deleteRecursively(File file)
+    {
+        if (file == null)
+        {
+            return;
+        }
+        File[] children = file.listFiles();
+        if (children != null)
+        {
+            for (File child : children)
+            {
+                deleteRecursively(child);
+            }
+        }
+        file.delete();
+    }
+}


### PR DESCRIPTION
Приводит в порядок Quality Gate на master (было 2 красных условия на новом коде).

## 1. new_security_rating: E → A (уязвимость = false-positive)

Единственный BLOCKER — S6418 «hard-coded secret» на константе `AUTH_DIALOG_TITLE_PREFIX_RU`. Это **русский заголовок диалога** EDT («Сконфигурируйте доступ к информационной базе»), который подавлятор сопоставляет по тексту; слово «AUTH» в имени константы триггерит эвристику секретов. Пометил `// NOSONAR` с обоснованием — ни секрета, ни изменения поведения.

## 2. new_coverage: 58.6% → выше (юнит-тесты на легко-покрываемое, в рамках #171)

Низкое покрытие нового кода — потому что тела `execute()` git-инструментов и фазы-2 ходят в живой JGit/EGit/EDT и проверяются **e2e** (на живом стенде), а SonarCloud считает только юнит-покрытие (JaCoCo). Здесь добавлены юнит-тесты для **честно тестируемой** части, без моков живых сервисов:
- `DcsStructureReader` (чистый рендерер) — покрыты непокрытые ветки рендера через in-memory EMF-фикстуры;
- value-объекты `GitCheckoutSupport.CheckoutOutcome` и `GitRepositoryResolver.Resolution`;
- `findGitDir`-резолвинг репозитория через временный git-репозиторий (headless);
- чистые статик-хелперы git-инструментов.

Остаток до 80% — это живые тела инструментов, покрытые e2e (Sonar их не видит). Это структурное натяжение между тестовой философией проекта (юниты + e2e) и порогом гейта; выношу на усмотрение — возможно, для таких инструментов имеет смысл исключение в coverage-конфиге.

Связано с #171 (повышение покрытия).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
