### PR TITLE
XDTO: редактирование членов пакета по FQN + инструмент валидации validate_xdto_package (#183)

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,30 @@ with `python docs/generate_tool_docs.py`.
 
 <!-- TOOLS-INDEX:END -->
 
+## XDTO Packages
+
+1C XDTO packages (`XDTOPackage`) can be authored end-to-end through MCP, down to their
+package-local structure, without hand-editing XML:
+
+- **`create_metadata`** / **`modify_metadata`** / **`delete_metadata`** address XDTO
+  package members by FQN, layered on top of the existing top-level `XDTOPackage.<Name>`
+  create/delete:
+  - `XDTOPackage.<Package>.ObjectType.<Type>` — an ObjectType in the package (optional
+    flags: `open`, `abstract`, `mixed`, `ordered`, `sequenced`).
+  - `XDTOPackage.<Package>.Property.<Name>` — a package-global Property.
+  - `XDTOPackage.<Package>.ObjectType.<Type>.Property.<Name>` — a Property nested in an
+    ObjectType.
+
+  A Property's `type` accepts a built-in XSD type name (e.g. `string`), the exact name
+  of another ObjectType already in the same package (a same-package reference), or an
+  explicit `{nsUri, name}` pair; optional `lowerBound`/`upperBound`, `nillable`,
+  `fixed`+`default` round out the vocabulary. See `get_tool_guide('create_metadata')`
+  for the full parameter list.
+- **`validate_xdto_package`** runs EDT's own configuration validation scoped to one
+  package and returns a pass/fail verdict plus any problems found (e.g. a Property left
+  referencing an ObjectType that was since deleted) — a thin, read-only wrapper over
+  `get_project_errors`, handy right after authoring or editing package members.
+
 ## Output Formats
 
 Each tool declares a response type (`IMcpTool.getResponseType()`). **The default — and the most common type — is Markdown**: any tool that does not override `getResponseType()` returns Markdown as an EmbeddedResource with `mimeType: text/markdown`. The non-default types are enumerated exhaustively below; everything not listed here is Markdown.
@@ -551,7 +575,7 @@ Which tool families stay JSON, and why:
 
 Errors are reported the same way regardless of a tool's normal format — see the **Error contract** below.
 
-- **Markdown tools** (the default): every tool that is not listed under another type below, returned as an EmbeddedResource with `mimeType: text/markdown`. This includes all read/list/search/navigation tools that emit human-readable reports — for example `list_projects`, `list_modules`, `list_subsystems`, `list_configurations`*, `get_project_errors`, `get_markers`, `get_problem_summary`, `get_check_description`, `get_metadata_objects`, `get_metadata_details`, `get_module_structure`, `get_subsystem_content`, `get_symbol_info`, `get_method_call_hierarchy`, `get_objects_by_tags`, `get_tags`, `get_platform_documentation`, `find_references`, `go_to_definition`, `search_in_code`, `read_module_source`, `read_method_source`, `write_module_source`, `rename_metadata_object`, `run_yaxunit_tests`, `terminate_launch`, `revalidate_objects`, `export_configuration_to_xml`, `import_configuration_from_xml`, and all three LanguageTool tools (`generate_translation_strings`, `translate_configuration`, `get_translation_project_info`). (*`list_configurations` is the exception among the `list_*` tools — it returns JSON; see below.)
+- **Markdown tools** (the default): every tool that is not listed under another type below, returned as an EmbeddedResource with `mimeType: text/markdown`. This includes all read/list/search/navigation tools that emit human-readable reports — for example `list_projects`, `list_modules`, `list_subsystems`, `list_configurations`*, `get_project_errors`, `validate_xdto_package`, `get_markers`, `get_problem_summary`, `get_check_description`, `get_metadata_objects`, `get_metadata_details`, `get_module_structure`, `get_subsystem_content`, `get_symbol_info`, `get_method_call_hierarchy`, `get_objects_by_tags`, `get_tags`, `get_platform_documentation`, `find_references`, `go_to_definition`, `search_in_code`, `read_module_source`, `read_method_source`, `write_module_source`, `rename_metadata_object`, `run_yaxunit_tests`, `terminate_launch`, `revalidate_objects`, `export_configuration_to_xml`, `import_configuration_from_xml`, and all three LanguageTool tools (`generate_translation_strings`, `translate_configuration`, `get_translation_project_info`). (*`list_configurations` is the exception among the `list_*` tools — it returns JSON; see below.)
 - **YAML tools**: `get_configuration_properties` — returns a human-readable YAML body as an EmbeddedResource (resource named `*.yaml`, `mimeType: text/yaml`).
 - **JSON tools** (return JSON with `structuredContent`): `get_server_status`, `get_applications`, `create_infobase`, `delete_infobase`, `get_content_assist`, `get_variables`, `get_profiling_results`, `list_configurations`, `list_breakpoints`, `set_breakpoint`, `remove_breakpoint`, `step`, `resume`, `wait_for_break`, `debug_launch`, `debug_status`, `debug_yaxunit_tests`, `evaluate_expression`, `start_profiling`, `stop_profiling`, `validate_query`, `clean_project`, `update_database`, `delete_project`, plus the metadata-write tools that inherit JSON from `AbstractMetadataWriteTool` (`create_metadata`, `modify_metadata`, `delete_metadata`).
 - **Text tools** (plain text): `get_edt_version`, `get_form_layout_snapshot`.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/META-INF/MANIFEST.MF
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/META-INF/MANIFEST.MF
@@ -110,4 +110,5 @@ Import-Package: com._1c.g5.v8.bm.common.collections,
  com._1c.g5.v8.dt.ql.dcs.resource,
  com._1c.g5.v8.dt.dcs.model.schema,
  com._1c.g5.v8.dt.dcs.model.core,
- com._1c.g5.v8.dt.dcs.model.common
+ com._1c.g5.v8.dt.dcs.model.common,
+ com._1c.g5.v8.dt.xdto.model

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/validate_xdto_package.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/validate_xdto_package.md
@@ -1,0 +1,26 @@
+Runs EDT's own configuration validation (the same check engine and marker set `get_project_errors` exposes) scoped to a single XDTO package, and reports a pass/fail verdict. It is a thin, read-only wrapper: the `fqn` you pass is checked to resolve to an `XDTOPackage` top object, then the request is delegated to `get_project_errors` with an `objects` filter of `[fqn]`, and the returned Markdown is reframed with a one-line verdict.
+
+## When to use
+- After authoring/editing an XDTO package (`create_metadata` / `modify_metadata` / `delete_metadata` on `XDTOPackage.<Name>...`), confirm it is still valid - e.g. after deleting an `ObjectType` that another `Property` referenced.
+- As a scoped alternative to `get_project_errors` when you only care about ONE package and want the "is it valid" question answered directly instead of reading a raw problem table.
+
+## Parameter details
+- `projectName` - EDT project name (required).
+- `fqn` - the package to validate, as `XDTOPackage.<Name>` (required). Must already exist. An FQN that does not resolve, or resolves to something other than an XDTOPackage (e.g. a Catalog, or an `ObjectType`/`Property` member FQN), is rejected with an actionable error - point this tool at the PACKAGE, not a member inside it.
+- `limit` - max problem rows; default 100, max 1000.
+
+The verdict always considers EVERY severity (a severity-filtered "no matches" would not be a validity guarantee), so there is intentionally no `severity` parameter - use `get_project_errors` if you need to filter by severity.
+
+## Output
+- Valid: `**XDTO package `XDTOPackage.<Name>` is valid** - no problems reported.` with no table below it.
+- Invalid: `**XDTO package `XDTOPackage.<Name>`: problems found**` followed by the SAME Markdown problem table `get_project_errors` renders (`Description` / `Location` / `Module path` / `Line` / `Check code`).
+
+## Gotchas
+- This reads EDT's ALREADY-COMPUTED validation markers - it does not force a fresh compile/revalidation. If you just made an edit and want up-to-the-second results, call `revalidate_objects` (or `clean_project`) first, then `validate_xdto_package`.
+- The scoping uses the RESOLVED package's canonical FQN with EXACT (segment-boundary) matching: a problem on the package itself or on a member strictly under it (an `ObjectType` / `Property`, whose presentation is `XDTOPackage.<Name>....`) is included, while a prefix-sharing SIBLING package (`XDTOPackage.<Name>2`) is not - so the verdict is about THIS package only. (`get_project_errors` on its own uses looser substring matching; this tool opts into the exact mode.)
+- This tool implements NO XDTO-specific validation rule of its own; it is strictly a scoped view over EDT's existing checks. It will not catch anything `get_project_errors` (with the matching `objects` filter) would not also show.
+
+## Examples
+- `{projectName: "MyConfig", fqn: "XDTOPackage.Orders"}` - full validation, default limit.
+- `{projectName: "MyConfig", fqn: "XDTOPackage.Orders", limit: 500}` - raise the reported-row cap.
+- A non-package FQN (`{projectName: "MyConfig", fqn: "Catalog.Products"}`) is rejected: use `get_project_errors` directly for a non-XDTO-scoped query.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/BuiltInToolRegistrar.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/BuiltInToolRegistrar.java
@@ -88,6 +88,7 @@ import com.ditrix.edt.mcp.server.tools.impl.TerminateLaunchTool;
 import com.ditrix.edt.mcp.server.tools.impl.TranslateConfigurationTool;
 import com.ditrix.edt.mcp.server.tools.impl.UpdateDatabaseTool;
 import com.ditrix.edt.mcp.server.tools.impl.ValidateQueryTool;
+import com.ditrix.edt.mcp.server.tools.impl.ValidateXdtoPackageTool;
 import com.ditrix.edt.mcp.server.tools.impl.WaitForBreakTool;
 import com.ditrix.edt.mcp.server.tools.impl.WriteModuleSourceTool;
 
@@ -211,6 +212,7 @@ public final class BuiltInToolRegistrar
         registry.register(new CreateMetadataTool());
         registry.register(new ModifyMetadataTool());
         registry.register(new AdoptMetadataObjectTool());
+        registry.register(new ValidateXdtoPackageTool());
 
         // LanguageTool translation tools
         registry.register(new GenerateTranslationStringsTool());

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/Toolsets.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/Toolsets.java
@@ -159,7 +159,8 @@ public final class Toolsets
             "clean_project", "revalidate_objects", "resync_to_disk", "update_database", "delete_project", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
             "export_configuration_to_xml", "import_configuration_from_xml", "build_external_objects", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             "create_infobase", "delete_infobase", "set_infobase_credentials", "create_project", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-            "get_problem_summary", "get_project_errors", "get_markers", "get_event_log", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            "get_problem_summary", "get_project_errors", "validate_xdto_package", "get_markers", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            "get_event_log", //$NON-NLS-1$
             "get_mcp_history", //$NON-NLS-1$
             "list_git_branches", "switch_git_branch", "set_branch_infobase", "create_git_branch", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
             "get_check_description", "get_platform_documentation"); //$NON-NLS-1$ //$NON-NLS-2$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
@@ -608,6 +608,15 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
             throw new XdtoWriteException(ToolResult.error("ObjectType already exists: '" + ref.objectTypeName //$NON-NLS-1$
                 + "' in package " + ref.packageFqn).toJson()); //$NON-NLS-1$
         }
+        // ObjectTypes and local ValueTypes share the package's TYPE namespace (the QName resolver
+        // treats both as local type targets), so an ObjectType may not reuse a ValueType's name -
+        // the serialized Package.xdto would carry two same-named local types.
+        if (XdtoWriter.findValueTypeExact(content, ref.objectTypeName) != null)
+        {
+            throw new XdtoWriteException(ToolResult.error("A local value type named '" + ref.objectTypeName //$NON-NLS-1$
+                + "' already exists in package " + ref.packageFqn //$NON-NLS-1$
+                + "; an ObjectType may not reuse a local type name.").toJson()); //$NON-NLS-1$
+        }
         ObjectType type = XdtoWriter.createObjectType(content, ref.objectTypeName);
         // The optional flags (open/abstract/mixed/ordered/sequenced) come from the SAME 'properties'
         // array a Property's attributes do - applied here too, else a caller's open=true / etc. is

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
@@ -601,7 +601,9 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
     private static XdtoCreateResult createObjectTypeInTx(Package content, XdtoWriter.MemberRef ref,
         List<JsonObject> properties)
     {
-        if (XdtoWriter.findObjectType(content, ref.objectTypeName) != null)
+        // EXACT duplicate check (no yo fallback): with normalizeYo=false a caller may legitimately
+        // create a distinct name differing only by yo from an existing one.
+        if (XdtoWriter.findObjectTypeExact(content, ref.objectTypeName) != null)
         {
             throw new XdtoWriteException(ToolResult.error("ObjectType already exists: '" + ref.objectTypeName //$NON-NLS-1$
                 + "' in package " + ref.packageFqn).toJson()); //$NON-NLS-1$
@@ -622,7 +624,8 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         XdtoWriter.MemberRef ref, List<JsonObject> properties)
     {
         String name = ref.propertyName;
-        if (XdtoWriter.findProperty(owner, name) != null)
+        // EXACT duplicate check (no yo fallback) - see createObjectTypeInTx.
+        if (XdtoWriter.findPropertyExact(owner, name) != null)
         {
             throw new XdtoWriteException(ToolResult.error("Property already exists: '" + name + "' on " //$NON-NLS-1$ //$NON-NLS-2$
                 + normFqnOfProperty(ref)).toJson());

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
@@ -488,7 +488,7 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
             return ctx.error;
         }
         MetadataNodeResolver.MetadataNode pkgNode =
-            MetadataNodeResolver.resolveExisting(ctx.config, ref.packageFqn);
+            MetadataNodeResolver.resolveExistingWithYoFallback(ctx.config, ref.packageFqn).node;
         if (pkgNode == null || !(pkgNode.object instanceof XDTOPackage)
             || !(pkgNode.object instanceof IBmObject))
         {
@@ -527,9 +527,13 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         }
 
         List<String> exportFqns = new java.util.ArrayList<>();
-        exportFqns.add(ref.packageFqn);
+        // Export by the RESOLVED package's canonical FQN: with the yo (ё->е) fallback the
+        // caller-typed ref.packageFqn may differ from the stored name, and force-export must
+        // target the stored top object (never the caller-supplied spelling).
+        String pkgExportFqn = "XDTOPackage." + ((XDTOPackage)pkgNode.object).getName(); //$NON-NLS-1$
+        exportFqns.add(pkgExportFqn);
         String contentFqn = contentFqnHolder[0];
-        if (contentFqn != null && !contentFqn.equals(ref.packageFqn))
+        if (contentFqn != null && !contentFqn.equals(pkgExportFqn))
         {
             exportFqns.add(contentFqn);
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
@@ -487,6 +487,15 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         {
             return ctx.error;
         }
+        // The leaf name is written verbatim into Package.xdto as an XML name - validate it with the
+        // same identifier rule the mdclass member create enforces (a 1C identifier is a safe subset
+        // of an XML NCName), or 'ObjectType.123Bad' would succeed yet produce an invalid file.
+        String newMemberName = ref.kind == XdtoWriter.Kind.OBJECT_TYPE ? ref.objectTypeName : ref.propertyName;
+        if (!isValidIdentifier(newMemberName))
+        {
+            return ToolResult.error("Invalid XDTO member name '" + newMemberName + "': a name must start " //$NON-NLS-1$ //$NON-NLS-2$
+                + "with a letter or underscore and contain only letters, digits and underscores.").toJson(); //$NON-NLS-1$
+        }
         MetadataNodeResolver.MetadataNode pkgNode =
             MetadataNodeResolver.resolveExistingWithYoFallback(ctx.config, ref.packageFqn).node;
         if (pkgNode == null || !(pkgNode.object instanceof XDTOPackage)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
@@ -35,6 +35,9 @@ import com._1c.g5.v8.dt.metadata.mdclass.ScriptVariant;
 import com._1c.g5.v8.dt.metadata.mdclass.TemplateType;
 import com._1c.g5.v8.dt.metadata.mdclass.XDTOPackage;
 import com._1c.g5.v8.dt.platform.version.Version;
+import com._1c.g5.v8.dt.xdto.model.ObjectType;
+import com._1c.g5.v8.dt.xdto.model.Package;
+import com._1c.g5.v8.dt.xdto.model.Property;
 import com.ditrix.edt.mcp.server.Activator;
 import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
 import com.ditrix.edt.mcp.server.protocol.JsonUtils;
@@ -51,6 +54,8 @@ import com.ditrix.edt.mcp.server.utils.MetadataNodeResolver;
 import com.ditrix.edt.mcp.server.utils.MetadataNodeResolver.CreateTarget;
 import com.ditrix.edt.mcp.server.utils.MetadataTypeBuilder;
 import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils;
+import com.ditrix.edt.mcp.server.utils.XdtoWriteException;
+import com.ditrix.edt.mcp.server.utils.XdtoWriter;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
@@ -98,6 +103,9 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
     /** Output key: whether the change was exported to disk. */
     private static final String KEY_PERSISTED = "persisted"; //$NON-NLS-1$
 
+    /** Output key: names of the optional attributes applied (XDTO member create only). */
+    private static final String KEY_APPLIED = "applied"; //$NON-NLS-1$
+
     /** Property / output key: the synonym display name. */
     private static final String KEY_SYNONYM = "synonym"; //$NON-NLS-1$
 
@@ -138,7 +146,11 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         return "Create a metadata node addressed by a 1C full-name FQN: a top-level object " //$NON-NLS-1$
             + "(Catalog.Products) or a subordinate member (Catalog.Products.Attribute.Weight, " //$NON-NLS-1$
             + "InformationRegister.Prices.Dimension.Product, Enum.Colors.EnumValue.Red). The kind " //$NON-NLS-1$
-            + "is inferred from the FQN; type and kind tokens may be English or Russian. " //$NON-NLS-1$
+            + "is inferred from the FQN; type and kind tokens may be English or Russian. Also creates " //$NON-NLS-1$
+            + "an XDTO package MEMBER: 'XDTOPackage.<Package>.ObjectType.<Name>' (an ObjectType), " //$NON-NLS-1$
+            + "'XDTOPackage.<Package>.Property.<Name>' (a package-global property) or " //$NON-NLS-1$
+            + "'XDTOPackage.<Package>.ObjectType.<Type>.Property.<Name>' (a property nested in an " //$NON-NLS-1$
+            + "ObjectType) - see 'properties' for the XDTO-specific attribute vocabulary. " //$NON-NLS-1$
             + "Full parameters and examples: call get_tool_guide('create_metadata')."; //$NON-NLS-1$
     }
 
@@ -154,9 +166,17 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
                 + "(e.g. 'Catalog.Products.Attribute.Weight'). The trailing Name is the new node's " //$NON-NLS-1$
                 + "programmatic Name; type / kind tokens may be English or Russian.", true) //$NON-NLS-1$
             .objectArrayProperty("properties", //$NON-NLS-1$
-                "Optional properties to apply at creation, as [{name, value, language?}]. This " //$NON-NLS-1$
-                + "version applies 'synonym' (with optional 'language' code) and 'comment'; other " //$NON-NLS-1$
-                + "property names are rejected (set them via modify_metadata).") //$NON-NLS-1$
+                "Optional properties to apply at creation, as [{name, value, language?}]. For most " //$NON-NLS-1$
+                + "kinds this applies 'synonym' (with optional 'language' code) and 'comment'; other " //$NON-NLS-1$
+                + "property names are rejected (set them via modify_metadata). XDTO PACKAGE MEMBERS " //$NON-NLS-1$
+                + "('XDTOPackage.<Package>.ObjectType.<Name>' / '...Property.<Name>' / " //$NON-NLS-1$
+                + "'...ObjectType.<Type>.Property.<Name>') use a DIFFERENT vocabulary instead: an " //$NON-NLS-1$
+                + "ObjectType takes the optional boolean flags 'open' / 'abstract' / 'mixed' / " //$NON-NLS-1$
+                + "'ordered' / 'sequenced'; a Property REQUIRES 'type' (a built-in XSD type name like " //$NON-NLS-1$
+                + "'string', the EXACT name of an ObjectType already in the same package for a " //$NON-NLS-1$
+                + "same-package reference, or an object {nsUri, name}) plus the optional 'lowerBound' / " //$NON-NLS-1$
+                + "'upperBound' (integers, ObjectType-nested properties only), 'nillable' / 'fixed' " //$NON-NLS-1$
+                + "(booleans, 'fixed'=true needs a 'default') and 'default' (string).") //$NON-NLS-1$
             .booleanProperty(KEY_EXPECTED_NOT_EXISTS,
                 "Optional stale-intent guard (default false): assert the node does not yet exist for " //$NON-NLS-1$
                 + "a sharper precondition error. A real duplicate is always rejected anyway.") //$NON-NLS-1$
@@ -235,6 +255,8 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
             .stringProperty("kind", "EClass of the created node (e.g. 'Catalog', 'CatalogAttribute')") //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty("name", "Programmatic name of the created node") //$NON-NLS-1$ //$NON-NLS-2$
             .booleanProperty(KEY_PERSISTED, "Whether the change was exported to disk") //$NON-NLS-1$
+            .stringArrayProperty(KEY_APPLIED,
+                "Names of the optional attributes actually applied (XDTO package member create only)") //$NON-NLS-1$
             .stringProperty(KEY_SYNONYM, "Display name written, when a synonym property was provided") //$NON-NLS-1$
             .stringProperty(KEY_LANGUAGE, "Language code the synonym was written for") //$NON-NLS-1$
             .stringArrayProperty("normalized", //$NON-NLS-1$
@@ -296,6 +318,20 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         if (formResult != null)
         {
             return formResult;
+        }
+
+        // A FQN that addresses an XDTO PACKAGE MEMBER (an ObjectType or a Property - issue #183 stream 1)
+        // is handled by a dedicated branch: an ObjectType/Property lives on the package's editable
+        // xdto.model content (a cross-model hop, the same @ExternalProperty shape a report's DCS uses),
+        // not the mdclass tree, and is addressed by its own small FQN grammar (XdtoWriter.parseMemberRef)
+        // rather than MetadataNodeResolver (which does not know "ObjectType"/"Property" as mdclass child
+        // kinds). Dispatched BEFORE the generic 'properties' parse (synonym/comment only) because an XDTO
+        // member's assignable attributes (type/bounds/nillable/flags) are a completely different
+        // vocabulary reusing the SAME 'properties' parameter shape.
+        XdtoWriter.MemberRef xdtoRef = XdtoWriter.parseMemberRef(normFqn);
+        if (xdtoRef != null)
+        {
+            return createXdtoMember(projectName, normFqn, xdtoRef, properties);
         }
 
         // Parse the supported properties (synonym/comment); reject anything else early. The synonym /
@@ -409,6 +445,213 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         return null;
     }
 
+    // ---- XDTO package member creation (issue #183 stream 1) --------------------------------------
+    //
+    // An ObjectType / Property lives on the package's lazily-materialized xdto.model content (a
+    // cross-model hop, the SAME transient @ExternalProperty shape a report's DCS uses), not the
+    // mdclass tree - MetadataNodeResolver cannot see it. The duplicate check runs INSIDE the write
+    // transaction (mirrors resolveMemberOwnerInTx's own "Member already exists" check for a generic
+    // mdclass member), because the package's content is lazy: only materializing it (inside the tx)
+    // proves whether a same-named member already exists on disk.
+
+    /** Groups a successfully created XDTO member's result fields for {@link #xdtoMemberSuccess}. */
+    private static final class XdtoCreateResult
+    {
+        final String eClassName;
+        final String name;
+        final List<String> applied;
+
+        XdtoCreateResult(String eClassName, String name, List<String> applied)
+        {
+            this.eClassName = eClassName;
+            this.name = name;
+            this.applied = applied;
+        }
+    }
+
+    /**
+     * Creates an XDTO PACKAGE MEMBER (an ObjectType or a Property, package-global or nested in an
+     * ObjectType) addressed by {@code ref}. Resolves the owning XDTOPackage top object, materializes +
+     * attaches its {@code Package} content inside ONE write transaction ({@link XdtoWriter#resolvePackageContent}),
+     * appends the new member after asserting no duplicate exists by name, and applies any optional
+     * {@code properties} (ObjectType flags, or a Property's REQUIRED {@code type} plus optional
+     * bounds/nillable/ref/fixed/default) via {@link XdtoWriter}. Force-exports the owning package's FQN
+     * (dual-export with the content's own resource FQN when it is a distinct top object, guarding the
+     * #239-class silent-false-success).
+     */
+    private String createXdtoMember(String projectName, String normFqn, XdtoWriter.MemberRef ref,
+        List<JsonObject> properties)
+    {
+        ProjectContext ctx = resolveProjectAndConfig(projectName);
+        if (ctx.hasError())
+        {
+            return ctx.error;
+        }
+        MetadataNodeResolver.MetadataNode pkgNode =
+            MetadataNodeResolver.resolveExisting(ctx.config, ref.packageFqn);
+        if (pkgNode == null || !(pkgNode.object instanceof XDTOPackage)
+            || !(pkgNode.object instanceof IBmObject))
+        {
+            return ToolResult.error("XDTOPackage not found: " + ref.packageFqn + ". Create it first " //$NON-NLS-1$ //$NON-NLS-2$
+                + "with create_metadata on 'XDTOPackage.<Name>'.").toJson(); //$NON-NLS-1$
+        }
+        IBmModelManager bmModelManager = Activator.getDefault().getBmModelManager();
+        ITopObjectFqnGenerator fqnGenerator = Activator.getDefault().getTopObjectFqnGenerator();
+        if (bmModelManager == null || fqnGenerator == null)
+        {
+            return ToolResult.error(ERR_SERVICES_UNAVAILABLE).toJson();
+        }
+        IBmModel bmModel = bmModelManager.getModel(ctx.project);
+        if (bmModel == null)
+        {
+            return ToolResult.error(ERR_NO_BM_MODEL + projectName).toJson();
+        }
+
+        final long pkgBmId = ((IBmObject)pkgNode.object).bmGetId();
+        final String[] contentFqnHolder = { null };
+        XdtoCreateResult result;
+        try
+        {
+            result = BmTransactions.<XdtoCreateResult> write(bmModel, "CreateXdtoMember", (tx, pm) -> //$NON-NLS-1$
+                createXdtoMemberInTx(tx, pkgBmId, fqnGenerator, ref, properties, contentFqnHolder));
+        }
+        catch (Exception e)
+        {
+            String ready = XdtoWriteException.jsonOf(e);
+            if (ready != null)
+            {
+                return ready;
+            }
+            Activator.logError("Error creating XDTO member", e); //$NON-NLS-1$
+            return ToolResult.error("Failed to create XDTO member: " + unwrapCauseMessage(e)).toJson(); //$NON-NLS-1$
+        }
+
+        List<String> exportFqns = new java.util.ArrayList<>();
+        exportFqns.add(ref.packageFqn);
+        String contentFqn = contentFqnHolder[0];
+        if (contentFqn != null && !contentFqn.equals(ref.packageFqn))
+        {
+            exportFqns.add(contentFqn);
+        }
+        boolean persisted = BmTransactions.forceExportToDisk(ctx.project, exportFqns);
+        return xdtoMemberSuccess(normFqn, result, persisted, VAL_CREATED, "Created "); //$NON-NLS-1$
+    }
+
+    /**
+     * The write-transaction body for {@link #createXdtoMember}: re-fetches the XDTOPackage, materializes
+     * its content, records the content's own export FQN (captured by {@link XdtoWriter#resolvePackageContent}
+     * itself - NEVER re-derived here via a post-attach {@code bmGetFqn()}, which throws on a just-attached,
+     * not-yet-settled object; a live-stand-caught regression) into {@code contentFqnHolder}, then
+     * dispatches to the ObjectType / Property creation by {@code ref.kind}. Throws
+     * {@link XdtoWriteException} (a ready JSON error) on a resolution / duplicate / validation failure,
+     * rolling the whole write back.
+     */
+    private static XdtoCreateResult createXdtoMemberInTx(IBmTransaction tx, long pkgBmId,
+        ITopObjectFqnGenerator fqnGenerator, XdtoWriter.MemberRef ref, List<JsonObject> properties,
+        String[] contentFqnHolder)
+    {
+        Object inTx = tx.getObjectById(pkgBmId);
+        if (!(inTx instanceof XDTOPackage))
+        {
+            throw new XdtoWriteException(ToolResult.error("The XDTO package could not be resolved " //$NON-NLS-1$
+                + "inside the transaction.").toJson()); //$NON-NLS-1$
+        }
+        XDTOPackage txPkg = (XDTOPackage)inTx;
+        XdtoWriter.ContentResolution resolved = XdtoWriter.resolvePackageContent(txPkg, tx, fqnGenerator);
+        if (resolved.error != null)
+        {
+            throw new XdtoWriteException(resolved.error);
+        }
+        Package content = resolved.content;
+        contentFqnHolder[0] = resolved.contentFqn;
+
+        if (ref.kind == XdtoWriter.Kind.OBJECT_TYPE)
+        {
+            return createObjectTypeInTx(content, ref, properties);
+        }
+        if (ref.kind == XdtoWriter.Kind.PACKAGE_PROPERTY)
+        {
+            return createPropertyInTx(content.getProperties(), content, ref, properties);
+        }
+        // OBJECT_TYPE_PROPERTY: the owning ObjectType must already exist (the parent must exist, like
+        // every other create_metadata member kind).
+        ObjectType owner = XdtoWriter.findObjectType(content, ref.objectTypeName);
+        if (owner == null)
+        {
+            throw new XdtoWriteException(ToolResult.error("ObjectType not found: '" + ref.objectTypeName //$NON-NLS-1$
+                + "' in package " + ref.packageFqn + ". Create it first with " //$NON-NLS-1$ //$NON-NLS-2$
+                + "'" + ref.packageFqn + ".ObjectType." + ref.objectTypeName + "'.").toJson()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        }
+        return createPropertyInTx(owner.getProperties(), content, ref, properties);
+    }
+
+    private static XdtoCreateResult createObjectTypeInTx(Package content, XdtoWriter.MemberRef ref,
+        List<JsonObject> properties)
+    {
+        if (XdtoWriter.findObjectType(content, ref.objectTypeName) != null)
+        {
+            throw new XdtoWriteException(ToolResult.error("ObjectType already exists: '" + ref.objectTypeName //$NON-NLS-1$
+                + "' in package " + ref.packageFqn).toJson()); //$NON-NLS-1$
+        }
+        ObjectType type = XdtoWriter.createObjectType(content, ref.objectTypeName);
+        // The optional flags (open/abstract/mixed/ordered/sequenced) come from the SAME 'properties'
+        // array a Property's attributes do - applied here too, else a caller's open=true / etc. is
+        // silently dropped (codex review finding #7).
+        XdtoWriter.Result applied = XdtoWriter.applyObjectTypeProperties(type, properties);
+        if (applied.hasError())
+        {
+            throw new XdtoWriteException(applied.error);
+        }
+        return new XdtoCreateResult(type.eClass().getName(), ref.objectTypeName, applied.applied);
+    }
+
+    private static XdtoCreateResult createPropertyInTx(EList<Property> owner, Package content,
+        XdtoWriter.MemberRef ref, List<JsonObject> properties)
+    {
+        String name = ref.propertyName;
+        if (XdtoWriter.findProperty(owner, name) != null)
+        {
+            throw new XdtoWriteException(ToolResult.error("Property already exists: '" + name + "' on " //$NON-NLS-1$ //$NON-NLS-2$
+                + normFqnOfProperty(ref)).toJson());
+        }
+        Property property = XdtoWriter.createProperty(owner, name);
+        XdtoWriter.Result applied = XdtoWriter.applyPropertyProperties(property, content, properties, true);
+        if (applied.hasError())
+        {
+            throw new XdtoWriteException(applied.error);
+        }
+        return new XdtoCreateResult(property.eClass().getName(), name, applied.applied);
+    }
+
+    /** Describes where a Property member lives, for an actionable duplicate error. */
+    private static String normFqnOfProperty(XdtoWriter.MemberRef ref)
+    {
+        return ref.kind == XdtoWriter.Kind.OBJECT_TYPE_PROPERTY
+            ? ref.packageFqn + ".ObjectType." + ref.objectTypeName //$NON-NLS-1$
+            : ref.packageFqn;
+    }
+
+    /**
+     * Builds the success JSON for a created/modified XDTO member: {@code fqn} / {@code kind} /
+     * {@code name} / {@code persisted} / {@code applied} (the optional attributes actually set) plus a
+     * confirmation message. Shared by {@link #createXdtoMember} (this tool) and reusable verbatim by the
+     * modify path's own success builder shape.
+     */
+    private static String xdtoMemberSuccess(String normFqn, XdtoCreateResult result, boolean persisted,
+        String action, String verb)
+    {
+        return ToolResult.success()
+            .put(McpKeys.ACTION, action)
+            .put("fqn", normFqn) //$NON-NLS-1$
+            .put("kind", result.eClassName) //$NON-NLS-1$
+            .put("name", result.name) //$NON-NLS-1$
+            .put(KEY_PERSISTED, persisted)
+            .put(KEY_APPLIED, result.applied)
+            .put(McpKeys.MESSAGE, verb + normFqn + (result.applied.isEmpty() ? "" //$NON-NLS-1$
+                : " (" + String.join(", ", result.applied) + ")")) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            .toJson();
+    }
+
     // ---- top-level creation (mirrors the former create_metadata_object) -------------------------
 
     /**
@@ -471,7 +714,11 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         final String configFeatureName = req.target.configFeatureName;
         final IModelObjectFactory factory = bm.factory;
         final Version version = bm.version;
+        // Only needed for an XDTOPackage create (below); resolved up front like the rest of the BM
+        // services this method uses, not inside the transaction.
+        final ITopObjectFqnGenerator fqnGenerator = Activator.getDefault().getTopObjectFqnGenerator();
 
+        final String[] xdtoContentFqnHolder = { null };
         final EClass createdKind;
         try
         {
@@ -490,11 +737,31 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
                 }
                 newObject.setName(name);
                 applyScalarProps(newObject, req.props, req.synonymLanguage);
-                // Type-specific defaults applied on top of the factory's default content.
+                // Type-specific defaults applied on top of the factory's default content (sets the
+                // namespace for an XDTOPackage - always non-empty, defaulted when omitted).
                 req.typeSpecific.applyTo(newObject);
                 tx.attachTopObject((IBmObject)newObject, req.normFqn);
                 addToCollection(cfg, configFeatureName, newObject);
                 factory.fillDefaultReferences(newObject);
+                // An XDTOPackage's content (Package.xdto) is a lazy @ExternalProperty; a live-stand
+                // finding showed the platform does NOT durably serialize it when it is first
+                // materialized in a LATER, separate transaction (the first member-edit call) - each
+                // subsequent edit re-materialized an empty content, discarding the previous one.
+                // Materializing it HERE instead, in the SAME transaction that creates and attaches the
+                // owning XDTOPackage, makes Package.xdto exist from creation, so every later member
+                // edit hits the proven-working EXISTING-content path. Best-effort: a resolution
+                // failure here is NOT fatal to the top-object create itself (the content still
+                // materializes lazily on the first member edit, same as before this change) - it is
+                // just not force-exported in THIS commit.
+                if (newObject instanceof XDTOPackage && fqnGenerator != null)
+                {
+                    XdtoWriter.ContentResolution resolved =
+                        XdtoWriter.resolvePackageContent((XDTOPackage)newObject, tx, fqnGenerator);
+                    if (resolved.error == null)
+                    {
+                        xdtoContentFqnHolder[0] = resolved.contentFqn;
+                    }
+                }
                 return newObject.eClass();
             });
         }
@@ -504,8 +771,13 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
             return ToolResult.error("Failed to create object: " + unwrapCauseMessage(e)).toJson(); //$NON-NLS-1$
         }
 
-        boolean persisted =
-            BmTransactions.forceExportToDisk(req.project, dirtyFqns(req.normFqn, configFqn));
+        List<String> exportFqns = dirtyFqns(req.normFqn, configFqn);
+        String xdtoContentFqn = xdtoContentFqnHolder[0];
+        if (xdtoContentFqn != null && !exportFqns.contains(xdtoContentFqn))
+        {
+            exportFqns.add(xdtoContentFqn);
+        }
+        boolean persisted = BmTransactions.forceExportToDisk(req.project, exportFqns);
         return success(new SuccessInfo(req.normFqn, createdKind, name, persisted, req.props,
             req.synonymLanguage, req.typeSpecific, req.normReport));
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
@@ -175,12 +175,6 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         }
         Configuration config = ctx.config;
 
-        IMdRefactoringService refactoringService = Activator.getDefault().getMdRefactoringService();
-        if (refactoringService == null)
-        {
-            return ToolResult.error("IMdRefactoringService not available").toJson(); //$NON-NLS-1$
-        }
-
         String normFqn = MetadataTypeUtils.normalizeFqn(fqn);
 
         // A FQN addressing a FORM member (item / attribute / command / handler) is handled by a
@@ -212,6 +206,15 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         if (xdtoRef != null)
         {
             return deleteXdtoMember(ctx, normFqn, xdtoRef, confirm);
+        }
+
+        // The md-refactoring service is needed ONLY by the generic mdclass path below - the
+        // form-member / form-object / XDTO-member branches above delete directly through their
+        // own content models, so its unavailability (e.g. during startup) must not block them.
+        IMdRefactoringService refactoringService = Activator.getDefault().getMdRefactoringService();
+        if (refactoringService == null)
+        {
+            return ToolResult.error("IMdRefactoringService not available").toJson(); //$NON-NLS-1$
         }
 
         // Exact-first resolve with the yo-addressing fallback: create_metadata normalizes

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
@@ -16,6 +16,7 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
@@ -23,14 +24,22 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 
 import com._1c.g5.v8.bm.core.IBmObject;
 import com._1c.g5.v8.bm.core.IBmTransaction;
+import com._1c.g5.v8.bm.integration.IBmModel;
+import com._1c.g5.v8.dt.core.naming.ITopObjectFqnGenerator;
+import com._1c.g5.v8.dt.core.platform.IBmModelManager;
 import com._1c.g5.v8.dt.md.refactoring.core.IMdRefactoringService;
 import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
+import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
 import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
+import com._1c.g5.v8.dt.metadata.mdclass.XDTOPackage;
 import com._1c.g5.v8.dt.refactoring.core.CleanReferenceProblem;
 import com._1c.g5.v8.dt.refactoring.core.IRefactoring;
 import com._1c.g5.v8.dt.refactoring.core.IRefactoringItem;
 import com._1c.g5.v8.dt.refactoring.core.IRefactoringProblem;
 import com._1c.g5.v8.dt.refactoring.core.RefactoringStatus;
+import com._1c.g5.v8.dt.xdto.model.ObjectType;
+import com._1c.g5.v8.dt.xdto.model.Package;
+import com._1c.g5.v8.dt.xdto.model.Property;
 import com.ditrix.edt.mcp.server.Activator;
 import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
 import com.ditrix.edt.mcp.server.protocol.JsonUtils;
@@ -46,6 +55,8 @@ import com.ditrix.edt.mcp.server.utils.FormValidationException;
 import com.ditrix.edt.mcp.server.utils.MetadataNodeResolver;
 import com.ditrix.edt.mcp.server.utils.MetadataPathResolver;
 import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils;
+import com.ditrix.edt.mcp.server.utils.XdtoWriteException;
+import com.ditrix.edt.mcp.server.utils.XdtoWriter;
 
 /**
  * Deletes a metadata node (a top-level object or a subordinate member) addressed by a 1C full-name
@@ -88,8 +99,10 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
     public String getDescription()
     {
         return "Delete a metadata node (object or member, including a FORM object " //$NON-NLS-1$
-            + "'Type.Object.Form.Name' or a FORM member - item / attribute / " //$NON-NLS-1$
-            + "command / handler) addressed by a 1C full-name FQN, cascading the cleanup of all " //$NON-NLS-1$
+            + "'Type.Object.Form.Name', a FORM member - item / attribute / " //$NON-NLS-1$
+            + "command / handler - or an XDTO package member 'XDTOPackage.<Package>.ObjectType.<Name>' " //$NON-NLS-1$
+            + "/ '...Property.<Name>' / '...ObjectType.<Type>.Property.<Name>') addressed by a 1C " //$NON-NLS-1$
+            + "full-name FQN, cascading the cleanup of all " //$NON-NLS-1$
             + "references in BSL code, forms and other metadata. Two-phase: call without confirm to " //$NON-NLS-1$
             + "preview what would be removed, then confirm=true to apply (deletion is hard to reverse). " //$NON-NLS-1$
             + "If the node is still referenced by metadata the refactoring cannot auto-clean, a " //$NON-NLS-1$
@@ -188,6 +201,17 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         if (formObjectRef != null)
         {
             return deleteFormObject(ctx, normFqn, formObjectRef, confirm);
+        }
+
+        // A FQN addressing an XDTO PACKAGE MEMBER (an ObjectType or a Property - issue #183 stream 1)
+        // is handled by a dedicated branch too: it lives on the package's lazily materialized
+        // xdto.model content (a cross-model hop), not the mdclass tree, so the md-refactoring service
+        // (mdclass-only) cannot see it - removed directly instead, mirroring the form-member delete's
+        // two-phase preview/confirm shape.
+        XdtoWriter.MemberRef xdtoRef = XdtoWriter.parseMemberRef(normFqn);
+        if (xdtoRef != null)
+        {
+            return deleteXdtoMember(ctx, normFqn, xdtoRef, confirm);
         }
 
         // Exact-first resolve with the yo-addressing fallback: create_metadata normalizes
@@ -904,6 +928,271 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
                 holder.eUnset(reference);
             }
         }
+    }
+
+    // ==================== XDTO package members (cross-model hop, issue #183 stream 1) ====================
+
+    /**
+     * Deletes an XDTO PACKAGE MEMBER (an ObjectType or a Property, package-global or nested in an
+     * ObjectType) addressed by {@code ref}. The md-refactoring service is mdclass-only, so the member is
+     * removed directly (EMF list removal - {@code ObjectType.getProperties()} is containment, so
+     * removing an ObjectType cascades its own properties). Two-phase like the rest of the tool:
+     * {@code confirm=false} previews (a rolled-back read, since the package's content is a lazy
+     * {@code @ExternalProperty}), {@code confirm=true} removes it (behind the SAME
+     * {@link DestructiveConsentGate} the generic mdclass delete path uses) and force-exports the owning
+     * package.
+     */
+    private String deleteXdtoMember(ProjectContext ctx, String normFqn, XdtoWriter.MemberRef ref,
+        boolean confirm)
+    {
+        MetadataNodeResolver.MetadataNode pkgNode =
+            MetadataNodeResolver.resolveExisting(ctx.config, ref.packageFqn);
+        if (pkgNode == null || !(pkgNode.object instanceof XDTOPackage)
+            || !(pkgNode.object instanceof IBmObject))
+        {
+            return ToolResult.error("XDTOPackage not found: " + ref.packageFqn //$NON-NLS-1$
+                + ". Use get_metadata_objects to find an FQN.").toJson(); //$NON-NLS-1$
+        }
+        IBmModelManager bmModelManager = Activator.getDefault().getBmModelManager();
+        // The generator is needed only on the confirm=true (write) path - to derive the content's own
+        // export FQN from the OWNER (never via bmGetFqn() on the content itself; see
+        // XdtoWriter.resolvePackageContent's javadoc for why that throws BmAssertionException even on
+        // content that looks "attached").
+        ITopObjectFqnGenerator fqnGenerator = Activator.getDefault().getTopObjectFqnGenerator();
+        if (bmModelManager == null || (confirm && fqnGenerator == null))
+        {
+            return ToolResult.error("IBmModelManager not available").toJson(); //$NON-NLS-1$
+        }
+        IBmModel bmModel = bmModelManager.getModel(ctx.project);
+        if (bmModel == null)
+        {
+            return ToolResult.error("BM model not available for project: " + ctx.project.getName()).toJson(); //$NON-NLS-1$
+        }
+        final long pkgBmId = ((IBmObject)pkgNode.object).bmGetId();
+        return confirm
+            ? performXdtoMemberDelete(ctx, normFqn, ref, bmModel, pkgBmId, fqnGenerator)
+            : buildXdtoMemberDeletePreview(normFqn, ref, bmModel, pkgBmId);
+    }
+
+    /** Preview inside a rolled-back (read-with-materialize) transaction: locates the target, no mutation. */
+    private String buildXdtoMemberDeletePreview(String normFqn, XdtoWriter.MemberRef ref, IBmModel bmModel,
+        long pkgBmId)
+    {
+        String[] found = BmTransactions.executeAndRollback(bmModel, "DeleteXdtoMemberPreview", (tx, pm) -> //$NON-NLS-1$
+        {
+            Object inTx = tx.getObjectById(pkgBmId);
+            Package content = inTx instanceof XDTOPackage ? ((XDTOPackage)inTx).getPackage() : null;
+            return locateXdtoMember(content, ref);
+        });
+        if (found == null)
+        {
+            return xdtoMemberNotFoundError(ref);
+        }
+
+        List<Map<String, Object>> items = new ArrayList<>();
+        items.add(formItem(ref.memberName(), found[0]));
+
+        ToolResult result = ToolResult.success()
+            .put(McpKeys.ACTION, VAL_PREVIEW)
+            .put("fqn", normFqn) //$NON-NLS-1$
+            .put(KEY_REFACTORING_TITLE, "Delete XDTO member " + ref.memberName()) //$NON-NLS-1$
+            .put(KEY_ITEMS, items)
+            .put(KEY_BLOCKING, false);
+        return putBlockingReferences(result, Collections.emptyList())
+            .put(McpKeys.MESSAGE, "Preview: deleting '" + ref.memberName() + "' (" + found[0] + ") from " //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                + ref.packageFqn
+                + (ref.kind == XdtoWriter.Kind.OBJECT_TYPE ? " would remove it and all its own properties." //$NON-NLS-1$
+                    : ".") //$NON-NLS-1$
+                + " Cross-references to it (a Property whose type/ref points at this ObjectType) are " //$NON-NLS-1$
+                + "NOT rewritten - re-check with get_metadata_details afterwards. Call confirm=true to " //$NON-NLS-1$
+                + "apply.") //$NON-NLS-1$
+            .toJson();
+    }
+
+    /** Delete behind the destructive-consent gate, then a write transaction; force-exports the package. */
+    private String performXdtoMemberDelete(ProjectContext ctx, String normFqn, XdtoWriter.MemberRef ref,
+        IBmModel bmModel, long pkgBmId, ITopObjectFqnGenerator fqnGenerator)
+    {
+        ConsentPreview preview = new ConsentPreview("Delete metadata node", //$NON-NLS-1$
+            "This deletes '" + normFqn + "'" //$NON-NLS-1$ //$NON-NLS-2$
+                + (ref.kind == XdtoWriter.Kind.OBJECT_TYPE ? " and all its own properties." : "."), //$NON-NLS-1$ //$NON-NLS-2$
+            1, Collections.singletonList(normFqn));
+        DestructiveConsentGate.ConsentDecision consentDecision =
+            DestructiveConsentGate.getInstance().requireConsent(NAME, preview);
+        if (consentDecision != DestructiveConsentGate.ConsentDecision.ALLOW)
+        {
+            return ToolResult.error(DestructiveConsentGate.consentDeniedMessage(consentDecision, NAME)).toJson();
+        }
+
+        XdtoDeleteResult result;
+        try
+        {
+            result = BmTransactions.<XdtoDeleteResult> write(bmModel, "DeleteXdtoMember", (tx, pm) -> //$NON-NLS-1$
+                deleteXdtoMemberInTx(tx, pkgBmId, ref, fqnGenerator));
+        }
+        catch (Exception e)
+        {
+            String ready = XdtoWriteException.jsonOf(e);
+            if (ready != null)
+            {
+                return ready;
+            }
+            Activator.logError("Error deleting XDTO member", e); //$NON-NLS-1$
+            return ToolResult.error("Delete failed: " + unwrapCauseMessage(e)).toJson(); //$NON-NLS-1$
+        }
+
+        // DUAL force-export, mirroring create_metadata / modify_metadata exactly: the owning
+        // XDTOPackage's FQN (drains the .mdo) AND the content's OWN resource FQN (drains the sibling
+        // .xdto) - exporting the package FQN alone would leave the deleted member on disk (a
+        // #239-class silent false "persisted").
+        List<String> exportFqns = new ArrayList<>();
+        exportFqns.add(ref.packageFqn);
+        if (!result.contentFqn.equals(ref.packageFqn))
+        {
+            exportFqns.add(result.contentFqn);
+        }
+        boolean persisted = BmTransactions.forceExportToDisk(ctx.project, exportFqns);
+        return ToolResult.success()
+            .put(McpKeys.ACTION, VAL_EXECUTED)
+            .put("fqn", normFqn) //$NON-NLS-1$
+            .put("forced", false) //$NON-NLS-1$
+            .put(McpKeys.MESSAGE, "Deleted XDTO member '" + ref.memberName() + "' (" + result.kind //$NON-NLS-1$ //$NON-NLS-2$
+                + ") from " + ref.packageFqn //$NON-NLS-1$
+                + (persisted ? " and persisted to disk." //$NON-NLS-1$
+                    : " (in-memory only; on-disk write did not complete - re-check before relying on " //$NON-NLS-1$
+                        + "it).")) //$NON-NLS-1$
+            .toJson();
+    }
+
+    /** The write-transaction result for {@link #performXdtoMemberDelete}: the removed kind + the content's own export FQN. */
+    private static final class XdtoDeleteResult
+    {
+        final String kind;
+        final String contentFqn;
+
+        XdtoDeleteResult(String kind, String contentFqn)
+        {
+            this.kind = kind;
+            this.contentFqn = contentFqn;
+        }
+    }
+
+    /**
+     * The write-transaction body for {@link #performXdtoMemberDelete}: re-fetches the XDTOPackage,
+     * reads its (possibly {@code null} / never-materialized) content directly - no ATTACH needed for a
+     * delete of an EXISTING member, since a package that already has a member was necessarily
+     * materialized + attached by an earlier create/modify - derives the content's OWN export FQN (for
+     * the dual force-export) from the OWNER via the generator, locates the target and removes it.
+     * Deriving the content FQN from the owner (never via {@code bmGetFqn()} on the content itself) is
+     * REQUIRED, not a style choice: a live-stand regression proved {@code bmGetFqn()} throws
+     * {@code BmAssertionException} on this package's content even when it looks fully attached
+     * ({@code bmIsTop() == true}) - see {@link XdtoWriter#resolvePackageContent}'s javadoc for the full
+     * trail. Throws {@link XdtoWriteException} (a ready JSON error) when the package or the target
+     * member cannot be resolved, rolling the whole write back with no partial mutation.
+     */
+    private static XdtoDeleteResult deleteXdtoMemberInTx(IBmTransaction tx, long pkgBmId,
+        XdtoWriter.MemberRef ref, ITopObjectFqnGenerator fqnGenerator)
+    {
+        Object inTx = tx.getObjectById(pkgBmId);
+        if (!(inTx instanceof XDTOPackage))
+        {
+            throw new XdtoWriteException(ToolResult.error("The XDTO package could not be resolved " //$NON-NLS-1$
+                + "inside the transaction.").toJson()); //$NON-NLS-1$
+        }
+        XDTOPackage txPkg = (XDTOPackage)inTx;
+        Package content = txPkg.getPackage();
+        if (content == null)
+        {
+            throw new XdtoWriteException(xdtoMemberNotFoundError(ref));
+        }
+        // Derived from the OWNER, never from the content (see the method javadoc above) - the ONLY call
+        // proven safe regardless of which transaction attached the content.
+        String contentFqn =
+            fqnGenerator.generateExternalPropertyFqn(txPkg, MdClassPackage.Literals.XDTO_PACKAGE__PACKAGE);
+        if (contentFqn == null || contentFqn.isEmpty())
+        {
+            throw new XdtoWriteException(ToolResult.error("Cannot resolve the on-disk resource for the " //$NON-NLS-1$
+                + "XDTO package content; report it with the package FQN '" + ref.packageFqn + "'.") //$NON-NLS-1$ //$NON-NLS-2$
+                    .toJson());
+        }
+
+        if (ref.kind == XdtoWriter.Kind.OBJECT_TYPE)
+        {
+            ObjectType type = XdtoWriter.findObjectType(content, ref.objectTypeName);
+            if (type == null)
+            {
+                throw new XdtoWriteException(xdtoMemberNotFoundError(ref));
+            }
+            String kind = type.eClass().getName();
+            XdtoWriter.removeObjectType(content, type);
+            return new XdtoDeleteResult(kind, contentFqn);
+        }
+        EList<Property> owner = content.getProperties();
+        if (ref.kind == XdtoWriter.Kind.OBJECT_TYPE_PROPERTY)
+        {
+            ObjectType type = XdtoWriter.findObjectType(content, ref.objectTypeName);
+            if (type == null)
+            {
+                throw new XdtoWriteException(xdtoMemberNotFoundError(ref));
+            }
+            owner = type.getProperties();
+        }
+        Property property = XdtoWriter.findProperty(owner, ref.propertyName);
+        if (property == null)
+        {
+            throw new XdtoWriteException(xdtoMemberNotFoundError(ref));
+        }
+        String kind = property.eClass().getName();
+        XdtoWriter.removeProperty(owner, property);
+        return new XdtoDeleteResult(kind, contentFqn);
+    }
+
+    /**
+     * Locates the target member (a pure read, used by the preview): {eClassName}, or {@code null}.
+     * Package-visible for tests.
+     */
+    static String[] locateXdtoMember(Package content, XdtoWriter.MemberRef ref)
+    {
+        if (content == null)
+        {
+            return null;
+        }
+        if (ref.kind == XdtoWriter.Kind.OBJECT_TYPE)
+        {
+            ObjectType type = XdtoWriter.findObjectType(content, ref.objectTypeName);
+            return type == null ? null : new String[] { type.eClass().getName() };
+        }
+        EList<Property> owner = content.getProperties();
+        if (ref.kind == XdtoWriter.Kind.OBJECT_TYPE_PROPERTY)
+        {
+            ObjectType type = XdtoWriter.findObjectType(content, ref.objectTypeName);
+            if (type == null)
+            {
+                return null;
+            }
+            owner = type.getProperties();
+        }
+        Property property = XdtoWriter.findProperty(owner, ref.propertyName);
+        return property == null ? null : new String[] { property.eClass().getName() };
+    }
+
+    /**
+     * The actionable "member not found" error, naming the ObjectType/Property and its owner.
+     * Package-visible for tests.
+     */
+    static String xdtoMemberNotFoundError(XdtoWriter.MemberRef ref)
+    {
+        if (ref.kind == XdtoWriter.Kind.OBJECT_TYPE)
+        {
+            return ToolResult.error("ObjectType not found: '" + ref.objectTypeName + "' in package " //$NON-NLS-1$ //$NON-NLS-2$
+                + ref.packageFqn + ". Use get_metadata_details on the package FQN to list its object " //$NON-NLS-1$
+                + "types.").toJson(); //$NON-NLS-1$
+        }
+        String owner = ref.kind == XdtoWriter.Kind.OBJECT_TYPE_PROPERTY
+            ? ref.packageFqn + ".ObjectType." + ref.objectTypeName //$NON-NLS-1$
+            : ref.packageFqn;
+        return ToolResult.error("Property not found: '" + ref.propertyName + "' on " + owner //$NON-NLS-1$ //$NON-NLS-2$
+            + ". Use get_metadata_details on the package FQN to list its properties.").toJson(); //$NON-NLS-1$
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
@@ -946,7 +946,7 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         boolean confirm)
     {
         MetadataNodeResolver.MetadataNode pkgNode =
-            MetadataNodeResolver.resolveExisting(ctx.config, ref.packageFqn);
+            MetadataNodeResolver.resolveExistingWithYoFallback(ctx.config, ref.packageFqn).node;
         if (pkgNode == null || !(pkgNode.object instanceof XDTOPackage)
             || !(pkgNode.object instanceof IBmObject))
         {
@@ -969,8 +969,11 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
             return ToolResult.error("BM model not available for project: " + ctx.project.getName()).toJson(); //$NON-NLS-1$
         }
         final long pkgBmId = ((IBmObject)pkgNode.object).bmGetId();
+        // The RESOLVED package's canonical FQN: with the yo fallback the caller-typed spelling may
+        // differ from the stored name, and force-export must target the stored top object.
+        final String pkgExportFqn = "XDTOPackage." + ((XDTOPackage)pkgNode.object).getName(); //$NON-NLS-1$
         return confirm
-            ? performXdtoMemberDelete(ctx, normFqn, ref, bmModel, pkgBmId, fqnGenerator)
+            ? performXdtoMemberDelete(ctx, normFqn, ref, bmModel, pkgBmId, fqnGenerator, pkgExportFqn)
             : buildXdtoMemberDeletePreview(normFqn, ref, bmModel, pkgBmId);
     }
 
@@ -1011,7 +1014,8 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
 
     /** Delete behind the destructive-consent gate, then a write transaction; force-exports the package. */
     private String performXdtoMemberDelete(ProjectContext ctx, String normFqn, XdtoWriter.MemberRef ref,
-        IBmModel bmModel, long pkgBmId, ITopObjectFqnGenerator fqnGenerator)
+        IBmModel bmModel, long pkgBmId, ITopObjectFqnGenerator fqnGenerator,
+        String pkgExportFqn)
     {
         ConsentPreview preview = new ConsentPreview("Delete metadata node", //$NON-NLS-1$
             "This deletes '" + normFqn + "'" //$NON-NLS-1$ //$NON-NLS-2$
@@ -1046,8 +1050,8 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         // .xdto) - exporting the package FQN alone would leave the deleted member on disk (a
         // #239-class silent false "persisted").
         List<String> exportFqns = new ArrayList<>();
-        exportFqns.add(ref.packageFqn);
-        if (!result.contentFqn.equals(ref.packageFqn))
+        exportFqns.add(pkgExportFqn);
+        if (!result.contentFqn.equals(pkgExportFqn))
         {
             exportFqns.add(result.contentFqn);
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataDetailsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataDetailsTool.java
@@ -31,6 +31,8 @@ import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
 import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
 import com._1c.g5.v8.dt.metadata.mdclass.Role;
 import com._1c.g5.v8.dt.metadata.mdclass.ScheduledJob;
+import com._1c.g5.v8.dt.metadata.mdclass.XDTOPackage;
+import com._1c.g5.v8.dt.xdto.model.Package;
 import com.ditrix.edt.mcp.server.Activator;
 import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
 import com.ditrix.edt.mcp.server.protocol.JsonUtils;
@@ -50,6 +52,7 @@ import com.ditrix.edt.mcp.server.utils.MetadataPropertyIntrospector;
 import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils;
 import com.ditrix.edt.mcp.server.utils.ProjectContext;
 import com.ditrix.edt.mcp.server.utils.RoleRightsReader;
+import com.ditrix.edt.mcp.server.utils.XdtoStructureReader;
 
 /**
  * Tool to get detailed properties of metadata objects from 1C configuration.
@@ -321,6 +324,19 @@ public class GetMetadataDetailsTool implements IMcpTool
         // Type-specific properties the universal reflective formatter's default view omits
         // (issue #288): ScheduledJob / CommonModule / an InformationRegister's dimension Indexing.
         sb.append(formatTypeSpecificProperties(mdObject, ctx.full));
+        // An XDTOPackage FQN additionally renders its CONTENT (object types with their properties,
+        // package-global properties, value types, dependencies - issue #183 stream 1) via the
+        // cross-model hop (XdtoStructureReader), APPENDED after the standard property block (unlike
+        // the template/DCS branch above, the package's own properties - namespace, comment, synonym -
+        // stay useful, so this augments rather than replaces the generic render).
+        if (mdObject instanceof XDTOPackage)
+        {
+            String xdtoStructure = renderXdtoPackageStructure(ctx.bmModel, (XDTOPackage)mdObject, fqn);
+            if (xdtoStructure != null)
+            {
+                sb.append(xdtoStructure);
+            }
+        }
         // ORIGIN footer: core / core (adopted) / extension. For a base
         // configuration this is always "core"; for an extension it distinguishes
         // an adopted base object from one the extension itself owns.
@@ -737,6 +753,33 @@ public class GetMetadataDetailsTool implements IMcpTool
                 return null;
             }
             return DcsStructureReader.render(normalized, (DataCompositionSchema)content, language);
+        });
+    }
+
+    /**
+     * Renders an XDTOPackage's CONTENT (object types with their properties, package-global properties,
+     * value types, dependencies - issue #183 stream 1) via {@link XdtoStructureReader}: re-fetches the
+     * package inside a {@link BmTransactions#executeAndRollback} boundary (required, not a plain read -
+     * {@code XDTOPackage.getPackage()} lazily materializes the content from the separate, lazily-loaded
+     * {@code .xdto} resource, a model-write side effect, exactly like {@code BasicTemplate.getTemplate()}
+     * for the DCS branch above) and renders it. Returns {@code null} only when the BM model or the
+     * package's BM id is unavailable (never - a resolved {@code mdObject} is always a real BM object);
+     * an XDTOPackage with NO content yet still renders the "(no package content)" note, matching
+     * {@link XdtoStructureReader#render}'s null-content contract.
+     */
+    private static String renderXdtoPackageStructure(IBmModel bmModel, XDTOPackage pkg, String fqn)
+    {
+        if (bmModel == null || !(pkg instanceof IBmObject))
+        {
+            return null;
+        }
+        final long pkgBmId = ((IBmObject)pkg).bmGetId();
+        final String normalized = MetadataTypeUtils.normalizeFqn(fqn);
+        return BmTransactions.executeAndRollback(bmModel, "GetMetadataDetailsXdtoPackage", (tx, monitor) -> //$NON-NLS-1$
+        {
+            EObject txPackage = tx.getObjectById(pkgBmId);
+            Package content = txPackage instanceof XDTOPackage ? ((XDTOPackage)txPackage).getPackage() : null;
+            return XdtoStructureReader.render(normalized, content);
         });
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -183,6 +183,19 @@ public class GetProjectErrorsTool implements IMcpTool
 
     public static String getProjectErrors(String projectName, String severity, String checkId, List<String> objects, int limit, boolean detailed)
     {
+        return getProjectErrors(projectName, severity, checkId, objects, limit, detailed, false);
+    }
+
+    /**
+     * As {@link #getProjectErrors(String, String, String, List, int, boolean)} but with an
+     * {@code exactScope} objects filter: segment-boundary matching instead of the default substring
+     * (see {@link #excludedByObjectsFilter(Set, boolean, String, int[], boolean)}). Package-private -
+     * only validate_xdto_package needs exact per-object scoping (a substring match across
+     * prefix-sharing package names would report a sibling package's problems).
+     */
+    static String getProjectErrors(String projectName, String severity, String checkId,
+        List<String> objects, int limit, boolean detailed, boolean exactScope)
+    {
         try
         {
             IMarkerManager markerManager = Activator.getDefault().getMarkerManager();
@@ -221,7 +234,7 @@ public class GetProjectErrorsTool implements IMcpTool
 
             final CollectContext collectContext = new CollectContext(finalSeverityFilter,
                 finalCheckId, finalObjects, checkRepository, limit, unresolvedShown,
-                unresolvedFilteredOut);
+                unresolvedFilteredOut, exactScope);
             final List<ErrorInfo> errors = collectErrors(markersByProject, bmModelManager,
                 collectContext);
 
@@ -360,7 +373,7 @@ public class GetProjectErrorsTool implements IMcpTool
             Runnable collector = () -> projectMarkers.stream()
                 .map(marker -> buildIfMatches(marker, context.severityFilter, context.checkId,
                     context.objects, context.checkRepository, context.unresolvedShown,
-                    context.unresolvedFilteredOut))
+                    context.unresolvedFilteredOut, context.exactScope))
                 .filter(Objects::nonNull)
                 .limit(remaining)
                 .forEach(errors::add);
@@ -397,10 +410,11 @@ public class GetProjectErrorsTool implements IMcpTool
         final int limit;
         final int[] unresolvedShown;
         final int[] unresolvedFilteredOut;
+        final boolean exactScope;
 
         CollectContext(MarkerSeverity severityFilter, String checkId, Set<String> objects,
             ICheckRepository checkRepository, int limit, int[] unresolvedShown,
-            int[] unresolvedFilteredOut)
+            int[] unresolvedFilteredOut, boolean exactScope)
         {
             this.severityFilter = severityFilter;
             this.checkId = checkId;
@@ -409,6 +423,7 @@ public class GetProjectErrorsTool implements IMcpTool
             this.limit = limit;
             this.unresolvedShown = unresolvedShown;
             this.unresolvedFilteredOut = unresolvedFilteredOut;
+            this.exactScope = exactScope;
         }
     }
 
@@ -564,6 +579,19 @@ public class GetProjectErrorsTool implements IMcpTool
     static ErrorInfo buildIfMatches(Marker marker, MarkerSeverity severityFilter, String checkId,
         Set<String> objects, ICheckRepository checkRepository, int[] unresolvedShown, int[] unresolvedFilteredOut)
     {
+        return buildIfMatches(marker, severityFilter, checkId, objects, checkRepository, unresolvedShown,
+            unresolvedFilteredOut, false);
+    }
+
+    /**
+     * As {@link #buildIfMatches(Marker, MarkerSeverity, String, Set, ICheckRepository, int[], int[])}
+     * but threading {@code exactScope} into the objects filter (segment-boundary vs substring - see
+     * {@link #excludedByObjectsFilter(Set, boolean, String, int[], boolean)}).
+     */
+    static ErrorInfo buildIfMatches(Marker marker, MarkerSeverity severityFilter, String checkId,
+        Set<String> objects, ICheckRepository checkRepository, int[] unresolvedShown, int[] unresolvedFilteredOut,
+        boolean exactScope)
+    {
         // Severity filter
         if (severityFilter != null && marker.getSeverity() != severityFilter)
         {
@@ -597,7 +625,8 @@ public class GetProjectErrorsTool implements IMcpTool
         }
         
         // Objects filter (FQN matching against the resolved object presentation)
-        if (excludedByObjectsFilter(objects, presentationResolved, objectPresentation, unresolvedFilteredOut))
+        if (excludedByObjectsFilter(objects, presentationResolved, objectPresentation, unresolvedFilteredOut,
+            exactScope))
         {
             return null;
         }
@@ -639,6 +668,24 @@ public class GetProjectErrorsTool implements IMcpTool
     static boolean excludedByObjectsFilter(Set<String> objects, boolean presentationResolved,
         String objectPresentation, int[] unresolvedFilteredOut)
     {
+        return excludedByObjectsFilter(objects, presentationResolved, objectPresentation,
+            unresolvedFilteredOut, false);
+    }
+
+    /**
+     * As {@link #excludedByObjectsFilter(Set, boolean, String, int[])} but with an
+     * {@code exactScope} mode. When {@code false} (the default get_project_errors behavior) a
+     * variant matches by SUBSTRING ({@code contains}) - loose on purpose, so a caller filtering
+     * by {@code Catalog.Order} also sees markers on its members. When {@code true} a variant
+     * matches only at a SEGMENT BOUNDARY: the presentation must EQUAL the variant or start with
+     * {@code variant + "."} (the object itself or a member strictly under it) - so
+     * {@code XDTOPackage.P} no longer matches {@code XDTOPackage.P2}'s markers. Used by
+     * validate_xdto_package, which needs exact per-package scoping (a substring match across
+     * prefix-sharing package names is a false failure).
+     */
+    static boolean excludedByObjectsFilter(Set<String> objects, boolean presentationResolved,
+        String objectPresentation, int[] unresolvedFilteredOut, boolean exactScope)
+    {
         if (objects.isEmpty())
         {
             return false;
@@ -659,7 +706,10 @@ public class GetProjectErrorsTool implements IMcpTool
         String presentationLower = objectPresentation.toLowerCase();
         for (String fqnVariant : objects)
         {
-            if (presentationLower.contains(fqnVariant))
+            boolean matches = exactScope
+                ? presentationLower.equals(fqnVariant) || presentationLower.startsWith(fqnVariant + ".") //$NON-NLS-1$
+                : presentationLower.contains(fqnVariant);
+            if (matches)
             {
                 return false;
             }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -2164,6 +2164,12 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 if (fqnGenerator != null && applyTo instanceof XDTOPackage)
                 {
                     XDTOPackage changedPkg = (XDTOPackage)applyTo;
+                    // Captured BEFORE resolvePackageContent: ensureNamespace re-syncs a STALE content
+                    // targetNamespace to the owner, and QNames still carrying that stale value must be
+                    // rewritten too (not only the old mdclass namespace).
+                    com._1c.g5.v8.dt.xdto.model.Package preContent = changedPkg.getPackage();
+                    String preContentNs = (preContent instanceof IBmObject
+                        && ((IBmObject)preContent).bmIsTop()) ? preContent.getNsUri() : null;
                     XdtoWriter.ContentResolution resolved =
                         XdtoWriter.resolvePackageContent(changedPkg, tx, fqnGenerator);
                     if (resolved.error != null)
@@ -2183,6 +2189,13 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                         // rewrite those too, or the package would dangle against ITSELF right after the
                         // rename. Its content FQN is already force-exported via contentFqnHolder.
                         XdtoWriter.rewriteNamespaceReferences(resolved.content, oldNamespace, newNamespace);
+                        if (preContentNs != null && !preContentNs.equals(oldNamespace)
+                            && !preContentNs.equals(newNamespace))
+                        {
+                            // The content targetNamespace was stale before this edit: QNames written
+                            // under THAT value would otherwise stay dangling after the rename.
+                            XdtoWriter.rewriteNamespaceReferences(resolved.content, preContentNs, newNamespace);
+                        }
                         cascadeNamespaceChange(tx, configBmId, changedPkg, oldNamespace, newNamespace,
                             fqnGenerator, cascadedPackageNames, cascadedExportFqns);
                     }
@@ -2268,6 +2281,11 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             {
                 continue;
             }
+            // resolvePackageContent may REPAIR this sibling as a side effect (ensureNamespace
+            // re-syncs a stale content targetNamespace to its own owner) - capture the pre-state so
+            // a repaired-but-not-rewritten sibling is still force-exported (an in-memory change that
+            // never reaches disk would leave BM and Package.xdto inconsistent).
+            String siblingPreNs = existingContent.getNsUri();
             XdtoWriter.ContentResolution resolved = XdtoWriter.resolvePackageContent(other, tx, fqnGenerator);
             if (resolved.error != null)
             {
@@ -2275,7 +2293,9 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 // yet) is skipped, not a failure of THIS modify.
                 continue;
             }
-            if (!XdtoWriter.rewriteNamespaceReferences(resolved.content, oldNamespace, newNamespace))
+            boolean rewritten = XdtoWriter.rewriteNamespaceReferences(resolved.content, oldNamespace, newNamespace);
+            boolean repaired = siblingPreNs == null || !siblingPreNs.equals(other.getNamespace());
+            if (!rewritten && !repaired)
             {
                 continue;
             }
@@ -2284,7 +2304,10 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             {
                 exportFqnsOut.add(resolved.contentFqn);
             }
-            cascadedNamesOut.add(other.getName());
+            if (rewritten)
+            {
+                cascadedNamesOut.add(other.getName());
+            }
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -2174,6 +2174,11 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                     String newNamespace = changedPkg.getNamespace();
                     if (oldNamespace != null && !oldNamespace.equals(newNamespace))
                     {
+                        // The renamed package's OWN content can hold SAME-PACKAGE references (a property
+                        // typed at a sibling ObjectType carries a QName with the package's own nsUri) -
+                        // rewrite those too, or the package would dangle against ITSELF right after the
+                        // rename. Its content FQN is already force-exported via contentFqnHolder.
+                        XdtoWriter.rewriteNamespaceReferences(resolved.content, oldNamespace, newNamespace);
                         cascadeNamespaceChange(tx, configBmId, changedPkg, oldNamespace, newNamespace,
                             fqnGenerator, cascadedPackageNames, cascadedExportFqns);
                     }
@@ -2248,6 +2253,14 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         for (XDTOPackage other : cfg.getXDTOPackages())
         {
             if (!(other instanceof IBmObject) || ((IBmObject)other).bmGetId() == changedPkgBmId)
+            {
+                continue;
+            }
+            // A sibling with NO attached content cannot reference any namespace - skip it WITHOUT
+            // resolvePackageContent, which would otherwise MATERIALIZE + attach a fresh empty content
+            // for an unrelated package as a committed-but-unexported side effect of this modify.
+            com._1c.g5.v8.dt.xdto.model.Package existingContent = other.getPackage();
+            if (!(existingContent instanceof IBmObject) || !((IBmObject)existingContent).bmIsTop())
             {
                 continue;
             }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -702,7 +702,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         List<JsonObject> properties)
     {
         MetadataNodeResolver.MetadataNode pkgNode =
-            MetadataNodeResolver.resolveExisting(ctx.config, ref.packageFqn);
+            MetadataNodeResolver.resolveExistingWithYoFallback(ctx.config, ref.packageFqn).node;
         if (pkgNode == null || !(pkgNode.object instanceof XDTOPackage)
             || !(pkgNode.object instanceof IBmObject))
         {
@@ -740,9 +740,13 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         }
 
         List<String> exportFqns = new ArrayList<>();
-        exportFqns.add(ref.packageFqn);
+        // Export by the RESOLVED package's canonical FQN: with the yo (ё->е) fallback the
+        // caller-typed ref.packageFqn may differ from the stored name, and force-export must
+        // target the stored top object (never the caller-supplied spelling).
+        String pkgExportFqn = "XDTOPackage." + ((XDTOPackage)pkgNode.object).getName(); //$NON-NLS-1$
+        exportFqns.add(pkgExportFqn);
         String contentFqn = contentFqnHolder[0];
-        if (contentFqn != null && !contentFqn.equals(ref.packageFqn))
+        if (contentFqn != null && !contentFqn.equals(pkgExportFqn))
         {
             exportFqns.add(contentFqn);
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -51,8 +51,12 @@ import com._1c.g5.v8.dt.metadata.mdclass.StyleElementType;
 import com._1c.g5.v8.dt.metadata.mdclass.Subsystem;
 import com._1c.g5.v8.dt.metadata.mdclass.Template;
 import com._1c.g5.v8.dt.metadata.mdclass.TemplateType;
+import com._1c.g5.v8.dt.metadata.mdclass.XDTOPackage;
 import com._1c.g5.v8.dt.moxel.SpreadsheetDocument;
 import com._1c.g5.v8.dt.moxel.sheet.SheetFactory;
+import com._1c.g5.v8.dt.xdto.model.ObjectType;
+import com._1c.g5.v8.dt.xdto.model.Package;
+import com._1c.g5.v8.dt.xdto.model.Property;
 import com._1c.g5.v8.dt.platform.version.Version;
 import com.ditrix.edt.mcp.server.Activator;
 import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
@@ -84,6 +88,8 @@ import com.ditrix.edt.mcp.server.utils.RoleRightsWriter;
 import com.ditrix.edt.mcp.server.utils.SpreadsheetTemplateWriter;
 import com.ditrix.edt.mcp.server.utils.StyleValueBuilder;
 import com.ditrix.edt.mcp.server.utils.SubsystemUtils;
+import com.ditrix.edt.mcp.server.utils.XdtoWriteException;
+import com.ditrix.edt.mcp.server.utils.XdtoWriter;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -238,6 +244,14 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             + "dataPath, title?, role?}]}], parameters:[{name, valueType?, title?, use?}]} builds the " //$NON-NLS-1$
             + "report's main schema (query data sets + fields + schema parameters), creating the DCS if " //$NON-NLS-1$
             + "the report has none. " //$NON-NLS-1$
+            + "Edit an XDTO package MEMBER through 'properties' on its own FQN " //$NON-NLS-1$
+            + "('XDTOPackage.<Package>.ObjectType.<Name>' or '...Property.<Name>' or " //$NON-NLS-1$
+            + "'...ObjectType.<Type>.Property.<Name>'): an ObjectType takes the boolean flags 'open' / " //$NON-NLS-1$
+            + "'abstract' / 'mixed' / 'ordered' / 'sequenced'; a Property takes 'type' (a built-in XSD " //$NON-NLS-1$
+            + "type name, the EXACT name of an ObjectType already in the same package, or " //$NON-NLS-1$
+            + "{nsUri, name}), 'lowerBound' / 'upperBound' (integers, ObjectType-nested properties " //$NON-NLS-1$
+            + "only), 'nillable' / 'fixed' (booleans, 'fixed'=true needs a 'default') and 'default' " //$NON-NLS-1$
+            + "(string). " //$NON-NLS-1$
             + "Discover assignable properties + allowed values with " //$NON-NLS-1$
             + "get_metadata_details(assignable:true). To rename, use rename_metadata_object. " //$NON-NLS-1$
             + "Full parameters and examples: call get_tool_guide('modify_metadata')."; //$NON-NLS-1$
@@ -385,6 +399,17 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         if (subsystemResult != null)
         {
             return subsystemResult;
+        }
+
+        // A FQN that addresses an XDTO PACKAGE MEMBER (an ObjectType or a Property - issue #183
+        // stream 1) is dispatched EARLY too: an ObjectType/Property lives on the package's lazily
+        // materialized xdto.model content (a cross-model hop, the SAME transient @ExternalProperty
+        // shape a report's DCS uses), not the mdclass tree, so the generic single-segment resolver
+        // below cannot see it (it does not know "ObjectType"/"Property" as mdclass child kinds).
+        String xdtoResult = dispatchXdtoMemberPayload(ctx, normFqn, args);
+        if (xdtoResult != null)
+        {
+            return xdtoResult;
         }
 
         // Exact-first resolve with the yo-addressing fallback: create_metadata normalizes
@@ -596,6 +621,216 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         }
         return modifySubsystemContent(ctx, normFqn, subsystem, args.properties, args.content,
             args.hasRolePayload);
+    }
+
+    // ===== XDTO package member editing (issue #183 stream 1) ==========================================
+    //
+    // An XDTOPackage member (an ObjectType or a Property, package-global or nested in an ObjectType) is
+    // modified through the SAME 'properties' surface as an ordinary mdclass member, but with an XDTO-
+    // specific vocabulary applied by XdtoWriter (open/abstract/mixed/ordered/sequenced for an ObjectType;
+    // type/ref/lowerBound/upperBound/nillable/fixed/default for a Property) - not the generic
+    // MetadataPropertyIntrospector reflection path (an XDTO Property/ObjectType is not an MdObject).
+    // Persistence mirrors the DCS content: the Package is a transient @ExternalProperty, materialized +
+    // attached via XdtoWriter.resolvePackageContent (shared with create_metadata / delete_metadata).
+
+    /**
+     * Dispatches an XDTO PACKAGE MEMBER FQN: refuses a role / content / template / dcs payload (an XDTO
+     * member is none of those - the same no-mixing policy every other cross-model-hop branch enforces,
+     * so a sibling payload is never silently dropped while this branch reports success), then requires a
+     * non-empty {@code properties} (the XDTO member's own change surface). Returns {@code null} when
+     * {@code normFqn} is not an XDTO member FQN, so the caller continues to the generic mdclass resolver.
+     */
+    private String dispatchXdtoMemberPayload(ProjectContext ctx, String normFqn, ModifyArgs args)
+    {
+        XdtoWriter.MemberRef ref = XdtoWriter.parseMemberRef(normFqn);
+        if (ref == null)
+        {
+            return null;
+        }
+        if (args.hasTemplatePayload)
+        {
+            return templateOnlyForTemplateFqnError(normFqn, "addresses an XDTO package member"); //$NON-NLS-1$
+        }
+        if (args.hasDcsPayload)
+        {
+            return dcsOnlyForReportFqnError(normFqn, "addresses an XDTO package member"); //$NON-NLS-1$
+        }
+        String payloadError =
+            xdtoMemberPayloadError(normFqn, args.hasRolePayload, args.hasContentPayload, args.properties);
+        if (payloadError != null)
+        {
+            return payloadError;
+        }
+        return modifyXdtoMember(ctx, normFqn, ref, args.properties);
+    }
+
+    /**
+     * The pure guard for an XDTO member FQN's payload: refuses a Role payload ({@code rights} /
+     * {@code templates} / {@code roleProperties}) or a membership {@code content} payload (an XDTO
+     * member is neither), then requires a non-empty {@code properties} (the XDTO member's own change
+     * surface - there is no dedicated {@code xdto} payload key, unlike {@code dcs}/{@code template}).
+     * Returns the ready JSON error, or {@code null} when the payload is valid. Package-visible for tests
+     * (mirrors {@link #dcsMixError} / {@link #templateMixError}).
+     */
+    static String xdtoMemberPayloadError(String normFqn, boolean hasRolePayload, boolean hasContentPayload,
+        List<JsonObject> properties)
+    {
+        if (hasRolePayload || hasContentPayload)
+        {
+            return ToolResult.error("'" + normFqn + "' addresses an XDTO package member, which cannot " //$NON-NLS-1$ //$NON-NLS-2$
+                + "take a Role payload ('rights' / 'templates' / 'roleProperties') or a membership " //$NON-NLS-1$
+                + "'content' payload. Use 'properties' to change an XDTO ObjectType/Property.").toJson(); //$NON-NLS-1$
+        }
+        if (properties.isEmpty())
+        {
+            return ToolResult.error("'properties' is required to modify an XDTO package member ('" //$NON-NLS-1$
+                + normFqn + "'): an ObjectType takes the optional flags 'open' / 'abstract' / 'mixed' " //$NON-NLS-1$
+                + "/ 'ordered' / 'sequenced'; a Property takes 'type' / 'lowerBound' / 'upperBound' / " //$NON-NLS-1$
+                + "'nillable' / 'fixed' / 'default'.").toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Modifies an EXISTING XDTO ObjectType / Property's attributes via {@link XdtoWriter}. The owning
+     * XDTOPackage's content is materialized + attached exactly like create_metadata's own XDTO member
+     * write ({@link XdtoWriter#resolvePackageContent}, shared); the target member must ALREADY exist (a
+     * modify does not create one - use create_metadata first). Force-exports the owning package's FQN
+     * (dual-export with the content's own resource FQN when it is a distinct top object).
+     */
+    private String modifyXdtoMember(ProjectContext ctx, String normFqn, XdtoWriter.MemberRef ref,
+        List<JsonObject> properties)
+    {
+        MetadataNodeResolver.MetadataNode pkgNode =
+            MetadataNodeResolver.resolveExisting(ctx.config, ref.packageFqn);
+        if (pkgNode == null || !(pkgNode.object instanceof XDTOPackage)
+            || !(pkgNode.object instanceof IBmObject))
+        {
+            return ToolResult.error("XDTOPackage not found: " + ref.packageFqn + ".").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        IBmModelManager bmModelManager = Activator.getDefault().getBmModelManager();
+        ITopObjectFqnGenerator fqnGenerator = Activator.getDefault().getTopObjectFqnGenerator();
+        if (bmModelManager == null || fqnGenerator == null)
+        {
+            return ToolResult.error(ERR_NO_BM_MANAGER).toJson();
+        }
+        IBmModel bmModel = bmModelManager.getModel(ctx.project);
+        if (bmModel == null)
+        {
+            return ToolResult.error(ERR_NO_BM_MODEL + ctx.project.getName()).toJson();
+        }
+
+        final long pkgBmId = ((IBmObject)pkgNode.object).bmGetId();
+        final String[] contentFqnHolder = { null };
+        XdtoWriter.Result result;
+        try
+        {
+            result = BmTransactions.<XdtoWriter.Result> write(bmModel, "ModifyXdtoMember", (tx, pm) -> //$NON-NLS-1$
+                modifyXdtoMemberInTx(tx, pkgBmId, fqnGenerator, ref, properties, contentFqnHolder));
+        }
+        catch (Exception e)
+        {
+            String ready = XdtoWriteException.jsonOf(e);
+            if (ready != null)
+            {
+                return ready;
+            }
+            Activator.logError("Error modifying XDTO member", e); //$NON-NLS-1$
+            return ToolResult.error("Failed to modify XDTO member: " + unwrapCauseMessage(e)).toJson(); //$NON-NLS-1$
+        }
+
+        List<String> exportFqns = new ArrayList<>();
+        exportFqns.add(ref.packageFqn);
+        String contentFqn = contentFqnHolder[0];
+        if (contentFqn != null && !contentFqn.equals(ref.packageFqn))
+        {
+            exportFqns.add(contentFqn);
+        }
+        boolean persisted = BmTransactions.forceExportToDisk(ctx.project, exportFqns);
+        return buildModifiedResult(normFqn, result.applied, persisted,
+            new MdNameNormalizer.Report(false));
+    }
+
+    /**
+     * The write-transaction body for {@link #modifyXdtoMember}: re-fetches the XDTOPackage, materializes
+     * its content, records the content's own export FQN (captured by {@link XdtoWriter#resolvePackageContent}
+     * itself - NEVER re-derived here via a post-attach {@code bmGetFqn()}, which throws on a just-attached,
+     * not-yet-settled object; a live-stand-caught regression) into {@code contentFqnHolder}, resolves the
+     * target ObjectType / Property (which must ALREADY exist), and applies {@code properties} via
+     * {@link XdtoWriter}. Throws {@link XdtoWriteException} (a ready JSON error) on a resolution /
+     * validation failure, rolling the whole write back.
+     */
+    private static XdtoWriter.Result modifyXdtoMemberInTx(IBmTransaction tx, long pkgBmId,
+        ITopObjectFqnGenerator fqnGenerator, XdtoWriter.MemberRef ref, List<JsonObject> properties,
+        String[] contentFqnHolder)
+    {
+        Object inTx = tx.getObjectById(pkgBmId);
+        if (!(inTx instanceof XDTOPackage))
+        {
+            throw new XdtoWriteException(ToolResult.error("The XDTO package could not be resolved " //$NON-NLS-1$
+                + "inside the transaction.").toJson()); //$NON-NLS-1$
+        }
+        XDTOPackage txPkg = (XDTOPackage)inTx;
+        XdtoWriter.ContentResolution resolved = XdtoWriter.resolvePackageContent(txPkg, tx, fqnGenerator);
+        if (resolved.error != null)
+        {
+            throw new XdtoWriteException(resolved.error);
+        }
+        Package content = resolved.content;
+        contentFqnHolder[0] = resolved.contentFqn;
+
+        XdtoWriter.Result applied;
+        if (ref.kind == XdtoWriter.Kind.OBJECT_TYPE)
+        {
+            ObjectType type = XdtoWriter.findObjectType(content, ref.objectTypeName);
+            if (type == null)
+            {
+                throw new XdtoWriteException(xdtoObjectTypeNotFoundError(ref));
+            }
+            applied = XdtoWriter.applyObjectTypeProperties(type, properties);
+        }
+        else
+        {
+            EList<Property> owner = content.getProperties();
+            if (ref.kind == XdtoWriter.Kind.OBJECT_TYPE_PROPERTY)
+            {
+                ObjectType type = XdtoWriter.findObjectType(content, ref.objectTypeName);
+                if (type == null)
+                {
+                    throw new XdtoWriteException(xdtoObjectTypeNotFoundError(ref));
+                }
+                owner = type.getProperties();
+            }
+            Property property = XdtoWriter.findProperty(owner, ref.propertyName);
+            if (property == null)
+            {
+                throw new XdtoWriteException(xdtoPropertyNotFoundError(ref));
+            }
+            applied = XdtoWriter.applyPropertyProperties(property, content, properties, false);
+        }
+        if (applied.hasError())
+        {
+            throw new XdtoWriteException(applied.error);
+        }
+        return applied;
+    }
+
+    /** The actionable "ObjectType not found" error, shared by the modify/delete XDTO branches. */
+    static String xdtoObjectTypeNotFoundError(XdtoWriter.MemberRef ref)
+    {
+        return ToolResult.error("ObjectType not found: '" + ref.objectTypeName + "' in package " //$NON-NLS-1$ //$NON-NLS-2$
+            + ref.packageFqn + ". Use get_metadata_details on the package FQN to list its object types.") //$NON-NLS-1$
+                .toJson();
+    }
+
+    /** The actionable "Property not found" error, shared by the modify/delete XDTO branches. */
+    static String xdtoPropertyNotFoundError(XdtoWriter.MemberRef ref)
+    {
+        String owner = ref.kind == XdtoWriter.Kind.OBJECT_TYPE_PROPERTY
+            ? ref.packageFqn + ".ObjectType." + ref.objectTypeName //$NON-NLS-1$
+            : ref.packageFqn;
+        return ToolResult.error("Property not found: '" + ref.propertyName + "' on " + owner //$NON-NLS-1$ //$NON-NLS-2$
+            + ". Use get_metadata_details on the package FQN to list its properties.").toJson(); //$NON-NLS-1$
     }
 
     /**
@@ -1877,6 +2112,29 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             return ToolResult.error(ERR_NO_BM_MODEL + projectName).toJson();
         }
 
+        final List<String> applied = appliedFeatureNames(changes);
+        // An XDTOPackage's target namespace lives in TWO synced places: the mdclass 'namespace' (this
+        // .mdo edit) and the content Package's targetNamespace (the sibling .xdto). The generic path
+        // exports only the .mdo, so when the namespace changes, re-sync the content (XdtoWriter treats
+        // the owner as the single source of truth) and force-export the .xdto too - else members would be
+        // authored under a stale namespace once the content is eagerly materialized at package-create (a
+        // live-stand-caught drift).
+        final boolean xdtoNamespaceChange =
+            applied.contains(MdClassPackage.Literals.XDTO_PACKAGE__NAMESPACE.getName());
+        final ITopObjectFqnGenerator fqnGenerator =
+            xdtoNamespaceChange ? Activator.getDefault().getTopObjectFqnGenerator() : null;
+        if (xdtoNamespaceChange && fqnGenerator == null)
+        {
+            // Fail BEFORE mutating: without the generator we cannot keep the content .xdto
+            // targetNamespace in sync, and committing only the .mdo would silently reintroduce the
+            // namespace drift while reporting success. Nothing is written here.
+            return ToolResult.error("Cannot change the XDTO package namespace right now: the " //$NON-NLS-1$
+                + "ITopObjectFqnGenerator service is unavailable, so the content resource (.xdto) " //$NON-NLS-1$
+                + "target namespace cannot be kept in sync. Retry once EDT has finished " //$NON-NLS-1$
+                + "initializing.").toJson(); //$NON-NLS-1$
+        }
+        final String[] contentFqnHolder = { null };
+
         try
         {
             BmTransactions.<Void>write(bmModel, "ModifyMetadata", (tx, pm) -> //$NON-NLS-1$
@@ -1886,18 +2144,42 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 {
                     change.applyTo(applyTo, tx);
                 }
+                if (fqnGenerator != null && applyTo instanceof XDTOPackage)
+                {
+                    XdtoWriter.ContentResolution resolved =
+                        XdtoWriter.resolvePackageContent((XDTOPackage)applyTo, tx, fqnGenerator);
+                    if (resolved.error != null)
+                    {
+                        // Abort + roll back the whole modify rather than committing only the .mdo and
+                        // leaving the content .xdto target namespace stale (a silent partial success).
+                        // Mirrors modifyXdtoMemberInTx.
+                        throw new XdtoWriteException(resolved.error);
+                    }
+                    contentFqnHolder[0] = resolved.contentFqn;
+                }
                 return null;
             });
         }
         catch (Exception e)
         {
+            String ready = XdtoWriteException.jsonOf(e);
+            if (ready != null)
+            {
+                return ready;
+            }
             Activator.logError("Error modifying metadata", e); //$NON-NLS-1$
             return ToolResult.error("Failed to modify: " + unwrapCauseMessage(e)).toJson(); //$NON-NLS-1$
         }
 
-        boolean persisted = BmTransactions.forceExportToDisk(ctx.project, topFqn);
+        List<String> exportFqns = new ArrayList<>();
+        exportFqns.add(topFqn);
+        String contentFqn = contentFqnHolder[0];
+        if (contentFqn != null && !contentFqn.equals(topFqn))
+        {
+            exportFqns.add(contentFqn);
+        }
+        boolean persisted = BmTransactions.forceExportToDisk(ctx.project, exportFqns);
 
-        List<String> applied = appliedFeatureNames(changes);
         return buildModifiedResult(normFqn, applied, persisted, normReport);
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -2193,8 +2193,10 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                             && !preContentNs.equals(newNamespace))
                         {
                             // The content targetNamespace was stale before this edit: QNames written
-                            // under THAT value would otherwise stay dangling after the rename.
-                            XdtoWriter.rewriteNamespaceReferences(resolved.content, preContentNs, newNamespace);
+                            // under THAT value and naming THIS package's own local types would stay
+                            // dangling after the rename. Targeted rewrite only (a genuine reference
+                            // to a third package whose namespace equals the stale value is kept).
+                            XdtoWriter.rewriteStaleSelfReferences(resolved.content, preContentNs, newNamespace);
                         }
                         cascadeNamespaceChange(tx, configBmId, changedPkg, oldNamespace, newNamespace,
                             fqnGenerator, cascadedPackageNames, cascadedExportFqns);
@@ -2293,8 +2295,17 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 // yet) is skipped, not a failure of THIS modify.
                 continue;
             }
-            boolean rewritten = XdtoWriter.rewriteNamespaceReferences(resolved.content, oldNamespace, newNamespace);
             boolean repaired = siblingPreNs == null || !siblingPreNs.equals(other.getNamespace());
+            if (repaired && siblingPreNs != null)
+            {
+                // FIRST restore the repaired sibling's SELF-consistency - but ONLY for QNames whose
+                // local name matches one of the sibling's OWN local types (the disambiguation): a
+                // genuine reference into another package whose namespace equals the stale value
+                // (e.g. the renamed package's old namespace) must stay for the cascade rewrite
+                // below, and imports are never self-imports, so they are not touched here.
+                XdtoWriter.rewriteStaleSelfReferences(resolved.content, siblingPreNs, other.getNamespace());
+            }
+            boolean rewritten = XdtoWriter.rewriteNamespaceReferences(resolved.content, oldNamespace, newNamespace);
             if (!rewritten && !repaired)
             {
                 continue;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -2133,21 +2133,35 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 + "target namespace cannot be kept in sync. Retry once EDT has finished " //$NON-NLS-1$
                 + "initializing.").toJson(); //$NON-NLS-1$
         }
+        // Needed only for the namespace CASCADE below (maintainer request: a namespace change on package
+        // P must not leave OTHER packages that import P's OLD namespace, or reference one of P's types via
+        // a QName carrying the OLD nsUri, dangling - renaming one package must not silently break a
+        // DIFFERENT, unrelated package). A Configuration BM id, captured OUTSIDE the write tx and
+        // re-fetched INSIDE it, mirrors CreateMetadataTool.createTopLevel's configBmId precedent.
+        final long configBmId =
+            xdtoNamespaceChange && config instanceof IBmObject ? ((IBmObject)config).bmGetId() : -1L;
         final String[] contentFqnHolder = { null };
+        final List<String> cascadedPackageNames = new ArrayList<>();
+        final List<String> cascadedExportFqns = new ArrayList<>();
 
         try
         {
             BmTransactions.<Void>write(bmModel, "ModifyMetadata", (tx, pm) -> //$NON-NLS-1$
             {
                 EObject applyTo = resolveApplyTarget(tx, topBmId, memberFeature, memberName, parts);
+                // Captured BEFORE the prepared changes are applied (only meaningful for an XDTOPackage
+                // namespace change - null otherwise, so the cascade below never fires).
+                final String oldNamespace = (xdtoNamespaceChange && applyTo instanceof XDTOPackage)
+                    ? ((XDTOPackage)applyTo).getNamespace() : null;
                 for (PreparedChange change : changes)
                 {
                     change.applyTo(applyTo, tx);
                 }
                 if (fqnGenerator != null && applyTo instanceof XDTOPackage)
                 {
+                    XDTOPackage changedPkg = (XDTOPackage)applyTo;
                     XdtoWriter.ContentResolution resolved =
-                        XdtoWriter.resolvePackageContent((XDTOPackage)applyTo, tx, fqnGenerator);
+                        XdtoWriter.resolvePackageContent(changedPkg, tx, fqnGenerator);
                     if (resolved.error != null)
                     {
                         // Abort + roll back the whole modify rather than committing only the .mdo and
@@ -2156,6 +2170,13 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                         throw new XdtoWriteException(resolved.error);
                     }
                     contentFqnHolder[0] = resolved.contentFqn;
+
+                    String newNamespace = changedPkg.getNamespace();
+                    if (oldNamespace != null && !oldNamespace.equals(newNamespace))
+                    {
+                        cascadeNamespaceChange(tx, configBmId, changedPkg, oldNamespace, newNamespace,
+                            fqnGenerator, cascadedPackageNames, cascadedExportFqns);
+                    }
                 }
                 return null;
             });
@@ -2178,9 +2199,76 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         {
             exportFqns.add(contentFqn);
         }
+        for (String cascadedFqn : cascadedExportFqns)
+        {
+            if (!exportFqns.contains(cascadedFqn))
+            {
+                exportFqns.add(cascadedFqn);
+            }
+        }
         boolean persisted = BmTransactions.forceExportToDisk(ctx.project, exportFqns);
 
-        return buildModifiedResult(normFqn, applied, persisted, normReport);
+        return buildModifiedResult(normFqn, applied, persisted, normReport, cascadedPackageNames);
+    }
+
+    /**
+     * Cascades an XDTOPackage namespace change to every OTHER XDTOPackage of the same configuration
+     * (maintainer request: changing package P's namespace must not silently break a SIBLING package that
+     * imports P's OLD namespace or references one of P's types via a QName carrying the OLD nsUri - the
+     * maintainer's exact complaint was that renaming one package breaks a DIFFERENT, unrelated package,
+     * not the one being renamed). Runs INSIDE the same write transaction that applied the target
+     * package's own namespace change, so the whole modify commits or rolls back together. A sibling
+     * package whose content cannot be resolved (e.g. it has no namespace of its own set yet - see
+     * {@link XdtoWriter#resolvePackageContent}) is SKIPPED, not treated as a failure of this modify: a
+     * sibling package's own unrelated problem is not this call's business. Appends the FQN of every
+     * REWRITTEN package (its own top-object FQN and its content's own resource FQN) to
+     * {@code exportFqnsOut}, and the package's Name to {@code cascadedNamesOut}, for the caller's
+     * force-export list and confirmation message.
+     *
+     * @param configBmId the Configuration's BM id, captured OUTSIDE this tx (-1 when unavailable, in
+     *            which case this is a no-op - the top-level guard above already required it whenever
+     *            {@code xdtoNamespaceChange} is true, so -1 here would mean the Configuration was not a
+     *            BM object at all)
+     */
+    private static void cascadeNamespaceChange(IBmTransaction tx, long configBmId, XDTOPackage changedPkg,
+        String oldNamespace, String newNamespace, ITopObjectFqnGenerator fqnGenerator,
+        List<String> cascadedNamesOut, List<String> exportFqnsOut)
+    {
+        if (configBmId < 0)
+        {
+            return;
+        }
+        Object cfgObj = tx.getObjectById(configBmId);
+        if (!(cfgObj instanceof Configuration))
+        {
+            return;
+        }
+        Configuration cfg = (Configuration)cfgObj;
+        long changedPkgBmId = ((IBmObject)changedPkg).bmGetId();
+        for (XDTOPackage other : cfg.getXDTOPackages())
+        {
+            if (!(other instanceof IBmObject) || ((IBmObject)other).bmGetId() == changedPkgBmId)
+            {
+                continue;
+            }
+            XdtoWriter.ContentResolution resolved = XdtoWriter.resolvePackageContent(other, tx, fqnGenerator);
+            if (resolved.error != null)
+            {
+                // Best-effort: a sibling package with no usable content of its own (e.g. no namespace set
+                // yet) is skipped, not a failure of THIS modify.
+                continue;
+            }
+            if (!XdtoWriter.rewriteNamespaceReferences(resolved.content, oldNamespace, newNamespace))
+            {
+                continue;
+            }
+            exportFqnsOut.add("XDTOPackage." + other.getName()); //$NON-NLS-1$
+            if (resolved.contentFqn != null)
+            {
+                exportFqnsOut.add(resolved.contentFqn);
+            }
+            cascadedNamesOut.add(other.getName());
+        }
     }
 
     /**
@@ -2325,10 +2413,24 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
     /**
      * Builds the success JSON for a completed modify (action / fqn / applied / persisted, the
      * normalization report and the confirmation message). Pure helper extracted from
-     * {@link #executeOnUiThread}; the same shape used by the form-member branch.
+     * {@link #executeOnUiThread}; the same shape used by the form-member branch and
+     * {@link #modifyXdtoMember} (neither of those ever cascades a namespace, so they use this overload).
      */
     private static String buildModifiedResult(String normFqn, List<String> applied, boolean persisted,
         MdNameNormalizer.Report normReport)
+    {
+        return buildModifiedResult(normFqn, applied, persisted, normReport, List.of());
+    }
+
+    /**
+     * Same as the 4-arg overload, plus the namespace-CASCADE report (maintainer request): when the
+     * namespace change propagated to one or more OTHER XDTOPackages (see
+     * {@link #cascadeNamespaceChange}), their Names are appended to the confirmation MESSAGE text only -
+     * the output schema / description are deliberately untouched (zero golden churn) - as
+     * {@code "; namespace propagated to N referencing package(s): Q, R"}.
+     */
+    private static String buildModifiedResult(String normFqn, List<String> applied, boolean persisted,
+        MdNameNormalizer.Report normReport, List<String> cascadedPackageNames)
     {
         ToolResult result = ToolResult.success()
             .put(McpKeys.ACTION, VAL_MODIFIED)
@@ -2336,9 +2438,13 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             .put(KEY_APPLIED, applied)
             .put(KEY_PERSISTED, persisted);
         normReport.addTo(result);
-        return result
-            .put(McpKeys.MESSAGE, MSG_MODIFIED_PREFIX + normFqn + " (" + String.join(", ", applied) + ")") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-            .toJson();
+        String message = MSG_MODIFIED_PREFIX + normFqn + " (" + String.join(", ", applied) + ")"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        if (!cascadedPackageNames.isEmpty())
+        {
+            message += "; namespace propagated to " + cascadedPackageNames.size() //$NON-NLS-1$
+                + " referencing package(s): " + String.join(", ", cascadedPackageNames); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return result.put(McpKeys.MESSAGE, message).toJson();
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ValidateXdtoPackageTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ValidateXdtoPackageTool.java
@@ -113,7 +113,10 @@ public class ValidateXdtoPackageTool implements IMcpTool
         Configuration config = resolved.configuration();
 
         String normFqn = MetadataTypeUtils.normalizeFqn(fqn);
-        MetadataNodeResolver.MetadataNode node = MetadataNodeResolver.resolveExisting(config, normFqn);
+        // Yo-fallback resolution (mirrors modify/delete): create_metadata normalizes ё->е in the stored
+        // name by default, so validating the ORIGINAL spelling must still find the stored package.
+        MetadataNodeResolver.MetadataNode node =
+            MetadataNodeResolver.resolveExistingWithYoFallback(config, normFqn).node;
         if (node == null || !(node.object instanceof XDTOPackage))
         {
             return ToolResult.error("Not an XDTOPackage: '" + fqn + "'. validate_xdto_package only " //$NON-NLS-1$ //$NON-NLS-2$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ValidateXdtoPackageTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ValidateXdtoPackageTool.java
@@ -1,0 +1,177 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
+import com._1c.g5.v8.dt.metadata.mdclass.XDTOPackage;
+
+import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
+import com.ditrix.edt.mcp.server.protocol.JsonUtils;
+import com.ditrix.edt.mcp.server.protocol.McpKeys;
+import com.ditrix.edt.mcp.server.protocol.ToolResult;
+import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.MetadataNodeResolver;
+import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils;
+import com.ditrix.edt.mcp.server.utils.Pagination;
+import com.ditrix.edt.mcp.server.utils.ProjectContext;
+import com.ditrix.edt.mcp.server.utils.ProjectStateChecker;
+
+/**
+ * Read-only "validate this XDTO package" verb: runs EDT's OWN validation (the same
+ * configuration-problem markers {@code get_project_errors} exposes) scoped to a single
+ * {@code XDTOPackage.<Name>} top object, and reframes the result with a one-line verdict.
+ * <p>
+ * This is a THIN wrapper over {@link GetProjectErrorsTool#getProjectErrors}: it does not
+ * hand-roll any XDTO validation rule of its own. The {@code objects} filter of
+ * {@code get_project_errors}, when passed an {@code XDTOPackage.<Name>} FQN, already scopes to
+ * that package's problems (a dangling XDTO type reference surfaces as a marker located at
+ * {@code XDTOPackage.<Name>.Package}, which the substring-matched {@code objects} filter picks
+ * up), so the only work this tool adds is: resolve + type-check the FQN, delegate, and prepend
+ * a verdict line to the returned Markdown table.
+ */
+public class ValidateXdtoPackageTool implements IMcpTool
+{
+    public static final String NAME = "validate_xdto_package"; //$NON-NLS-1$
+
+    /** Default result cap when {@code limit} is omitted (mirrors get_project_errors). */
+    private static final int DEFAULT_LIMIT = 100;
+
+    /** Markdown heading {@code get_project_errors} emits when no problem matched the filters. */
+    private static final String NO_ERRORS_MARKER = "# No Errors Found"; //$NON-NLS-1$
+
+    /**
+     * Fragment of the {@code get_project_errors} warning shown when some marker's location could not
+     * be resolved (so its package membership could not be decided). When it appears alongside "no
+     * problems", the "valid" verdict must be qualified rather than asserted.
+     */
+    private static final String UNRESOLVED_WARNING_FRAGMENT = "could not be resolved"; //$NON-NLS-1$
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Validate a single XDTO package by running EDT's OWN configuration validation " //$NON-NLS-1$
+            + "(the same check engine behind get_project_errors) scoped to that package, and " //$NON-NLS-1$
+            + "return a pass/fail verdict plus any problems found (e.g. a dangling reference to a " //$NON-NLS-1$
+            + "deleted ObjectType). It reflects the LATEST validation state already computed by " //$NON-NLS-1$
+            + "EDT (reads existing markers) rather than forcing a fresh compile; run " //$NON-NLS-1$
+            + "revalidate_objects first if you need up-to-the-second results. Does not implement " //$NON-NLS-1$
+            + "any XDTO-specific rule itself - it is a scoped view over get_project_errors. " //$NON-NLS-1$
+            + "Full parameters and examples: call get_tool_guide('validate_xdto_package')."; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getInputSchema()
+    {
+        return JsonSchemaBuilder.object()
+            .stringProperty(McpKeys.PROJECT_NAME,
+                "EDT project name (required).", true) //$NON-NLS-1$
+            .stringProperty("fqn", //$NON-NLS-1$
+                "FQN of the XDTO package to validate, as 'XDTOPackage.<Name>' (required). Must " //$NON-NLS-1$
+                + "already exist; check with get_metadata_objects.", true) //$NON-NLS-1$
+            .integerProperty(McpKeys.LIMIT, "Max problem rows to report; default 100, max 1000 (optional)") //$NON-NLS-1$
+            .build();
+    }
+
+    @Override
+    public String execute(Map<String, String> params)
+    {
+        String err = JsonUtils.requireArguments(params, McpKeys.PROJECT_NAME, "fqn"); //$NON-NLS-1$
+        if (err != null)
+        {
+            return err;
+        }
+
+        String projectName = JsonUtils.extractStringArgument(params, McpKeys.PROJECT_NAME);
+        String fqn = JsonUtils.extractStringArgument(params, "fqn"); //$NON-NLS-1$
+        int limit = JsonUtils.extractIntArgument(params, McpKeys.LIMIT, DEFAULT_LIMIT);
+        limit = Pagination.clampLimit(limit, 1000);
+
+        String building = ProjectStateChecker.buildingErrorOrNull(projectName);
+        if (building != null)
+        {
+            return ToolResult.error(building).toJson();
+        }
+
+        ProjectContext.ConfigurationResult resolved = ProjectContext.resolveConfiguration(projectName);
+        if (!resolved.ok())
+        {
+            return resolved.errorJson();
+        }
+        Configuration config = resolved.configuration();
+
+        String normFqn = MetadataTypeUtils.normalizeFqn(fqn);
+        MetadataNodeResolver.MetadataNode node = MetadataNodeResolver.resolveExisting(config, normFqn);
+        if (node == null || !(node.object instanceof XDTOPackage))
+        {
+            return ToolResult.error("Not an XDTOPackage: '" + fqn + "'. validate_xdto_package only " //$NON-NLS-1$ //$NON-NLS-2$
+                + "validates an existing XDTO package top object, addressed as 'XDTOPackage.<Name>'. " //$NON-NLS-1$
+                + "Check the name with get_metadata_objects, or call get_project_errors directly for " //$NON-NLS-1$
+                + "a general (not XDTO-scoped) problem query.").toJson(); //$NON-NLS-1$
+        }
+
+        // Scope by the RESOLVED package's canonical FQN (not the raw input): this ignores a
+        // malformed-but-resolvable literal (e.g. a stray trailing dot) that would otherwise be used
+        // verbatim as a filter and match nothing (a false "valid"). Report ALL severities (a
+        // severity-filtered "no matches" is NOT a validity guarantee), with EXACT per-package scope
+        // (exactScope=true) so a prefix-sharing sibling package's problems are not attributed here.
+        String pkgFqn = "XDTOPackage." + ((XDTOPackage)node.object).getName(); //$NON-NLS-1$
+        String problems = GetProjectErrorsTool.getProjectErrors(projectName, null, null,
+            List.of(pkgFqn), limit, false, true);
+        return withVerdict(pkgFqn, problems);
+    }
+
+    /**
+     * Prepends a one-line pass/fail verdict to the {@code get_project_errors} Markdown result,
+     * derived from whether it opens with the "No Errors Found" heading. A JSON error payload
+     * (e.g. the marker manager being unavailable) is returned verbatim - it is a whole-call
+     * failure, not a validation outcome, so it gets no verdict wrapping.
+     *
+     * @param fqn the validated package FQN (already normalized), echoed in the verdict
+     * @param problems the Markdown (or JSON error) returned by {@code getProjectErrors}
+     * @return the final Markdown response, or the untouched JSON error
+     */
+    private static String withVerdict(String fqn, String problems)
+    {
+        if (problems == null || problems.startsWith("{")) //$NON-NLS-1$
+        {
+            // A ready JSON error (ToolResult.error(...).toJson()) from the delegate: propagate
+            // unchanged rather than wrapping a failure in a "valid"/"problems found" verdict.
+            return problems;
+        }
+
+        StringBuilder md = new StringBuilder();
+        if (problems.startsWith(NO_ERRORS_MARKER))
+        {
+            if (problems.contains(UNRESOLVED_WARNING_FRAGMENT))
+            {
+                // No problem matched, but at least one marker's location was unresolvable, so
+                // membership in this package could not be decided - do not assert validity.
+                md.append("**XDTO package `").append(fqn).append("`: no problems matched, but some " //$NON-NLS-1$ //$NON-NLS-2$
+                    + "markers could not be checked** — run revalidate_objects and validate again.\n\n"); //$NON-NLS-1$
+            }
+            else
+            {
+                md.append("**XDTO package `").append(fqn).append("` is valid** — no problems reported.\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+            }
+        }
+        else
+        {
+            md.append("**XDTO package `").append(fqn).append("`: problems found**\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        md.append(problems);
+        return md.toString();
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoStructureReader.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoStructureReader.java
@@ -201,14 +201,19 @@ public final class XdtoStructureReader
     }
 
     /**
-     * The property's {@code default} value, or {@code ""} when unset. {@link Property} has no
-     * {@code isSetDefault()}/unset pair ({@code null} is the only "absent" signal - see
-     * {@link XdtoWriter#applyPropertyProperties}'s javadoc), so this mirrors {@link #emptyIfNull} rather
-     * than the {@code isSet}-gated style {@link #nillableSummary}/{@link #fixedSummary} use.
+     * The property's {@code default} value: a blank cell when ABSENT ({@code null} - {@link Property}
+     * has no {@code isSetDefault()} pair, {@code null} is the only absent signal), the quoted marker
+     * {@code ""} for an EXPLICIT EMPTY default (a legitimate value, e.g. under {@code fixed=true} -
+     * rendering it blank would make the read-back lossy), else the value itself.
      */
     private static String defaultSummary(Property property)
     {
-        return emptyIfNull(property.getDefault());
+        String value = property.getDefault();
+        if (value == null)
+        {
+            return ""; //$NON-NLS-1$
+        }
+        return value.isEmpty() ? "\"\"" : value; //$NON-NLS-1$
     }
 
     // ==================== Value types / enumerations ====================

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoStructureReader.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoStructureReader.java
@@ -1,0 +1,292 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import java.util.List;
+
+import org.eclipse.emf.common.util.EList;
+
+import com._1c.g5.v8.dt.mcore.QName;
+import com._1c.g5.v8.dt.xdto.model.Enumeration;
+import com._1c.g5.v8.dt.xdto.model.Import;
+import com._1c.g5.v8.dt.xdto.model.ObjectType;
+import com._1c.g5.v8.dt.xdto.model.Package;
+import com._1c.g5.v8.dt.xdto.model.Property;
+import com._1c.g5.v8.dt.xdto.model.ValueType;
+
+/**
+ * Shared READER that renders an XDTO Package's CONTENT (issue #183 stream 1) - the model behind an
+ * {@code XDTOPackage}'s lazy {@code Package} content - to a Markdown section: the package's namespace /
+ * form-qualification attributes, its ObjectTypes (each with its own properties), its package-global
+ * properties, its value types (with their nested enumerations), and its imported-package dependencies.
+ * Mirrors {@link DcsStructureReader}: a pure typed-API render (the xdto.model package is NOT Tycho
+ * access-restricted, unlike the DCS "default settings" subtree or the form content model, so no EMF
+ * reflection is needed here), wired into {@code GetMetadataDetailsTool} the same way.
+ *
+ * <p>Pure aside from reading the supplied {@link Package}, which the caller must still hold inside its
+ * BM transaction when {@link #render} runs (the package is a transient {@code @ExternalProperty} whose
+ * containing resource is only valid inside that boundary).</p>
+ */
+public final class XdtoStructureReader
+{
+    /** Shared Markdown table column header: a member's programmatic name. */
+    private static final String COLUMN_NAME = "Name"; //$NON-NLS-1$
+
+    /** Shared Markdown table column header: an XDTO type reference. */
+    private static final String COLUMN_TYPE = "Type"; //$NON-NLS-1$
+
+    private XdtoStructureReader()
+    {
+        // utility class
+    }
+
+    /**
+     * Renders the FULL package structure to a Markdown section: attributes, object types (with their
+     * properties), package-global properties, value types (with enumerations) and dependencies. Every
+     * subsection is skipped when its underlying collection is empty.
+     *
+     * @param fqn the (normalized) XDTOPackage FQN, for the heading
+     * @param pkg the resolved package content (must still be inside the caller's read/rollback
+     *            transaction); {@code null} renders a minimal note
+     * @return the Markdown section
+     */
+    public static String render(String fqn, Package pkg)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("\n## XDTO content: ").append(fqn).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (pkg == null)
+        {
+            sb.append("_(no package content)_\n"); //$NON-NLS-1$
+            return sb.toString();
+        }
+        renderPackageAttributes(sb, pkg);
+        renderObjectTypes(sb, pkg);
+        renderPackageProperties(sb, pkg);
+        renderValueTypes(sb, pkg);
+        renderDependencies(sb, pkg);
+        return sb.toString();
+    }
+
+    // ==================== Package attributes ====================
+
+    private static void renderPackageAttributes(StringBuilder sb, Package pkg)
+    {
+        sb.append("**Namespace (nsUri):** ").append(emptyIfNull(pkg.getNsUri())).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (pkg.isSetElementFormQualified())
+        {
+            sb.append("**Element form qualified:** ").append(pkg.isElementFormQualified()).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        if (pkg.isSetAttributeFormQualified())
+        {
+            sb.append("**Attribute form qualified:** ").append(pkg.isAttributeFormQualified()) //$NON-NLS-1$
+                .append("\n\n"); //$NON-NLS-1$
+        }
+    }
+
+    // ==================== Object types ====================
+
+    private static void renderObjectTypes(StringBuilder sb, Package pkg)
+    {
+        EList<ObjectType> types = pkg.getObjects();
+        if (types.isEmpty())
+        {
+            return;
+        }
+        sb.append("### Object types\n\n"); //$NON-NLS-1$
+        for (ObjectType type : types)
+        {
+            renderObjectType(sb, type);
+        }
+    }
+
+    private static void renderObjectType(StringBuilder sb, ObjectType type)
+    {
+        sb.append("#### ").append(nameOrUnnamed(type.getName())); //$NON-NLS-1$
+        String flags = objectTypeFlagsSummary(type);
+        if (!flags.isEmpty())
+        {
+            sb.append(" (").append(flags).append(')'); //$NON-NLS-1$
+        }
+        sb.append("\n\n"); //$NON-NLS-1$
+        QName baseType = type.getBaseType();
+        if (baseType != null)
+        {
+            sb.append("**Base type:** ").append(describeQName(baseType)).append("\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        renderPropertyTable(sb, type.getProperties());
+    }
+
+    /** Comma-joined list of the object type's SET (non-default) boolean flags. */
+    private static String objectTypeFlagsSummary(ObjectType type)
+    {
+        List<String> flags = new java.util.ArrayList<>();
+        if (type.isSetOpen())
+        {
+            flags.add("open=" + type.isOpen()); //$NON-NLS-1$
+        }
+        if (type.isSetAbstract())
+        {
+            flags.add("abstract=" + type.isAbstract()); //$NON-NLS-1$
+        }
+        if (type.isSetMixed())
+        {
+            flags.add("mixed=" + type.isMixed()); //$NON-NLS-1$
+        }
+        if (type.isSetOrdered())
+        {
+            flags.add("ordered=" + type.isOrdered()); //$NON-NLS-1$
+        }
+        if (type.isSetSequenced())
+        {
+            flags.add("sequenced=" + type.isSequenced()); //$NON-NLS-1$
+        }
+        return String.join(", ", flags); //$NON-NLS-1$
+    }
+
+    // ==================== Properties (shared: object-owned and package-global) ====================
+
+    private static void renderPackageProperties(StringBuilder sb, Package pkg)
+    {
+        EList<Property> properties = pkg.getProperties();
+        if (properties.isEmpty())
+        {
+            return;
+        }
+        sb.append("### Package-global properties\n\n"); //$NON-NLS-1$
+        renderPropertyTable(sb, properties);
+    }
+
+    private static void renderPropertyTable(StringBuilder sb, EList<Property> properties)
+    {
+        if (properties.isEmpty())
+        {
+            return;
+        }
+        sb.append(MarkdownUtils.tableHeader(COLUMN_NAME, COLUMN_TYPE, "Bounds", "Nillable", "Ref")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        for (Property property : properties)
+        {
+            sb.append(MarkdownUtils.tableRow(nameOrUnnamed(property.getName()),
+                describeQName(property.getType()), boundsSummary(property), nillableSummary(property),
+                describeQName(property.getRef())));
+        }
+        sb.append('\n');
+    }
+
+    /** {@code "[lower..upper]"} when either bound is explicitly SET, else {@code ""} (platform defaults). */
+    private static String boundsSummary(Property property)
+    {
+        if (!property.isSetLowerBound() && !property.isSetUpperBound())
+        {
+            return ""; //$NON-NLS-1$
+        }
+        int lower = property.getLowerBound();
+        int upper = property.getUpperBound();
+        return "[" + lower + ".." + (upper < 0 ? "*" : Integer.toString(upper)) + "]"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+    }
+
+    private static String nillableSummary(Property property)
+    {
+        return property.isSetNillable() ? Boolean.toString(property.isNillable()) : ""; //$NON-NLS-1$
+    }
+
+    // ==================== Value types / enumerations ====================
+
+    private static void renderValueTypes(StringBuilder sb, Package pkg)
+    {
+        EList<ValueType> types = pkg.getTypes();
+        if (types.isEmpty())
+        {
+            return;
+        }
+        sb.append("### Value types\n\n"); //$NON-NLS-1$
+        for (ValueType type : types)
+        {
+            sb.append("- **").append(nameOrUnnamed(type.getName())).append("**"); //$NON-NLS-1$ //$NON-NLS-2$
+            QName baseType = type.getBaseType();
+            if (baseType != null)
+            {
+                sb.append(" (base: ").append(describeQName(baseType)).append(')'); //$NON-NLS-1$
+            }
+            sb.append('\n');
+            String enumerations = enumerationsSummary(type);
+            if (!enumerations.isEmpty())
+            {
+                sb.append("  - Enumerations: ").append(enumerations).append('\n'); //$NON-NLS-1$
+            }
+        }
+        sb.append('\n');
+    }
+
+    private static String enumerationsSummary(ValueType type)
+    {
+        EList<Enumeration> enumerations = type.getEnumerations();
+        if (enumerations.isEmpty())
+        {
+            return ""; //$NON-NLS-1$
+        }
+        List<String> values = new java.util.ArrayList<>();
+        for (Enumeration enumeration : enumerations)
+        {
+            values.add(emptyIfNull(enumeration.getContent()));
+        }
+        return String.join(", ", values); //$NON-NLS-1$
+    }
+
+    // ==================== Dependencies (imports) ====================
+
+    private static void renderDependencies(StringBuilder sb, Package pkg)
+    {
+        EList<Import> dependencies = pkg.getDependencies();
+        if (dependencies.isEmpty())
+        {
+            return;
+        }
+        sb.append("### Dependencies\n\n"); //$NON-NLS-1$
+        sb.append(MarkdownUtils.tableHeader("Namespace", "Location")); //$NON-NLS-1$ //$NON-NLS-2$
+        for (Import dependency : dependencies)
+        {
+            sb.append(MarkdownUtils.tableRow(emptyIfNull(dependency.getNamespace()),
+                emptyIfNull(dependency.getLocation())));
+        }
+        sb.append('\n');
+    }
+
+    // ==================== shared helpers ====================
+
+    /**
+     * Describes an mcore {@link QName} as {@code "name"}, or {@code "name [nsUri]"} when the namespace
+     * is present (no prefix registry is maintained here, so the raw {@code nsUri} is shown rather than a
+     * synthesized prefix).
+     *
+     * @return the described QName, or {@code ""} when {@code qname} is {@code null}
+     */
+    private static String describeQName(QName qname)
+    {
+        if (qname == null)
+        {
+            return ""; //$NON-NLS-1$
+        }
+        String name = emptyIfNull(qname.getName());
+        String nsUri = qname.getNsUri();
+        return nonEmpty(nsUri) ? name + " [" + nsUri + "]" : name; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    private static String nameOrUnnamed(String name)
+    {
+        return nonEmpty(name) ? name : "(unnamed)"; //$NON-NLS-1$
+    }
+
+    private static String emptyIfNull(String value)
+    {
+        return nonEmpty(value) ? value : ""; //$NON-NLS-1$
+    }
+
+    private static boolean nonEmpty(String value)
+    {
+        return value != null && !value.isEmpty();
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoStructureReader.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoStructureReader.java
@@ -166,12 +166,13 @@ public final class XdtoStructureReader
         {
             return;
         }
-        sb.append(MarkdownUtils.tableHeader(COLUMN_NAME, COLUMN_TYPE, "Bounds", "Nillable", "Ref")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        sb.append(MarkdownUtils.tableHeader(COLUMN_NAME, COLUMN_TYPE, "Bounds", "Nillable", "Fixed", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            "Default", "Ref")); //$NON-NLS-1$ //$NON-NLS-2$
         for (Property property : properties)
         {
             sb.append(MarkdownUtils.tableRow(nameOrUnnamed(property.getName()),
                 describeQName(property.getType()), boundsSummary(property), nillableSummary(property),
-                describeQName(property.getRef())));
+                fixedSummary(property), defaultSummary(property), describeQName(property.getRef())));
         }
         sb.append('\n');
     }
@@ -191,6 +192,23 @@ public final class XdtoStructureReader
     private static String nillableSummary(Property property)
     {
         return property.isSetNillable() ? Boolean.toString(property.isNillable()) : ""; //$NON-NLS-1$
+    }
+
+    /** {@code "true"/"false"} when {@code fixed} is explicitly SET, else {@code ""} - mirrors {@link #nillableSummary}. */
+    private static String fixedSummary(Property property)
+    {
+        return property.isSetFixed() ? Boolean.toString(property.isFixed()) : ""; //$NON-NLS-1$
+    }
+
+    /**
+     * The property's {@code default} value, or {@code ""} when unset. {@link Property} has no
+     * {@code isSetDefault()}/unset pair ({@code null} is the only "absent" signal - see
+     * {@link XdtoWriter#applyPropertyProperties}'s javadoc), so this mirrors {@link #emptyIfNull} rather
+     * than the {@code isSet}-gated style {@link #nillableSummary}/{@link #fixedSummary} use.
+     */
+    private static String defaultSummary(Property property)
+    {
+        return emptyIfNull(property.getDefault());
     }
 
     // ==================== Value types / enumerations ====================

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriteException.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriteException.java
@@ -1,0 +1,59 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+/**
+ * Thrown out of an XDTO member create/modify/delete write transaction (issue #183 stream 1) when the
+ * operation must fail with a READY {@code ToolResult.error(...).toJson()} payload: the caller ({@code
+ * CreateMetadataTool} / {@code ModifyMetadataTool} / {@code DeleteMetadataTool}) surfaces the actionable
+ * JSON directly (via {@link #jsonOf}) instead of wrapping it in a generic failure message. Throwing
+ * BEFORE any model mutation rolls the enclosing BM write transaction back with no partial mutation.
+ * Mirrors {@link FormValidationException} (the same shape for a form read/write transaction) and
+ * {@code ModifyMetadataTool.TemplateWriteException} (the same shape for the template/DCS content write) -
+ * a small, per-feature exception rather than reusing one whose name would misleadingly suggest form
+ * validation.
+ */
+public final class XdtoWriteException extends RuntimeException
+{
+    private static final long serialVersionUID = 1L;
+
+    private final String json;
+
+    /**
+     * @param json the ready {@code ToolResult.error(...).toJson()} payload to surface verbatim
+     */
+    public XdtoWriteException(String json)
+    {
+        super("xdto write failed"); //$NON-NLS-1$
+        this.json = json;
+    }
+
+    /** @return the ready JSON error payload carried by this exception */
+    public String json()
+    {
+        return json;
+    }
+
+    /**
+     * Finds an {@link XdtoWriteException} in the cause chain (the BM task runner may wrap the thrown
+     * exception) and returns its JSON, or {@code null} when none is present.
+     *
+     * @param t the caught exception (may be {@code null})
+     * @return the ready JSON error, or {@code null}
+     */
+    public static String jsonOf(Throwable t)
+    {
+        for (Throwable c = t; c != null; c = c.getCause())
+        {
+            if (c instanceof XdtoWriteException)
+            {
+                return ((XdtoWriteException)c).json;
+            }
+        }
+        return null;
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
@@ -677,7 +677,19 @@ public final class XdtoWriter
                     ToolResult.error("Property 'fixed' must be a boolean (true/false).").toJson()); //$NON-NLS-1$
             }
         }
-        String default_ = values.containsKey("default") ? stringProp(values, "default") : null; //$NON-NLS-1$ //$NON-NLS-2$
+        String default_ = null;
+        if (values.containsKey("default")) //$NON-NLS-1$
+        {
+            default_ = stringProp(values, "default"); //$NON-NLS-1$
+            if (default_ == null)
+            {
+                // Present but not a string primitive (object/array/JSON null): reject like the sibling
+                // properties above - silently applying would call setDefault(null) and CLEAR an existing
+                // default while reporting the property as applied.
+                return Result.failed(
+                    ToolResult.error("Property 'default' must be a string.").toJson()); //$NON-NLS-1$
+            }
+        }
 
         // Validate the EFFECTIVE post-change state (this call's new values layered over whatever the
         // property already carries) BEFORE any mutation - a bad combination must leave the property

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
@@ -1,0 +1,1051 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.EList;
+
+import com._1c.g5.v8.bm.core.IBmObject;
+import com._1c.g5.v8.bm.core.IBmTransaction;
+import com._1c.g5.v8.dt.core.naming.ITopObjectFqnGenerator;
+import com._1c.g5.v8.dt.mcore.McoreFactory;
+import com._1c.g5.v8.dt.mcore.QName;
+import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
+import com._1c.g5.v8.dt.metadata.mdclass.XDTOPackage;
+import com._1c.g5.v8.dt.xdto.model.Import;
+import com._1c.g5.v8.dt.xdto.model.ObjectType;
+import com._1c.g5.v8.dt.xdto.model.Package;
+import com._1c.g5.v8.dt.xdto.model.Property;
+import com._1c.g5.v8.dt.xdto.model.XdtoFactory;
+import com.ditrix.edt.mcp.server.protocol.ToolResult;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+/**
+ * Authors the MEMBERS (ObjectTypes and Properties) of an XDTO Package (issue #183 stream 1) - the
+ * {@link Package} model behind an {@code XDTOPackage}'s lazy {@code @ExternalProperty} content, reached
+ * by the caller inside a BM boundary from {@code XDTOPackage.getPackage()} (the same transient
+ * {@code @ExternalProperty} shape {@link DcsWriter} authors for a report's Data Composition Schema and
+ * {@code SpreadsheetTemplateWriter} authors for a template's spreadsheet content).
+ *
+ * <p>Unlike {@link DcsWriter} (a bulk JSON spec applied wholesale to a schema), an XDTO Package's
+ * CONTENTS are addressed one member at a time, by a 1C full-name FQN - the SAME per-member addressing
+ * {@code create_metadata} / {@code modify_metadata} / {@code delete_metadata} already use for a
+ * mdclass member (an Attribute, a TabularSection, ...). Because an XDTO {@link ObjectType} / {@link
+ * Property} is NOT an {@code MdObject} (they live in the wholly separate, PUBLIC (not
+ * access-restricted) {@code com._1c.g5.v8.dt.xdto.model} package), {@link MetadataNodeResolver} cannot
+ * see them, so this class provides its own small FQN grammar ({@link #parseMemberRef}) mirroring the
+ * {@code Type.Name.Kind.Name(.Kind.Name)*} shape:</p>
+ *
+ * <ul>
+ * <li>{@code XDTOPackage.<Package>.ObjectType.<Name>} - an ObjectType in the package
+ * ({@link Kind#OBJECT_TYPE});</li>
+ * <li>{@code XDTOPackage.<Package>.Property.<Name>} - a PACKAGE-GLOBAL property ({@code Package.getProperties()},
+ * {@link Kind#PACKAGE_PROPERTY});</li>
+ * <li>{@code XDTOPackage.<Package>.ObjectType.<Type>.Property.<Name>} - a property nested in an
+ * ObjectType ({@code ObjectType.getProperties()}, {@link Kind#OBJECT_TYPE_PROPERTY}).</li>
+ * </ul>
+ *
+ * <p>Every mutator here uses the TYPED xdto.model API directly ({@code XdtoFactory.eINSTANCE}, typed
+ * getters/setters) - never a reflective {@code eSet} - because, unlike the DCS "default settings" subtree
+ * or the form content model, the xdto.model package is NOT Tycho access-restricted (see the Property /
+ * ObjectType / Package javadoc - all public API), so there is no reason to fall back to reflection.</p>
+ *
+ * <p>A Property's {@code type} is an mcore {@link QName} (a {@code {nsUri, name}} pair). {@link #resolveQName}
+ * accepts either the explicit object form {@code {nsUri, name}} (its {@code nsUri} must be the XSD
+ * namespace, the package's own namespace, or a namespace reachable via a {@code Package.getDependencies()}
+ * {@link Import}) or a shorthand STRING: an EXACT (case-sensitive) name match against an ObjectType
+ * already in the SAME package resolves to a same-package reference ({@code nsUri} = the package's own
+ * {@code nsUri}); any other string must be a whitelisted XSD built-in datatype name
+ * ({@link #XSD_BUILTIN_TYPES}, under {@code http://www.w3.org/2001/XMLSchema}) - a bare string matching
+ * neither is REJECTED (never silently turned into an invalid {@code xs:<typo>} reference). {@code ref}
+ * (a reference to a GLOBAL PROPERTY - a different XDTO concept) is NOT supported for v1 - see
+ * {@link #PROPERTY_PROPS}'s javadoc.</p>
+ *
+ * <p>Does NOT open a transaction and does NOT force-export - the caller ({@code CreateMetadataTool} /
+ * {@code ModifyMetadataTool} / {@code DeleteMetadataTool}) reaches the {@link Package} inside its own BM
+ * write boundary (materializing + {@code attachTopObject}-ing it exactly like a DCS schema / a
+ * spreadsheet template) and drains it to the sibling {@code .xdto} after this returns.</p>
+ */
+public final class XdtoWriter
+{
+    /** Canonical English singular type token for the XDTOPackage top object (mirrors CreateMetadataTool). */
+    private static final String TYPE_XDTO_PACKAGE = "XDTOPackage"; //$NON-NLS-1$
+
+    /** FQN kind token addressing an ObjectType member. */
+    private static final String KIND_OBJECT_TYPE = "ObjectType"; //$NON-NLS-1$
+
+    /** FQN kind token addressing a Property member (package-global or nested in an ObjectType). */
+    private static final String KIND_PROPERTY = "Property"; //$NON-NLS-1$
+
+    /** The standard XML Schema namespace, used for the primitive-type-name QName shorthand. */
+    private static final String XSD_NS = "http://www.w3.org/2001/XMLSchema"; //$NON-NLS-1$
+
+    /**
+     * The full set of XSD built-in datatype local names (19 primitives + 25 derived) accepted for the
+     * bare-STRING {@code type}/{@code ref} shorthand. Case-SENSITIVE (matches XSD's own canonical
+     * casing, e.g. {@code "dateTime"} not {@code "datetime"}) - a name outside this set is rejected
+     * rather than silently becoming an invalid {@code xs:<typo>} reference.
+     */
+    private static final Set<String> XSD_BUILTIN_TYPES = setOf(
+        // primitives
+        "string", "boolean", "decimal", "float", "double", "duration", "dateTime", "time", "date", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$
+        "gYearMonth", "gYear", "gMonthDay", "gDay", "gMonth", "hexBinary", "base64Binary", "anyURI", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$
+        "QName", "NOTATION", //$NON-NLS-1$ //$NON-NLS-2$
+        // derived
+        "normalizedString", "token", "language", "NMTOKEN", "NMTOKENS", "Name", "NCName", "ID", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$
+        "IDREF", "IDREFS", "ENTITY", "ENTITIES", "integer", "nonPositiveInteger", "negativeInteger", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$
+        "long", "int", "short", "byte", "nonNegativeInteger", "unsignedLong", "unsignedInt", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$
+        "unsignedShort", "unsignedByte", "positiveInteger", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        // the two XSD/EDT root ur-types (codex review residual #2/finding #4: a valid shorthand, not a typo)
+        "anySimpleType", "anyType"); //$NON-NLS-1$ //$NON-NLS-2$
+
+    /** ObjectType assignable property names (the boolean content-model flags). */
+    private static final Set<String> OBJECT_TYPE_PROPS =
+        setOf("open", "abstract", "mixed", "ordered", "sequenced"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+
+    /**
+     * Property assignable property names. {@code ref} (a reference to a GLOBAL PROPERTY - a different
+     * XDTO concept from a {@code type} reference to a type) is DELIBERATELY excluded for v1 (codex review
+     * residual #3 / finding #5): rejected explicitly by {@link #applyPropertyProperties} with a
+     * "not yet supported" error rather than silently accepted half-broken (unusable on create since
+     * {@code type} alone satisfies the required-attribute check but a caller meaning to use {@code ref}
+     * would get no type; and unchecked-target on modify - no verification the referenced global property
+     * even exists). A future increment can reintroduce it with real target-existence validation.
+     */
+    private static final Set<String> PROPERTY_PROPS =
+        setOf("type", "lowerBound", "upperBound", "nillable", "fixed", "default"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+
+    private static Set<String> setOf(String... values)
+    {
+        return new LinkedHashSet<>(List.of(values));
+    }
+
+    private XdtoWriter()
+    {
+        // Utility class
+    }
+
+    // ==================== FQN member addressing ====================
+
+    /** The kind of XDTO member an {@link MemberRef} addresses. */
+    public enum Kind
+    {
+        /** {@code XDTOPackage.<Package>.ObjectType.<Name>}. */
+        OBJECT_TYPE,
+        /** {@code XDTOPackage.<Package>.Property.<Name>} (package-global). */
+        PACKAGE_PROPERTY,
+        /** {@code XDTOPackage.<Package>.ObjectType.<Type>.Property.<Name>}. */
+        OBJECT_TYPE_PROPERTY
+    }
+
+    /**
+     * A parsed XDTO member FQN: the owning package's own (2-part) FQN, the addressed ObjectType /
+     * Property names (whichever apply to {@link #kind}), and the {@link Kind}.
+     */
+    public static final class MemberRef
+    {
+        /** Normalized 2-part FQN of the owning XDTOPackage, e.g. {@code "XDTOPackage.MyPackage"}. */
+        public final String packageFqn;
+        /** The ObjectType name; non-{@code null} for {@link Kind#OBJECT_TYPE} / {@link Kind#OBJECT_TYPE_PROPERTY}. */
+        public final String objectTypeName;
+        /** The Property name; non-{@code null} for {@link Kind#PACKAGE_PROPERTY} / {@link Kind#OBJECT_TYPE_PROPERTY}. */
+        public final String propertyName;
+        public final Kind kind;
+
+        MemberRef(String packageFqn, String objectTypeName, String propertyName, Kind kind)
+        {
+            this.packageFqn = packageFqn;
+            this.objectTypeName = objectTypeName;
+            this.propertyName = propertyName;
+            this.kind = kind;
+        }
+
+        /** The addressed member's own name (the trailing FQN segment), for messages / result payloads. */
+        public String memberName()
+        {
+            return kind == Kind.OBJECT_TYPE ? objectTypeName : propertyName;
+        }
+    }
+
+    /**
+     * Parses an XDTO member FQN (already normalized by {@link MetadataTypeUtils#normalizeFqn}) into a
+     * {@link MemberRef}, or {@code null} when {@code normFqn} does not address an XDTO member (a
+     * top-level {@code XDTOPackage.<Name>} FQN, or any non-XDTOPackage FQN) - the caller then falls
+     * through to the generic mdclass path, mirroring {@code FormElementWriter.parse}'s null-means-not-mine
+     * contract.
+     *
+     * @param normFqn the normalized FQN
+     * @return the parsed member reference, or {@code null} when not an XDTO member FQN
+     */
+    public static MemberRef parseMemberRef(String normFqn)
+    {
+        if (normFqn == null || normFqn.isEmpty())
+        {
+            return null;
+        }
+        String[] parts = normFqn.split("\\."); //$NON-NLS-1$
+        if (parts.length != 4 && parts.length != 6)
+        {
+            return null;
+        }
+        String type = MetadataTypeUtils.toEnglishSingular(parts[0]);
+        if (!TYPE_XDTO_PACKAGE.equals(type))
+        {
+            return null;
+        }
+        String packageFqn = TYPE_XDTO_PACKAGE + "." + parts[1]; //$NON-NLS-1$
+        if (parts.length == 4)
+        {
+            if (KIND_OBJECT_TYPE.equalsIgnoreCase(parts[2]))
+            {
+                return new MemberRef(packageFqn, parts[3], null, Kind.OBJECT_TYPE);
+            }
+            if (KIND_PROPERTY.equalsIgnoreCase(parts[2]))
+            {
+                return new MemberRef(packageFqn, null, parts[3], Kind.PACKAGE_PROPERTY);
+            }
+            return null;
+        }
+        // parts.length == 6: XDTOPackage.<Package>.ObjectType.<Type>.Property.<Name>
+        if (!KIND_OBJECT_TYPE.equalsIgnoreCase(parts[2]) || !KIND_PROPERTY.equalsIgnoreCase(parts[4]))
+        {
+            return null;
+        }
+        return new MemberRef(packageFqn, parts[3], parts[5], Kind.OBJECT_TYPE_PROPERTY);
+    }
+
+    // ==================== persistence (materialize the @ExternalProperty content) ====================
+    //
+    // XDTOPackage.getPackage() is a transient @ExternalProperty - the SAME lazy-external-property shape
+    // BasicTemplate.getTemplate() is for a moxel template / a report's DCS (#245 / #241). Unlike those,
+    // ALL THREE write tools (create/modify/delete_metadata) need to reach an XDTO Package's content - the
+    // DCS content, by contrast, is reached from exactly one call site (ModifyMetadataTool's `dcs`
+    // payload branch). So the materialize + attachTopObject step is centralized HERE (not duplicated
+    // three times per tool) rather than copied into ModifyMetadataTool's private
+    // resolveSpreadsheetContent/resolveDcsContent pair, which stay untouched (those still each have only
+    // ONE caller).
+
+    /**
+     * The outcome of {@link #resolvePackageContent}: exactly one of ({@link #content} + {@link #contentFqn})
+     * / {@link #error} is non-null/non-empty. {@link #contentFqn} is ALWAYS the content's own canonical
+     * top-object FQN when {@link #content} is non-null - ALWAYS derived from the OWNER via
+     * {@link ITopObjectFqnGenerator#generateExternalPropertyFqn}, NEVER read via {@code bmGetFqn()} on the
+     * content object itself (see {@link #resolvePackageContent}'s javadoc for why) - so callers building
+     * the dual force-export list must use THIS field, never call {@code bmGetFqn()} on {@link #content}
+     * themselves.
+     */
+    public static final class ContentResolution
+    {
+        public final Package content;
+        /** The content's own canonical top-object FQN; non-empty whenever {@link #content} is non-null. */
+        public final String contentFqn;
+        public final String error;
+
+        private ContentResolution(Package content, String contentFqn, String error)
+        {
+            this.content = content;
+            this.contentFqn = contentFqn;
+            this.error = error;
+        }
+
+        static ContentResolution of(Package content, String contentFqn)
+        {
+            return new ContentResolution(content, contentFqn, null);
+        }
+
+        static ContentResolution failed(String error)
+        {
+            return new ContentResolution(null, null, error);
+        }
+    }
+
+    /**
+     * Resolves the {@link Package} content of an in-transaction {@link XDTOPackage}, materializing an
+     * empty one when the package has none usable yet. Mirrors {@code ModifyMetadataTool}'s
+     * {@code resolveDcsContent} / {@code resolveSpreadsheetContent}: a fresh/never-authored XDTOPackage
+     * has NO usable content (either {@code getPackage() == null} or a non-attached placeholder), so a
+     * fresh {@link Package} is built via {@link XdtoFactory#createPackage()} and ATTACHED as a BM top
+     * object under its generated external-property FQN - else committing the write fails "Failed to
+     * persist reference value" (the #245 lesson). An EXISTING, already-attached content is reused as-is.
+     * MUST run inside the write boundary ({@code tx.attachTopObject}, {@code bmIsTop()} are only legal
+     * there).
+     *
+     * <p>The owning {@code XDTOPackage}'s own {@code namespace} (mdclass) property is the SINGLE SOURCE
+     * OF TRUTH for the target namespace: the content {@link Package}'s {@code nsUri} is RE-SYNCED to it on
+     * every resolution whenever the two differ (not merely when the content's own {@code nsUri} is
+     * missing) - never left {@code null} - so a same-package QName shorthand ({@link #resolveQName},
+     * {@code qname.setNsUri(pkg.getNsUri())}) never writes a broken {@code null}-namespace reference and
+     * the serialized {@code .xdto} always declares the CURRENT target namespace. This matters because
+     * {@code create_metadata XDTOPackage.<Name>} eagerly materializes the content at package-create time
+     * (seeded with the namespace as it stood THEN); a later {@code modify_metadata} of the mdclass
+     * {@code namespace} updates only the owner, so without this re-sync the content's {@code targetNamespace}
+     * would go stale and members would be authored under the OLD namespace. Running on BOTH paths (fresh
+     * and already-attached) also covers an XML-imported / adopted package whose owner namespace was cleared
+     * or changed after the content was first authored. A metadata package with NO namespace set at all
+     * (should not happen for a {@code create_metadata}-made package, which always defaults one, but is
+     * possible for an XML-imported / adopted one) is rejected up front rather than silently materializing
+     * or reusing a nsUri-less package.</p>
+     *
+     * <p><b>The content FQN is ALWAYS derived from the OWNER via the generator, NEVER read via
+     * {@code bmGetFqn()} on the content object itself</b> (three live-stand findings, post-review, fixed
+     * the wrong way twice before landing here - see the trail below):</p>
+     * <ul>
+     * <li>Calling {@code bmGetFqn()} on a {@link Package} THIS SAME transaction just
+     * {@code attachTopObject}-ed throws {@code BmAssertionException} - {@code bmIsTop()} is already
+     * {@code true} right after attach, but the object is not yet "settled" enough for a
+     * {@code bmGetFqn()} read within the SAME transaction.</li>
+     * <li>{@code create_metadata XDTOPackage.<Name>} already auto-materializes an EMPTY content on the
+     * TOP-object create - so the very FIRST member write already sees an EXISTING, {@code bmIsTop()==true}
+     * content, and calling {@code bmGetFqn()} on THAT ("existing path is safe, it was settled by a prior
+     * committed tx" - WRONG) throws the SAME assertion: {@code bmIsTop()} and
+     * "attached-enough-for-{@code bmGetFqn()}" are DIFFERENT states, and a {@code getPackage()}-returned
+     * content can satisfy the former while still failing the latter, regardless of which transaction
+     * attached it.</li>
+     * <li>Fixing the above by hoisting ONE {@code generateExternalPropertyFqn} call before the
+     * existing-vs-fresh branch ("it is a pure function of the OWNER, order doesn't matter") was ALSO
+     * wrong in practice: it made the FRESH branch call the generator BEFORE {@code txPkg.setPackage(pkg)} -
+     * unlike every proven-working sibling ({@code ModifyMetadataTool.resolveDcsContent} /
+     * {@code resolveSpreadsheetContent} / {@code FormElementWriter}'s content-form attach), which ALL
+     * generate the external-property FQN AFTER the owner's reference already points at the fresh content,
+     * THEN {@code attachTopObject}. With the generator called before the reference was set, an EXISTING
+     * (real, platform-loaded) package persisted correctly on live re-test, but a BRAND-NEW package's first
+     * member never made it to disk - and every subsequent create silently re-materialized ANOTHER fresh,
+     * empty {@link Package}, discarding the previous one: {@code attachTopObject} "succeeded" (no
+     * exception, the reference reads back fine within the model) but did not durably register the object
+     * as a force-exportable top object under that FQN. The fix restores the EXACT proven order per branch:
+     * point the reference at the target content FIRST, THEN generate its FQN, THEN (fresh only)
+     * attach.</li>
+     * </ul>
+     * <p>{@code bmGetFqn()} is never called on the content in this class - do not reintroduce it.</p>
+     *
+     * @param txPkg the XDTOPackage re-fetched inside the write transaction
+     * @param tx the active write transaction
+     * @param fqnGenerator the external-property FQN generator
+     * @return the resolution - check {@link ContentResolution#error} first
+     */
+    public static ContentResolution resolvePackageContent(XDTOPackage txPkg, IBmTransaction tx,
+        ITopObjectFqnGenerator fqnGenerator)
+    {
+        Package existing = txPkg.getPackage();
+        if (existing instanceof IBmObject && ((IBmObject)existing).bmIsTop())
+        {
+            String namespaceError = ensureNamespace(txPkg, existing);
+            if (namespaceError != null)
+            {
+                return ContentResolution.failed(namespaceError);
+            }
+            // The reference ALREADY points at `existing` - generate AFTER, mirroring the proven order.
+            String contentFqn =
+                fqnGenerator.generateExternalPropertyFqn(txPkg, MdClassPackage.Literals.XDTO_PACKAGE__PACKAGE);
+            if (contentFqn == null || contentFqn.isEmpty())
+            {
+                return ContentResolution.failed(ToolResult.error("Could not generate the content resource " //$NON-NLS-1$
+                    + "FQN for the XDTO package; report it with the package FQN.").toJson()); //$NON-NLS-1$
+            }
+            return ContentResolution.of(existing, contentFqn);
+        }
+        String namespaceError = ensureNamespace(txPkg, null);
+        if (namespaceError != null)
+        {
+            return ContentResolution.failed(namespaceError);
+        }
+        Package pkg = XdtoFactory.eINSTANCE.createPackage();
+        pkg.setNsUri(txPkg.getNamespace());
+        // SET the reference to the fresh content FIRST, THEN generate its FQN, THEN attach - the exact
+        // order ModifyMetadataTool.resolveDcsContent / resolveSpreadsheetContent / FormElementWriter's
+        // content-form attach all use (see the javadoc trail above for why the order matters here).
+        txPkg.setPackage(pkg);
+        String contentFqn =
+            fqnGenerator.generateExternalPropertyFqn(txPkg, MdClassPackage.Literals.XDTO_PACKAGE__PACKAGE);
+        if (contentFqn == null || contentFqn.isEmpty())
+        {
+            return ContentResolution.failed(ToolResult.error("Could not generate the content resource FQN " //$NON-NLS-1$
+                + "for the XDTO package; report it with the package FQN.").toJson()); //$NON-NLS-1$
+        }
+        tx.attachTopObject((IBmObject)pkg, contentFqn);
+        return ContentResolution.of(pkg, contentFqn);
+    }
+
+    /**
+     * Requires {@code txPkg.getNamespace()} to be non-empty (a ready JSON error otherwise) and, when
+     * {@code content} is supplied and its {@code nsUri} differs from the owner namespace, RE-SYNCS it to
+     * the owner (the owner is the single source of truth - this propagates a namespace changed AFTER the
+     * content was materialized, not only a missing one). Pass {@code content == null} for the
+     * fresh-materialize path (nothing to sync yet - the caller seeds the freshly-created
+     * {@link Package}'s {@code nsUri} itself once this returns {@code null}).
+     *
+     * @return a ready {@link ToolResult#error} JSON when the owner has no namespace set, else {@code null}
+     */
+    private static String ensureNamespace(XDTOPackage txPkg, Package content)
+    {
+        String namespace = txPkg.getNamespace();
+        if (namespace == null || namespace.isEmpty())
+        {
+            return ToolResult.error("XDTOPackage '" + safeName(txPkg) //$NON-NLS-1$
+                + "' has no target namespace set; set one first (modify_metadata with a 'namespace' " //$NON-NLS-1$
+                + "property) before authoring its content.").toJson(); //$NON-NLS-1$
+        }
+        if (content != null && !namespace.equals(content.getNsUri()))
+        {
+            content.setNsUri(namespace);
+        }
+        return null;
+    }
+
+    private static String safeName(XDTOPackage txPkg)
+    {
+        String name = txPkg.getName();
+        return name != null ? name : "?"; //$NON-NLS-1$
+    }
+
+    // ==================== find / create / remove ====================
+
+    /**
+     * Finds an ObjectType by EXACT (case-SENSITIVE) name, or {@code null} when {@code pkg} is
+     * {@code null} or has none by that name. Unlike a 1C mdclass member name (matched
+     * case-insensitively elsewhere in this codebase, e.g. {@link MetadataNodeResolver}), an XDTO/XML
+     * QName local name is case-SENSITIVE: {@code "Order"} and {@code "order"} are different names, so a
+     * case-insensitive match would wrongly collide two distinct members or make a case-distinct member
+     * uncreatable.
+     */
+    public static ObjectType findObjectType(Package pkg, String name)
+    {
+        if (pkg == null || name == null)
+        {
+            return null;
+        }
+        for (ObjectType type : pkg.getObjects())
+        {
+            if (name.equals(type.getName()))
+            {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds a Property by EXACT (case-SENSITIVE) name in an owner list (either
+     * {@code Package.getProperties()} - package-global - or {@code ObjectType.getProperties()} - object
+     * members), or {@code null} when not found. Case-sensitive for the same reason as
+     * {@link #findObjectType} (an XDTO/XML QName local name is case-sensitive).
+     */
+    public static Property findProperty(EList<Property> owner, String name)
+    {
+        if (owner == null || name == null)
+        {
+            return null;
+        }
+        for (Property property : owner)
+        {
+            if (name.equals(property.getName()))
+            {
+                return property;
+            }
+        }
+        return null;
+    }
+
+    /** Creates and appends a new (unchecked - the caller must have already rejected a duplicate) ObjectType. */
+    public static ObjectType createObjectType(Package pkg, String name)
+    {
+        ObjectType type = XdtoFactory.eINSTANCE.createObjectType();
+        type.setName(name);
+        pkg.getObjects().add(type);
+        return type;
+    }
+
+    /** Creates and appends a new (unchecked - the caller must have already rejected a duplicate) Property. */
+    public static Property createProperty(EList<Property> owner, String name)
+    {
+        Property property = XdtoFactory.eINSTANCE.createProperty();
+        property.setName(name);
+        owner.add(property);
+        return property;
+    }
+
+    /** Removes an ObjectType from its package (its own properties are containment - removed with it). */
+    public static void removeObjectType(Package pkg, ObjectType type)
+    {
+        pkg.getObjects().remove(type);
+    }
+
+    /** Removes a Property from its owner list (package-global or nested in an ObjectType). */
+    public static void removeProperty(EList<Property> owner, Property property)
+    {
+        owner.remove(property);
+    }
+
+    // ==================== apply (typed attribute writes) ====================
+
+    /**
+     * The outcome of applying property/attribute changes to one XDTO member: either an actionable
+     * {@link ToolResult#error} JSON string in {@link #error} (an unassignable name / a malformed
+     * QName / a required 'type' missing on create) or the list of attribute names actually applied.
+     */
+    public static final class Result
+    {
+        /** Non-null when the change was rejected (nothing was mutated): a ready ToolResult.error. */
+        public final String error;
+        /** Names of the attributes actually set, in input order. */
+        public final List<String> applied;
+
+        private Result(String error, List<String> applied)
+        {
+            this.error = error;
+            this.applied = applied;
+        }
+
+        static Result failed(String error)
+        {
+            return new Result(error, List.of());
+        }
+
+        static Result ok(List<String> applied)
+        {
+            return new Result(null, applied);
+        }
+
+        public boolean hasError()
+        {
+            return error != null;
+        }
+    }
+
+    /**
+     * Applies the ObjectType boolean flags ({@code open} / {@code abstract} / {@code mixed} /
+     * {@code ordered} / {@code sequenced}) found in {@code properties} ({@code [{name, value}]}, the same
+     * shape {@code modify_metadata} / {@code create_metadata} already use). Every entry is VALIDATED
+     * (name must be assignable, value must be a boolean) before ANY mutation, so a bad entry leaves
+     * {@code type} untouched.
+     *
+     * @param type the ObjectType to mutate (may be a freshly created, still-unattached instance)
+     * @param properties the raw {@code [{name, value}]} entries
+     * @return the result - check {@link Result#hasError()} first
+     */
+    public static Result applyObjectTypeProperties(ObjectType type, List<JsonObject> properties)
+    {
+        Map<String, JsonElement> values = toMap(properties);
+        String unknown = firstUnknownKey(values.keySet(), OBJECT_TYPE_PROPS);
+        if (unknown != null)
+        {
+            return Result.failed(unassignableError(unknown, "an XDTO ObjectType", OBJECT_TYPE_PROPS)); //$NON-NLS-1$
+        }
+        for (String key : values.keySet())
+        {
+            if (boolProp(values, key) == null)
+            {
+                return Result.failed(ToolResult.error("Property '" + key //$NON-NLS-1$
+                    + "' on an XDTO ObjectType must be a boolean (true/false).").toJson()); //$NON-NLS-1$
+            }
+        }
+        List<String> applied = new ArrayList<>();
+        Boolean open = boolProp(values, "open"); //$NON-NLS-1$
+        if (open != null)
+        {
+            type.setOpen(open.booleanValue());
+            applied.add("open"); //$NON-NLS-1$
+        }
+        Boolean isAbstract = boolProp(values, "abstract"); //$NON-NLS-1$
+        if (isAbstract != null)
+        {
+            type.setAbstract(isAbstract.booleanValue());
+            applied.add("abstract"); //$NON-NLS-1$
+        }
+        Boolean mixed = boolProp(values, "mixed"); //$NON-NLS-1$
+        if (mixed != null)
+        {
+            type.setMixed(mixed.booleanValue());
+            applied.add("mixed"); //$NON-NLS-1$
+        }
+        Boolean ordered = boolProp(values, "ordered"); //$NON-NLS-1$
+        if (ordered != null)
+        {
+            type.setOrdered(ordered.booleanValue());
+            applied.add("ordered"); //$NON-NLS-1$
+        }
+        Boolean sequenced = boolProp(values, "sequenced"); //$NON-NLS-1$
+        if (sequenced != null)
+        {
+            type.setSequenced(sequenced.booleanValue());
+            applied.add("sequenced"); //$NON-NLS-1$
+        }
+        return Result.ok(applied);
+    }
+
+    /**
+     * Applies the Property attributes ({@code type} - a {@link QName} spec - plus the optional
+     * {@code lowerBound} / {@code upperBound} / {@code nillable} / {@code fixed} / {@code default}) found
+     * in {@code properties}. Every entry is VALIDATED (name assignable, a {@code type} QName spec
+     * well-formed, a numeric/boolean shape correct) before ANY mutation. {@code type} is a created-once
+     * REQUIRED attribute when {@code requireType} is {@code true} (a fresh Property needs a type; a
+     * modify of an existing Property does not have to touch it).
+     *
+     * <p>{@code ref} (a reference to a GLOBAL PROPERTY) is NOT supported for v1 - a {@code ref} entry is
+     * rejected with an actionable "not yet supported" error, not silently dropped, pointing the caller at
+     * {@code type} (see {@link #PROPERTY_PROPS}'s javadoc for why).</p>
+     *
+     * @param property the Property to mutate (may be freshly created, still-unattached)
+     * @param pkg the owning Package (for the same-package ObjectType-name QName shorthand)
+     * @param properties the raw {@code [{name, value}]} entries
+     * @param requireType {@code true} to require a {@code type} entry (a Property CREATE)
+     * @return the result - check {@link Result#hasError()} first
+     */
+    public static Result applyPropertyProperties(Property property, Package pkg, List<JsonObject> properties,
+        boolean requireType)
+    {
+        Map<String, JsonElement> values = toMap(properties);
+        if (values.containsKey("ref")) //$NON-NLS-1$
+        {
+            return Result.failed(ToolResult.error("Property 'ref' (a global-property reference) is not " //$NON-NLS-1$
+                + "yet supported; set a 'type' instead (a built-in XSD type name, the name of an " //$NON-NLS-1$
+                + "ObjectType already in the same package, or the explicit object form " //$NON-NLS-1$
+                + "{nsUri, name}).").toJson()); //$NON-NLS-1$
+        }
+        String unknown = firstUnknownKey(values.keySet(), PROPERTY_PROPS);
+        if (unknown != null)
+        {
+            return Result.failed(unassignableError(unknown, "an XDTO Property", PROPERTY_PROPS)); //$NON-NLS-1$
+        }
+        if (requireType && !values.containsKey("type")) //$NON-NLS-1$
+        {
+            return Result.failed(ToolResult.error("Property 'type' is required: {name:'type', value:'string'} " //$NON-NLS-1$
+                + "(a built-in XSD type) or {name:'type', value:{nsUri:'...', name:'...'}}, or the name " //$NON-NLS-1$
+                + "of an ObjectType already in the same package (a same-package reference).").toJson()); //$NON-NLS-1$
+        }
+
+        // Resolve 'type' up front (before any mutation), so a bad spec leaves the Property untouched.
+        QName typeQName = null;
+        if (values.containsKey("type")) //$NON-NLS-1$
+        {
+            QNameResult r = resolveQName(values.get("type"), pkg, "'type'"); //$NON-NLS-1$ //$NON-NLS-2$
+            if (r.error != null)
+            {
+                return Result.failed(r.error);
+            }
+            typeQName = r.qname;
+        }
+        Integer lowerBound = null;
+        if (values.containsKey("lowerBound")) //$NON-NLS-1$
+        {
+            lowerBound = intProp(values, "lowerBound"); //$NON-NLS-1$
+            if (lowerBound == null)
+            {
+                return Result.failed(
+                    ToolResult.error("Property 'lowerBound' must be a non-negative integer.").toJson()); //$NON-NLS-1$
+            }
+        }
+        Integer upperBound = null;
+        if (values.containsKey("upperBound")) //$NON-NLS-1$
+        {
+            upperBound = intProp(values, "upperBound"); //$NON-NLS-1$
+            if (upperBound == null)
+            {
+                return Result.failed(
+                    ToolResult.error("Property 'upperBound' must be an integer (-1 for unbounded).").toJson()); //$NON-NLS-1$
+            }
+        }
+        Boolean nillable = null;
+        if (values.containsKey("nillable")) //$NON-NLS-1$
+        {
+            nillable = boolProp(values, "nillable"); //$NON-NLS-1$
+            if (nillable == null)
+            {
+                return Result.failed(ToolResult.error("Property 'nillable' must be a boolean (true/false).") //$NON-NLS-1$
+                    .toJson());
+            }
+        }
+        Boolean fixed = null;
+        if (values.containsKey("fixed")) //$NON-NLS-1$
+        {
+            fixed = boolProp(values, "fixed"); //$NON-NLS-1$
+            if (fixed == null)
+            {
+                return Result.failed(
+                    ToolResult.error("Property 'fixed' must be a boolean (true/false).").toJson()); //$NON-NLS-1$
+            }
+        }
+        String default_ = values.containsKey("default") ? stringProp(values, "default") : null; //$NON-NLS-1$ //$NON-NLS-2$
+
+        // Validate the EFFECTIVE post-change state (this call's new values layered over whatever the
+        // property already carries) BEFORE any mutation - a bad combination must leave the property
+        // untouched, not partially applied.
+        String boundsError = validateEffectiveBounds(property, pkg, lowerBound, upperBound);
+        if (boundsError != null)
+        {
+            return Result.failed(boundsError);
+        }
+        String fixedError = validateEffectiveFixed(property, values, fixed, default_);
+        if (fixedError != null)
+        {
+            return Result.failed(fixedError);
+        }
+
+        List<String> applied = new ArrayList<>();
+        if (typeQName != null)
+        {
+            property.setType(typeQName);
+            // 'type' and 'ref' are mutually exclusive XDTO alternative forms - clear any pre-existing
+            // 'ref' (e.g. from an XML import; this code never SETS 'ref' itself, v1 rejects it above) so
+            // a freshly-typed property never ends up carrying both.
+            property.setRef(null);
+            applied.add("type"); //$NON-NLS-1$
+        }
+        if (lowerBound != null)
+        {
+            property.setLowerBound(lowerBound.intValue());
+            applied.add("lowerBound"); //$NON-NLS-1$
+        }
+        if (upperBound != null)
+        {
+            property.setUpperBound(upperBound.intValue());
+            applied.add("upperBound"); //$NON-NLS-1$
+        }
+        if (nillable != null)
+        {
+            property.setNillable(nillable.booleanValue());
+            applied.add("nillable"); //$NON-NLS-1$
+        }
+        if (fixed != null)
+        {
+            property.setFixed(fixed.booleanValue());
+            applied.add("fixed"); //$NON-NLS-1$
+        }
+        if (values.containsKey("default")) //$NON-NLS-1$
+        {
+            property.setDefault(default_);
+            applied.add("default"); //$NON-NLS-1$
+        }
+        return Result.ok(applied);
+    }
+
+    /**
+     * Validates the EFFECTIVE {@code lowerBound}/{@code upperBound} once this call's new values (if any)
+     * are layered over the property's current ones: {@code lowerBound >= 0} (whenever it is known - just
+     * set now, or already set before); {@code upperBound}, whenever known, must be {@code -1} (unbounded)
+     * or {@code >= 0} (a bare negative OTHER than {@code -1}, e.g. {@code -2}, is never valid XDTO - codex
+     * review residual #4a); {@code upperBound >= lowerBound} is additionally checked when BOTH bounds are
+     * actually known (just set or already set - so a call that touches only ONE bound and leaves the
+     * other genuinely never-set is not rejected against an invented default); and a PACKAGE-GLOBAL
+     * property (its direct container is the Package itself, not an ObjectType) cannot carry occurrence
+     * bounds at all - XDTO only gives cardinality meaning to a property nested in an ObjectType. Returns a
+     * ready JSON error, or {@code null} when the effective state is valid.
+     */
+    private static String validateEffectiveBounds(Property property, Package pkg, Integer newLower,
+        Integer newUpper)
+    {
+        if (newLower == null && newUpper == null)
+        {
+            return null;
+        }
+        boolean isPackageGlobal = property.eContainer() == pkg;
+        if (isPackageGlobal)
+        {
+            return ToolResult.error("A package-global property cannot carry occurrence bounds " //$NON-NLS-1$
+                + "('lowerBound'/'upperBound'); those apply only to a property nested in an ObjectType.") //$NON-NLS-1$
+                    .toJson();
+        }
+        Integer effectiveLower =
+            newLower != null ? newLower : (property.isSetLowerBound() ? Integer.valueOf(property.getLowerBound()) : null);
+        Integer effectiveUpper =
+            newUpper != null ? newUpper : (property.isSetUpperBound() ? Integer.valueOf(property.getUpperBound()) : null);
+        if (effectiveLower != null && effectiveLower.intValue() < 0)
+        {
+            return ToolResult.error("Property 'lowerBound' must be >= 0.").toJson(); //$NON-NLS-1$
+        }
+        if (effectiveUpper != null && effectiveUpper.intValue() < -1)
+        {
+            return ToolResult.error("Property 'upperBound' must be -1 (unbounded) or >= 0.").toJson(); //$NON-NLS-1$
+        }
+        if (effectiveLower != null && effectiveUpper != null && effectiveUpper.intValue() != -1
+            && effectiveUpper.intValue() < effectiveLower.intValue())
+        {
+            return ToolResult.error("Property 'upperBound' must be -1 (unbounded) or >= 'lowerBound' (" //$NON-NLS-1$
+                + effectiveLower + ").").toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Validates the EFFECTIVE {@code fixed}/{@code default} once this call's new values (if any) are
+     * layered over the property's current ones: a default is REQUIRED only when {@code fixed=true} is
+     * being NEWLY set BY THIS CALL and no default is set now nor supplied in this call (codex review
+     * residual #4b) - a call that leaves an ALREADY-{@code fixed} property's {@code fixed} flag untouched
+     * (e.g. editing an unrelated bound) never re-fires this check. "Set" is {@code getDefault() != null} -
+     * an EMPTY STRING default (a legitimate value; {@link Property} has no {@code isSetDefault()}/unset
+     * pair, so {@code null} is the only "absent" signal) counts as present, not absent. Returns a ready
+     * JSON error, or {@code null} when the effective state is valid.
+     */
+    private static String validateEffectiveFixed(Property property, Map<String, JsonElement> values,
+        Boolean newFixed, String newDefault)
+    {
+        boolean fixedNewlySetTrue = newFixed != null && newFixed.booleanValue();
+        if (!fixedNewlySetTrue)
+        {
+            return null;
+        }
+        String effectiveDefault = values.containsKey("default") ? newDefault : property.getDefault(); //$NON-NLS-1$
+        if (effectiveDefault == null)
+        {
+            return ToolResult.error("Property 'fixed'=true requires a 'default' value (either in this " //$NON-NLS-1$
+                + "call or already set).").toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    // ==================== QName resolution ====================
+
+    /** The outcome of {@link #resolveQName}: exactly one of {@link #qname} / {@link #error} is non-null. */
+    public static final class QNameResult
+    {
+        public final QName qname;
+        public final String error;
+
+        private QNameResult(QName qname, String error)
+        {
+            this.qname = qname;
+            this.error = error;
+        }
+
+        static QNameResult of(QName qname)
+        {
+            return new QNameResult(qname, null);
+        }
+
+        static QNameResult failed(String error)
+        {
+            return new QNameResult(null, error);
+        }
+    }
+
+    /**
+     * Resolves a {@code type} / {@code ref} JSON spec into an mcore {@link QName}: a JSON STRING is
+     * resolved as a same-package {@link ObjectType} name (EXACT, case-sensitive match against one
+     * already in {@code pkg} - the resulting QName's {@code nsUri} is the package's own {@code nsUri}) or,
+     * failing that, as an XSD built-in datatype name ({@link #XSD_BUILTIN_TYPES}, under
+     * {@code http://www.w3.org/2001/XMLSchema}) - ANY OTHER bare string is REJECTED (not silently turned
+     * into an invalid {@code xs:<typo>} reference), pointing the caller at the explicit object form. A
+     * JSON OBJECT {@code {nsUri, name}} is that explicit form (a non-empty {@code name} is required;
+     * {@code nsUri} defaults to the XSD namespace when omitted) - a NON-XSD, non-same-package
+     * {@code nsUri} must be reachable via a matching {@code Package.getDependencies()} Import, else it is
+     * rejected as an unimported (invalid) namespace reference.
+     *
+     * @param spec the raw JSON value of the {@code type}/{@code ref} entry
+     * @param pkg the owning Package (for the same-package ObjectType-name shorthand and the Import
+     *            reachability check); may be {@code null} (the same-package shorthand and the Import
+     *            check then both no-op)
+     * @param fieldLabel the quoted field name, for an actionable error (e.g. {@code "'type'"})
+     * @return the resolution - check {@link QNameResult#error} first
+     */
+    public static QNameResult resolveQName(JsonElement spec, Package pkg, String fieldLabel)
+    {
+        if (spec == null || spec.isJsonNull())
+        {
+            return QNameResult.failed(ToolResult.error(fieldLabel + " must not be null.").toJson()); //$NON-NLS-1$
+        }
+        if (spec.isJsonPrimitive() && spec.getAsJsonPrimitive().isString())
+        {
+            return resolveQNameShorthand(spec.getAsString().trim(), pkg, fieldLabel);
+        }
+        if (spec.isJsonObject())
+        {
+            return resolveQNameObjectForm(spec.getAsJsonObject(), pkg, fieldLabel);
+        }
+        return QNameResult.failed(ToolResult.error(fieldLabel + " must be a string (the EXACT name of an " //$NON-NLS-1$
+            + "ObjectType already in the same package, or a built-in XSD type name) or an object " //$NON-NLS-1$
+            + "{nsUri, name}.").toJson()); //$NON-NLS-1$
+    }
+
+    /**
+     * The bare-STRING shorthand branch of {@link #resolveQName}: an exact same-package ObjectType name,
+     * else a whitelisted XSD built-in, else a rejection (never a silently-invented namespace).
+     */
+    private static QNameResult resolveQNameShorthand(String token, Package pkg, String fieldLabel)
+    {
+        if (token.isEmpty())
+        {
+            return QNameResult.failed(ToolResult.error(fieldLabel + " must be a non-empty string or an " //$NON-NLS-1$
+                + "object {nsUri, name}.").toJson()); //$NON-NLS-1$
+        }
+        ObjectType sameName = findObjectType(pkg, token);
+        if (sameName != null)
+        {
+            QName qname = McoreFactory.eINSTANCE.createQName();
+            qname.setNsUri(pkg.getNsUri());
+            qname.setName(sameName.getName());
+            return QNameResult.of(qname);
+        }
+        if (XSD_BUILTIN_TYPES.contains(token))
+        {
+            QName qname = McoreFactory.eINSTANCE.createQName();
+            qname.setNsUri(XSD_NS);
+            qname.setName(token);
+            return QNameResult.of(qname);
+        }
+        return QNameResult.failed(ToolResult.error(fieldLabel + " '" + token + "' is neither the EXACT " //$NON-NLS-1$ //$NON-NLS-2$
+            + "(case-sensitive) name of an ObjectType already in the same package nor a built-in XSD " //$NON-NLS-1$
+            + "type (e.g. 'string', 'boolean', 'decimal', 'dateTime', 'date', 'int'). Use the exact " //$NON-NLS-1$
+            + "ObjectType name, a built-in XSD type name, or the explicit object form {nsUri, name} for " //$NON-NLS-1$
+            + "a cross-namespace reference.").toJson()); //$NON-NLS-1$
+    }
+
+    /** The {@code {nsUri, name}} object-form branch of {@link #resolveQName}, with the Import reachability check. */
+    private static QNameResult resolveQNameObjectForm(JsonObject obj, Package pkg, String fieldLabel)
+    {
+        String name = stringMember(obj, "name"); //$NON-NLS-1$
+        if (name == null || name.isEmpty())
+        {
+            return QNameResult.failed(ToolResult.error(fieldLabel + " object form needs a non-empty " //$NON-NLS-1$
+                + "'name', e.g. {nsUri:'http://www.w3.org/2001/XMLSchema', name:'string'}.").toJson()); //$NON-NLS-1$
+        }
+        String nsUri = stringMember(obj, "nsUri"); //$NON-NLS-1$
+        String resolvedNsUri = nsUri != null && !nsUri.isEmpty() ? nsUri : XSD_NS;
+        String importError = validateNamespaceReachable(resolvedNsUri, pkg, fieldLabel);
+        if (importError != null)
+        {
+            return QNameResult.failed(importError);
+        }
+        QName qname = McoreFactory.eINSTANCE.createQName();
+        qname.setNsUri(resolvedNsUri);
+        qname.setName(name);
+        return QNameResult.of(qname);
+    }
+
+    /**
+     * Validates that {@code nsUri} is REACHABLE from {@code pkg}: the XSD namespace and the package's
+     * OWN namespace are implicitly reachable (no Import needed); any other namespace must have a
+     * matching {@link Import} in {@code pkg.getDependencies()} - an unimported namespace is an invalid
+     * XDTO reference (EDT's own validator would reject it). Returns a ready JSON error, or {@code null}
+     * when {@code nsUri} is reachable (or {@code pkg} is {@code null}, in which case the check no-ops -
+     * the caller has no package context to check against).
+     */
+    private static String validateNamespaceReachable(String nsUri, Package pkg, String fieldLabel)
+    {
+        if (pkg == null || XSD_NS.equals(nsUri) || nsUri.equals(pkg.getNsUri()))
+        {
+            return null;
+        }
+        for (Import dependency : pkg.getDependencies())
+        {
+            if (nsUri.equals(dependency.getNamespace()))
+            {
+                return null;
+            }
+        }
+        return ToolResult.error(fieldLabel + " namespace '" + nsUri + "' is not reachable from this XDTO " //$NON-NLS-1$ //$NON-NLS-2$
+            + "package (no matching entry in its Import dependencies, and it is neither the XSD " //$NON-NLS-1$
+            + "namespace nor the package's own namespace). Add an Import for it first, or use the " //$NON-NLS-1$
+            + "package's own namespace / a built-in XSD type.").toJson(); //$NON-NLS-1$
+    }
+
+    // ==================== JSON helpers ====================
+
+    /**
+     * Flattens the raw {@code [{name, value, language?}]} property entries into a {@code name -> value}
+     * map (last entry wins on a repeated name). An entry missing a non-empty {@code name} or a
+     * {@code value} is skipped.
+     */
+    private static Map<String, JsonElement> toMap(List<JsonObject> properties)
+    {
+        Map<String, JsonElement> map = new LinkedHashMap<>();
+        if (properties == null)
+        {
+            return map;
+        }
+        for (JsonObject entry : properties)
+        {
+            String name = stringMember(entry, "name"); //$NON-NLS-1$
+            if (name == null || name.isEmpty() || !entry.has("value")) //$NON-NLS-1$
+            {
+                continue;
+            }
+            map.put(name, entry.get("value")); //$NON-NLS-1$
+        }
+        return map;
+    }
+
+    /** The first key in {@code keys} that is NOT in {@code allowed}, or {@code null} when all are known. */
+    private static String firstUnknownKey(Set<String> keys, Set<String> allowed)
+    {
+        for (String key : keys)
+        {
+            if (!allowed.contains(key))
+            {
+                return key;
+            }
+        }
+        return null;
+    }
+
+    /** A ready {@link ToolResult#error} JSON (issue #183 codex review #9: never a bare string). */
+    private static String unassignableError(String name, String targetDescription, Set<String> allowed)
+    {
+        return ToolResult.error("Property '" + name + "' is not assignable on " + targetDescription //$NON-NLS-1$ //$NON-NLS-2$
+            + ". Assignable: " + String.join(", ", allowed) + ".").toJson(); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    private static String stringMember(JsonObject obj, String name)
+    {
+        if (obj == null || !obj.has(name))
+        {
+            return null;
+        }
+        JsonElement element = obj.get(name);
+        return (element != null && element.isJsonPrimitive()) ? element.getAsString() : null;
+    }
+
+    private static Boolean boolProp(Map<String, JsonElement> values, String key)
+    {
+        JsonElement element = values.get(key);
+        if (element == null || !element.isJsonPrimitive())
+        {
+            return null;
+        }
+        JsonPrimitive primitive = element.getAsJsonPrimitive();
+        return primitive.isBoolean() ? Boolean.valueOf(primitive.getAsBoolean()) : null;
+    }
+
+    private static Integer intProp(Map<String, JsonElement> values, String key)
+    {
+        JsonElement element = values.get(key);
+        if (element == null || !element.isJsonPrimitive())
+        {
+            return null;
+        }
+        try
+        {
+            double d = element.getAsDouble();
+            if (d != Math.floor(d) || d < Integer.MIN_VALUE || d > Integer.MAX_VALUE)
+            {
+                return null;
+            }
+            return Integer.valueOf((int)d);
+        }
+        catch (NumberFormatException e)
+        {
+            return null;
+        }
+    }
+
+    private static String stringProp(Map<String, JsonElement> values, String key)
+    {
+        JsonElement element = values.get(key);
+        if (element == null || element.isJsonNull())
+        {
+            return null;
+        }
+        return element.isJsonPrimitive() ? element.getAsString() : null;
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
@@ -460,6 +460,32 @@ public final class XdtoWriter
     }
 
     /**
+     * Finds a LOCAL type (an {@link ObjectType} from {@code Package.getObjects()} OR a
+     * {@link ValueType} from {@code Package.getTypes()}) by name, with the same yo fallback
+     * {@link #findObjectType} applies. XDTO property QNames may legitimately target a local
+     * value type (e.g. an imported package's enumerations), not only object types.
+     *
+     * @return the matching type, or {@code null}
+     */
+    public static Type findLocalType(Package pkg, String name)
+    {
+        ObjectType objectType = findObjectType(pkg, name);
+        if (objectType != null || pkg == null || name == null)
+        {
+            return objectType;
+        }
+        String yoNormalized = MdNameNormalizer.normalizeYo(name);
+        for (ValueType valueType : pkg.getTypes())
+        {
+            if (name.equals(valueType.getName()) || yoNormalized.equals(valueType.getName()))
+            {
+                return valueType;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Finds a Property by EXACT (case-SENSITIVE) name in an owner list (either
      * {@code Package.getProperties()} - package-global - or {@code ObjectType.getProperties()} - object
      * members), or {@code null} when not found. Case-sensitive for the same reason as
@@ -923,10 +949,16 @@ public final class XdtoWriter
                 + "('lowerBound'/'upperBound'); those apply only to a property nested in an ObjectType.") //$NON-NLS-1$
                     .toJson();
         }
-        Integer effectiveLower =
-            newLower != null ? newLower : (property.isSetLowerBound() ? Integer.valueOf(property.getLowerBound()) : null);
-        Integer effectiveUpper =
-            newUpper != null ? newUpper : (property.isSetUpperBound() ? Integer.valueOf(property.getUpperBound()) : null);
+        // A side neither set in this call nor already set still has an EFFECTIVE value: the model
+        // DEFAULT the platform serializes/reads. Comparing against it (read from the EMF feature,
+        // not hardcoded) rejects a one-sided range the platform would refuse, e.g. lowerBound=2
+        // with the other side at its default.
+        Integer effectiveLower = newLower != null ? newLower
+            : (property.isSetLowerBound() ? Integer.valueOf(property.getLowerBound())
+                : boundDefault(property, "lowerBound")); //$NON-NLS-1$
+        Integer effectiveUpper = newUpper != null ? newUpper
+            : (property.isSetUpperBound() ? Integer.valueOf(property.getUpperBound())
+                : boundDefault(property, "upperBound")); //$NON-NLS-1$
         if (effectiveLower != null && effectiveLower.intValue() < 0)
         {
             return ToolResult.error("Property 'lowerBound' must be >= 0.").toJson(); //$NON-NLS-1$
@@ -942,6 +974,13 @@ public final class XdtoWriter
                 + effectiveLower + ").").toJson(); //$NON-NLS-1$
         }
         return null;
+    }
+
+    /** The EMF DEFAULT of an occurrence-bound feature ({@code null} when the model declares none). */
+    private static Integer boundDefault(Property property, String featureName)
+    {
+        Object def = property.eClass().getEStructuralFeature(featureName).getDefaultValue();
+        return def instanceof Integer ? (Integer)def : null;
     }
 
     /**
@@ -1045,7 +1084,7 @@ public final class XdtoWriter
             return QNameResult.failed(ToolResult.error(fieldLabel + " must be a non-empty string or an " //$NON-NLS-1$
                 + "object {nsUri, name}.").toJson()); //$NON-NLS-1$
         }
-        ObjectType sameName = findObjectType(pkg, token);
+        Type sameName = findLocalType(pkg, token);
         if (sameName != null)
         {
             QName qname = McoreFactory.eINSTANCE.createQName();
@@ -1101,12 +1140,12 @@ public final class XdtoWriter
         // spelling variant, and serializing the raw input would dangle against the stored name.
         if (pkg != null && !XSD_NS.equals(resolvedNsUri) && resolvedNsUri.equals(pkg.getNsUri()))
         {
-            ObjectType localTarget = findObjectType(pkg, name);
+            Type localTarget = findLocalType(pkg, name);
             if (localTarget == null)
             {
                 return QNameResult.failed(ToolResult.error(fieldLabel + " name '" + name + "' does not match " //$NON-NLS-1$ //$NON-NLS-2$
-                    + "any ObjectType in this package (its own namespace '" + resolvedNsUri + "'). Create " //$NON-NLS-1$ //$NON-NLS-2$
-                    + "the ObjectType first, or reference an imported / XSD type.").toJson()); //$NON-NLS-1$
+                    + "any ObjectType or value type in this package (its own namespace '" + resolvedNsUri //$NON-NLS-1$
+                    + "'). Create the ObjectType first, or reference an imported / XSD type.").toJson()); //$NON-NLS-1$
             }
             name = localTarget.getName();
         }
@@ -1191,7 +1230,10 @@ public final class XdtoWriter
             String name = stringMember(entry, "name"); //$NON-NLS-1$
             if (name == null || name.isEmpty())
             {
-                continue;
+                // A named-value list entry without a (string) name is malformed input, not something
+                // to skip: silently dropping it would report success while the flag never applied.
+                return MapResult.failed(ToolResult.error(
+                    "Each property entry must carry a non-empty string 'name'.").toJson()); //$NON-NLS-1$
             }
             if (!entry.has("value")) //$NON-NLS-1$
             {
@@ -1229,7 +1271,9 @@ public final class XdtoWriter
             return null;
         }
         JsonElement element = obj.get(name);
-        return (element != null && element.isJsonPrimitive()) ? element.getAsString() : null;
+        // Strict STRING primitive (see stringProp): {name: 123} must be rejected, not coerced to "123".
+        return (element != null && element.isJsonPrimitive() && element.getAsJsonPrimitive().isString())
+            ? element.getAsString() : null;
     }
 
     private static Boolean boolProp(Map<String, JsonElement> values, String key)
@@ -1272,6 +1316,9 @@ public final class XdtoWriter
         {
             return null;
         }
-        return element.isJsonPrimitive() ? element.getAsString() : null;
+        // Strict STRING primitive: a number/boolean (default: 42) must not silently coerce to "42" -
+        // the contract documents these fields as strings and the sibling props reject wrong JSON types.
+        return element.isJsonPrimitive() && element.getAsJsonPrimitive().isString()
+            ? element.getAsString() : null;
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
@@ -474,12 +474,24 @@ public final class XdtoWriter
         {
             return objectType;
         }
-        String yoNormalized = MdNameNormalizer.normalizeYo(name);
+        // Exact pass FIRST, yo fallback second (mirrors findObjectType): a yo-normalized match
+        // earlier in the list must never shadow an exact match later in it.
         for (ValueType valueType : pkg.getTypes())
         {
-            if (name.equals(valueType.getName()) || yoNormalized.equals(valueType.getName()))
+            if (name.equals(valueType.getName()))
             {
                 return valueType;
+            }
+        }
+        String yoNormalized = MdNameNormalizer.normalizeYo(name);
+        if (!name.equals(yoNormalized))
+        {
+            for (ValueType valueType : pkg.getTypes())
+            {
+                if (yoNormalized.equals(valueType.getName()))
+                {
+                    return valueType;
+                }
             }
         }
         return null;
@@ -1116,6 +1128,14 @@ public final class XdtoWriter
                 + "'name', e.g. {nsUri:'http://www.w3.org/2001/XMLSchema', name:'string'}.").toJson()); //$NON-NLS-1$
         }
         String nsUri = stringMember(obj, "nsUri"); //$NON-NLS-1$
+        if (nsUri == null && obj.has("nsUri") && !obj.get("nsUri").isJsonNull()) //$NON-NLS-1$ //$NON-NLS-2$
+        {
+            // A PRESENT but non-string nsUri is malformed input - treating it like an omitted one
+            // would silently default to the XSD namespace and persist a different reference than
+            // the caller supplied.
+            return QNameResult.failed(ToolResult.error(fieldLabel
+                + " 'nsUri' must be a string when present.").toJson()); //$NON-NLS-1$
+        }
         String resolvedNsUri = nsUri != null && !nsUri.isEmpty() ? nsUri : XSD_NS;
         String importError = validateNamespaceReachable(resolvedNsUri, pkg, fieldLabel);
         if (importError != null)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
@@ -22,10 +22,13 @@ import com._1c.g5.v8.dt.mcore.McoreFactory;
 import com._1c.g5.v8.dt.mcore.QName;
 import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
 import com._1c.g5.v8.dt.metadata.mdclass.XDTOPackage;
+import com._1c.g5.v8.dt.xdto.model.Enumeration;
 import com._1c.g5.v8.dt.xdto.model.Import;
 import com._1c.g5.v8.dt.xdto.model.ObjectType;
 import com._1c.g5.v8.dt.xdto.model.Package;
 import com._1c.g5.v8.dt.xdto.model.Property;
+import com._1c.g5.v8.dt.xdto.model.Type;
+import com._1c.g5.v8.dt.xdto.model.ValueType;
 import com._1c.g5.v8.dt.xdto.model.XdtoFactory;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.google.gson.JsonElement;
@@ -419,6 +422,15 @@ public final class XdtoWriter
      * QName local name is case-SENSITIVE: {@code "Order"} and {@code "order"} are different names, so a
      * case-insensitive match would wrongly collide two distinct members or make a case-distinct member
      * uncreatable.
+     *
+     * <p>On an EXACT miss, retries once with {@code name} run through {@link MdNameNormalizer#normalizeYo}
+     * (issue #183 P2): {@code create_metadata} normalizes 'yo'->'ye' in a member's own NAME segment by
+     * default (the FQN LEAF only - {@code CreateMetadataTool#normalizeLeafName}), so an ObjectType created
+     * from an FQN spelled with the original 'yo' is stored under its 'ye'-normalized name. A LATER
+     * member-FQN request (modify/delete, or a create addressing this ObjectType as the OWNER segment of a
+     * nested Property FQN - never the leaf, so never normalized on the way in) that still spells the name
+     * with 'yo' would otherwise miss it entirely and report "not found" for a member that in fact exists.
+     * The retry is a no-op (and therefore free) whenever {@code name} carries no 'yo' at all.</p>
      */
     public static ObjectType findObjectType(Package pkg, String name)
     {
@@ -433,6 +445,17 @@ public final class XdtoWriter
                 return type;
             }
         }
+        String yoNormalized = MdNameNormalizer.normalizeYo(name);
+        if (!name.equals(yoNormalized))
+        {
+            for (ObjectType type : pkg.getObjects())
+            {
+                if (yoNormalized.equals(type.getName()))
+                {
+                    return type;
+                }
+            }
+        }
         return null;
     }
 
@@ -441,6 +464,10 @@ public final class XdtoWriter
      * {@code Package.getProperties()} - package-global - or {@code ObjectType.getProperties()} - object
      * members), or {@code null} when not found. Case-sensitive for the same reason as
      * {@link #findObjectType} (an XDTO/XML QName local name is case-sensitive).
+     *
+     * <p>On an EXACT miss, retries once with the yo-normalized {@code name} - see
+     * {@link #findObjectType}'s javadoc for the full rationale (the SAME create-time normalization /
+     * later-lookup mismatch applies to a Property's own name).</p>
      */
     public static Property findProperty(EList<Property> owner, String name)
     {
@@ -453,6 +480,17 @@ public final class XdtoWriter
             if (name.equals(property.getName()))
             {
                 return property;
+            }
+        }
+        String yoNormalized = MdNameNormalizer.normalizeYo(name);
+        if (!name.equals(yoNormalized))
+        {
+            for (Property property : owner)
+            {
+                if (yoNormalized.equals(property.getName()))
+                {
+                    return property;
+                }
             }
         }
         return null;
@@ -486,6 +524,112 @@ public final class XdtoWriter
     public static void removeProperty(EList<Property> owner, Property property)
     {
         owner.remove(property);
+    }
+
+    // ==================== namespace cascade (maintainer request) ====================
+    //
+    // modify_metadata's own xdtoNamespaceChange handling (ModifyMetadataTool#applyGenericPropertyChanges)
+    // re-syncs the CHANGED package's own content nsUri to its new namespace - but every OTHER package of
+    // the same configuration that either imports the OLD namespace, or references one of the changed
+    // package's types via a QName carrying the OLD nsUri, is left dangling (the maintainer's exact
+    // complaint: renaming one package's namespace silently breaks a DIFFERENT, unrelated package, not
+    // this one). rewriteNamespaceReferences is the PURE per-package rewrite; the caller
+    // (ModifyMetadataTool) enumerates every OTHER XDTOPackage of the configuration,
+    // materializes each one's content via resolvePackageContent, and applies this to it.
+
+    /**
+     * Rewrites every reference to {@code oldNs} found in {@code content} to {@code newNs}: an
+     * {@link Import} in {@code content.getDependencies()} whose {@code namespace} equals {@code oldNs};
+     * a {@link Property}'s {@code type} / {@code ref} QName - both PACKAGE-GLOBAL
+     * ({@code content.getProperties()}) and NESTED in every {@link ObjectType}
+     * ({@code content.getObjects()}) - whose {@code nsUri} equals {@code oldNs}; an {@link ObjectType}'s
+     * or a {@link ValueType}'s own {@code baseType} QName (both extend {@link Type}, which is where
+     * {@code baseType} actually lives - an ObjectType can extend/restrict a type in another namespace
+     * exactly like a Property can reference one, so it carries the SAME dangling-reference risk as a
+     * ValueType's); and each {@link ValueType}'s {@link Enumeration}'s own {@code type} QName. A
+     * Property's {@code getTypeDefs()} (an anonymous INLINE type definition, not a QName reference) is
+     * deliberately NOT touched - it has no {@code nsUri} of its own to go stale, and this codebase never
+     * authors one.
+     *
+     * <p>Pure - mutates {@code content} in place and returns whether anything changed; does not touch BM,
+     * does not force-export (the caller decides what to do with a {@code true} result).</p>
+     *
+     * @param content the OTHER package's content to rewrite (never the changed package's own content -
+     *            that one is re-synced by {@link #resolvePackageContent} already)
+     * @param oldNs the namespace being replaced
+     * @param newNs the namespace to replace it with
+     * @return {@code true} when at least one reference was rewritten (the caller must force-export this
+     *         package), {@code false} when nothing matched {@code oldNs} (nothing to export)
+     */
+    public static boolean rewriteNamespaceReferences(Package content, String oldNs, String newNs)
+    {
+        if (content == null || oldNs == null || newNs == null)
+        {
+            return false;
+        }
+        boolean changed = false;
+        for (Import dependency : content.getDependencies())
+        {
+            if (oldNs.equals(dependency.getNamespace()))
+            {
+                dependency.setNamespace(newNs);
+                changed = true;
+            }
+        }
+        changed |= rewritePropertyQNames(content.getProperties(), oldNs, newNs);
+        for (ObjectType type : content.getObjects())
+        {
+            changed |= rewriteBaseType(type, oldNs, newNs);
+            changed |= rewritePropertyQNames(type.getProperties(), oldNs, newNs);
+        }
+        for (ValueType type : content.getTypes())
+        {
+            changed |= rewriteBaseType(type, oldNs, newNs);
+            for (Enumeration enumeration : type.getEnumerations())
+            {
+                QName qname = enumeration.getType();
+                if (qname != null && oldNs.equals(qname.getNsUri()))
+                {
+                    qname.setNsUri(newNs);
+                    changed = true;
+                }
+            }
+        }
+        return changed;
+    }
+
+    /** Rewrites {@code type}/{@code ref} on every Property in {@code properties} whose nsUri is {@code oldNs}. */
+    private static boolean rewritePropertyQNames(EList<Property> properties, String oldNs, String newNs)
+    {
+        boolean changed = false;
+        for (Property property : properties)
+        {
+            QName type = property.getType();
+            if (type != null && oldNs.equals(type.getNsUri()))
+            {
+                type.setNsUri(newNs);
+                changed = true;
+            }
+            QName ref = property.getRef();
+            if (ref != null && oldNs.equals(ref.getNsUri()))
+            {
+                ref.setNsUri(newNs);
+                changed = true;
+            }
+        }
+        return changed;
+    }
+
+    /** Rewrites an ObjectType's/ValueType's own {@code baseType} QName (via the shared {@link Type}) when it is {@code oldNs}. */
+    private static boolean rewriteBaseType(Type type, String oldNs, String newNs)
+    {
+        QName baseType = type.getBaseType();
+        if (baseType != null && oldNs.equals(baseType.getNsUri()))
+        {
+            baseType.setNsUri(newNs);
+            return true;
+        }
+        return false;
     }
 
     // ==================== apply (typed attribute writes) ====================
@@ -537,7 +681,12 @@ public final class XdtoWriter
      */
     public static Result applyObjectTypeProperties(ObjectType type, List<JsonObject> properties)
     {
-        Map<String, JsonElement> values = toMap(properties);
+        MapResult mapResult = toMap(properties);
+        if (mapResult.error != null)
+        {
+            return Result.failed(mapResult.error);
+        }
+        Map<String, JsonElement> values = mapResult.values;
         String unknown = firstUnknownKey(values.keySet(), OBJECT_TYPE_PROPS);
         if (unknown != null)
         {
@@ -606,7 +755,12 @@ public final class XdtoWriter
     public static Result applyPropertyProperties(Property property, Package pkg, List<JsonObject> properties,
         boolean requireType)
     {
-        Map<String, JsonElement> values = toMap(properties);
+        MapResult mapResult = toMap(properties);
+        if (mapResult.error != null)
+        {
+            return Result.failed(mapResult.error);
+        }
+        Map<String, JsonElement> values = mapResult.values;
         if (values.containsKey("ref")) //$NON-NLS-1$
         {
             return Result.failed(ToolResult.error("Property 'ref' (a global-property reference) is not " //$NON-NLS-1$
@@ -929,6 +1083,17 @@ public final class XdtoWriter
         {
             return QNameResult.failed(importError);
         }
+        // The object form's 'name' is free-text (unlike the bare-STRING shorthand, whose same-package
+        // ObjectType branch never reaches here): when the RESOLVED namespace is XSD, the name must still
+        // be one of the whitelisted built-ins, or a typo like {name:'strng'} (explicit or via the
+        // omitted-nsUri default) would silently persist an invalid 'xs:strng' reference (issue #183 P2 -
+        // the bare-string shorthand already rejects this; the object form did not).
+        if (XSD_NS.equals(resolvedNsUri) && !XSD_BUILTIN_TYPES.contains(name))
+        {
+            return QNameResult.failed(ToolResult.error(fieldLabel + " name '" + name + "' is not a " //$NON-NLS-1$ //$NON-NLS-2$
+                + "built-in XSD type (e.g. 'string', 'boolean', 'decimal', 'dateTime', 'date', 'int'); " //$NON-NLS-1$
+                + "the XSD namespace only accepts a built-in type name.").toJson()); //$NON-NLS-1$
+        }
         QName qname = McoreFactory.eINSTANCE.createQName();
         qname.setNsUri(resolvedNsUri);
         qname.setName(name);
@@ -965,27 +1130,60 @@ public final class XdtoWriter
     // ==================== JSON helpers ====================
 
     /**
-     * Flattens the raw {@code [{name, value, language?}]} property entries into a {@code name -> value}
-     * map (last entry wins on a repeated name). An entry missing a non-empty {@code name} or a
-     * {@code value} is skipped.
+     * The outcome of {@link #toMap}: exactly one of {@link #values} / {@link #error} is non-null.
      */
-    private static Map<String, JsonElement> toMap(List<JsonObject> properties)
+    private static final class MapResult
+    {
+        final Map<String, JsonElement> values;
+        final String error;
+
+        private MapResult(Map<String, JsonElement> values, String error)
+        {
+            this.values = values;
+            this.error = error;
+        }
+
+        static MapResult of(Map<String, JsonElement> values)
+        {
+            return new MapResult(values, null);
+        }
+
+        static MapResult failed(String error)
+        {
+            return new MapResult(null, error);
+        }
+    }
+
+    /**
+     * Flattens the raw {@code [{name, value, language?}]} property entries into a {@code name -> value}
+     * map (last entry wins on a repeated name). An entry missing a non-empty {@code name} is skipped (it
+     * addresses nothing actionable). An entry that HAS a non-empty {@code name} but NO {@code value} at
+     * all is a HARD ERROR (issue #183 P2), not a silent drop: {@code toMap} used to skip it the same way
+     * as an unnamed entry, so a caller that mistyped {@code {name:'open'}} (forgetting {@code value})
+     * saw the tool report SUCCESS with that property silently missing from {@code applied} - actionable
+     * only if the caller happened to notice the shorter list.
+     */
+    private static MapResult toMap(List<JsonObject> properties)
     {
         Map<String, JsonElement> map = new LinkedHashMap<>();
         if (properties == null)
         {
-            return map;
+            return MapResult.of(map);
         }
         for (JsonObject entry : properties)
         {
             String name = stringMember(entry, "name"); //$NON-NLS-1$
-            if (name == null || name.isEmpty() || !entry.has("value")) //$NON-NLS-1$
+            if (name == null || name.isEmpty())
             {
                 continue;
             }
+            if (!entry.has("value")) //$NON-NLS-1$
+            {
+                return MapResult.failed(ToolResult.error("Property '" + name + "' has no 'value'.").toJson()); //$NON-NLS-1$ //$NON-NLS-2$
+            }
             map.put(name, entry.get("value")); //$NON-NLS-1$
         }
-        return map;
+        return MapResult.of(map);
     }
 
     /** The first key in {@code keys} that is NOT in {@code allowed}, or {@code null} when all are known. */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
@@ -469,13 +469,19 @@ public final class XdtoWriter
      */
     public static Type findLocalType(Package pkg, String name)
     {
-        ObjectType objectType = findObjectType(pkg, name);
-        if (objectType != null || pkg == null || name == null)
+        if (pkg == null || name == null)
         {
-            return objectType;
+            return null;
         }
-        // Exact pass FIRST, yo fallback second (mirrors findObjectType): a yo-normalized match
-        // earlier in the list must never shadow an exact match later in it.
+        // ALL exact passes precede ANY yo fallback: an ObjectType yo-match must not shadow a
+        // ValueType stored under the exact requested spelling (and vice versa).
+        for (ObjectType type : pkg.getObjects())
+        {
+            if (name.equals(type.getName()))
+            {
+                return type;
+            }
+        }
         for (ValueType valueType : pkg.getTypes())
         {
             if (name.equals(valueType.getName()))
@@ -486,6 +492,13 @@ public final class XdtoWriter
         String yoNormalized = MdNameNormalizer.normalizeYo(name);
         if (!name.equals(yoNormalized))
         {
+            for (ObjectType type : pkg.getObjects())
+            {
+                if (yoNormalized.equals(type.getName()))
+                {
+                    return type;
+                }
+            }
             for (ValueType valueType : pkg.getTypes())
             {
                 if (yoNormalized.equals(valueType.getName()))
@@ -1169,11 +1182,44 @@ public final class XdtoWriter
             }
             name = localTarget.getName();
         }
+        // An IMPORTED-namespace name is free text so far - the XSD branch has its whitelist and
+        // the own-namespace branch resolves a real local type, but an imported name like
+        // "123 bad" would persist an invalid XML local name.
+        if (!isNcNameLite(name))
+        {
+            return QNameResult.failed(ToolResult.error(fieldLabel + " name " + QUOTE + name + QUOTE + " is not a " //$NON-NLS-1$ //$NON-NLS-2$
+                + "valid XML type name (must start with a letter or underscore and contain only " //$NON-NLS-1$
+                + "letters, digits, underscores, dots or hyphens).").toJson()); //$NON-NLS-1$
+        }
         QName qname = McoreFactory.eINSTANCE.createQName();
         qname.setNsUri(resolvedNsUri);
         qname.setName(name);
         return QNameResult.of(qname);
     }
+
+    /** XML NCName-lite: letter/underscore start; letters, digits, underscore, dot, hyphen after. */
+    private static boolean isNcNameLite(String name)
+    {
+        if (name == null || name.isEmpty()
+            || (!Character.isLetter(name.charAt(0)) && name.charAt(0) != UNDERSCORE))
+        {
+            return false;
+        }
+        for (int i = 1; i < name.length(); i++)
+        {
+            char c = name.charAt(i);
+            if (!Character.isLetterOrDigit(c) && c != UNDERSCORE && c != DOT && c != HYPHEN)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static final String QUOTE = String.valueOf((char)39); // apostrophe, kept out of the literal
+    private static final char UNDERSCORE = 95;   // underscore
+    private static final char DOT = 46;          // .
+    private static final char HYPHEN = 45;       // -
 
     /**
      * Validates that {@code nsUri} is REACHABLE from {@code pkg}: the XSD namespace and the package's
@@ -1310,7 +1356,9 @@ public final class XdtoWriter
     private static Integer intProp(Map<String, JsonElement> values, String key)
     {
         JsonElement element = values.get(key);
-        if (element == null || !element.isJsonPrimitive())
+        // Strict NUMERIC primitive: a stringified bound ("2") is malformed input, not something to
+        // coerce - the contract documents these as integers (mirrors the strict string fields).
+        if (element == null || !element.isJsonPrimitive() || !element.getAsJsonPrimitive().isNumber())
         {
             return null;
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
@@ -1097,12 +1097,18 @@ public final class XdtoWriter
         // Same parity for the package's OWN namespace: the bare-string shorthand only resolves to an
         // ObjectType that actually exists, so the object form must not silently persist a dangling
         // same-package reference (e.g. {nsUri: <own ns>, name: 'Adress'} with no such ObjectType).
-        if (pkg != null && !XSD_NS.equals(resolvedNsUri) && resolvedNsUri.equals(pkg.getNsUri())
-            && findObjectType(pkg, name) == null)
+        // The persisted name is the RESOLVED ObjectType's stored name: findObjectType tolerates a yo
+        // spelling variant, and serializing the raw input would dangle against the stored name.
+        if (pkg != null && !XSD_NS.equals(resolvedNsUri) && resolvedNsUri.equals(pkg.getNsUri()))
         {
-            return QNameResult.failed(ToolResult.error(fieldLabel + " name '" + name + "' does not match " //$NON-NLS-1$ //$NON-NLS-2$
-                + "any ObjectType in this package (its own namespace '" + resolvedNsUri + "'). Create " //$NON-NLS-1$ //$NON-NLS-2$
-                + "the ObjectType first, or reference an imported / XSD type.").toJson()); //$NON-NLS-1$
+            ObjectType localTarget = findObjectType(pkg, name);
+            if (localTarget == null)
+            {
+                return QNameResult.failed(ToolResult.error(fieldLabel + " name '" + name + "' does not match " //$NON-NLS-1$ //$NON-NLS-2$
+                    + "any ObjectType in this package (its own namespace '" + resolvedNsUri + "'). Create " //$NON-NLS-1$ //$NON-NLS-2$
+                    + "the ObjectType first, or reference an imported / XSD type.").toJson()); //$NON-NLS-1$
+            }
+            name = localTarget.getName();
         }
         QName qname = McoreFactory.eINSTANCE.createQName();
         qname.setNsUri(resolvedNsUri);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
@@ -467,6 +467,44 @@ public final class XdtoWriter
      *
      * @return the matching type, or {@code null}
      */
+    /**
+     * EXACT-name ObjectType lookup, NO yo fallback: used by create-time duplicate checks, where the
+     * yo-tolerant {@link #findObjectType} would wrongly flag a distinct name differing only by yo as
+     * a duplicate (XDTO local names are character-sensitive).
+     */
+    public static ObjectType findObjectTypeExact(Package pkg, String name)
+    {
+        if (pkg == null || name == null)
+        {
+            return null;
+        }
+        for (ObjectType type : pkg.getObjects())
+        {
+            if (name.equals(type.getName()))
+            {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    /** EXACT-name Property lookup, NO yo fallback (see {@link #findObjectTypeExact}). */
+    public static Property findPropertyExact(EList<Property> owner, String name)
+    {
+        if (owner == null || name == null)
+        {
+            return null;
+        }
+        for (Property property : owner)
+        {
+            if (name.equals(property.getName()))
+            {
+                return property;
+            }
+        }
+        return null;
+    }
+
     public static Type findLocalType(Package pkg, String name)
     {
         if (pkg == null || name == null)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
@@ -1094,6 +1094,16 @@ public final class XdtoWriter
                 + "built-in XSD type (e.g. 'string', 'boolean', 'decimal', 'dateTime', 'date', 'int'); " //$NON-NLS-1$
                 + "the XSD namespace only accepts a built-in type name.").toJson()); //$NON-NLS-1$
         }
+        // Same parity for the package's OWN namespace: the bare-string shorthand only resolves to an
+        // ObjectType that actually exists, so the object form must not silently persist a dangling
+        // same-package reference (e.g. {nsUri: <own ns>, name: 'Adress'} with no such ObjectType).
+        if (pkg != null && !XSD_NS.equals(resolvedNsUri) && resolvedNsUri.equals(pkg.getNsUri())
+            && findObjectType(pkg, name) == null)
+        {
+            return QNameResult.failed(ToolResult.error(fieldLabel + " name '" + name + "' does not match " //$NON-NLS-1$ //$NON-NLS-2$
+                + "any ObjectType in this package (its own namespace '" + resolvedNsUri + "'). Create " //$NON-NLS-1$ //$NON-NLS-2$
+                + "the ObjectType first, or reference an imported / XSD type.").toJson()); //$NON-NLS-1$
+        }
         QName qname = McoreFactory.eINSTANCE.createQName();
         qname.setNsUri(resolvedNsUri);
         qname.setName(name);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
@@ -374,6 +374,11 @@ public final class XdtoWriter
             fqnGenerator.generateExternalPropertyFqn(txPkg, MdClassPackage.Literals.XDTO_PACKAGE__PACKAGE);
         if (contentFqn == null || contentFqn.isEmpty())
         {
+            // UNDO the just-set reference: leaving the owner pointing at a fresh, UNATTACHED Package
+            // would make the surrounding transaction fail at commit ("Failed to persist reference
+            // value") even for callers that treat this resolution as best-effort (the top-level
+            // XDTOPackage create). The owner is then created cleanly WITHOUT content.
+            txPkg.setPackage(null);
             return ContentResolution.failed(ToolResult.error("Could not generate the content resource FQN " //$NON-NLS-1$
                 + "for the XDTO package; report it with the package FQN.").toJson()); //$NON-NLS-1$
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/XdtoWriter.java
@@ -488,6 +488,134 @@ public final class XdtoWriter
         return null;
     }
 
+    /**
+     * Rewrites STALE SELF-REFERENCES only, walking the SAME recursive surface as
+     * {@link #rewriteNamespaceReferences} (properties incl. anonymous nested {@code typeDefs} trees,
+     * baseType / itemType / union member / enumeration QNames at every depth). A QName whose
+     * {@code nsUri} equals {@code staleNs} is moved to {@code ownNs} ONLY when its local name matches
+     * (exactly) a symbol of THIS content in the QName's OWN symbol space: a {@code type}-position
+     * QName against the local ObjectTypes/ValueTypes, a {@code ref} QName against the PACKAGE-GLOBAL
+     * properties. That disambiguation keeps a GENUINE reference into another package (whose namespace
+     * happens to equal the stale value, e.g. a rename-collision) untouched for the broader cascade
+     * rewrite to handle. Imports are deliberately NOT touched (importing one's own namespace is
+     * meaningless - an import of the stale value is a remote reference by construction).
+     *
+     * @return {@code true} when at least one QName was rewritten
+     */
+    public static boolean rewriteStaleSelfReferences(Package content, String staleNs, String ownNs)
+    {
+        if (content == null || staleNs == null || ownNs == null || staleNs.equals(ownNs))
+        {
+            return false;
+        }
+        boolean changed = selfRewriteProperties(content.getProperties(), content, staleNs, ownNs);
+        for (ObjectType type : content.getObjects())
+        {
+            changed |= selfRewriteTypeTree(type, content, staleNs, ownNs);
+        }
+        for (ValueType type : content.getTypes())
+        {
+            changed |= selfRewriteTypeTree(type, content, staleNs, ownNs);
+        }
+        return changed;
+    }
+
+    /** Recursive self-pass mirror of {@link #rewriteTypeTree}: every TYPE-space QName (baseType,
+     * itemType, union members, enumeration types) at any nesting depth is disambiguated against the
+     * content's local types; nested anonymous {@code typeDefs} are walked too. */
+    private static boolean selfRewriteTypeTree(Type type, Package content, String staleNs, String ownNs)
+    {
+        boolean changed = retargetSelfTypeQName(type.getBaseType(), content, staleNs, ownNs);
+        if (type instanceof ObjectType)
+        {
+            changed |= selfRewriteProperties(((ObjectType)type).getProperties(), content, staleNs, ownNs);
+        }
+        if (type instanceof ValueType)
+        {
+            ValueType valueType = (ValueType)type;
+            changed |= retargetSelfTypeQName(valueType.getItemType(), content, staleNs, ownNs);
+            for (QName member : valueType.getMemeberTypes())
+            {
+                changed |= retargetSelfTypeQName(member, content, staleNs, ownNs);
+            }
+            for (Enumeration enumeration : valueType.getEnumerations())
+            {
+                changed |= retargetSelfTypeQName(enumeration.getType(), content, staleNs, ownNs);
+            }
+            for (Type nested : valueType.getTypeDefs())
+            {
+                changed |= selfRewriteTypeTree(nested, content, staleNs, ownNs);
+            }
+        }
+        return changed;
+    }
+
+    /** Self-pass property walk: type QNames against the TYPE space, ref QNames against PACKAGE-GLOBAL
+     * properties, plus each property's anonymous nested {@code typeDefs} tree. */
+    private static boolean selfRewriteProperties(EList<Property> properties, Package content,
+        String staleNs, String ownNs)
+    {
+        boolean changed = false;
+        for (Property property : properties)
+        {
+            changed |= retargetSelfTypeQName(property.getType(), content, staleNs, ownNs);
+            changed |= retargetSelfRefQName(property.getRef(), content, staleNs, ownNs);
+            if (property.getTypeDefs() != null)
+            {
+                changed |= selfRewriteTypeTree(property.getTypeDefs(), content, staleNs, ownNs);
+            }
+        }
+        return changed;
+    }
+
+    /** Self-retarget for a TYPE-space QName: the local name must match a local ObjectType/ValueType. */
+    private static boolean retargetSelfTypeQName(QName qname, Package content, String staleNs, String ownNs)
+    {
+        if (qname == null || !staleNs.equals(qname.getNsUri()))
+        {
+            return false;
+        }
+        String local = qname.getName();
+        if (findObjectTypeExact(content, local) == null && findValueTypeExact(content, local) == null)
+        {
+            return false;
+        }
+        qname.setNsUri(ownNs);
+        return true;
+    }
+
+    /** Self-retarget for a REF QName: refs target PACKAGE-GLOBAL properties, not types. */
+    private static boolean retargetSelfRefQName(QName qname, Package content, String staleNs, String ownNs)
+    {
+        if (qname == null || !staleNs.equals(qname.getNsUri()))
+        {
+            return false;
+        }
+        if (findPropertyExact(content.getProperties(), qname.getName()) == null)
+        {
+            return false;
+        }
+        qname.setNsUri(ownNs);
+        return true;
+    }
+
+    /** EXACT-name local ValueType lookup, NO yo fallback (see {@link #findObjectTypeExact}). */
+    public static ValueType findValueTypeExact(Package pkg, String name)
+    {
+        if (pkg == null || name == null)
+        {
+            return null;
+        }
+        for (ValueType valueType : pkg.getTypes())
+        {
+            if (name.equals(valueType.getName()))
+            {
+                return valueType;
+            }
+        }
+        return null;
+    }
+
     /** EXACT-name Property lookup, NO yo fallback (see {@link #findObjectTypeExact}). */
     public static Property findPropertyExact(EList<Property> owner, String name)
     {
@@ -633,12 +761,11 @@ public final class XdtoWriter
      * ({@code content.getProperties()}) and NESTED in every {@link ObjectType}
      * ({@code content.getObjects()}) - whose {@code nsUri} equals {@code oldNs}; an {@link ObjectType}'s
      * or a {@link ValueType}'s own {@code baseType} QName (both extend {@link Type}, which is where
-     * {@code baseType} actually lives - an ObjectType can extend/restrict a type in another namespace
-     * exactly like a Property can reference one, so it carries the SAME dangling-reference risk as a
-     * ValueType's); and each {@link ValueType}'s {@link Enumeration}'s own {@code type} QName. A
-     * Property's {@code getTypeDefs()} (an anonymous INLINE type definition, not a QName reference) is
-     * deliberately NOT touched - it has no {@code nsUri} of its own to go stale, and this codebase never
-     * authors one.
+     * {@code baseType} actually lives); a {@link ValueType}'s {@code itemType} (list) and
+     * {@code getMemeberTypes()} (union - the EDT API's own spelling) QNames and each of its
+     * {@link Enumeration}'s {@code type} QNames; and the WHOLE anonymous nested {@code typeDefs}
+     * tree (a Property's single nested Type and a ValueType's list of them) - nested definitions
+     * recursively carry the same QName surface, so the walk covers every depth.
      *
      * <p>Pure - mutates {@code content} in place and returns whether anything changed; does not touch BM,
      * does not force-export (the caller decides what to do with a {@code true} result).</p>
@@ -668,31 +795,70 @@ public final class XdtoWriter
         changed |= rewritePropertyQNames(content.getProperties(), oldNs, newNs);
         for (ObjectType type : content.getObjects())
         {
-            changed |= rewriteBaseType(type, oldNs, newNs);
-            changed |= rewritePropertyQNames(type.getProperties(), oldNs, newNs);
+            changed |= rewriteTypeTree(type, oldNs, newNs);
         }
         for (ValueType type : content.getTypes())
         {
-            changed |= rewriteBaseType(type, oldNs, newNs);
-            for (Enumeration enumeration : type.getEnumerations())
+            changed |= rewriteTypeTree(type, oldNs, newNs);
+        }
+        return changed;
+    }
+
+    /**
+     * Recursive per-type rewrite for the broad pass: baseType, an ObjectType's properties (each of
+     * which may carry an ANONYMOUS nested {@code typeDefs} type), a ValueType's itemType / union
+     * member types / enumeration types and its own nested {@code typeDefs} - the model nests type
+     * definitions arbitrarily deep, and a QName at any depth can carry the old namespace.
+     */
+    private static boolean rewriteTypeTree(Type type, String oldNs, String newNs)
+    {
+        boolean changed = retargetQName(type.getBaseType(), oldNs, newNs);
+        if (type instanceof ObjectType)
+        {
+            changed |= rewritePropertyQNames(((ObjectType)type).getProperties(), oldNs, newNs);
+        }
+        if (type instanceof ValueType)
+        {
+            ValueType valueType = (ValueType)type;
+            changed |= retargetQName(valueType.getItemType(), oldNs, newNs);
+            for (QName member : valueType.getMemeberTypes())
             {
-                QName qname = enumeration.getType();
-                if (qname != null && oldNs.equals(qname.getNsUri()))
-                {
-                    qname.setNsUri(newNs);
-                    changed = true;
-                }
+                changed |= retargetQName(member, oldNs, newNs);
+            }
+            for (Enumeration enumeration : valueType.getEnumerations())
+            {
+                changed |= retargetQName(enumeration.getType(), oldNs, newNs);
+            }
+            for (Type nested : valueType.getTypeDefs())
+            {
+                changed |= rewriteTypeTree(nested, oldNs, newNs);
             }
         }
         return changed;
     }
 
-    /** Rewrites {@code type}/{@code ref} on every Property in {@code properties} whose nsUri is {@code oldNs}. */
+    /** Moves {@code qname} from {@code oldNs} to {@code newNs}; {@code false} when null/other ns. */
+    private static boolean retargetQName(QName qname, String oldNs, String newNs)
+    {
+        if (qname == null || !oldNs.equals(qname.getNsUri()))
+        {
+            return false;
+        }
+        qname.setNsUri(newNs);
+        return true;
+    }
+
+    /** Rewrites {@code type}/{@code ref} (and any anonymous nested {@code typeDefs} tree) on every
+     * Property in {@code properties} whose QNames carry {@code oldNs}. */
     private static boolean rewritePropertyQNames(EList<Property> properties, String oldNs, String newNs)
     {
         boolean changed = false;
         for (Property property : properties)
         {
+            if (property.getTypeDefs() != null)
+            {
+                changed |= rewriteTypeTree(property.getTypeDefs(), oldNs, newNs);
+            }
             QName type = property.getType();
             if (type != null && oldNs.equals(type.getNsUri()))
             {
@@ -707,18 +873,6 @@ public final class XdtoWriter
             }
         }
         return changed;
-    }
-
-    /** Rewrites an ObjectType's/ValueType's own {@code baseType} QName (via the shared {@link Type}) when it is {@code oldNs}. */
-    private static boolean rewriteBaseType(Type type, String oldNs, String newNs)
-    {
-        QName baseType = type.getBaseType();
-        if (baseType != null && oldNs.equals(baseType.getNsUri()))
-        {
-            baseType.setNsUri(newNs);
-            return true;
-        }
-        return false;
     }
 
     // ==================== apply (typed attribute writes) ====================

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataToolTest.java
@@ -384,4 +384,47 @@ public class CreateMetadataToolTest
         assertTrue("guide should document nested-object members", //$NON-NLS-1$
             guide.contains("tabular-section attribute")); //$NON-NLS-1$
     }
+
+    // ===== XDTO package member creation (issue #183 stream 1) - schema/description contract ==========
+    //
+    // create_metadata's execute() needs a live workbench + BM model, so the ObjectType/Property write
+    // path itself (XdtoWriter.createObjectType / createProperty / applyObjectTypeProperties /
+    // applyPropertyProperties, the FQN grammar XdtoWriter.parseMemberRef) is unit-tested headlessly in
+    // XdtoWriterTest; the live materialize + attach + force-export is covered by the E2E suite. Here:
+    // the wire-contract surface (description / schema) documents the new FQN shapes and vocabulary.
+
+    @Test
+    public void testDescriptionDocumentsXdtoPackageMembers()
+    {
+        String desc = new CreateMetadataTool().getDescription();
+        assertTrue("description should mention the ObjectType member FQN shape", //$NON-NLS-1$
+            desc.contains("ObjectType")); //$NON-NLS-1$
+        assertTrue("description should mention a nested Property member FQN shape", //$NON-NLS-1$
+            desc.contains("XDTOPackage.<Package>.ObjectType.<Type>.Property.<Name>")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testPropertiesDescriptionDocumentsXdtoVocabulary()
+    {
+        String schema = new CreateMetadataTool().getInputSchema();
+        // The 'properties' array is reused (not a new payload key) for XDTO members - its description
+        // must document the different vocabulary (ObjectType flags, Property attributes incl. the
+        // REQUIRED 'type').
+        int propsIdx = schema.indexOf("\"properties\""); //$NON-NLS-1$
+        assertTrue(propsIdx >= 0);
+        String tail = schema.substring(propsIdx);
+        assertTrue("properties doc should mention the ObjectType 'open' flag", tail.contains("'open'")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("properties doc should mention the REQUIRED Property 'type'", //$NON-NLS-1$
+            tail.contains("REQUIRES 'type'")); //$NON-NLS-1$
+        assertTrue("properties doc should mention 'lowerBound'/'upperBound'", //$NON-NLS-1$
+            tail.contains("lowerBound")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testOutputSchemaDeclaresApplied()
+    {
+        String schema = new CreateMetadataTool().getOutputSchema();
+        assertTrue("output schema must declare 'applied' (XDTO member create counts)", //$NON-NLS-1$
+            schema.contains("\"applied\"")); //$NON-NLS-1$
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataToolTest.java
@@ -21,6 +21,7 @@ import com._1c.g5.v8.dt.metadata.mdclass.ReturnValuesReuse;
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 import com.ditrix.edt.mcp.server.tools.impl.CreateMetadataTool.CommonModuleFlags;
 import com.ditrix.edt.mcp.server.tools.impl.CreateMetadataTool.CommonModuleKind;
+import com.ditrix.edt.mcp.server.utils.MetadataLanguageUtils;
 
 /**
  * Lightweight contract tests for {@link CreateMetadataTool}: tool metadata and JSON schema,
@@ -418,6 +419,32 @@ public class CreateMetadataToolTest
             tail.contains("REQUIRES 'type'")); //$NON-NLS-1$
         assertTrue("properties doc should mention 'lowerBound'/'upperBound'", //$NON-NLS-1$
             tail.contains("lowerBound")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testCreateMemberOwnerLookupToleratesYoSpelledObjectTypeName()
+    {
+        // issue #183 P2 #4: createXdtoMemberInTx's OBJECT_TYPE_PROPERTY branch (creating a nested
+        // Property) looks up its OWNER ObjectType via XdtoWriter.findObjectType, using the FQN's OWNER
+        // segment - which, unlike the FQN LEAF, is NEVER yo-normalized on the way in
+        // (CreateMetadataTool#normalizeLeafName only touches the trailing leaf segment). When the
+        // ObjectType itself was created earlier from a yo-spelled name (and is therefore stored
+        // yo-normalized), a LATER nested-Property create whose FQN still spells the OWNER segment with
+        // the original "yo" must still resolve it - findObjectType now falls back to the yo-normalized
+        // stored name on an exact miss.
+        com._1c.g5.v8.dt.xdto.model.Package pkg =
+            com._1c.g5.v8.dt.xdto.model.XdtoFactory.eINSTANCE.createPackage();
+        com._1c.g5.v8.dt.xdto.model.ObjectType owner =
+            com._1c.g5.v8.dt.xdto.model.XdtoFactory.eINSTANCE.createObjectType();
+        // "Zakaz-e" (a Russian word for "order"), yo-normalized - the spelling create_metadata stores.
+        owner.setName(MetadataLanguageUtils.cp(0x0417, 0x0430, 0x043a, 0x0430, 0x0437, 0x0435));
+        pkg.getObjects().add(owner);
+
+        // The SAME word, but spelled with the ORIGINAL "yo" - as a later nested-Property create's FQN
+        // owner segment might still be.
+        String yoSpelledOwnerName = MetadataLanguageUtils.cp(0x0417, 0x0430, 0x043a, 0x0430, 0x0437, 0x0451);
+        assertEquals("the OBJECT_TYPE_PROPERTY owner lookup must tolerate a yo-spelled owner segment", //$NON-NLS-1$
+            owner, com.ditrix.edt.mcp.server.utils.XdtoWriter.findObjectType(pkg, yoSpelledOwnerName));
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataToolTest.java
@@ -26,6 +26,7 @@ import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 import com.ditrix.edt.mcp.server.utils.FormElementWriter;
 import com.ditrix.edt.mcp.server.utils.FormElementWriter.FormObjectRef;
+import com.ditrix.edt.mcp.server.utils.MetadataLanguageUtils;
 
 /**
  * Lightweight contract tests for {@link DeleteMetadataTool}: tool metadata and JSON schema, without
@@ -496,6 +497,29 @@ public class DeleteMetadataToolTest
         String[] found = DeleteMetadataTool.locateXdtoMember(pkg, ref);
         assertNotNull("a nested Property must be located", found); //$NON-NLS-1$
         assertEquals("Property", found[0]); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testLocateXdtoMemberToleratesYoSpelledLookup()
+    {
+        // issue #183 P2 #4: locateXdtoMember delegates to XdtoWriter.findObjectType, which now falls
+        // back to the yo-normalized stored name on an exact miss - so delete_metadata's own preview
+        // (and, by the SAME shared helper, the actual delete) resolves a member even when the request
+        // FQN still spells its name with the original "yo" that create_metadata normalized away.
+        com._1c.g5.v8.dt.xdto.model.Package pkg = fixturePackage();
+        com._1c.g5.v8.dt.xdto.model.ObjectType type =
+            com._1c.g5.v8.dt.xdto.model.XdtoFactory.eINSTANCE.createObjectType();
+        // "Zakaz-e" (a Russian word for "order"), yo-normalized - the spelling create_metadata stores.
+        type.setName(MetadataLanguageUtils.cp(0x0417, 0x0430, 0x043a, 0x0430, 0x0437, 0x0435));
+        pkg.getObjects().add(type);
+
+        // The SAME word, but spelled with the ORIGINAL "yo".
+        String yoSpelledName = MetadataLanguageUtils.cp(0x0417, 0x0430, 0x043a, 0x0430, 0x0437, 0x0451);
+        com.ditrix.edt.mcp.server.utils.XdtoWriter.MemberRef ref = com.ditrix.edt.mcp.server.utils.XdtoWriter
+            .parseMemberRef("XDTOPackage.MyPackage.ObjectType." + yoSpelledName); //$NON-NLS-1$
+        String[] found = DeleteMetadataTool.locateXdtoMember(pkg, ref);
+        assertNotNull("delete_metadata's own locate must tolerate a yo-spelled lookup FQN", found); //$NON-NLS-1$
+        assertEquals("ObjectType", found[0]); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataToolTest.java
@@ -430,4 +430,101 @@ public class DeleteMetadataToolTest
         ref.put("reference", feature); //$NON-NLS-1$
         return ref;
     }
+
+    // ===== XDTO package member deletion (issue #183 stream 1) ========================================
+    //
+    // An XDTO ObjectType/Property member is removed directly (the md-refactoring service is mdclass-only),
+    // mirroring the form-member delete's two-phase shape. execute() needs a live workbench + BM model, so
+    // the write itself is E2E-covered; the pure locate / "not found" message builders (used by BOTH the
+    // rolled-back preview read and the write) are unit-tested here against an in-memory
+    // XdtoFactory-built Package fixture (mirrors XdtoWriterTest).
+
+    private static com._1c.g5.v8.dt.xdto.model.Package fixturePackage()
+    {
+        return com._1c.g5.v8.dt.xdto.model.XdtoFactory.eINSTANCE.createPackage();
+    }
+
+    @Test
+    public void testLocateXdtoMemberFindsObjectType()
+    {
+        com._1c.g5.v8.dt.xdto.model.Package pkg = fixturePackage();
+        com._1c.g5.v8.dt.xdto.model.ObjectType type =
+            com._1c.g5.v8.dt.xdto.model.XdtoFactory.eINSTANCE.createObjectType();
+        type.setName("MyType"); //$NON-NLS-1$
+        pkg.getObjects().add(type);
+
+        com.ditrix.edt.mcp.server.utils.XdtoWriter.MemberRef ref = com.ditrix.edt.mcp.server.utils.XdtoWriter
+            .parseMemberRef("XDTOPackage.MyPackage.ObjectType.MyType"); //$NON-NLS-1$
+        String[] found = DeleteMetadataTool.locateXdtoMember(pkg, ref);
+        assertNotNull("an existing ObjectType must be located", found); //$NON-NLS-1$
+        assertEquals("ObjectType", found[0]); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testLocateXdtoMemberMissingReturnsNull()
+    {
+        com._1c.g5.v8.dt.xdto.model.Package pkg = fixturePackage();
+        com.ditrix.edt.mcp.server.utils.XdtoWriter.MemberRef ref = com.ditrix.edt.mcp.server.utils.XdtoWriter
+            .parseMemberRef("XDTOPackage.MyPackage.ObjectType.Missing"); //$NON-NLS-1$
+        assertNull("a missing ObjectType must not be located", DeleteMetadataTool.locateXdtoMember(pkg, ref)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testLocateXdtoMemberNullContentReturnsNull()
+    {
+        com.ditrix.edt.mcp.server.utils.XdtoWriter.MemberRef ref = com.ditrix.edt.mcp.server.utils.XdtoWriter
+            .parseMemberRef("XDTOPackage.MyPackage.Property.MyProp"); //$NON-NLS-1$
+        assertNull("a never-authored package (null content) must not locate a member", //$NON-NLS-1$
+            DeleteMetadataTool.locateXdtoMember(null, ref));
+    }
+
+    @Test
+    public void testLocateXdtoMemberFindsNestedProperty()
+    {
+        com._1c.g5.v8.dt.xdto.model.Package pkg = fixturePackage();
+        com._1c.g5.v8.dt.xdto.model.ObjectType type =
+            com._1c.g5.v8.dt.xdto.model.XdtoFactory.eINSTANCE.createObjectType();
+        type.setName("MyType"); //$NON-NLS-1$
+        pkg.getObjects().add(type);
+        com._1c.g5.v8.dt.xdto.model.Property property =
+            com._1c.g5.v8.dt.xdto.model.XdtoFactory.eINSTANCE.createProperty();
+        property.setName("MyProp"); //$NON-NLS-1$
+        type.getProperties().add(property);
+
+        com.ditrix.edt.mcp.server.utils.XdtoWriter.MemberRef ref = com.ditrix.edt.mcp.server.utils.XdtoWriter
+            .parseMemberRef("XDTOPackage.MyPackage.ObjectType.MyType.Property.MyProp"); //$NON-NLS-1$
+        String[] found = DeleteMetadataTool.locateXdtoMember(pkg, ref);
+        assertNotNull("a nested Property must be located", found); //$NON-NLS-1$
+        assertEquals("Property", found[0]); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testXdtoMemberNotFoundErrorNamesObjectTypeAndPackage()
+    {
+        com.ditrix.edt.mcp.server.utils.XdtoWriter.MemberRef ref = com.ditrix.edt.mcp.server.utils.XdtoWriter
+            .parseMemberRef("XDTOPackage.MyPackage.ObjectType.Missing"); //$NON-NLS-1$
+        String err = DeleteMetadataTool.xdtoMemberNotFoundError(ref);
+        assertTrue("the refusal must be a ToolResult error json", err.contains("\"error\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(err.contains("Missing")); //$NON-NLS-1$
+        assertTrue(err.contains("XDTOPackage.MyPackage")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testXdtoMemberNotFoundErrorNamesNestedPropertyOwner()
+    {
+        com.ditrix.edt.mcp.server.utils.XdtoWriter.MemberRef ref = com.ditrix.edt.mcp.server.utils.XdtoWriter
+            .parseMemberRef("XDTOPackage.MyPackage.ObjectType.MyType.Property.Missing"); //$NON-NLS-1$
+        String err = DeleteMetadataTool.xdtoMemberNotFoundError(ref);
+        assertTrue("a nested property's not-found error must name its ObjectType owner", //$NON-NLS-1$
+            err.contains("ObjectType.MyType")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testDescriptionDocumentsXdtoPackageMembers()
+    {
+        String desc = new DeleteMetadataTool().getDescription();
+        assertTrue("description should mention the XDTO package member FQN shape", //$NON-NLS-1$
+            desc.contains("XDTOPackage")); //$NON-NLS-1$
+        assertTrue("description should mention the ObjectType member kind", desc.contains("ObjectType")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
@@ -1295,4 +1295,27 @@ public class ModifyMetadataToolTest
         assertTrue("a nested property error must name its owning ObjectType", //$NON-NLS-1$
             nestedErr.contains("ObjectType.MyType")); //$NON-NLS-1$
     }
+
+    @Test
+    public void testModifyMemberLookupToleratesYoSpelledObjectTypeName()
+    {
+        // issue #183 P2 #4: modifyXdtoMemberInTx resolves its target ObjectType/Property via
+        // XdtoWriter.findObjectType / findProperty - the SAME shared lookup create_metadata's owner
+        // lookup and delete_metadata's locateXdtoMember use. It now falls back to the yo-normalized
+        // stored name on an exact miss, so a modify_metadata FQN that still spells an ObjectType's name
+        // with the original "yo" (create_metadata normalizes 'yo'->'ye' in a member's own NAME by
+        // default) resolves it instead of reporting "not found" for a member that in fact exists.
+        com._1c.g5.v8.dt.xdto.model.Package pkg =
+            com._1c.g5.v8.dt.xdto.model.XdtoFactory.eINSTANCE.createPackage();
+        com._1c.g5.v8.dt.xdto.model.ObjectType type =
+            com._1c.g5.v8.dt.xdto.model.XdtoFactory.eINSTANCE.createObjectType();
+        // "Zakaz-e" (a Russian word for "order"), yo-normalized - the spelling create_metadata stores.
+        type.setName(MetadataLanguageUtils.cp(0x0417, 0x0430, 0x043a, 0x0430, 0x0437, 0x0435));
+        pkg.getObjects().add(type);
+
+        // The modify_metadata FQN's target segment, still spelled with the original "yo".
+        String yoSpelledName = MetadataLanguageUtils.cp(0x0417, 0x0430, 0x043a, 0x0430, 0x0437, 0x0451);
+        assertEquals("modifyXdtoMemberInTx's own target resolution must tolerate a yo-spelled FQN segment", //$NON-NLS-1$
+            type, com.ditrix.edt.mcp.server.utils.XdtoWriter.findObjectType(pkg, yoSpelledName));
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
@@ -1220,4 +1220,79 @@ public class ModifyMetadataToolTest
         // Unguarded combo: value passes through unchanged.
         assertEquals("x.y", ModifyMetadataTool.canonicalMethodReference(config, module, "methodName", "x.y")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
     }
+
+    // ===== XDTO package member payload dispatch guards (issue #183 stream 1) =========================
+    //
+    // An XDTO ObjectType/Property member is edited through the SAME 'properties' surface as an ordinary
+    // mdclass member (there is no dedicated 'xdto' payload key, unlike 'dcs'/'template'), so the guard is
+    // narrower: refuse a Role / membership content payload (neither applies to an XDTO member), then
+    // require a non-empty 'properties'. The pure guard (xdtoMemberPayloadError) and the "member not
+    // found" message builders are covered here; the live BM materialize + write + force-export is
+    // covered by the E2E suite.
+
+    @Test
+    public void testXdtoMemberPayloadRefusesRoleAndContentPayloads()
+    {
+        String roleMix = ModifyMetadataTool.xdtoMemberPayloadError("XDTOPackage.MyPackage.ObjectType.MyType", //$NON-NLS-1$
+            true, false, Collections.singletonList(prop("open", "true"))); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNotNull("an XDTO member FQN carrying a Role payload must be refused", roleMix); //$NON-NLS-1$
+        assertTrue("the refusal must be a ToolResult error json", roleMix.contains("\"error\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the refusal must name the offending FQN", //$NON-NLS-1$
+            roleMix.contains("XDTOPackage.MyPackage.ObjectType.MyType")); //$NON-NLS-1$
+        assertTrue("the refusal must point at 'properties'", roleMix.contains("properties")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        String contentMix = ModifyMetadataTool.xdtoMemberPayloadError(
+            "XDTOPackage.MyPackage.Property.MyProp", false, true, //$NON-NLS-1$
+            Collections.singletonList(prop("type", "string"))); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNotNull("an XDTO member FQN carrying a membership content payload must be refused", //$NON-NLS-1$
+            contentMix);
+    }
+
+    @Test
+    public void testXdtoMemberPayloadRequiresNonEmptyProperties()
+    {
+        String empty = ModifyMetadataTool.xdtoMemberPayloadError("XDTOPackage.MyPackage.ObjectType.MyType", //$NON-NLS-1$
+            false, false, Collections.<JsonObject> emptyList());
+        assertNotNull("an XDTO member modify with no 'properties' must be refused", empty); //$NON-NLS-1$
+        assertTrue("the refusal must be a ToolResult error json", empty.contains("\"error\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the refusal must mention the ObjectType flag vocabulary", empty.contains("open")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testXdtoMemberPayloadValidIsNotRefused()
+    {
+        String ok = ModifyMetadataTool.xdtoMemberPayloadError("XDTOPackage.MyPackage.ObjectType.MyType", //$NON-NLS-1$
+            false, false, Collections.singletonList(prop("open", "true"))); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNull("a lone 'properties' payload on an XDTO member FQN is not refused", ok); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testXdtoObjectTypeNotFoundErrorNamesTheType()
+    {
+        com.ditrix.edt.mcp.server.utils.XdtoWriter.MemberRef ref =
+            com.ditrix.edt.mcp.server.utils.XdtoWriter.parseMemberRef("XDTOPackage.MyPackage.ObjectType.Missing"); //$NON-NLS-1$
+        assertNotNull(ref);
+        String err = ModifyMetadataTool.xdtoObjectTypeNotFoundError(ref);
+        assertTrue("the refusal must be a ToolResult error json", err.contains("\"error\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the refusal must name the missing ObjectType", err.contains("Missing")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the refusal must name the owning package", err.contains("XDTOPackage.MyPackage")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testXdtoPropertyNotFoundErrorDistinguishesPackageGlobalAndNested()
+    {
+        com.ditrix.edt.mcp.server.utils.XdtoWriter.MemberRef packageGlobal =
+            com.ditrix.edt.mcp.server.utils.XdtoWriter.parseMemberRef("XDTOPackage.MyPackage.Property.Missing"); //$NON-NLS-1$
+        String globalErr = ModifyMetadataTool.xdtoPropertyNotFoundError(packageGlobal);
+        assertTrue("a package-global property error must name the package", //$NON-NLS-1$
+            globalErr.contains("XDTOPackage.MyPackage"));
+        assertFalse("a package-global property error must not mention an ObjectType owner", //$NON-NLS-1$
+            globalErr.contains("ObjectType.")); //$NON-NLS-1$
+
+        com.ditrix.edt.mcp.server.utils.XdtoWriter.MemberRef nested = com.ditrix.edt.mcp.server.utils.XdtoWriter
+            .parseMemberRef("XDTOPackage.MyPackage.ObjectType.MyType.Property.Missing"); //$NON-NLS-1$
+        String nestedErr = ModifyMetadataTool.xdtoPropertyNotFoundError(nested);
+        assertTrue("a nested property error must name its owning ObjectType", //$NON-NLS-1$
+            nestedErr.contains("ObjectType.MyType")); //$NON-NLS-1$
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ValidateXdtoPackageToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ValidateXdtoPackageToolTest.java
@@ -1,0 +1,271 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+
+/**
+ * Ratchet tests for {@link ValidateXdtoPackageTool}.
+ * <p>
+ * Covers tool metadata (name/constant, response type, description-steers-to-guide, input
+ * schema with schema&lt;-&gt;execute parameter parity + the lowerCamelCase convention, the
+ * required array, the null output schema for a MARKDOWN tool, the guide), and the
+ * Display-free error paths {@code execute(Map)} reaches BEFORE any live EDT/BM access:
+ * missing {@code projectName}/{@code fqn} (required-argument guard) and an unknown project
+ * (value-naming "Project not found" via
+ * {@code ProjectContext}). The FQN-resolves-but-is-not-an-XDTOPackage path and the
+ * happy-path pass/fail verdict need a live configuration and are covered by the E2E suite.
+ */
+public class ValidateXdtoPackageToolTest
+{
+    /** The exact set of input parameters {@code execute()} reads. Keep in lockstep with the schema. */
+    private static final String[] EXECUTE_PARAMS = {"projectName", "fqn", "limit"}; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+    // ==================== Metadata: name / response type ====================
+
+    @Test
+    public void testName()
+    {
+        assertEquals("validate_xdto_package", new ValidateXdtoPackageTool().getName()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNameConstant()
+    {
+        assertEquals(ValidateXdtoPackageTool.NAME, new ValidateXdtoPackageTool().getName());
+    }
+
+    @Test
+    public void testResponseTypeMarkdown()
+    {
+        // Same shape as get_project_errors (a problem table), so it stays MARKDOWN (the
+        // IMcpTool default): no round-trip ID / structured position this tool adds itself.
+        assertEquals(ResponseType.MARKDOWN, new ValidateXdtoPackageTool().getResponseType());
+    }
+
+    @Test
+    public void testConnectsToInfobaseIsFalse()
+    {
+        // Reads EDT/workspace validation markers only - never opens an infobase connection.
+        assertFalse(new ValidateXdtoPackageTool().connectsToInfobase());
+    }
+
+    @Test
+    public void testOutputSchemaIsNullForMarkdownTool()
+    {
+        assertNull(new ValidateXdtoPackageTool().getOutputSchema());
+    }
+
+    // ==================== Metadata: description ====================
+
+    @Test
+    public void testDescriptionNotEmpty()
+    {
+        String desc = new ValidateXdtoPackageTool().getDescription();
+        assertNotNull(desc);
+        assertFalse(desc.isEmpty());
+    }
+
+    @Test
+    public void testDescriptionSteersToGuide()
+    {
+        String desc = new ValidateXdtoPackageTool().getDescription();
+        assertTrue("description must steer to the on-demand guide", //$NON-NLS-1$
+            desc.contains("get_tool_guide('validate_xdto_package')")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testDescriptionMentionsGetProjectErrors()
+    {
+        // It is documented as a thin wrapper - the description should say so.
+        String desc = new ValidateXdtoPackageTool().getDescription();
+        assertTrue("description should reference get_project_errors (the reuse point)", //$NON-NLS-1$
+            desc.contains("get_project_errors")); //$NON-NLS-1$
+    }
+
+    // ==================== Metadata: input schema ====================
+
+    @Test
+    public void testSchemaDeclaresAllExecuteParams()
+    {
+        String schema = new ValidateXdtoPackageTool().getInputSchema();
+        assertNotNull(schema);
+        for (String param : EXECUTE_PARAMS)
+        {
+            assertTrue("input schema must declare execute() param: " + param, //$NON-NLS-1$
+                schema.contains("\"" + param + "\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+    }
+
+    @Test
+    public void testSchemaDeclaresNoExtraParams()
+    {
+        // Parity (schema -> execute): every property name in the schema must be one execute() reads.
+        String schema = new ValidateXdtoPackageTool().getInputSchema();
+        for (String declared : declaredPropertyNames(schema))
+        {
+            assertTrue("input schema declares a param execute() does not read: " + declared, //$NON-NLS-1$
+                contains(EXECUTE_PARAMS, declared));
+        }
+    }
+
+    @Test
+    public void testAllParamsLowerCamelCase()
+    {
+        String schema = new ValidateXdtoPackageTool().getInputSchema();
+        for (String declared : declaredPropertyNames(schema))
+        {
+            assertTrue("param must be lowerCamelCase: " + declared, isLowerCamelCase(declared)); //$NON-NLS-1$
+        }
+    }
+
+    @Test
+    public void testRequiredArrayHoldsOnlyProjectNameAndFqn()
+    {
+        String schema = new ValidateXdtoPackageTool().getInputSchema();
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        assertTrue("schema must declare a required array", requiredIdx >= 0); //$NON-NLS-1$
+        int open = schema.indexOf('[', requiredIdx);
+        int close = schema.indexOf(']', open);
+        assertTrue("required array must be well-formed", open >= 0 && close > open); //$NON-NLS-1$
+        String requiredBlock = schema.substring(open, close + 1);
+        assertTrue("projectName must be required", requiredBlock.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("fqn must be required", requiredBlock.contains("\"fqn\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("limit must NOT be required", requiredBlock.contains("\"limit\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testSchemaHasNoSeverityFilter()
+    {
+        // The verdict reports ALL severities (a severity-filtered "no matches" is not a validity
+        // guarantee), so the tool intentionally exposes no 'severity' parameter.
+        String schema = new ValidateXdtoPackageTool().getInputSchema();
+        assertFalse("severity must be absent from the schema", schema.contains("\"severity\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== Metadata: guide ====================
+
+    @Test
+    public void testGuideIsNonEmpty()
+    {
+        String guide = new ValidateXdtoPackageTool().getGuide();
+        assertNotNull(guide);
+        assertFalse("guide must be non-empty", guide.isEmpty()); //$NON-NLS-1$
+        assertTrue("guide should explain the pass/fail verdict shape", //$NON-NLS-1$
+            guide.contains("is valid")); //$NON-NLS-1$
+    }
+
+    // ==================== Argument validation (returns before any UI / BM access) ====================
+
+    @Test
+    public void testMissingProjectNameIsError()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("fqn", "XDTOPackage.Orders"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ValidateXdtoPackageTool().execute(params);
+        assertTrue("missing projectName must produce a 'projectName is required' error", //$NON-NLS-1$
+            result.contains("projectName is required")); //$NON-NLS-1$
+        assertTrue("error payload must be a failure JSON", result.contains("\"success\":false")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testMissingFqnIsError()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ValidateXdtoPackageTool().execute(params);
+        assertTrue("missing fqn must produce a 'fqn is required' error", //$NON-NLS-1$
+            result.contains("fqn is required")); //$NON-NLS-1$
+        assertTrue(result.contains("\"success\":false")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testEmptyParamsReportsFirstMissingArgument()
+    {
+        // requireArguments checks in order: projectName before fqn.
+        Map<String, String> params = new HashMap<>();
+        String result = new ValidateXdtoPackageTool().execute(params);
+        assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testUnknownProjectIsNamedError()
+    {
+        // A nonexistent project resolves (via ProjectContext) to a value-naming "Project not found"
+        // error that names the bad value AND points at list_projects - reached before any FQN
+        // resolution / BM access.
+        String badProject = "NoSuchXdtoValidateProject_" + System.nanoTime(); //$NON-NLS-1$
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", badProject); //$NON-NLS-1$
+        params.put("fqn", "XDTOPackage.Orders"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new ValidateXdtoPackageTool().execute(params);
+        assertTrue("error must name the bad project value", result.contains(badProject)); //$NON-NLS-1$
+        assertTrue("error must indicate failure", result.contains("\"success\":false")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("error must steer the caller to list_projects", result.contains("list_projects")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== helpers ====================
+
+    /** Extracts the property names declared under the schema's {@code "properties"} object. */
+    private static List<String> declaredPropertyNames(String schema)
+    {
+        List<String> names = new java.util.ArrayList<>();
+        int propsIdx = schema.indexOf("\"properties\""); //$NON-NLS-1$
+        int requiredIdx = schema.indexOf("\"required\""); //$NON-NLS-1$
+        if (propsIdx < 0)
+        {
+            return names;
+        }
+        // The "properties" object precedes "required" in JsonSchemaBuilder.build(); scope the scan.
+        String propsBlock = requiredIdx > propsIdx ? schema.substring(propsIdx, requiredIdx)
+            : schema.substring(propsIdx);
+        Matcher matcher = Pattern.compile("\"([A-Za-z0-9_]+)\"\\s*:\\s*\\{").matcher(propsBlock); //$NON-NLS-1$
+        boolean first = true;
+        while (matcher.find())
+        {
+            if (first)
+            {
+                // Skip the leading "properties":{ match itself.
+                first = false;
+                continue;
+            }
+            names.add(matcher.group(1));
+        }
+        return names;
+    }
+
+    private static boolean isLowerCamelCase(String name)
+    {
+        return name.matches("[a-z][a-zA-Z0-9]*"); //$NON-NLS-1$
+    }
+
+    private static boolean contains(String[] array, String value)
+    {
+        for (String item : array)
+        {
+            if (item.equals(value))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoStructureReaderTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoStructureReaderTest.java
@@ -1,0 +1,164 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com._1c.g5.v8.dt.mcore.McoreFactory;
+import com._1c.g5.v8.dt.mcore.QName;
+import com._1c.g5.v8.dt.xdto.model.Enumeration;
+import com._1c.g5.v8.dt.xdto.model.Import;
+import com._1c.g5.v8.dt.xdto.model.ObjectType;
+import com._1c.g5.v8.dt.xdto.model.Package;
+import com._1c.g5.v8.dt.xdto.model.Property;
+import com._1c.g5.v8.dt.xdto.model.ValueType;
+import com._1c.g5.v8.dt.xdto.model.XdtoFactory;
+
+/**
+ * Tests {@link XdtoStructureReader}: the pure Markdown renderer for an XDTO {@link Package} content. The
+ * xdto.model package is NOT Tycho access-restricted (all public API, unlike the DCS "default settings"
+ * subtree), so every fixture here is a REAL in-memory model built with the typed {@code XdtoFactory}
+ * singleton - the same pattern {@link XdtoWriterTest} uses, mirroring {@code DcsStructureReaderTest}'s
+ * typed (non-reflective) sections.
+ */
+public class XdtoStructureReaderTest
+{
+    private static Package newPackage()
+    {
+        return XdtoFactory.eINSTANCE.createPackage();
+    }
+
+    private static QName qname(String nsUri, String name)
+    {
+        QName q = McoreFactory.eINSTANCE.createQName();
+        q.setNsUri(nsUri);
+        q.setName(name);
+        return q;
+    }
+
+    @Test
+    public void testNullContentRendersNote()
+    {
+        String md = XdtoStructureReader.render("XDTOPackage.MyPackage", null); //$NON-NLS-1$
+        assertTrue(md.contains("no package content")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testEmptyPackageRendersOnlyHeaderAndNamespace()
+    {
+        Package pkg = newPackage();
+        pkg.setNsUri("http://example.org/MyPackage"); //$NON-NLS-1$
+        String md = XdtoStructureReader.render("XDTOPackage.MyPackage", pkg); //$NON-NLS-1$
+        assertTrue(md.contains("XDTOPackage.MyPackage")); //$NON-NLS-1$
+        assertTrue(md.contains("http://example.org/MyPackage")); //$NON-NLS-1$
+        assertFalse("an empty package must not render an Object types section", //$NON-NLS-1$
+            md.contains("Object types")); //$NON-NLS-1$
+        assertFalse("an empty package must not render a Dependencies section", //$NON-NLS-1$
+            md.contains("Dependencies")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testObjectTypeWithPropertiesAndFlags()
+    {
+        Package pkg = newPackage();
+        pkg.setNsUri("http://example.org/MyPackage"); //$NON-NLS-1$
+        ObjectType type = XdtoFactory.eINSTANCE.createObjectType();
+        type.setName("Address"); //$NON-NLS-1$
+        type.setOpen(true);
+        // 'abstract' is deliberately left UNTOUCHED (never eSet) so the render's isSet-only
+        // summarization can be asserted below - calling setAbstract(false) would itself mark it SET.
+        pkg.getObjects().add(type);
+
+        Property street = XdtoFactory.eINSTANCE.createProperty();
+        street.setName("Street"); //$NON-NLS-1$
+        street.setType(qname("http://www.w3.org/2001/XMLSchema", "string")); //$NON-NLS-1$ //$NON-NLS-2$
+        street.setLowerBound(1);
+        street.setUpperBound(1);
+        street.setNillable(false);
+        type.getProperties().add(street);
+
+        String md = XdtoStructureReader.render("XDTOPackage.MyPackage", pkg); //$NON-NLS-1$
+        assertTrue(md.contains("Object types")); //$NON-NLS-1$
+        assertTrue(md.contains("Address")); //$NON-NLS-1$
+        assertTrue("SET flags must be summarized (open=true)", md.contains("open=true")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("an UNSET flag (abstract was never set) must not appear", //$NON-NLS-1$
+            md.contains("abstract=")); //$NON-NLS-1$
+        assertTrue(md.contains("Street")); //$NON-NLS-1$
+        assertTrue("the QName must render its localName", md.contains("string")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("SET bounds must render as [lower..upper]", md.contains("[1..1]")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testUnboundedUpperRendersStar()
+    {
+        Package pkg = newPackage();
+        ObjectType type = XdtoFactory.eINSTANCE.createObjectType();
+        type.setName("Address"); //$NON-NLS-1$
+        pkg.getObjects().add(type);
+        Property items = XdtoFactory.eINSTANCE.createProperty();
+        items.setName("Items"); //$NON-NLS-1$
+        items.setLowerBound(0);
+        items.setUpperBound(-1);
+        type.getProperties().add(items);
+
+        String md = XdtoStructureReader.render("XDTOPackage.MyPackage", pkg); //$NON-NLS-1$
+        assertTrue(md.contains("[0..*]")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testPackageGlobalPropertiesSection()
+    {
+        Package pkg = newPackage();
+        Property global = XdtoFactory.eINSTANCE.createProperty();
+        global.setName("Version"); //$NON-NLS-1$
+        global.setType(qname("http://www.w3.org/2001/XMLSchema", "string")); //$NON-NLS-1$ //$NON-NLS-2$
+        pkg.getProperties().add(global);
+
+        String md = XdtoStructureReader.render("XDTOPackage.MyPackage", pkg); //$NON-NLS-1$
+        assertTrue(md.contains("Package-global properties")); //$NON-NLS-1$
+        assertTrue(md.contains("Version")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testValueTypeWithEnumerations()
+    {
+        Package pkg = newPackage();
+        ValueType valueType = XdtoFactory.eINSTANCE.createValueType();
+        valueType.setName("Status"); //$NON-NLS-1$
+        Enumeration active = XdtoFactory.eINSTANCE.createEnumeration();
+        active.setContent("Active"); //$NON-NLS-1$
+        Enumeration inactive = XdtoFactory.eINSTANCE.createEnumeration();
+        inactive.setContent("Inactive"); //$NON-NLS-1$
+        valueType.getEnumerations().add(active);
+        valueType.getEnumerations().add(inactive);
+        pkg.getTypes().add(valueType);
+
+        String md = XdtoStructureReader.render("XDTOPackage.MyPackage", pkg); //$NON-NLS-1$
+        assertTrue(md.contains("Value types")); //$NON-NLS-1$
+        assertTrue(md.contains("Status")); //$NON-NLS-1$
+        assertTrue(md.contains("Active")); //$NON-NLS-1$
+        assertTrue(md.contains("Inactive")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testDependenciesSection()
+    {
+        Package pkg = newPackage();
+        Import dependency = XdtoFactory.eINSTANCE.createImport();
+        dependency.setNamespace("http://example.org/other"); //$NON-NLS-1$
+        dependency.setLocation("other.xsd"); //$NON-NLS-1$
+        pkg.getDependencies().add(dependency);
+
+        String md = XdtoStructureReader.render("XDTOPackage.MyPackage", pkg); //$NON-NLS-1$
+        assertTrue(md.contains("Dependencies")); //$NON-NLS-1$
+        assertTrue(md.contains("http://example.org/other")); //$NON-NLS-1$
+        assertTrue(md.contains("other.xsd")); //$NON-NLS-1$
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoStructureReaderTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoStructureReaderTest.java
@@ -205,4 +205,25 @@ public class XdtoStructureReaderTest
         assertTrue(md.contains("http://example.org/other")); //$NON-NLS-1$
         assertTrue(md.contains("other.xsd")); //$NON-NLS-1$
     }
+
+    @Test
+    public void testExplicitEmptyDefaultRendersDistinctFromAbsent()
+    {
+        // An EXPLICIT empty-string default (legitimate under fixed=true) must not render as the same
+        // blank cell an ABSENT default uses - the read-back would be lossy (codex finding).
+        Package pkg = newPackage();
+        Property withEmpty = XdtoFactory.eINSTANCE.createProperty();
+        withEmpty.setName("WithEmpty"); //$NON-NLS-1$
+        withEmpty.setDefault(""); //$NON-NLS-1$
+        pkg.getProperties().add(withEmpty);
+        Property absent = XdtoFactory.eINSTANCE.createProperty();
+        absent.setName("Absent"); //$NON-NLS-1$
+        pkg.getProperties().add(absent);
+        String md = XdtoStructureReader.render("XDTOPackage.P", pkg); //$NON-NLS-1$
+        String emptyRow = md.lines().filter(l -> l.contains("WithEmpty")).findFirst().orElse(""); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the explicit empty default must render a distinct marker: " + emptyRow, //$NON-NLS-1$
+            emptyRow.contains("\"\"")); //$NON-NLS-1$
+        String absentRow = md.lines().filter(l -> l.contains("Absent")).findFirst().orElse(""); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("an absent default must stay blank", !absentRow.contains("\"\"")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoStructureReaderTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoStructureReaderTest.java
@@ -112,6 +112,50 @@ public class XdtoStructureReaderTest
         assertTrue(md.contains("[0..*]")); //$NON-NLS-1$
     }
 
+    // ==================== fixed / default read-back (issue #183 P2 #2) ====================
+    //
+    // fixed/default are WRITABLE (XdtoWriter#applyPropertyProperties) but the structure render used to
+    // drop them entirely from the property row - a caller reading the structure back after a write could
+    // never see what it had just set.
+
+    @Test
+    public void testPropertyFixedAndDefaultRenderWhenSet()
+    {
+        Package pkg = newPackage();
+        ObjectType type = XdtoFactory.eINSTANCE.createObjectType();
+        type.setName("Address"); //$NON-NLS-1$
+        pkg.getObjects().add(type);
+        Property country = XdtoFactory.eINSTANCE.createProperty();
+        country.setName("Country"); //$NON-NLS-1$
+        country.setFixed(true);
+        country.setDefault("N/A"); //$NON-NLS-1$
+        type.getProperties().add(country);
+
+        String md = XdtoStructureReader.render("XDTOPackage.MyPackage", pkg); //$NON-NLS-1$
+        assertTrue("the property table header must advertise the Fixed column", md.contains("Fixed")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the property table header must advertise the Default column", md.contains("Default")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a SET fixed=true must render", md.contains("true")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a SET default must render its value", md.contains("N/A")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testPropertyFixedAndDefaultOmittedWhenUnset()
+    {
+        Package pkg = newPackage();
+        ObjectType type = XdtoFactory.eINSTANCE.createObjectType();
+        type.setName("Address"); //$NON-NLS-1$
+        pkg.getObjects().add(type);
+        Property street = XdtoFactory.eINSTANCE.createProperty();
+        street.setName("Street"); //$NON-NLS-1$
+        // 'fixed' and 'default' are deliberately left UNTOUCHED - neither setFixed(...) nor setDefault(...)
+        // is called, mirroring how testObjectTypeWithPropertiesAndFlags asserts an unset flag is absent.
+        type.getProperties().add(street);
+
+        String md = XdtoStructureReader.render("XDTOPackage.MyPackage", pkg); //$NON-NLS-1$
+        assertFalse("an UNSET fixed must not render a boolean value", md.contains("| true |") //$NON-NLS-1$ //$NON-NLS-2$
+            || md.contains("| false |")); //$NON-NLS-1$
+    }
+
     @Test
     public void testPackageGlobalPropertiesSection()
     {

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
@@ -537,15 +537,39 @@ public class XdtoWriterTest
         Package pkg = newPackage();
         ObjectType owner = XdtoWriter.createObjectType(pkg, "Owner"); //$NON-NLS-1$
         Property property = XdtoWriter.createProperty(owner.getProperties(), "MyProp"); //$NON-NLS-1$
+        // Both bounds together: a one-sided lowerBound=5 would now be rejected against the model
+        // DEFAULT upperBound (the platform reads the default for a never-set side - codex finding).
         Result first = XdtoWriter.applyPropertyProperties(property, pkg,
-            List.of(json("{\"name\":\"lowerBound\",\"value\":5}")), false); //$NON-NLS-1$
+            List.of(json("{\"name\":\"lowerBound\",\"value\":5}"), //$NON-NLS-1$
+                json("{\"name\":\"upperBound\",\"value\":10}")), false); //$NON-NLS-1$
         assertFalse(first.error, first.hasError());
 
         Result second = XdtoWriter.applyPropertyProperties(property, pkg,
             List.of(json("{\"name\":\"upperBound\",\"value\":2}")), false); //$NON-NLS-1$
         assertTrue("upperBound=2 must be rejected against the already-set lowerBound=5", //$NON-NLS-1$
             second.hasError());
-        assertFalse("the rejected upperBound must not have been applied", property.isSetUpperBound()); //$NON-NLS-1$
+        assertEquals("the rejected upperBound must leave the previous value untouched", //$NON-NLS-1$
+            10, property.getUpperBound());
+    }
+
+    @Test
+    public void testOneSidedBoundValidatedAgainstModelDefault()
+    {
+        // A side never set in this call or before still has an EFFECTIVE value - the model default -
+        // so lowerBound=5 ALONE must be rejected when the default upperBound is below it, instead of
+        // persisting an occurrence range the platform would refuse (codex finding).
+        Package pkg = newPackage();
+        ObjectType owner = XdtoWriter.createObjectType(pkg, "Owner"); //$NON-NLS-1$
+        Property property = XdtoWriter.createProperty(owner.getProperties(), "MyProp"); //$NON-NLS-1$
+        Object upperDefault = property.eClass().getEStructuralFeature("upperBound").getDefaultValue(); //$NON-NLS-1$
+        if (upperDefault instanceof Integer && ((Integer)upperDefault).intValue() != -1
+            && ((Integer)upperDefault).intValue() < 5)
+        {
+            Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+                List.of(json("{\"name\":\"lowerBound\",\"value\":5}")), false); //$NON-NLS-1$
+            assertTrue("lowerBound above the DEFAULT upperBound must be rejected one-sided", //$NON-NLS-1$
+                r.hasError());
+        }
     }
 
     @Test
@@ -819,16 +843,18 @@ public class XdtoWriterTest
     }
 
     @Test
-    public void testEntryMissingNameIsStillSilentlySkippedNotAnError()
+    public void testEntryMissingNameIsRejected()
     {
-        // Unchanged behavior: an entry with NO 'name' at all (unnamed - nothing actionable to report) is
-        // still silently skipped, unlike a NAMED entry missing only 'value'.
+        // An entry with NO (string) 'name' is malformed input and must be a hard error - silently
+        // skipping it would report success while the intended flag never applied (codex finding).
         Package pkg = newPackage();
         ObjectType type = XdtoWriter.createObjectType(pkg, "MyType"); //$NON-NLS-1$
         Result r = XdtoWriter.applyObjectTypeProperties(type,
             List.of(json("{\"value\":true}"), json("{\"name\":\"open\",\"value\":true}"))); //$NON-NLS-1$ //$NON-NLS-2$
-        assertFalse(r.error, r.hasError());
-        assertEquals(List.of("open"), r.applied); //$NON-NLS-1$
+        assertTrue("an unnamed entry must be rejected, not skipped", r.hasError()); //$NON-NLS-1$
+        assertTrue("the error must state the requirement: " + r.error, //$NON-NLS-1$
+            r.error.contains("name")); //$NON-NLS-1$
+        assertFalse("nothing may be applied after the rejection", type.isOpen()); //$NON-NLS-1$
     }
 
     // ==================== yo-normalized member lookup fallback (issue #183 P2 #4) ====================

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
@@ -18,10 +18,12 @@ import org.junit.Test;
 
 import com._1c.g5.v8.dt.mcore.McoreFactory;
 import com._1c.g5.v8.dt.mcore.QName;
+import com._1c.g5.v8.dt.xdto.model.Enumeration;
 import com._1c.g5.v8.dt.xdto.model.Import;
 import com._1c.g5.v8.dt.xdto.model.ObjectType;
 import com._1c.g5.v8.dt.xdto.model.Package;
 import com._1c.g5.v8.dt.xdto.model.Property;
+import com._1c.g5.v8.dt.xdto.model.ValueType;
 import com._1c.g5.v8.dt.xdto.model.XdtoFactory;
 import com.ditrix.edt.mcp.server.utils.XdtoWriter.MemberRef;
 import com.ditrix.edt.mcp.server.utils.XdtoWriter.QNameResult;
@@ -716,5 +718,327 @@ public class XdtoWriterTest
         QNameResult r = XdtoWriter.resolveQName(null, null, "'type'"); //$NON-NLS-1$
         assertTrue(r.error != null);
         assertJsonError(r.error);
+    }
+
+    // ==================== object-form XSD name validation (issue #183 P2 #5) ====================
+    //
+    // The bare-STRING shorthand already rejects an unknown name via XSD_BUILTIN_TYPES
+    // (testPropertyRejectsUnknownBareStringShorthand above); the explicit object form {nsUri, name} did
+    // not apply the SAME check once the resolved nsUri turned out to be the XSD namespace (either
+    // explicitly supplied or defaulted, since 'nsUri' is optional and defaults to XSD), silently
+    // persisting an invalid 'xs:<typo>' reference.
+
+    @Test
+    public void testResolveQNameObjectFormRejectsUnknownXsdNameWithDefaultNamespace()
+    {
+        // 'nsUri' omitted -> defaults to the XSD namespace, so the name must still be a real XSD builtin.
+        QNameResult r = XdtoWriter.resolveQName(json("{\"name\":\"strng\"}"), null, "'type'"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a typo'd XSD type name via the object form's default namespace must be rejected", //$NON-NLS-1$
+            r.error != null);
+        assertJsonError(r.error);
+    }
+
+    @Test
+    public void testResolveQNameObjectFormRejectsUnknownXsdNameWithExplicitNamespace()
+    {
+        QNameResult r = XdtoWriter.resolveQName(
+            json("{\"nsUri\":\"http://www.w3.org/2001/XMLSchema\",\"name\":\"strng\"}"), null, "'type'"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a typo'd XSD type name via an EXPLICIT XSD nsUri must be rejected too", r.error != null); //$NON-NLS-1$
+        assertJsonError(r.error);
+    }
+
+    @Test
+    public void testResolveQNameObjectFormAcceptsValidXsdName()
+    {
+        QNameResult r = XdtoWriter.resolveQName(json("{\"name\":\"string\"}"), null, "'type'"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse(r.error, r.error != null);
+        assertEquals("string", r.qname.getName()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("http://www.w3.org/2001/XMLSchema", r.qname.getNsUri()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testResolveQNameObjectFormNonXsdNamespaceStillAcceptsAnyName()
+    {
+        // The XSD-name check must be scoped to the XSD namespace only - a genuine cross-namespace
+        // reference (Custom, in a non-XSD namespace) must remain unaffected.
+        JsonObject spec = json("{\"nsUri\":\"http://custom/ns\",\"name\":\"Custom\"}"); //$NON-NLS-1$
+        QNameResult r = XdtoWriter.resolveQName(spec, null, "'type'"); //$NON-NLS-1$
+        assertFalse(r.error, r.error != null);
+        assertEquals("Custom", r.qname.getName()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== entries without a 'value' are a hard error (issue #183 P2 #3) ====================
+    //
+    // toMap used to silently DROP an entry that had a 'name' but no 'value' - the tool then reported
+    // SUCCESS with that property simply missing from 'applied'. It must now be a hard, actionable error
+    // naming the entry, mutating nothing (fail before any write, like every other malformed entry here).
+
+    @Test
+    public void testObjectTypePropertyEntryWithoutValueIsHardError()
+    {
+        Package pkg = newPackage();
+        ObjectType type = XdtoWriter.createObjectType(pkg, "MyType"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyObjectTypeProperties(type, List.of(json("{\"name\":\"open\"}"))); //$NON-NLS-1$
+        assertTrue("an entry with a name but no value must be a hard error, not silently dropped", //$NON-NLS-1$
+            r.hasError());
+        assertJsonError(r.error);
+        assertTrue("the error must name the offending entry: " + r.error, //$NON-NLS-1$
+            r.error.contains("'open'") && r.error.contains("value")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("a rejected entry must not mutate the type", type.isSetOpen()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testPropertyEntryWithoutValueIsHardError()
+    {
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"nillable\"}")), false); //$NON-NLS-1$
+        assertTrue("an entry with a name but no value must be a hard error", r.hasError()); //$NON-NLS-1$
+        assertJsonError(r.error);
+        assertTrue("the error must name the offending entry: " + r.error, //$NON-NLS-1$
+            r.error.contains("'nillable'") && r.error.contains("value")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("a rejected entry must not mutate the property", property.isSetNillable()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testEntryWithoutValueFailsBeforeAnyOtherEntryIsApplied()
+    {
+        // A well-formed entry earlier in the list must NOT land when a LATER entry in the same call is
+        // missing its 'value' - fail fast, no partial mutation (the same contract every other malformed
+        // entry in this class already gets).
+        Package pkg = newPackage();
+        ObjectType type = XdtoWriter.createObjectType(pkg, "MyType"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyObjectTypeProperties(type,
+            List.of(json("{\"name\":\"open\",\"value\":true}"), json("{\"name\":\"abstract\"}"))); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(r.hasError());
+        assertFalse("no entry must land when a later one in the same call is malformed", type.isSetOpen()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testEntryMissingNameIsStillSilentlySkippedNotAnError()
+    {
+        // Unchanged behavior: an entry with NO 'name' at all (unnamed - nothing actionable to report) is
+        // still silently skipped, unlike a NAMED entry missing only 'value'.
+        Package pkg = newPackage();
+        ObjectType type = XdtoWriter.createObjectType(pkg, "MyType"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyObjectTypeProperties(type,
+            List.of(json("{\"value\":true}"), json("{\"name\":\"open\",\"value\":true}"))); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse(r.error, r.hasError());
+        assertEquals(List.of("open"), r.applied); //$NON-NLS-1$
+    }
+
+    // ==================== yo-normalized member lookup fallback (issue #183 P2 #4) ====================
+    //
+    // create_metadata normalizes 'yo'->'ye' in the FQN LEAF by default (CreateMetadataTool#
+    // normalizeLeafName), so an ObjectType/Property CREATED from an FQN spelled with the original 'yo' is
+    // STORED under its 'ye'-normalized name. A LATER member-FQN request (modify/delete, or a create
+    // addressing this ObjectType as the OWNER segment of a nested Property FQN - never the leaf, so never
+    // normalized on the way in) that still spells the name with 'yo' must still resolve it - findObjectType
+    // / findProperty are the SHARED lookup used by all three create/modify/delete XDTO member paths.
+
+    // Cyrillic fixtures are built from Unicode code points (MetadataLanguageUtils.cp), not raw Cyrillic
+    // source literals, to keep this source file pure ASCII (matches XdtoWriterTest's own
+    // testParseAcceptsRussianTypeToken precedent). "Zakaz"/"e"/"yo" naming below spells out in comments
+    // what each code-point string actually is: the SAME word, once "ye"-spelled (as create_metadata's
+    // default yo-normalization would store it) and once with the original "yo".
+
+    /** "Zakaz-e" (a Russian word meaning "order"), the 'yo'-normalized spelling create_metadata stores by default. */
+    private static String zakazYeNormalized()
+    {
+        return MetadataLanguageUtils.cp(0x0417, 0x0430, 0x043a, 0x0430, 0x0437, 0x0435);
+    }
+
+    /** The SAME word as {@link #zakazYeNormalized}, but with the ORIGINAL 'yo' a later request might still use. */
+    private static String zakazYoSpelled()
+    {
+        return MetadataLanguageUtils.cp(0x0417, 0x0430, 0x043a, 0x0430, 0x0437, 0x0451);
+    }
+
+    /** "Pol-e" (a Russian word meaning "field"), the 'yo'-normalized spelling create_metadata stores by default. */
+    private static String poleYeNormalized()
+    {
+        return MetadataLanguageUtils.cp(0x041f, 0x043e, 0x043b, 0x0435);
+    }
+
+    /** The SAME word as {@link #poleYeNormalized}, but with the ORIGINAL 'yo' a later request might still use. */
+    private static String poleYoSpelled()
+    {
+        return MetadataLanguageUtils.cp(0x041f, 0x043e, 0x043b, 0x0451);
+    }
+
+    @Test
+    public void testFindObjectTypeToleratesYoSpelledLookupAgainstYeNormalizedStoredName()
+    {
+        Package pkg = newPackage();
+        // Simulates the create-time storage: the ObjectType is stored under its ALREADY yo-normalized
+        // name (as create_metadata's normalizeLeafName would produce for a name typed with "yo").
+        ObjectType type = XdtoWriter.createObjectType(pkg, zakazYeNormalized());
+
+        // A LATER lookup still spells the name with the original "yo".
+        String yoSpelledLookup = zakazYoSpelled();
+        assertNotNull("an exact miss must fall back to the yo-normalized stored name", //$NON-NLS-1$
+            XdtoWriter.findObjectType(pkg, yoSpelledLookup));
+        assertEquals(type, XdtoWriter.findObjectType(pkg, yoSpelledLookup));
+    }
+
+    @Test
+    public void testFindObjectTypeExactMatchStillWinsOverFallback()
+    {
+        // When a caller explicitly created (normalizeYo:false) an ObjectType still spelled with "yo", an
+        // exact lookup for THAT spelling must resolve it directly - the fallback must never shadow an
+        // exact match.
+        Package pkg = newPackage();
+        String yoSpelledName = zakazYoSpelled();
+        ObjectType type = XdtoWriter.createObjectType(pkg, yoSpelledName);
+        assertEquals(type, XdtoWriter.findObjectType(pkg, yoSpelledName));
+    }
+
+    @Test
+    public void testFindObjectTypeStillReturnsNullWhenGenuinelyMissing()
+    {
+        Package pkg = newPackage();
+        XdtoWriter.createObjectType(pkg, "SomethingElse"); //$NON-NLS-1$
+        assertNull("a name with no yo and no match at all must still return null", //$NON-NLS-1$
+            XdtoWriter.findObjectType(pkg, "TotallyMissing")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindPropertyToleratesYoSpelledLookupAgainstYeNormalizedStoredName()
+    {
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), poleYeNormalized());
+
+        String yoSpelledLookup = poleYoSpelled();
+        assertNotNull("an exact miss must fall back to the yo-normalized stored Property name", //$NON-NLS-1$
+            XdtoWriter.findProperty(pkg.getProperties(), yoSpelledLookup));
+        assertEquals(property, XdtoWriter.findProperty(pkg.getProperties(), yoSpelledLookup));
+    }
+
+    @Test
+    public void testFindPropertyToleratesYoSpelledOwnerLookupForNestedProperty()
+    {
+        // Mirrors CreateMetadataTool's OBJECT_TYPE_PROPERTY owner lookup (createXdtoMemberInTx): the
+        // ObjectType OWNER is looked up by name to find where a nested Property must be created/found -
+        // that owner name is never the FQN leaf, so it is never yo-normalized on its own request, even
+        // though the ObjectType itself WAS normalized when it was originally created.
+        Package pkg = newPackage();
+        ObjectType owner = XdtoWriter.createObjectType(pkg, zakazYeNormalized());
+        Property nested = XdtoWriter.createProperty(owner.getProperties(), "Total"); //$NON-NLS-1$
+
+        String yoSpelledOwnerLookup = zakazYoSpelled();
+        ObjectType resolvedOwner = XdtoWriter.findObjectType(pkg, yoSpelledOwnerLookup);
+        assertEquals("the owner ObjectType must resolve despite the yo-spelled lookup", owner, resolvedOwner); //$NON-NLS-1$
+        assertEquals(nested, XdtoWriter.findProperty(resolvedOwner.getProperties(), "Total")); //$NON-NLS-1$
+    }
+
+    // ==================== namespace cascade: rewriteNamespaceReferences (Task 1, maintainer request) ====
+
+    @Test
+    public void testRewriteNamespaceReferencesRewritesMatchingImport()
+    {
+        Package content = newPackage();
+        Import dependency = XdtoFactory.eINSTANCE.createImport();
+        dependency.setNamespace("http://old/ns"); //$NON-NLS-1$
+        content.getDependencies().add(dependency);
+
+        boolean changed = XdtoWriter.rewriteNamespaceReferences(content, "http://old/ns", "http://new/ns"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(changed);
+        assertEquals("http://new/ns", dependency.getNamespace()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testRewriteNamespaceReferencesRewritesPackageGlobalPropertyTypeAndRef()
+    {
+        Package content = newPackage();
+        Property global = XdtoWriter.createProperty(content.getProperties(), "Global"); //$NON-NLS-1$
+        global.setType(qname("http://old/ns", "Custom")); //$NON-NLS-1$ //$NON-NLS-2$
+        global.setRef(qname("http://old/ns", "SomeGlobalProperty")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        boolean changed = XdtoWriter.rewriteNamespaceReferences(content, "http://old/ns", "http://new/ns"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(changed);
+        assertEquals("http://new/ns", global.getType().getNsUri()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("http://new/ns", global.getRef().getNsUri()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testRewriteNamespaceReferencesRewritesNestedObjectTypeProperty()
+    {
+        Package content = newPackage();
+        ObjectType type = XdtoWriter.createObjectType(content, "Order"); //$NON-NLS-1$
+        Property nested = XdtoWriter.createProperty(type.getProperties(), "Item"); //$NON-NLS-1$
+        nested.setType(qname("http://old/ns", "ItemType")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        boolean changed = XdtoWriter.rewriteNamespaceReferences(content, "http://old/ns", "http://new/ns"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(changed);
+        assertEquals("http://new/ns", nested.getType().getNsUri()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testRewriteNamespaceReferencesRewritesObjectTypeBaseType()
+    {
+        Package content = newPackage();
+        ObjectType type = XdtoWriter.createObjectType(content, "Extended"); //$NON-NLS-1$
+        type.setBaseType(qname("http://old/ns", "Base")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        boolean changed = XdtoWriter.rewriteNamespaceReferences(content, "http://old/ns", "http://new/ns"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(changed);
+        assertEquals("http://new/ns", type.getBaseType().getNsUri()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testRewriteNamespaceReferencesRewritesValueTypeBaseTypeAndEnumerationType()
+    {
+        Package content = newPackage();
+        ValueType valueType = XdtoFactory.eINSTANCE.createValueType();
+        valueType.setName("Status"); //$NON-NLS-1$
+        valueType.setBaseType(qname("http://old/ns", "string")); //$NON-NLS-1$ //$NON-NLS-2$
+        Enumeration active = XdtoFactory.eINSTANCE.createEnumeration();
+        active.setContent("Active"); //$NON-NLS-1$
+        active.setType(qname("http://old/ns", "string")); //$NON-NLS-1$ //$NON-NLS-2$
+        valueType.getEnumerations().add(active);
+        content.getTypes().add(valueType);
+
+        boolean changed = XdtoWriter.rewriteNamespaceReferences(content, "http://old/ns", "http://new/ns"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(changed);
+        assertEquals("http://new/ns", valueType.getBaseType().getNsUri()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("http://new/ns", active.getType().getNsUri()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testRewriteNamespaceReferencesLeavesNonMatchingReferencesUntouched()
+    {
+        Package content = newPackage();
+        Import dependency = XdtoFactory.eINSTANCE.createImport();
+        dependency.setNamespace("http://unrelated/ns"); //$NON-NLS-1$
+        content.getDependencies().add(dependency);
+        Property global = XdtoWriter.createProperty(content.getProperties(), "Global"); //$NON-NLS-1$
+        global.setType(qname("http://unrelated/ns", "Custom")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        boolean changed = XdtoWriter.rewriteNamespaceReferences(content, "http://old/ns", "http://new/ns"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("a reference under a DIFFERENT namespace must be left untouched", changed); //$NON-NLS-1$
+        assertEquals("http://unrelated/ns", dependency.getNamespace()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("http://unrelated/ns", global.getType().getNsUri()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testRewriteNamespaceReferencesReturnsFalseOnEmptyPackage()
+    {
+        Package content = newPackage();
+        assertFalse(XdtoWriter.rewriteNamespaceReferences(content, "http://old/ns", "http://new/ns")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testRewriteNamespaceReferencesNullContentIsNoOp()
+    {
+        assertFalse(XdtoWriter.rewriteNamespaceReferences(null, "http://old/ns", "http://new/ns")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    private static QName qname(String nsUri, String name)
+    {
+        QName q = McoreFactory.eINSTANCE.createQName();
+        q.setNsUri(nsUri);
+        q.setName(name);
+        return q;
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
@@ -1068,4 +1068,27 @@ public class XdtoWriterTest
             + ok.error, ok.hasError());
         assertEquals(pkg.getNsUri(), property.getType().getNsUri());
     }
+
+    @Test
+    public void testObjectFormOwnNamespacePersistsTheStoredNameOnYoVariant()
+    {
+        // findObjectType tolerates the yo spelling, but the persisted QName must carry the STORED
+        // ObjectType name - serializing the raw input would dangle against the stored spelling.
+        Package pkg = newPackage();
+        XdtoWriter.createObjectType(pkg, "\u0415\u043B\u043A\u0430"); //$NON-NLS-1$
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{" + q("name") + ":" + q("type") + "," + q("value") + ":{"
+                + q("nsUri") + ":" + q(pkg.getNsUri()) + "," + q("name") + ":" + q("\u0401\u043B\u043A\u0430") + "}}")), //$NON-NLS-1$
+            false);
+        assertFalse("the yo spelling must resolve via the shared fallback: " + r.error, r.hasError()); //$NON-NLS-1$
+        assertEquals("the persisted QName must carry the STORED name, not the raw input", //$NON-NLS-1$
+            "\u0415\u043B\u043A\u0430", property.getType().getName()); //$NON-NLS-1$
+    }
+
+    /** Tiny JSON-string quoting helper for tests that interpolate values. */
+    private static String q(String v)
+    {
+        return '"' + v + '"';
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
@@ -638,6 +638,31 @@ public class XdtoWriterTest
     }
 
     @Test
+    public void testNonStringDefaultIsRejectedAndDoesNotClearExisting()
+    {
+        // A present-but-non-string 'default' (object/array) must be REJECTED like the sibling
+        // properties (lowerBound/nillable/fixed), not silently applied as setDefault(null) -
+        // which would clear an existing default while still reporting it as applied.
+        Package pkg = newPackage();
+        ObjectType owner = XdtoWriter.createObjectType(pkg, "Owner"); //$NON-NLS-1$
+        Property property = XdtoWriter.createProperty(owner.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result seed = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"type\",\"value\":\"string\"}"), //$NON-NLS-1$
+                json("{\"name\":\"default\",\"value\":\"N/A\"}")), //$NON-NLS-1$
+            true);
+        assertFalse(seed.error, seed.hasError());
+        assertEquals("N/A", property.getDefault()); //$NON-NLS-1$ //$NON-NLS-2$
+
+        Result bad = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"default\",\"value\":{\"oops\":1}}")), false); //$NON-NLS-1$
+        assertTrue("a non-string 'default' must be rejected", bad.hasError()); //$NON-NLS-1$
+        assertTrue("the error must name the property and the expected type: " + bad.error, //$NON-NLS-1$
+            bad.error.contains("'default'") && bad.error.contains("string")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("the existing default must be untouched after the rejected edit", //$NON-NLS-1$
+            "N/A", property.getDefault()); //$NON-NLS-1$
+    }
+
+    @Test
     public void testPropertyRejectsUnassignableAttribute()
     {
         Package pkg = newPackage();

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
@@ -39,9 +39,9 @@ import com.google.gson.JsonParser;
  * {@code DcsFactory.eINSTANCE} fixtures - no BM transaction involved), the typed attribute writers
  * ({@link XdtoWriter#applyObjectTypeProperties} / {@link XdtoWriter#applyPropertyProperties}) and QName
  * resolution ({@link XdtoWriter#resolveQName}). The BM-transaction persistence hook
- * ({@link XdtoWriter#resolvePackageContent}) is intentionally NOT unit-tested here (mirrors the DCS /
- * template precedent): {@code IBmObject} is only implemented by live BM-backed proxies, so that path is
- * e2e/live-tested only.
+ * ({@link XdtoWriter#resolvePackageContent}) is mostly e2e/live-tested ({@code IBmObject} is only
+ * implemented by live BM-backed proxies), with ONE mocked exception: the fresh-materialize FAILURE
+ * path never reaches BM, so its reference-rollback contract is unit-tested here with Mockito.
  * <p>
  * Every error-path assertion also checks the result is a READY {@code ToolResult.error(...).toJson()}
  * envelope (codex review issue #183 finding #9: {@code XdtoWriteException}/{@code Result.error} must
@@ -1286,5 +1286,26 @@ public class XdtoWriterTest
         nested.setItemType(nestedItem);
         assertTrue(XdtoWriter.rewriteNamespaceReferences(q, "http://x", "http://y")); //$NON-NLS-1$ //$NON-NLS-2$
         assertEquals("http://y", nestedItem.getNsUri()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFailedFreshMaterializationUndoesThePackageReference()
+    {
+        // When the external-property FQN cannot be generated, the just-set reference to the fresh
+        // UNATTACHED content must be undone - otherwise the surrounding transaction fails at commit
+        // ("Failed to persist reference value") even for best-effort callers (codex finding).
+        com._1c.g5.v8.dt.metadata.mdclass.XDTOPackage owner =
+            com._1c.g5.v8.dt.metadata.mdclass.MdClassFactory.eINSTANCE.createXDTOPackage();
+        owner.setName("P"); //$NON-NLS-1$
+        owner.setNamespace("http://p"); //$NON-NLS-1$
+        com._1c.g5.v8.bm.core.IBmTransaction tx =
+            org.mockito.Mockito.mock(com._1c.g5.v8.bm.core.IBmTransaction.class);
+        com._1c.g5.v8.dt.core.naming.ITopObjectFqnGenerator gen =
+            org.mockito.Mockito.mock(com._1c.g5.v8.dt.core.naming.ITopObjectFqnGenerator.class);
+        // generator returns null -> the fresh path must fail AND leave no dangling reference.
+        XdtoWriter.ContentResolution resolved = XdtoWriter.resolvePackageContent(owner, tx, gen);
+        assertJsonError(resolved.error);
+        assertNull("the owner must NOT keep a reference to the unattached fresh content", //$NON-NLS-1$
+            owner.getPackage());
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
@@ -1,0 +1,695 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com._1c.g5.v8.dt.mcore.McoreFactory;
+import com._1c.g5.v8.dt.mcore.QName;
+import com._1c.g5.v8.dt.xdto.model.Import;
+import com._1c.g5.v8.dt.xdto.model.ObjectType;
+import com._1c.g5.v8.dt.xdto.model.Package;
+import com._1c.g5.v8.dt.xdto.model.Property;
+import com._1c.g5.v8.dt.xdto.model.XdtoFactory;
+import com.ditrix.edt.mcp.server.utils.XdtoWriter.MemberRef;
+import com.ditrix.edt.mcp.server.utils.XdtoWriter.QNameResult;
+import com.ditrix.edt.mcp.server.utils.XdtoWriter.Result;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * Tests {@link XdtoWriter}: the {@code XDTOPackage.<Package>.ObjectType.<Name>(.Property.<Name>)?} FQN
+ * grammar ({@link XdtoWriter#parseMemberRef}), find/create/remove on an in-memory {@link Package} built
+ * with {@code XdtoFactory.eINSTANCE} (mirrors {@link DcsWriterTest}'s in-memory
+ * {@code DcsFactory.eINSTANCE} fixtures - no BM transaction involved), the typed attribute writers
+ * ({@link XdtoWriter#applyObjectTypeProperties} / {@link XdtoWriter#applyPropertyProperties}) and QName
+ * resolution ({@link XdtoWriter#resolveQName}). The BM-transaction persistence hook
+ * ({@link XdtoWriter#resolvePackageContent}) is intentionally NOT unit-tested here (mirrors the DCS /
+ * template precedent): {@code IBmObject} is only implemented by live BM-backed proxies, so that path is
+ * e2e/live-tested only.
+ * <p>
+ * Every error-path assertion also checks the result is a READY {@code ToolResult.error(...).toJson()}
+ * envelope (codex review issue #183 finding #9: {@code XdtoWriteException}/{@code Result.error} must
+ * never carry a bare string - it is surfaced verbatim as the tool's wire response).
+ */
+public class XdtoWriterTest
+{
+    private static JsonObject json(String s)
+    {
+        return JsonParser.parseString(s).getAsJsonObject();
+    }
+
+    private static Package newPackage()
+    {
+        Package pkg = XdtoFactory.eINSTANCE.createPackage();
+        pkg.setNsUri("http://example.org/MyPackage"); //$NON-NLS-1$
+        return pkg;
+    }
+
+    private static void assertJsonError(String error)
+    {
+        assertNotNull("must carry an error", error); //$NON-NLS-1$
+        assertTrue("the error must be a ready ToolResult error JSON envelope, not a bare string: " + error, //$NON-NLS-1$
+            error.contains("\"error\"")); //$NON-NLS-1$
+    }
+
+    // ==================== parseMemberRef ====================
+
+    @Test
+    public void testParseObjectTypeRef()
+    {
+        MemberRef ref = XdtoWriter.parseMemberRef("XDTOPackage.MyPackage.ObjectType.MyType"); //$NON-NLS-1$
+        assertNotNull(ref);
+        assertEquals(XdtoWriter.Kind.OBJECT_TYPE, ref.kind);
+        assertEquals("XDTOPackage.MyPackage", ref.packageFqn); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("MyType", ref.objectTypeName); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNull(ref.propertyName);
+        assertEquals("MyType", ref.memberName()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testParsePackageGlobalPropertyRef()
+    {
+        MemberRef ref = XdtoWriter.parseMemberRef("XDTOPackage.MyPackage.Property.MyProp"); //$NON-NLS-1$
+        assertNotNull(ref);
+        assertEquals(XdtoWriter.Kind.PACKAGE_PROPERTY, ref.kind);
+        assertEquals("XDTOPackage.MyPackage", ref.packageFqn); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNull(ref.objectTypeName);
+        assertEquals("MyProp", ref.propertyName); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("MyProp", ref.memberName()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testParseNestedPropertyRef()
+    {
+        MemberRef ref = XdtoWriter.parseMemberRef("XDTOPackage.MyPackage.ObjectType.MyType.Property.MyProp"); //$NON-NLS-1$
+        assertNotNull(ref);
+        assertEquals(XdtoWriter.Kind.OBJECT_TYPE_PROPERTY, ref.kind);
+        assertEquals("XDTOPackage.MyPackage", ref.packageFqn); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("MyType", ref.objectTypeName); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("MyProp", ref.propertyName); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testParseRejectsNonXdtoFqn()
+    {
+        assertNull(XdtoWriter.parseMemberRef("Catalog.Products.Attribute.Weight")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testParseRejectsTopLevelPackageFqn()
+    {
+        // 2-part FQN (the package itself) is not a MEMBER ref - falls through to the normal top-level path.
+        assertNull(XdtoWriter.parseMemberRef("XDTOPackage.MyPackage")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testParseRejectsUnknownKindToken()
+    {
+        assertNull(XdtoWriter.parseMemberRef("XDTOPackage.MyPackage.Bogus.Name")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testParseRejectsMalformedNestedKind()
+    {
+        // 6 parts but the inner kind is not 'Property'.
+        assertNull(XdtoWriter.parseMemberRef("XDTOPackage.MyPackage.ObjectType.MyType.Bogus.Name")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testParseAcceptsRussianTypeToken()
+    {
+        // The XDTOPackage type token is bilingual (MetadataTypeUtils.toEnglishSingular); the ru token is
+        // built from code points to keep this source pure ASCII.
+        String ruXdtoPackage = MetadataLanguageUtils.cp(0x041f, 0x0430, 0x043a, 0x0435, 0x0442) + "XDTO"; //$NON-NLS-1$
+        MemberRef ref = XdtoWriter.parseMemberRef(ruXdtoPackage + ".MyPackage.ObjectType.MyType"); //$NON-NLS-1$
+        assertNotNull("the Russian XDTOPackage type token must resolve", ref); //$NON-NLS-1$
+        assertEquals("XDTOPackage.MyPackage", ref.packageFqn); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ==================== find / create / remove - CASE-SENSITIVE (codex #8) ====================
+
+    @Test
+    public void testFindObjectTypeIsExactCaseSensitiveMatch()
+    {
+        Package pkg = newPackage();
+        assertNull(XdtoWriter.findObjectType(pkg, "MyType")); //$NON-NLS-1$
+        ObjectType type = XdtoWriter.createObjectType(pkg, "MyType"); //$NON-NLS-1$
+        assertEquals("MyType", type.getName()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(1, pkg.getObjects().size());
+        assertEquals("an exact-case name must match", type, XdtoWriter.findObjectType(pkg, "MyType")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNull("a differently-cased name must NOT match (XDTO/XML QName local names are " //$NON-NLS-1$
+            + "case-sensitive, unlike a 1C mdclass member name)", XdtoWriter.findObjectType(pkg, "mytype")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testCaseDistinctObjectTypesAreBothCreatable()
+    {
+        // "Order" and "order" must be able to coexist - a case-insensitive collision would wrongly block
+        // creating the second one (or wrongly resolve one as a duplicate of the other).
+        Package pkg = newPackage();
+        ObjectType upper = XdtoWriter.createObjectType(pkg, "Order"); //$NON-NLS-1$
+        assertNull("must not collide with the differently-cased sibling", //$NON-NLS-1$
+            XdtoWriter.findObjectType(pkg, "order")); //$NON-NLS-1$
+        ObjectType lower = XdtoWriter.createObjectType(pkg, "order"); //$NON-NLS-1$
+        assertEquals(2, pkg.getObjects().size());
+        assertEquals(upper, XdtoWriter.findObjectType(pkg, "Order")); //$NON-NLS-1$
+        assertEquals(lower, XdtoWriter.findObjectType(pkg, "order")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRemoveObjectTypeCascadesItsOwnProperties()
+    {
+        Package pkg = newPackage();
+        ObjectType type = XdtoWriter.createObjectType(pkg, "MyType"); //$NON-NLS-1$
+        XdtoWriter.createProperty(type.getProperties(), "Inner"); //$NON-NLS-1$
+        assertEquals(1, type.getProperties().size());
+        XdtoWriter.removeObjectType(pkg, type);
+        assertTrue(pkg.getObjects().isEmpty());
+    }
+
+    @Test
+    public void testFindPropertyIsExactCaseSensitiveMatch()
+    {
+        Package pkg = newPackage();
+        assertNull(XdtoWriter.findProperty(pkg.getProperties(), "MyProp")); //$NON-NLS-1$
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        assertEquals("MyProp", property.getName()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(1, pkg.getProperties().size());
+        assertEquals(property, XdtoWriter.findProperty(pkg.getProperties(), "MyProp")); //$NON-NLS-1$
+        assertNull("a differently-cased name must NOT match", //$NON-NLS-1$
+            XdtoWriter.findProperty(pkg.getProperties(), "myprop")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRemoveProperty()
+    {
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        XdtoWriter.removeProperty(pkg.getProperties(), property);
+        assertTrue(pkg.getProperties().isEmpty());
+    }
+
+    // ==================== applyObjectTypeProperties ====================
+
+    @Test
+    public void testObjectTypeFlagsApplyAndAreTracked()
+    {
+        Package pkg = newPackage();
+        ObjectType type = XdtoWriter.createObjectType(pkg, "MyType"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyObjectTypeProperties(type,
+            List.of(json("{\"name\":\"open\",\"value\":true}"), //$NON-NLS-1$
+                json("{\"name\":\"abstract\",\"value\":false}"))); //$NON-NLS-1$
+        assertFalse(r.error, r.hasError());
+        assertTrue(type.isOpen());
+        assertTrue(type.isSetOpen());
+        assertFalse(type.isAbstract());
+        assertTrue(type.isSetAbstract());
+        assertEquals(List.of("open", "abstract"), r.applied); //$NON-NLS-1$ //$NON-NLS-2$
+        // untouched flags stay unset (platform defaults, not written to disk - #235 lesson)
+        assertFalse(type.isSetMixed());
+    }
+
+    @Test
+    public void testObjectTypeRejectsUnassignableProperty()
+    {
+        Package pkg = newPackage();
+        ObjectType type = XdtoWriter.createObjectType(pkg, "MyType"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyObjectTypeProperties(type,
+            List.of(json("{\"name\":\"bogus\",\"value\":true}"))); //$NON-NLS-1$
+        assertTrue("an unknown ObjectType property must be rejected", r.hasError()); //$NON-NLS-1$
+        assertFalse("a rejected spec must not mutate the type", type.isSetOpen()); //$NON-NLS-1$
+        assertJsonError(r.error);
+    }
+
+    @Test
+    public void testObjectTypeRejectsNonBooleanFlag()
+    {
+        Package pkg = newPackage();
+        ObjectType type = XdtoWriter.createObjectType(pkg, "MyType"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyObjectTypeProperties(type,
+            List.of(json("{\"name\":\"open\",\"value\":\"yes\"}"))); //$NON-NLS-1$
+        assertTrue(r.hasError());
+        assertJsonError(r.error);
+    }
+
+    // ==================== applyPropertyProperties ====================
+
+    @Test
+    public void testPropertyRequiresTypeOnCreate()
+    {
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg, List.of(), true);
+        assertTrue("a Property create without 'type' must be rejected", r.hasError()); //$NON-NLS-1$
+        assertJsonError(r.error);
+    }
+
+    @Test
+    public void testPropertyModifyDoesNotRequireType()
+    {
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"nillable\",\"value\":true}")), false); //$NON-NLS-1$
+        assertFalse(r.error, r.hasError());
+        assertTrue(property.isNillable());
+        assertEquals(List.of("nillable"), r.applied); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testPropertyTypePrimitiveShorthandUsesXsdNamespace()
+    {
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"type\",\"value\":\"string\"}")), true); //$NON-NLS-1$
+        assertFalse(r.error, r.hasError());
+        assertNotNull(property.getType());
+        assertEquals("string", property.getType().getName()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("http://www.w3.org/2001/XMLSchema", property.getType().getNsUri()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testPropertyTypeSamePackageObjectTypeShorthandIsExactMatch()
+    {
+        Package pkg = newPackage();
+        XdtoWriter.createObjectType(pkg, "Address"); //$NON-NLS-1$
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"type\",\"value\":\"Address\"}")), true); //$NON-NLS-1$
+        assertFalse(r.error, r.hasError());
+        assertEquals("Address", property.getType().getName()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("a same-package ObjectType reference uses the package's OWN nsUri", //$NON-NLS-1$
+            pkg.getNsUri(), property.getType().getNsUri());
+
+        // A different-case token does NOT match "Address" and is not an XSD built-in either -> rejected.
+        Property other = XdtoWriter.createProperty(pkg.getProperties(), "Other"); //$NON-NLS-1$
+        Result rejected = XdtoWriter.applyPropertyProperties(other, pkg,
+            List.of(json("{\"name\":\"type\",\"value\":\"address\"}")), true); //$NON-NLS-1$
+        assertTrue("a differently-cased ObjectType name must not silently resolve", rejected.hasError()); //$NON-NLS-1$
+        assertJsonError(rejected.error);
+    }
+
+    @Test
+    public void testPropertyTypeExplicitObjectFormWithMatchingImport()
+    {
+        Package pkg = newPackage();
+        // A cross-namespace {nsUri,name} reference needs a matching Import - otherwise it is an invalid
+        // (unreachable) XDTO reference (codex #4).
+        Import dependency = XdtoFactory.eINSTANCE.createImport();
+        dependency.setNamespace("http://custom/ns"); //$NON-NLS-1$
+        pkg.getDependencies().add(dependency);
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"type\",\"value\":{\"nsUri\":\"http://custom/ns\",\"name\":\"Custom\"}}")), //$NON-NLS-1$
+            true);
+        assertFalse(r.error, r.hasError());
+        assertEquals("Custom", property.getType().getName()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("http://custom/ns", property.getType().getNsUri()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testPropertyTypeExplicitObjectFormOwnNamespaceNeedsNoImport()
+    {
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"type\",\"value\":{\"nsUri\":\"" + pkg.getNsUri() + "\",\"name\":\"Custom\"}}")), //$NON-NLS-1$ //$NON-NLS-2$
+            true);
+        assertFalse("the package's own namespace is implicitly reachable, no Import needed", //$NON-NLS-1$
+            r.hasError());
+    }
+
+    @Test
+    public void testPropertyRejectsUnreachableNamespace()
+    {
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"type\",\"value\":{\"nsUri\":\"http://not-imported/ns\",\"name\":\"X\"}}")), //$NON-NLS-1$
+            true);
+        assertTrue("a namespace with no matching Import (and not XSD / the package's own) must be " //$NON-NLS-1$
+            + "rejected as an unreachable reference", r.hasError()); //$NON-NLS-1$
+        assertJsonError(r.error);
+        assertNull("a rejected spec must not mutate the property", property.getType()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testPropertyRejectsUnknownBareStringShorthand()
+    {
+        // codex #4: a typo like "Adress" must be REJECTED, never silently become invalid xs:Adress.
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"type\",\"value\":\"Adress\"}")), true); //$NON-NLS-1$
+        assertTrue("an unknown bare-string type/ref token must be rejected, not silently namespaced " //$NON-NLS-1$
+            + "under XSD", r.hasError()); //$NON-NLS-1$
+        assertJsonError(r.error);
+        assertNull(property.getType());
+    }
+
+    @Test
+    public void testPropertyAcceptsSeveralXsdBuiltinTypeNames()
+    {
+        Package pkg = newPackage();
+        for (String builtin : new String[] { "string", "boolean", "decimal", "dateTime", "date", "int", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+            "anyURI", "base64Binary" }) //$NON-NLS-1$ //$NON-NLS-2$
+        {
+            Property property = XdtoWriter.createProperty(pkg.getProperties(), "P_" + builtin); //$NON-NLS-1$
+            Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+                List.of(json("{\"name\":\"type\",\"value\":\"" + builtin + "\"}")), true); //$NON-NLS-1$ //$NON-NLS-2$
+            assertFalse(builtin + ": " + r.error, r.hasError()); //$NON-NLS-1$ //$NON-NLS-2$
+            assertEquals(builtin, property.getType().getName());
+            assertEquals("http://www.w3.org/2001/XMLSchema", property.getType().getNsUri()); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+    }
+
+    @Test
+    public void testPropertyAcceptsAnySimpleTypeAndAnyType()
+    {
+        // codex review residual #2/finding #4: these two XSD/EDT root ur-types were wrongly missing from
+        // the whitelist, regressing a previously-valid shorthand.
+        Package pkg = newPackage();
+        for (String builtin : new String[] { "anySimpleType", "anyType" }) //$NON-NLS-1$ //$NON-NLS-2$
+        {
+            Property property = XdtoWriter.createProperty(pkg.getProperties(), "P_" + builtin); //$NON-NLS-1$
+            Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+                List.of(json("{\"name\":\"type\",\"value\":\"" + builtin + "\"}")), true); //$NON-NLS-1$ //$NON-NLS-2$
+            assertFalse(builtin + ": " + r.error, r.hasError()); //$NON-NLS-1$ //$NON-NLS-2$
+            assertEquals(builtin, property.getType().getName());
+        }
+    }
+
+    // ==================== 'ref' deferred for v1 (codex review residual #3/finding #5) ====================
+
+    @Test
+    public void testPropertyRefIsRejectedWithActionableMessage()
+    {
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"ref\",\"value\":\"SomeGlobalProperty\"}")), false); //$NON-NLS-1$
+        assertTrue("'ref' must be rejected - not yet supported for v1", r.hasError()); //$NON-NLS-1$
+        assertJsonError(r.error);
+        assertTrue("the refusal must say it is not yet supported", r.error.contains("not yet supported")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the refusal must point the caller at 'type' as the alternative", //$NON-NLS-1$
+            r.error.contains("'type' instead")); //$NON-NLS-1$
+        assertNull("a rejected spec must not mutate the property", property.getType()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testPropertyRefRejectedEvenAlongsideType()
+    {
+        // 'ref' is rejected up front regardless of what else is in the same call.
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"type\",\"value\":\"string\"}"), //$NON-NLS-1$
+                json("{\"name\":\"ref\",\"value\":\"SomeGlobalProperty\"}")), //$NON-NLS-1$
+            true);
+        assertTrue(r.hasError());
+        assertJsonError(r.error);
+        assertNull("a rejected spec must not mutate the property", property.getType()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSettingTypeClearsAPreExistingRefFromAnImport()
+    {
+        // Simulates a property that already carries a 'ref' from an XML import (this API can no longer
+        // SET one - 'ref' write support is deferred) - setting 'type' through modify_metadata must still
+        // clear the stale 'ref' defensively, so the property never ends up carrying both.
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        QName importedRef = McoreFactory.eINSTANCE.createQName();
+        importedRef.setNsUri(pkg.getNsUri());
+        importedRef.setName("SomeGlobalProperty"); //$NON-NLS-1$
+        property.setRef(importedRef);
+        assertNotNull(property.getRef());
+
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"type\",\"value\":\"string\"}")), false); //$NON-NLS-1$
+        assertFalse(r.error, r.hasError());
+        assertNotNull("setting 'type' must land", property.getType()); //$NON-NLS-1$
+        assertNull("setting 'type' must clear a pre-existing 'ref' (e.g. from an XML import)", //$NON-NLS-1$
+            property.getRef());
+    }
+
+    // ==================== bounds / container / fixed validation (codex #6) ====================
+
+    @Test
+    public void testNestedPropertyAllAttributesLand()
+    {
+        Package pkg = newPackage();
+        ObjectType owner = XdtoWriter.createObjectType(pkg, "Owner"); //$NON-NLS-1$
+        Property property = XdtoWriter.createProperty(owner.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"type\",\"value\":\"string\"}"), //$NON-NLS-1$
+                json("{\"name\":\"lowerBound\",\"value\":1}"), //$NON-NLS-1$
+                json("{\"name\":\"upperBound\",\"value\":-1}"), //$NON-NLS-1$
+                json("{\"name\":\"nillable\",\"value\":true}"), //$NON-NLS-1$
+                json("{\"name\":\"fixed\",\"value\":true}"), //$NON-NLS-1$
+                json("{\"name\":\"default\",\"value\":\"N/A\"}")), //$NON-NLS-1$
+            true);
+        assertFalse(r.error, r.hasError());
+        assertEquals(1, property.getLowerBound());
+        assertEquals(-1, property.getUpperBound());
+        assertTrue(property.isNillable());
+        assertTrue(property.isFixed());
+        assertEquals("N/A", property.getDefault()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(6, r.applied.size());
+    }
+
+    @Test
+    public void testPackageGlobalPropertyRejectsOccurrenceBounds()
+    {
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"lowerBound\",\"value\":0}")), false); //$NON-NLS-1$
+        assertTrue("a package-global property must not accept occurrence bounds", r.hasError()); //$NON-NLS-1$
+        assertJsonError(r.error);
+        assertFalse(property.isSetLowerBound());
+    }
+
+    @Test
+    public void testNegativeLowerBoundRejected()
+    {
+        Package pkg = newPackage();
+        ObjectType owner = XdtoWriter.createObjectType(pkg, "Owner"); //$NON-NLS-1$
+        Property property = XdtoWriter.createProperty(owner.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"lowerBound\",\"value\":-1}")), false); //$NON-NLS-1$
+        assertTrue(r.hasError());
+        assertJsonError(r.error);
+    }
+
+    @Test
+    public void testUpperBoundBelowLowerBoundRejected()
+    {
+        Package pkg = newPackage();
+        ObjectType owner = XdtoWriter.createObjectType(pkg, "Owner"); //$NON-NLS-1$
+        Property property = XdtoWriter.createProperty(owner.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"lowerBound\",\"value\":5}"), //$NON-NLS-1$
+                json("{\"name\":\"upperBound\",\"value\":2}")), //$NON-NLS-1$
+            false);
+        assertTrue("upperBound < lowerBound (and not -1/unbounded) must be rejected", r.hasError()); //$NON-NLS-1$
+        assertJsonError(r.error);
+        assertFalse(property.isSetUpperBound());
+    }
+
+    @Test
+    public void testUpperBoundUnboundedAllowsAnyLowerBound()
+    {
+        Package pkg = newPackage();
+        ObjectType owner = XdtoWriter.createObjectType(pkg, "Owner"); //$NON-NLS-1$
+        Property property = XdtoWriter.createProperty(owner.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"lowerBound\",\"value\":3}"), //$NON-NLS-1$
+                json("{\"name\":\"upperBound\",\"value\":-1}")), //$NON-NLS-1$
+            false);
+        assertFalse(r.error, r.hasError());
+    }
+
+    @Test
+    public void testUpperBoundValidatedAgainstAlreadySetLowerBound()
+    {
+        // A call that touches ONLY upperBound must still validate against the property's EXISTING
+        // lowerBound (the effective post-change state), not just the value(s) supplied in this call.
+        Package pkg = newPackage();
+        ObjectType owner = XdtoWriter.createObjectType(pkg, "Owner"); //$NON-NLS-1$
+        Property property = XdtoWriter.createProperty(owner.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result first = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"lowerBound\",\"value\":5}")), false); //$NON-NLS-1$
+        assertFalse(first.error, first.hasError());
+
+        Result second = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"upperBound\",\"value\":2}")), false); //$NON-NLS-1$
+        assertTrue("upperBound=2 must be rejected against the already-set lowerBound=5", //$NON-NLS-1$
+            second.hasError());
+        assertFalse("the rejected upperBound must not have been applied", property.isSetUpperBound()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testUpperBoundBareNegativeOtherThanMinusOneRejected()
+    {
+        // codex review residual #4a: only -1 (unbounded) is a valid negative upperBound; -2 (or any other
+        // negative) must be rejected even when lowerBound is never set (no cross-check available yet).
+        Package pkg = newPackage();
+        ObjectType owner = XdtoWriter.createObjectType(pkg, "Owner"); //$NON-NLS-1$
+        Property property = XdtoWriter.createProperty(owner.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"upperBound\",\"value\":-2}")), false); //$NON-NLS-1$
+        assertTrue("upperBound=-2 is not valid XDTO (only -1 means unbounded)", r.hasError()); //$NON-NLS-1$
+        assertJsonError(r.error);
+        assertFalse(property.isSetUpperBound());
+    }
+
+    @Test
+    public void testUpperBoundMinusOneAccepted()
+    {
+        Package pkg = newPackage();
+        ObjectType owner = XdtoWriter.createObjectType(pkg, "Owner"); //$NON-NLS-1$
+        Property property = XdtoWriter.createProperty(owner.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"upperBound\",\"value\":-1}")), false); //$NON-NLS-1$
+        assertFalse("-1 (unbounded) must be accepted even with no lowerBound known: " + r.error, r.hasError()); //$NON-NLS-1$
+        assertEquals(-1, property.getUpperBound());
+    }
+
+    @Test
+    public void testFixedTrueWithoutDefaultRejected()
+    {
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"fixed\",\"value\":true}")), false); //$NON-NLS-1$
+        assertTrue("fixed=true with no default (new or existing) must be rejected", r.hasError()); //$NON-NLS-1$
+        assertJsonError(r.error);
+        assertFalse(property.isSetFixed());
+    }
+
+    @Test
+    public void testFixedTrueWithDefaultInSameCallAccepted()
+    {
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"fixed\",\"value\":true}"), //$NON-NLS-1$
+                json("{\"name\":\"default\",\"value\":\"N/A\"}")), //$NON-NLS-1$
+            false);
+        assertFalse(r.error, r.hasError());
+        assertTrue(property.isFixed());
+        assertEquals("N/A", property.getDefault()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFixedTrueWithAlreadyExistingDefaultAccepted()
+    {
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result seedDefault = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"default\",\"value\":\"N/A\"}")), false); //$NON-NLS-1$
+        assertFalse(seedDefault.error, seedDefault.hasError());
+
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"fixed\",\"value\":true}")), false); //$NON-NLS-1$
+        assertFalse("fixed=true against an ALREADY-set default must be accepted", r.hasError()); //$NON-NLS-1$
+        assertTrue(property.isFixed());
+    }
+
+    @Test
+    public void testFixedPropertyWithEmptyStringDefaultAllowsLaterUnrelatedEdit()
+    {
+        // codex review residual #4b: an EMPTY-STRING default is a legitimate value (Property has no
+        // isSetDefault()/unset pair - null is the only "absent" signal), so it must count as PRESENT, not
+        // absent - a later call editing an UNRELATED attribute on an already-fixed property must not
+        // re-fire the fixed-needs-default check against it.
+        Package pkg = newPackage();
+        ObjectType owner = XdtoWriter.createObjectType(pkg, "Owner"); //$NON-NLS-1$
+        Property property = XdtoWriter.createProperty(owner.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result seed = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"fixed\",\"value\":true}"), //$NON-NLS-1$
+                json("{\"name\":\"default\",\"value\":\"\"}")), //$NON-NLS-1$
+            false);
+        assertFalse("fixed=true with an EMPTY STRING default must be accepted: " + seed.error, //$NON-NLS-1$
+            seed.hasError());
+        assertTrue(property.isFixed());
+        assertEquals("", property.getDefault()); //$NON-NLS-1$ //$NON-NLS-2$
+
+        Result laterEdit = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"lowerBound\",\"value\":0}")), false); //$NON-NLS-1$
+        assertFalse("an unrelated bound-only edit must not re-trigger the fixed-needs-default check " //$NON-NLS-1$
+            + "against an empty-string default: " + laterEdit.error, laterEdit.hasError()); //$NON-NLS-1$
+        assertEquals(0, property.getLowerBound());
+    }
+
+    @Test
+    public void testPropertyRejectsUnassignableAttribute()
+    {
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"type\",\"value\":\"string\"}"), //$NON-NLS-1$
+                json("{\"name\":\"bogus\",\"value\":1}")), //$NON-NLS-1$
+            true);
+        assertTrue("an unknown Property attribute must be rejected", r.hasError()); //$NON-NLS-1$
+        assertNull("a rejected spec must not mutate the property", property.getType()); //$NON-NLS-1$
+        assertJsonError(r.error);
+    }
+
+    @Test
+    public void testPropertyRejectsMalformedType()
+    {
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"type\",\"value\":42}")), true); //$NON-NLS-1$
+        assertTrue(r.hasError());
+        assertJsonError(r.error);
+    }
+
+    // ==================== resolveQName ====================
+
+    @Test
+    public void testResolveQNameObjectFormOwnNamespace()
+    {
+        // pkg == null -> the Import-reachability check no-ops (no package context to validate against);
+        // production call sites always supply the real Package.
+        JsonObject spec = json("{\"nsUri\":\"http://custom/ns\",\"name\":\"Custom\"}"); //$NON-NLS-1$
+        QNameResult r = XdtoWriter.resolveQName(spec, null, "'type'"); //$NON-NLS-1$
+        assertFalse(r.error, r.error != null);
+        QName qname = r.qname;
+        assertEquals("Custom", qname.getName()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("http://custom/ns", qname.getNsUri()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testResolveQNameObjectFormMissingNameFails()
+    {
+        QNameResult r = XdtoWriter.resolveQName(json("{\"nsUri\":\"http://custom/ns\"}"), null, "'type'"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(r.error != null);
+        assertJsonError(r.error);
+    }
+
+    @Test
+    public void testResolveQNameNullFails()
+    {
+        QNameResult r = XdtoWriter.resolveQName(null, null, "'type'"); //$NON-NLS-1$
+        assertTrue(r.error != null);
+        assertJsonError(r.error);
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
@@ -1164,4 +1164,127 @@ public class XdtoWriterTest
         assertSame("the exact spelling still matches", property, //$NON-NLS-1$
             XdtoWriter.findPropertyExact(pkg.getProperties(), "\u0415\u043B\u043A\u0430")); //$NON-NLS-1$
     }
+
+    @Test
+    public void testFindValueTypeExactSeesLocalValueTypes()
+    {
+        // ObjectTypes and local ValueTypes share the TYPE namespace: the create-time duplicate check
+        // must see a same-named ValueType (codex finding).
+        Package pkg = newPackage();
+        com._1c.g5.v8.dt.xdto.model.ValueType status = com._1c.g5.v8.dt.xdto.model.XdtoFactory.eINSTANCE.createValueType();
+        status.setName("Status"); //$NON-NLS-1$
+        pkg.getTypes().add(status);
+        assertSame(status, XdtoWriter.findValueTypeExact(pkg, "Status")); //$NON-NLS-1$
+        assertNull(XdtoWriter.findValueTypeExact(pkg, "status")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStaleSelfRewriteKeepsGenuineRemoteReferences()
+    {
+        // The rename-collision regression: sibling Q (own ns "http://q") carries a STALE content
+        // namespace equal to the renamed package P's OLD namespace "http://a". A QName under the
+        // stale value naming Q's OWN local type must move to Q's namespace; a QName naming a REMOTE
+        // type (P's) must be left for the cascade old->new rewrite - and imports stay untouched.
+        Package q = XdtoFactory.eINSTANCE.createPackage();
+        q.setNsUri("http://a"); //$NON-NLS-1$ (stale - own is http://q)
+        XdtoWriter.createObjectType(q, "LocalType"); //$NON-NLS-1$
+        Import imp = XdtoFactory.eINSTANCE.createImport();
+        imp.setNamespace("http://a"); //$NON-NLS-1$
+        q.getDependencies().add(imp);
+        Property selfRef = XdtoWriter.createProperty(q.getProperties(), "SelfRef"); //$NON-NLS-1$
+        com._1c.g5.v8.dt.mcore.QName selfQ = com._1c.g5.v8.dt.mcore.McoreFactory.eINSTANCE.createQName();
+        selfQ.setNsUri("http://a"); selfQ.setName("LocalType"); //$NON-NLS-1$ //$NON-NLS-2$
+        selfRef.setType(selfQ);
+        Property remoteRef = XdtoWriter.createProperty(q.getProperties(), "RemoteRef"); //$NON-NLS-1$
+        com._1c.g5.v8.dt.mcore.QName remoteQ = com._1c.g5.v8.dt.mcore.McoreFactory.eINSTANCE.createQName();
+        remoteQ.setNsUri("http://a"); remoteQ.setName("PType"); //$NON-NLS-1$ //$NON-NLS-2$
+        remoteRef.setType(remoteQ);
+
+        assertTrue(XdtoWriter.rewriteStaleSelfReferences(q, "http://a", "http://q")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("the self-reference must follow the repair to Q's own namespace", //$NON-NLS-1$
+            "http://q", selfQ.getNsUri()); //$NON-NLS-1$
+        assertEquals("the genuine remote reference must be left for the cascade rewrite", //$NON-NLS-1$
+            "http://a", remoteQ.getNsUri()); //$NON-NLS-1$
+        assertEquals("imports are never self-imports and must stay untouched", //$NON-NLS-1$
+            "http://a", imp.getNamespace()); //$NON-NLS-1$
+
+        // ...and the cascade old->new pass then picks up exactly the remote one.
+        assertTrue(XdtoWriter.rewriteNamespaceReferences(q, "http://a", "http://b")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("http://b", remoteQ.getNsUri()); //$NON-NLS-1$
+        assertEquals("http://b", imp.getNamespace()); //$NON-NLS-1$
+        assertEquals("http://q", selfQ.getNsUri()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStaleSelfRewriteCoversRefsAndTypeStructureQNames()
+    {
+        // ref QNames disambiguate against PACKAGE-GLOBAL PROPERTY names (not type names), and
+        // baseType / itemType / union member / enumeration QNames are covered by the self pass -
+        // a stale self-QName there must not be hijacked by the following broad old->new rewrite.
+        Package q = XdtoFactory.eINSTANCE.createPackage();
+        q.setNsUri("http://a"); //$NON-NLS-1$ (stale - own is http://q)
+        XdtoWriter.createObjectType(q, "LocalType"); //$NON-NLS-1$
+        XdtoWriter.createProperty(q.getProperties(), "GlobalProp"); //$NON-NLS-1$
+
+        // ref naming a LOCAL global property -> self; ref naming a type (not a property) -> remote.
+        Property refSelf = XdtoWriter.createProperty(q.getProperties(), "RefSelf"); //$NON-NLS-1$
+        com._1c.g5.v8.dt.mcore.QName rq = com._1c.g5.v8.dt.mcore.McoreFactory.eINSTANCE.createQName();
+        rq.setNsUri("http://a"); rq.setName("GlobalProp"); //$NON-NLS-1$ //$NON-NLS-2$
+        refSelf.setRef(rq);
+        Property refRemote = XdtoWriter.createProperty(q.getProperties(), "RefRemote"); //$NON-NLS-1$
+        com._1c.g5.v8.dt.mcore.QName rr = com._1c.g5.v8.dt.mcore.McoreFactory.eINSTANCE.createQName();
+        rr.setNsUri("http://a"); rr.setName("LocalType"); //$NON-NLS-1$ //$NON-NLS-2$ (a TYPE name - not a global property)
+        refRemote.setRef(rr);
+
+        // A list ValueType whose itemType names the local type -> self.
+        com._1c.g5.v8.dt.xdto.model.ValueType list = XdtoFactory.eINSTANCE.createValueType();
+        list.setName("ListOfLocal"); //$NON-NLS-1$
+        com._1c.g5.v8.dt.mcore.QName item = com._1c.g5.v8.dt.mcore.McoreFactory.eINSTANCE.createQName();
+        item.setNsUri("http://a"); item.setName("LocalType"); //$NON-NLS-1$ //$NON-NLS-2$
+        list.setItemType(item);
+        q.getTypes().add(list);
+
+        assertTrue(XdtoWriter.rewriteStaleSelfReferences(q, "http://a", "http://q")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("a ref naming a local GLOBAL PROPERTY follows the repair", //$NON-NLS-1$
+            "http://q", rq.getNsUri()); //$NON-NLS-1$
+        assertEquals("a ref naming a TYPE (not a property) is NOT a self-ref - left for the cascade", //$NON-NLS-1$
+            "http://a", rr.getNsUri()); //$NON-NLS-1$
+        assertEquals("a list itemType naming a local type follows the repair", //$NON-NLS-1$
+            "http://q", item.getNsUri()); //$NON-NLS-1$
+
+        // The broad pass now also covers itemType/member QNames for an ORDINARY cascade.
+        com._1c.g5.v8.dt.mcore.QName member = com._1c.g5.v8.dt.mcore.McoreFactory.eINSTANCE.createQName();
+        member.setNsUri("http://x"); member.setName("Whatever"); //$NON-NLS-1$ //$NON-NLS-2$
+        list.getMemeberTypes().add(member);
+        assertTrue(XdtoWriter.rewriteNamespaceReferences(q, "http://x", "http://y")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("http://y", member.getNsUri()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNamespaceRewriteWalksNestedTypeDefs()
+    {
+        // Anonymous nested type definitions (Property.typeDefs / ValueType.typeDefs) carry the same
+        // QName surface recursively - BOTH passes must walk them (codex finding).
+        Package q = XdtoFactory.eINSTANCE.createPackage();
+        q.setNsUri("http://a"); //$NON-NLS-1$ (stale - own is http://q)
+        XdtoWriter.createObjectType(q, "LocalType"); //$NON-NLS-1$
+        // A property with an ANONYMOUS nested ValueType whose baseType names the local type.
+        Property holder = XdtoWriter.createProperty(q.getProperties(), "Holder"); //$NON-NLS-1$
+        com._1c.g5.v8.dt.xdto.model.ValueType nested = XdtoFactory.eINSTANCE.createValueType();
+        com._1c.g5.v8.dt.mcore.QName nestedBase = com._1c.g5.v8.dt.mcore.McoreFactory.eINSTANCE.createQName();
+        nestedBase.setNsUri("http://a"); nestedBase.setName("LocalType"); //$NON-NLS-1$ //$NON-NLS-2$
+        nested.setBaseType(nestedBase);
+        holder.setTypeDefs(nested);
+
+        // Self pass: the nested baseType naming a local type follows the repair.
+        assertTrue(XdtoWriter.rewriteStaleSelfReferences(q, "http://a", "http://q")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("http://q", nestedBase.getNsUri()); //$NON-NLS-1$
+
+        // Broad pass: a nested REMOTE QName is rewritten by the ordinary cascade too.
+        com._1c.g5.v8.dt.mcore.QName nestedItem = com._1c.g5.v8.dt.mcore.McoreFactory.eINSTANCE.createQName();
+        nestedItem.setNsUri("http://x"); nestedItem.setName("Remote"); //$NON-NLS-1$ //$NON-NLS-2$
+        nested.setItemType(nestedItem);
+        assertTrue(XdtoWriter.rewriteNamespaceReferences(q, "http://x", "http://y")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("http://y", nestedItem.getNsUri()); //$NON-NLS-1$
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
@@ -1148,4 +1148,20 @@ public class XdtoWriterTest
         assertSame("the exact yo-spelled ValueType must win over the earlier normalized one", //$NON-NLS-1$
             yoT, XdtoWriter.findLocalType(pkg, "\u0401\u043B\u043A\u0430")); //$NON-NLS-1$
     }
+
+    @Test
+    public void testExactLookupsDoNotYoFallback()
+    {
+        // Create-time duplicate checks must be character-sensitive: with normalizeYo=false a caller
+        // may legitimately create a distinct name differing only by yo (codex finding).
+        Package pkg = newPackage();
+        XdtoWriter.createObjectType(pkg, "\u0415\u043B\u043A\u0430"); //$NON-NLS-1$
+        assertNull("the yo spelling is NOT an exact duplicate of the ye-stored ObjectType", //$NON-NLS-1$
+            XdtoWriter.findObjectTypeExact(pkg, "\u0401\u043B\u043A\u0430")); //$NON-NLS-1$
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "\u0415\u043B\u043A\u0430"); //$NON-NLS-1$
+        assertNull("the yo spelling is NOT an exact duplicate of the ye-stored Property", //$NON-NLS-1$
+            XdtoWriter.findPropertyExact(pkg.getProperties(), "\u0401\u043B\u043A\u0430")); //$NON-NLS-1$
+        assertSame("the exact spelling still matches", property, //$NON-NLS-1$
+            XdtoWriter.findPropertyExact(pkg.getProperties(), "\u0415\u043B\u043A\u0430")); //$NON-NLS-1$
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
@@ -1116,5 +1117,35 @@ public class XdtoWriterTest
     private static String q(String v)
     {
         return '"' + v + '"';
+    }
+
+    @Test
+    public void testObjectFormNonStringNsUriIsRejectedNotDefaulted()
+    {
+        // {nsUri: 123, name: "string"} must be REJECTED - a present-but-non-string nsUri treated as
+        // "omitted" would silently default to the XSD namespace (codex finding).
+        Package pkg = newPackage();
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result r = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{" + q("name") + ":" + q("type") + "," + q("value") + ":{"
+                + q("nsUri") + ":123," + q("name") + ":" + q("string") + "}}")), false); //$NON-NLS-1$
+        assertTrue("a non-string nsUri must be rejected, not defaulted to XSD", r.hasError()); //$NON-NLS-1$
+        assertTrue("the error must name nsUri: " + r.error, r.error.contains("nsUri")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFindLocalTypeExactValueTypeBeatsYoFallback()
+    {
+        // Two local value types differing only by yo: the EXACT match must win even when the
+        // yo-normalized one sits earlier in the list (mirrors findObjectType, codex finding).
+        Package pkg = newPackage();
+        com._1c.g5.v8.dt.xdto.model.ValueType ye = com._1c.g5.v8.dt.xdto.model.XdtoFactory.eINSTANCE.createValueType();
+        ye.setName("\u0415\u043B\u043A\u0430"); //$NON-NLS-1$
+        pkg.getTypes().add(ye);
+        com._1c.g5.v8.dt.xdto.model.ValueType yoT = com._1c.g5.v8.dt.xdto.model.XdtoFactory.eINSTANCE.createValueType();
+        yoT.setName("\u0401\u043B\u043A\u0430"); //$NON-NLS-1$
+        pkg.getTypes().add(yoT);
+        assertSame("the exact yo-spelled ValueType must win over the earlier normalized one", //$NON-NLS-1$
+            yoT, XdtoWriter.findLocalType(pkg, "\u0401\u043B\u043A\u0430")); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/XdtoWriterTest.java
@@ -327,6 +327,9 @@ public class XdtoWriterTest
     public void testPropertyTypeExplicitObjectFormOwnNamespaceNeedsNoImport()
     {
         Package pkg = newPackage();
+        // The referenced ObjectType must exist: the own-namespace object form now validates the local
+        // target (parity with the string shorthand), so the no-Import point is proven with a real one.
+        XdtoWriter.createObjectType(pkg, "Custom"); //$NON-NLS-1$
         Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
         Result r = XdtoWriter.applyPropertyProperties(property, pkg,
             List.of(json("{\"name\":\"type\",\"value\":{\"nsUri\":\"" + pkg.getNsUri() + "\",\"name\":\"Custom\"}}")), //$NON-NLS-1$ //$NON-NLS-2$
@@ -1040,5 +1043,29 @@ public class XdtoWriterTest
         q.setNsUri(nsUri);
         q.setName(name);
         return q;
+    }
+
+    @Test
+    public void testObjectFormOwnNamespaceRequiresExistingObjectType()
+    {
+        // Parity with the bare-string shorthand: the explicit object form pointing at the package's
+        // OWN namespace must reference an ObjectType that actually exists - a typo must not silently
+        // persist a dangling same-package reference.
+        Package pkg = newPackage();
+        XdtoWriter.createObjectType(pkg, "Address"); //$NON-NLS-1$
+        Property property = XdtoWriter.createProperty(pkg.getProperties(), "MyProp"); //$NON-NLS-1$
+        Result bad = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"type\",\"value\":{\"nsUri\":\"" + pkg.getNsUri() //$NON-NLS-1$
+                + "\",\"name\":\"Adress\"}}")), false); //$NON-NLS-1$
+        assertTrue("an own-namespace object-form name with no matching ObjectType must be rejected", //$NON-NLS-1$
+            bad.hasError());
+        assertTrue("the error must name the bad value: " + bad.error, bad.error.contains("Adress")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        Result ok = XdtoWriter.applyPropertyProperties(property, pkg,
+            List.of(json("{\"name\":\"type\",\"value\":{\"nsUri\":\"" + pkg.getNsUri() //$NON-NLS-1$
+                + "\",\"name\":\"Address\"}}")), false); //$NON-NLS-1$
+        assertFalse("an own-namespace object-form name matching an ObjectType must be accepted: " //$NON-NLS-1$
+            + ok.error, ok.hasError());
+        assertEquals(pkg.getNsUri(), property.getType().getNsUri());
     }
 }

--- a/tests/e2e/tools/test_delete_metadata.py
+++ b/tests/e2e/tools/test_delete_metadata.py
@@ -31,6 +31,7 @@ from harness import (
     assert_not_contains,
     assert_no_diff,
     assert_tree_unchanged,
+    assert_diff_contains,
     poll_disk_path_gone,
     poll_disk_lacks,
     tree_snapshot,
@@ -591,3 +592,56 @@ def test_bare_token_without_dot_is_error():
     e = assert_error(r, "malformed FQN (no dot)")
     assert_error_quality(e, names=[bad], suggests=["Type.Name"])
     assert_no_diff("a rejected call must not touch the project on disk")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# XDTO PACKAGE MEMBER delete (issue #183 stream 1) — a Property nested in an
+# ObjectType is deleted by its own FQN; its SIBLING property + the owning (now
+# emptied) ObjectType both survive. Confirmed live: after the delete, the owner
+# collapses to a self-closed <objectType name="Row"/> once its last remaining
+# property is also gone, but here ONE sibling survives, so the ObjectType stays
+# non-empty. On disk the change lands in the package's own Package.xdto.
+# ──────────────────────────────────────────────────────────────────────────────
+
+@e2e_test(tool="delete_metadata", kind="write-metadata")
+def test_delete_xdto_member():
+    pkg, obj = "E2EXdtoDel", "Row"
+    pkg_fqn = "XDTOPackage." + pkg
+    xdto_path = "src/XDTOPackages/%s/Package.xdto" % pkg
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": pkg_fqn}), "seed the XDTO package")
+    wait_for_project_ready()
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": pkg_fqn + ".ObjectType." + obj}),
+              "seed the ObjectType " + obj)
+    wait_for_project_ready()
+    gone_fqn = pkg_fqn + ".ObjectType.%s.Property.Gone" % obj
+    kept_fqn = pkg_fqn + ".ObjectType.%s.Property.Kept" % obj
+    assert_ok(call("create_metadata", {
+        "projectName": PROJECT, "fqn": gone_fqn,
+        "properties": [{"name": "type", "value": "string"}]}), "seed Property Gone")
+    wait_for_project_ready()
+    assert_ok(call("create_metadata", {
+        "projectName": PROJECT, "fqn": kept_fqn,
+        "properties": [{"name": "type", "value": "string"}]}), "seed Property Kept")
+    wait_for_project_ready()
+
+    r = call("delete_metadata", {"projectName": PROJECT, "fqn": gone_fqn, "confirm": True})
+    assert_ok(r, "delete the Gone property (confirm=true)")
+    assert r.structured.get("action") == "executed", "confirm must execute: %r" % (r.structured,)
+    assert r.structured.get("fqn") == gone_fqn, "must echo the target fqn"
+
+    # Package.xdto is a brand-new UNTRACKED file (this test creates the whole package), so a plain
+    # `git diff` (tracked files only) would never see it -- assert_diff_contains covers untracked
+    # files too (the same reason poll_disk_lacks / poll_disk_path_gone read the actual file for
+    # "gone" checks rather than relying on git diff).
+    poll_disk_lacks(xdto_path, 'name="Gone"',
+                    ctx="the deleted property must be gone from Package.xdto on disk")
+    assert_diff_contains('name="Kept"',
+                         ctx="the surviving sibling property must remain in Package.xdto on disk")
+    assert_diff_contains('name="%s"' % obj,
+                         ctx="the owning ObjectType must survive a member-only delete")
+
+    # MODEL read-back: get_metadata_details on the package no longer lists Gone, still lists Kept.
+    d = call("get_metadata_details", {"projectName": PROJECT, "objectFqns": [pkg_fqn]})
+    assert_ok(d, "get_metadata_details read-back on the package")
+    assert_not_contains(d.text, "| Gone |", "the deleted property must be GONE from the model read-back")
+    assert_contains(d.text, "| Kept |", "the surviving property must remain in the model read-back")

--- a/tests/e2e/tools/test_get_metadata_details.py
+++ b/tests/e2e/tools/test_get_metadata_details.py
@@ -563,3 +563,43 @@ def test_information_register_dimension_indexing_rendered():
     assert_ok(r_full, "get_metadata_details on the register (full)")
     assert_contains(r_full.text, "### Dimension Indexing", "the section must also render in full mode")
     assert_contains(r_full.text, dim, "the seeded dimension must be listed in full mode too")
+
+
+# XDTO PACKAGE structure (issue #183 stream 1) — a package FQN renders its
+# ObjectTypes + their nested Properties (XdtoStructureReader, folded into the
+# generic render as a "## XDTO content" section, alongside the Basic Properties
+# section every top object gets). The fixture ships no XDTOPackage, so seed one.
+# ──────────────────────────────────────────────────────────────────────────────
+
+@e2e_test(tool="get_metadata_details", kind="write-metadata")
+def test_get_metadata_details_renders_xdto_structure():
+    pkg, obj, prop = "E2EXdtoDet", "Card", "Title"
+    pkg_fqn = "XDTOPackage." + pkg
+    r0 = call("create_metadata", {"projectName": PROJECT, "fqn": pkg_fqn})
+    assert_ok(r0, "seed the XDTO package " + pkg)
+    wait_for_project_ready()
+    r1 = call("create_metadata", {"projectName": PROJECT, "fqn": pkg_fqn + ".ObjectType." + obj})
+    assert_ok(r1, "seed the ObjectType " + obj)
+    wait_for_project_ready()
+    r2 = call("create_metadata", {
+        "projectName": PROJECT, "fqn": pkg_fqn + ".ObjectType.%s.Property.%s" % (obj, prop),
+        "properties": [{"name": "type", "value": "string"}]})
+    assert_ok(r2, "seed the Property " + prop)
+    wait_for_project_ready()
+
+    r = call("get_metadata_details", {"projectName": PROJECT, "objectFqns": [pkg_fqn]})
+    assert_ok(r, "get_metadata_details on the XDTOPackage FQN")
+    if "## Errors" in r.text:
+        raise AssertionError(
+            "the freshly seeded XDTO package should resolve, but a ## Errors section was emitted:\n"
+            + r.text[:400])
+    assert_contains(r.text, "XDTO content", "the XDTO content section must render")
+    assert_contains(r.text, "#### " + obj, "the ObjectType must be enumerated as its own heading")
+    # The nested property must appear as its own table row under the ObjectType (not merely
+    # anywhere in the body -- a false match on the FQN heading would not prove enumeration).
+    row = next((ln for ln in r.text.splitlines() if ln.strip().startswith("| " + prop + " |")), None)
+    assert row is not None, \
+        "the nested property must be listed in the ObjectType's property table: %r" % (r.text[:800])
+    assert_contains(row, "string", "the property row must show its XSD string type")
+    # (No assert_no_diff: the test intentionally seeds a fresh XDTO package + members, so the tree
+    # is dirty by design -- kind="write-metadata" resets it after the test.)

--- a/tests/e2e/tools/test_modify_metadata.py
+++ b/tests/e2e/tools/test_modify_metadata.py
@@ -18,6 +18,9 @@ reset: kind="write-metadata" -> reset_model() after each test.
 Fixture: Catalog.Catalog (attribute "Attribute"), CommonModule.Error/OK/Calc, ...
 """
 
+import os
+import uuid
+
 from harness import (
     call,
     assert_ok,
@@ -35,6 +38,7 @@ from harness import (
     read_disk,
     e2e_test,
     PROJECT,
+    PROJECT_DIR,
     TESTS_PROJECT,
 )
 
@@ -1556,3 +1560,106 @@ def test_event_subscription_handler_missing_method_is_error():
     assert_error_quality(e, names=["E2EMrvSubNoSuchMethod", "Calc"], suggests=["write_module_source"],
                          ctx="a missing handler method must be named with a create-it-first hint")
     assert_tree_unchanged(before, "a rejected handler must not touch the project")
+
+
+# ----------------------------------------------------------------------------
+# XDTO NAMESPACE CASCADE - changing a package namespace must rewrite every OTHER
+# package that references the old namespace (imports + QNames), or the rename
+# silently breaks the REFERENCING package, not the renamed one.
+# ----------------------------------------------------------------------------
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_xdto_namespace_change_cascades_into_referencing_package():
+    """The maintainer case, end-to-end: package P is authored via MCP; package Q -
+    planted straight on the fixture path, because imports are not authorable through
+    MCP - IMPORTS P namespace and types a property into it. Renaming P namespace
+    must (a) report the propagation, (b) rewrite Q import AND the property QName
+    on disk with no trace of the old namespace, and (c) rewrite P own same-package
+    references. kind=write-metadata reverts the fixture afterwards."""
+    old_ns = "http://e2e/casc-old"
+    new_ns = "http://e2e/casc-new"
+    p_fqn = "XDTOPackage.E2ECascP"
+    r = call("create_metadata", {"projectName": PROJECT, "fqn": p_fqn, "targetNamespace": old_ns})
+    assert_ok(r, "seed " + p_fqn)
+    r = call("create_metadata", {"projectName": PROJECT, "fqn": p_fqn + ".ObjectType.Src"})
+    assert_ok(r, "seed ObjectType Src")
+    r = call("create_metadata", {"projectName": PROJECT, "fqn": p_fqn + ".ObjectType.User"})
+    assert_ok(r, "seed ObjectType User")
+    r = call("create_metadata", {
+        "projectName": PROJECT, "fqn": p_fqn + ".ObjectType.User.Property.Link",
+        "properties": [{"name": "type", "value": "Src"}]})
+    assert_ok(r, "seed the self-referencing property")
+    wait_for_project_ready()
+
+    # Plant the REFERENCING package Q on disk (mdo + content importing P namespace).
+    q_dir = os.path.join(PROJECT_DIR, "src", "XDTOPackages", "E2ECascQ")
+    os.makedirs(q_dir, exist_ok=True)
+    mdo_lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<mdclass:XDTOPackage xmlns:mdclass="http://g5.1c.ru/v8/dt/metadata/mdclass" uuid="%s">' % uuid.uuid4(),
+        '  <name>E2ECascQ</name>',
+        '  <namespace>http://e2e/casc-q</namespace>',
+        '</mdclass:XDTOPackage>',
+        "",
+    ]
+    with open(os.path.join(q_dir, "E2ECascQ.mdo"), "w", encoding="utf-8") as f:
+        f.write("\n".join(mdo_lines))
+    xdto_lines = [
+        '<package xmlns="http://v8.1c.ru/8.1/xdto" xmlns:xs="http://www.w3.org/2001/XMLSchema" '
+        'xmlns:d3p1="%s" targetNamespace="http://e2e/casc-q">' % old_ns,
+        '<import namespace="%s"/>' % old_ns,
+        '<objectType name="UsesP">',
+        '<property name="Link" type="d3p1:Src"/>',
+        '</objectType>',
+        '</package>',
+        "",
+    ]
+    with open(os.path.join(q_dir, "Package.xdto"), "w", encoding="utf-8") as f:
+        f.write("\n".join(xdto_lines))
+    cfg_path = os.path.join(PROJECT_DIR, "src", "Configuration", "Configuration.mdo")
+    with open(cfg_path, encoding="utf-8") as f:
+        cfg = f.read()
+    anchor = "<xDTOPackages>XDTOPackage.E2ECascP</xDTOPackages>"
+    if anchor not in cfg:
+        raise AssertionError("setup failed: %s not registered in Configuration.mdo" % p_fqn)
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        f.write(cfg.replace(anchor,
+            anchor + "\n  <xDTOPackages>XDTOPackage.E2ECascQ</xDTOPackages>", 1))
+    r = call("resync_to_disk", {"projectName": PROJECT})
+    assert_ok(r, "resync loads the planted referencing package")
+    wait_for_project_ready()
+    # The planted files land OUTSIDE the Eclipse resource API, so EDT picks them up via its own
+    # auto-refresh/import job - POLL until Q's content is actually visible in the MODEL (the cascade
+    # walks the model, not the disk; renaming before the import completes would see no referencer).
+    import time as _time
+    for _ in range(60):
+        d = call("get_metadata_details", {"projectName": PROJECT, "objectFqns": ["XDTOPackage.E2ECascQ"]})
+        if not d.is_error and d.text and "UsesP" in d.text:
+            break
+        _time.sleep(2)
+    else:
+        raise AssertionError("setup failed: the planted E2ECascQ never became visible in the model")
+    wait_for_project_ready()
+
+    # The rename under test.
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": p_fqn,
+        "properties": [{"name": "namespace", "value": new_ns}]})
+    assert_ok(r, "change the namespace of " + p_fqn)
+    msg = (r.structured or {}).get("message", "")
+    if "propagated" not in msg or "E2ECascQ" not in msg:
+        raise AssertionError("the result must report the propagation to E2ECascQ: %r" % msg)
+
+    # Ground truth on disk: Q import + property QName carry the NEW namespace only...
+    poll_diff_contains(new_ns, ctx="Q must be rewritten to the new namespace on disk")
+    q_text = read_disk("src/XDTOPackages/E2ECascQ/Package.xdto")
+    assert_contains(q_text, "import namespace=" + chr(34) + new_ns + chr(34),
+        "Q import must point at the NEW namespace")
+    if old_ns in q_text:
+        raise AssertionError("no trace of the OLD namespace may remain in Q: %r" % q_text)
+    # ...and P own content (targetNamespace + the self-reference QName) moved as one.
+    p_text = read_disk("src/XDTOPackages/E2ECascP/Package.xdto")
+    assert_contains(p_text, "targetNamespace=" + chr(34) + new_ns + chr(34),
+        "P own targetNamespace must move")
+    if old_ns in p_text:
+        raise AssertionError("P own self-reference must be rewritten too: %r" % p_text)

--- a/tests/e2e/tools/test_modify_metadata.py
+++ b/tests/e2e/tools/test_modify_metadata.py
@@ -27,10 +27,12 @@ from harness import (
     assert_not_contains,
     assert_no_diff,
     assert_tree_unchanged,
+    assert_diff_contains,
     poll_diff_contains,
     tree_snapshot,
     wait_for_project_ready,
     diff,
+    read_disk,
     e2e_test,
     PROJECT,
     TESTS_PROJECT,
@@ -991,6 +993,85 @@ def test_rebind_button_command_mixed_with_other_property_rejected():
     assert_error_quality(e, suggests=["cannot be combined", "separate call"],
                          ctx="a button command rebind cannot be mixed with a property change")
     assert_tree_unchanged(before, "a rejected mixed rebind must change nothing")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# XDTO PACKAGE MEMBER editing (issue #183 stream 1) — an ObjectType-nested Property
+# is addressed by 'XDTOPackage.<P>.ObjectType.<T>.Property.<N>' and takes the
+# XDTO-specific vocabulary (type/lowerBound/upperBound/nillable/fixed/default) via
+# XdtoWriter, not the generic mdclass reflection path. On disk the change lands in
+# the package's own Package.xdto (confirmed live: <property name="Amount"
+# type="xs:decimal" lowerBound="0" nillable="true"/>), sibling to the
+# XDTOPackage's own .mdo (which carries only <namespace>).
+# ──────────────────────────────────────────────────────────────────────────────
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_modify_xdto_object_type_property():
+    pkg, obj, prop = "E2EXdtoMod", "Doc", "Amount"
+    pkg_fqn = "XDTOPackage." + pkg
+    ns = "http://example.org/e2e/%s" % pkg
+    assert_ok(call("create_metadata", {
+        "projectName": PROJECT, "fqn": pkg_fqn, "targetNamespace": ns}), "seed the XDTO package")
+    wait_for_project_ready()
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": pkg_fqn + ".ObjectType." + obj}),
+              "seed the ObjectType " + obj)
+    wait_for_project_ready()
+    prop_fqn = pkg_fqn + ".ObjectType.%s.Property.%s" % (obj, prop)
+    assert_ok(call("create_metadata", {
+        "projectName": PROJECT, "fqn": prop_fqn,
+        "properties": [{"name": "type", "value": "string"}]}),
+        "seed the Property %s (type=string)" % prop)
+    wait_for_project_ready()
+
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": prop_fqn,
+        "properties": [
+            {"name": "type", "value": "decimal"},
+            {"name": "lowerBound", "value": 0},
+            {"name": "nillable", "value": True},
+        ],
+    })
+    assert_ok(r, "modify the ObjectType-nested Property's type/lowerBound/nillable")
+    assert r.structured.get("action") == "modified", "must report modified: %r" % (r.structured,)
+    applied = r.structured.get("applied") or []
+    for f in ("type", "lowerBound", "nillable"):
+        assert f in applied, "%s must be in applied: %r" % (f, r.structured)
+    assert r.structured.get("persisted") is True, \
+        "the XDTO member change must force-export the package content to disk: %r" % (r.structured,)
+
+    # ON-DISK: Package.xdto now carries the changed type + the new nillable flag, and the stale
+    # xs:string type is gone (replaced, not left dangling alongside the new one). Package.xdto is a
+    # brand-new UNTRACKED file (this test creates the whole package), so a plain `git diff` (tracked
+    # files only) would never see it -- assert_diff_contains / poll_diff_contains cover untracked
+    # files too; the "must NOT contain" check reads the file directly (read_disk) for the same reason.
+    xdto_path = "src/XDTOPackages/%s/Package.xdto" % pkg
+    poll_diff_contains('type="xs:decimal"',
+                       ctx="the changed type must land as xs:decimal in Package.xdto on disk")
+    assert_diff_contains('name="%s"' % prop,
+                         ctx="the property's own name attribute must be present in the .xdto diff")
+    assert_diff_contains('nillable="true"',
+                         ctx="the nillable=true flag must land in Package.xdto on disk")
+    assert_not_contains(read_disk(xdto_path), 'type="xs:string"',
+                        "the old xs:string type must be replaced, not left dangling")
+
+    # MODEL read-back: the package structure render shows the Amount row with the new type/nillable.
+    d = call("get_metadata_details", {"projectName": PROJECT, "objectFqns": [pkg_fqn]})
+    assert_ok(d, "get_metadata_details read-back on the package")
+    row = next((ln for ln in d.text.splitlines() if ln.strip().startswith("| " + prop + " |")), None)
+    assert row is not None, "the %s property row must be listed in the read-back: %r" % (prop, d.text[:800])
+    assert_contains(row, "decimal", "the read-back row must show the new decimal type")
+    assert_contains(row, "true", "the read-back row must show nillable=true")
+
+    # Negative: an unknown type token is neither an XSD builtin nor a same-package ObjectType name.
+    before_bad = tree_snapshot()
+    r2 = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": prop_fqn,
+        "properties": [{"name": "type", "value": "NoSuchType_e2e"}],
+    })
+    e = assert_error(r2, "unknown XDTO type token")
+    assert_error_quality(e, names=["NoSuchType_e2e"], suggests=["ObjectType", "XSD"],
+                         ctx="an unrecognized type token names the bad value and explains the two valid forms")
+    assert_tree_unchanged(before_bad, "a rejected type set must change nothing")
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/e2e/tools/test_modify_metadata.py
+++ b/tests/e2e/tools/test_modify_metadata.py
@@ -1625,12 +1625,17 @@ def test_xdto_namespace_change_cascades_into_referencing_package():
     with open(cfg_path, "w", encoding="utf-8") as f:
         f.write(cfg.replace(anchor,
             anchor + "\n  <xDTOPackages>XDTOPackage.E2ECascQ</xDTOPackages>", 1))
-    r = call("resync_to_disk", {"projectName": PROJECT})
-    assert_ok(r, "resync loads the planted referencing package")
+    # The planted files land OUTSIDE the Eclipse resource API. A Windows stand happens to pick
+    # them up via auto-refresh, but the Linux CI runner does NOT (no native refresh hooks), so the
+    # import must be DETERMINISTIC: clean_project re-imports the whole project from disk - the same
+    # mechanism the harness itself uses in reset_model(). The MCP-created P was force-exported to
+    # disk by its create, so it survives the re-import unchanged.
     wait_for_project_ready()
-    # The planted files land OUTSIDE the Eclipse resource API, so EDT picks them up via its own
-    # auto-refresh/import job - POLL until Q's content is actually visible in the MODEL (the cascade
-    # walks the model, not the disk; renaming before the import completes would see no referencer).
+    r = call("clean_project", {"projectName": PROJECT})
+    assert_ok(r, "clean_project re-imports the planted referencing package from disk")
+    wait_for_project_ready()
+    # Belt-and-braces: POLL until Q's content is actually visible in the MODEL (the cascade walks
+    # the model, not the disk; renaming before the import completes would see no referencer).
     import time as _time
     for _ in range(60):
         d = call("get_metadata_details", {"projectName": PROJECT, "objectFqns": ["XDTOPackage.E2ECascQ"]})

--- a/tests/e2e/tools/test_validate_xdto_package.py
+++ b/tests/e2e/tools/test_validate_xdto_package.py
@@ -1,0 +1,178 @@
+"""
+e2e tests for validate_xdto_package (kind: read tool, but two tests SEED via
+create_metadata/delete_metadata and are therefore declared kind="write-metadata" so the
+orchestrator resets the fixture + model afterward -- see test_get_metadata_details.py for
+the same pattern of a read tool needing a write-metadata SETUP).
+
+validate_xdto_package is a THIN wrapper over get_project_errors: it resolves + type-checks
+the `fqn` (must be an existing XDTOPackage top object), then delegates to
+GetProjectErrorsTool.getProjectErrors(projectName, null, null, [pkgFqn], limit, false,
+exactScope=true) -- ALL severities, EXACT per-package scope, using the resolved package's
+canonical FQN -- and prepends a one-line pass/fail verdict to the returned Markdown.
+
+Happy paths:
+  - a freshly created, empty XDTO package validates clean ("is valid" verdict).
+  - deleting an ObjectType that another Property references (same-package reference) leaves
+    a DANGLING reference; delete_metadata does NOT cascade into the xdto.model content (see
+    DeleteMetadataTool's own "Cross-references to it ... are NOT cleaned up" note), so EDT's
+    own validator reports it as a problem once revalidated -- proving the tool's `objects`
+    scoping and verdict wiring both actually work (a broken/no-op tool would report "is
+    valid" here).
+
+Negative matrix:
+  - fqn resolves to something other than an XDTOPackage (an existing Catalog) -> rejected.
+  - fqn does not resolve at all (unknown package name) -> rejected (same error path).
+  - non-existent projectName -> "Project not found: <name>".
+"""
+
+from harness import (
+    call,
+    assert_ok,
+    assert_error,
+    assert_contains,
+    assert_not_contains,
+    assert_error_quality,
+    assert_no_diff,
+    wait_for_project_ready,
+    e2e_test,
+    PROJECT,
+)
+
+
+def _create_ok(fqn, properties=None, ctx=""):
+    args = {"projectName": PROJECT, "fqn": fqn}
+    if properties is not None:
+        args["properties"] = properties
+    r = call("create_metadata", args)
+    assert_ok(r, ctx or ("create " + fqn))
+    wait_for_project_ready()
+    return r
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# HAPPY PATHS
+# ──────────────────────────────────────────────────────────────────────────────
+
+@e2e_test(tool="validate_xdto_package", kind="write-metadata")
+def test_fresh_empty_package_is_valid():
+    pkg = "VXPCleanPkg"
+    fqn = "XDTOPackage." + pkg
+    _create_ok(fqn, ctx="seed a fresh XDTO package")
+
+    r = call("validate_xdto_package", {"projectName": PROJECT, "fqn": fqn})
+    assert_ok(r, "validate a freshly created, unmodified XDTO package")
+    assert_contains(r.text, "is valid", "a clean package must get the pass verdict")
+    assert_contains(r.text, fqn, "the verdict must name the validated package")
+    assert_not_contains(r.text, "problems found", "a clean package must not report problems")
+
+
+@e2e_test(tool="validate_xdto_package", kind="write-metadata")
+def test_dangling_object_type_reference_is_reported_after_delete():
+    pkg = "VXPDanglingPkg"
+    pkg_fqn = "XDTOPackage." + pkg
+    type_a = "VXPObjTypeA"
+    type_b = "VXPObjTypeB"
+    ref_prop = "VXPRefToA"
+
+    _create_ok(pkg_fqn, ctx="seed the XDTO package")
+    _create_ok(pkg_fqn + ".ObjectType." + type_a, ctx="seed ObjectType A")
+    _create_ok(pkg_fqn + ".ObjectType." + type_b, ctx="seed ObjectType B")
+    # A same-package reference: a Property's 'type' value is the EXACT name of another
+    # ObjectType already in the package (resolves to a same-package QName - no {nsUri,name}
+    # object needed).
+    _create_ok(pkg_fqn + ".ObjectType." + type_b + ".Property." + ref_prop,
+               properties=[{"name": "type", "value": type_a}],
+               ctx="seed Property B.%s referencing ObjectType A" % ref_prop)
+
+    # Sanity: before the delete, the package must validate clean (proves the NEXT check is
+    # really caused by the delete, not a pre-existing unrelated problem in this package).
+    before = call("validate_xdto_package", {"projectName": PROJECT, "fqn": pkg_fqn})
+    assert_ok(before, "validate before the delete")
+    assert_contains(before.text, "is valid", "package must be valid before the dangling delete")
+
+    # Delete ObjectType A. The xdto.model content is NOT covered by the mdclass refactoring
+    # service, so Property B.RefToA's type reference is left dangling on purpose.
+    d = call("delete_metadata", {
+        "projectName": PROJECT, "fqn": pkg_fqn + ".ObjectType." + type_a, "confirm": True})
+    assert_ok(d, "delete ObjectType A (confirm=true)")
+    wait_for_project_ready()
+
+    # validate_xdto_package documents that it reads EXISTING markers rather than forcing a
+    # fresh compile; force one so the assertion below is deterministic.
+    reval = call("revalidate_objects", {"projectName": PROJECT, "objects": [pkg_fqn]})
+    assert_ok(reval, "revalidate the package after the dangling delete")
+
+    r = call("validate_xdto_package", {"projectName": PROJECT, "fqn": pkg_fqn})
+    assert_ok(r, "validate after the dangling-reference delete")
+    assert_contains(r.text, "problems found", "a dangling type reference must fail validation")
+    assert_contains(r.text, pkg_fqn, "the verdict must name the validated package")
+    assert_not_contains(r.text, "is valid", "a broken package must not get the pass verdict")
+    # The delegated get_project_errors table must actually be present (not a bare verdict
+    # line) - proves the tool really scoped + rendered EDT's own problem list.
+    assert_contains(r.text, "Check code", "the underlying problem table must be rendered")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# NEGATIVE MATRIX
+# ──────────────────────────────────────────────────────────────────────────────
+
+@e2e_test(tool="validate_xdto_package", kind="read")
+def test_non_xdto_fqn_is_rejected():
+    """An FQN that resolves but is NOT an XDTOPackage (an existing Catalog) must be rejected
+    with an actionable error, not silently validated as if it were the package."""
+    r = call("validate_xdto_package", {"projectName": PROJECT, "fqn": "Catalog.Catalog"})
+    err = assert_error(r, "a non-XDTOPackage fqn")
+    assert_error_quality(
+        err,
+        names=["Catalog.Catalog"],
+        suggests=["XDTOPackage", "get_metadata_objects"],
+        ctx="non-XDTOPackage fqn names the bad value and explains the expected shape",
+    )
+    assert_no_diff("a rejected read must not touch the project on disk")
+
+
+@e2e_test(tool="validate_xdto_package", kind="read")
+def test_unknown_package_fqn_is_rejected():
+    """An fqn that does not resolve to ANY existing node hits the same not-an-XDTOPackage
+    guard and must still name the bad value."""
+    bad_fqn = "XDTOPackage.NoSuchXdtoPackage_e2e_zzz"
+    r = call("validate_xdto_package", {"projectName": PROJECT, "fqn": bad_fqn})
+    err = assert_error(r, "an unknown XDTOPackage fqn")
+    assert_error_quality(
+        err,
+        names=[bad_fqn],
+        suggests=["get_metadata_objects"],
+        ctx="unknown package fqn names the bad value and points at get_metadata_objects",
+    )
+    assert_no_diff("a rejected read must not touch the project on disk")
+
+
+@e2e_test(tool="validate_xdto_package", kind="read")
+def test_nonexistent_project_is_rejected():
+    """A non-existent projectName must error and name the bad value (not silently validate
+    against the wrong / default project)."""
+    bad = "NoSuchProject_e2e_xyz_vxp"
+    r = call("validate_xdto_package", {"projectName": bad, "fqn": "XDTOPackage.Whatever"})
+    err = assert_error(r, "non-existent projectName")
+    assert_error_quality(
+        err,
+        names=[bad],
+        suggests=["list_projects"],
+        ctx="non-existent project names the bad value and points at list_projects",
+    )
+    assert_no_diff("a rejected read must not touch the project on disk")
+
+
+@e2e_test(tool="validate_xdto_package", kind="read")
+def test_missing_fqn_is_rejected():
+    """The required `fqn` parameter must be enforced at the live wire level too (not just
+    the headless JUnit contract test)."""
+    r = call("validate_xdto_package", {"projectName": PROJECT})
+    err = assert_error(r, "missing fqn")
+    assert_error_quality(
+        err,
+        names=["fqn"],
+        suggests=["required"],
+        ctx="missing fqn must say which parameter is required",
+    )
+    assert_no_diff("a rejected read must not touch the project on disk")

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -471,7 +471,7 @@
       "openWorldHint": false,
       "readOnlyHint": false
     },
-    "description": "Create a metadata node addressed by a 1C full-name FQN: a top-level object (Catalog.Products) or a subordinate member (Catalog.Products.Attribute.Weight, InformationRegister.Prices.Dimension.Product, Enum.Colors.EnumValue.Red). The kind is inferred from the FQN; type and kind tokens may be English or Russian. Full parameters and examples: call get_tool_guide('create_metadata').",
+    "description": "Create a metadata node addressed by a 1C full-name FQN: a top-level object (Catalog.Products) or a subordinate member (Catalog.Products.Attribute.Weight, InformationRegister.Prices.Dimension.Product, Enum.Colors.EnumValue.Red). The kind is inferred from the FQN; type and kind tokens may be English or Russian. Also creates an XDTO package MEMBER: 'XDTOPackage.<Package>.ObjectType.<Name>' (an ObjectType), 'XDTOPackage.<Package>.Property.<Name>' (a package-global property) or 'XDTOPackage.<Package>.ObjectType.<Type>.Property.<Name>' (a property nested in an ObjectType) - see 'properties' for the XDTO-specific attribute vocabulary. Full parameters and examples: call get_tool_guide('create_metadata').",
     "inputSchema": {
       "properties": {
         "callType": {
@@ -527,7 +527,7 @@
           "type": "string"
         },
         "properties": {
-          "description": "Optional properties to apply at creation, as [{name, value, language?}]. This version applies 'synonym' (with optional 'language' code) and 'comment'; other property names are rejected (set them via modify_metadata).",
+          "description": "Optional properties to apply at creation, as [{name, value, language?}]. For most kinds this applies 'synonym' (with optional 'language' code) and 'comment'; other property names are rejected (set them via modify_metadata). XDTO PACKAGE MEMBERS ('XDTOPackage.<Package>.ObjectType.<Name>' / '...Property.<Name>' / '...ObjectType.<Type>.Property.<Name>') use a DIFFERENT vocabulary instead: an ObjectType takes the optional boolean flags 'open' / 'abstract' / 'mixed' / 'ordered' / 'sequenced'; a Property REQUIRES 'type' (a built-in XSD type name like 'string', the EXACT name of an ObjectType already in the same package for a same-package reference, or an object {nsUri, name}) plus the optional 'lowerBound' / 'upperBound' (integers, ObjectType-nested properties only), 'nillable' / 'fixed' (booleans, 'fixed'=true needs a 'default') and 'default' (string).",
           "items": {
             "type": "object"
           },
@@ -567,6 +567,13 @@
         "action": {
           "description": "'created' on success",
           "type": "string"
+        },
+        "applied": {
+          "description": "Names of the optional attributes actually applied (XDTO package member create only)",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "callType": {
           "description": "Extension event call type written (Before/After/Instead), when an extension event handler (form:EventHandlerExtension) was created",
@@ -1134,7 +1141,7 @@
       "openWorldHint": false,
       "readOnlyHint": false
     },
-    "description": "Delete a metadata node (object or member, including a FORM object 'Type.Object.Form.Name' or a FORM member - item / attribute / command / handler) addressed by a 1C full-name FQN, cascading the cleanup of all references in BSL code, forms and other metadata. Two-phase: call without confirm to preview what would be removed, then confirm=true to apply (deletion is hard to reverse). If the node is still referenced by metadata the refactoring cannot auto-clean, a confirm=true delete is BLOCKED and the referencing objects are listed; pass force=true to delete anyway (those references are left dangling). Full parameters and examples: call get_tool_guide('delete_metadata').",
+    "description": "Delete a metadata node (object or member, including a FORM object 'Type.Object.Form.Name', a FORM member - item / attribute / command / handler - or an XDTO package member 'XDTOPackage.<Package>.ObjectType.<Name>' / '...Property.<Name>' / '...ObjectType.<Type>.Property.<Name>') addressed by a 1C full-name FQN, cascading the cleanup of all references in BSL code, forms and other metadata. Two-phase: call without confirm to preview what would be removed, then confirm=true to apply (deletion is hard to reverse). If the node is still referenced by metadata the refactoring cannot auto-clean, a confirm=true delete is BLOCKED and the referencing objects are listed; pass force=true to delete anyway (those references are left dangling). Full parameters and examples: call get_tool_guide('delete_metadata').",
     "inputSchema": {
       "properties": {
         "confirm": {
@@ -3314,7 +3321,7 @@
       "openWorldHint": false,
       "readOnlyHint": false
     },
-    "description": "Set properties of a metadata node (object or member, including a FORM member - item / attribute / command) addressed by a 1C full-name FQN, as properties=[{name, value, language?}]. Each property is validated (it must be assignable, and an enum value must be one of the allowed literals) with an actionable error. Move/reorder a FORM ITEM with the 'parent' (a group name, 'AutoCommandBar' for the form's command bar, or the form name for the form root) and/or 'position' ('first'/'last'/'before:<name>'/'after:<name>'/index) properties. REBIND a form event handler's procedure with a 'procedure' property on a Handler FQN, or re-point a Button at a different form command with a 'command' property. Set a StyleItem's value with a 'value' property: a Color {value:{color:{red:255,green:0,blue:0}}} (or {color:'auto'}) or a Font {value:{font:{faceName:'Arial',height:12,bold:true}}}. Give a form list FORM ATTRIBUTE a custom dynamic-list query with a 'queryText' property (and 'customQuery' true/false, plus an optional 'mainTable' object FQN): this turns the attribute into a DynamicList and lets EDT auto-fill the available fields from the query (no manual XML; output a column with create_metadata Field dataPath 'List.<field>'). For a ROLE FQN ('Role.Name'), set access rights instead of 'properties': 'rights' (per-object right VALUES + optional per-field RLS restriction conditions), 'templates' (RLS restriction templates: add/edit/delete) and 'roleProperties' (the three role booleans). Read a role's rights matrix with get_metadata_details on the Role FQN. Edit a structured membership LIST with 'content' instead of 'properties', dispatched by the FQN's kind: a COMMON ATTRIBUTE's owners ('CommonAttribute.Name'), an EXCHANGE PLAN's content objects ('ExchangePlan.Name'), a CATALOG's owners ('Catalog.Name'), a DOCUMENT's register records / движения ('Document.Name') or a SUBSYSTEM's content objects ('Subsystem.Name', including a nested 'Subsystem.Parent.Subsystem.Child'). 'content'=[{op?:'add'|'remove' (default add), metadata:'Catalog.X', use?, autoRecord?}] adds a member (idempotent) or removes one by its metadata FQN; a CommonAttribute entry takes 'use' ('Use'|'DontUse'|'Auto'), an ExchangePlan entry takes 'autoRecord' ('Allow'|'Deny'), and a Catalog owner / Document register record / Subsystem content object is a plain reference (no flag). AUTHOR a SpreadsheetDocument (print form / макет) TEMPLATE's content with a 'template' payload instead of 'properties' on a template FQN (a common template 'CommonTemplate.<Name>' or an object-owned template '<Type>.<Owner>.Template.<Name>'): 'template'={cells:[{row, col, text?|parameter?, bold?, fontSize?, hAlign?, vAlign?, wrap?}], merges:[{fromRow, fromCol, toRow, toCol}], areas:[{name, fromRow, fromCol, toRow, toCol}], columnWidths:[{col, width}], rowHeights:[{row, height}]} writes the cells (text or a print-time parameter) with formatting, merged ranges, named areas and column / row sizes into the template's spreadsheet content; render the result with get_template_screenshot. AUTHOR a REPORT's Data Composition Schema (СКД / .dcs) with a 'dcs' payload instead of 'properties' on a Report FQN ('Report.<Name>'): 'dcs'={dataSources:[{name, type?}], dataSets:[{name, type:'query', query, dataSource?, autoFillFields?, fields:[{name?, dataPath, title?, role?}]}], parameters:[{name, valueType?, title?, use?}]} builds the report's main schema (query data sets + fields + schema parameters), creating the DCS if the report has none. Discover assignable properties + allowed values with get_metadata_details(assignable:true). To rename, use rename_metadata_object. Full parameters and examples: call get_tool_guide('modify_metadata').",
+    "description": "Set properties of a metadata node (object or member, including a FORM member - item / attribute / command) addressed by a 1C full-name FQN, as properties=[{name, value, language?}]. Each property is validated (it must be assignable, and an enum value must be one of the allowed literals) with an actionable error. Move/reorder a FORM ITEM with the 'parent' (a group name, 'AutoCommandBar' for the form's command bar, or the form name for the form root) and/or 'position' ('first'/'last'/'before:<name>'/'after:<name>'/index) properties. REBIND a form event handler's procedure with a 'procedure' property on a Handler FQN, or re-point a Button at a different form command with a 'command' property. Set a StyleItem's value with a 'value' property: a Color {value:{color:{red:255,green:0,blue:0}}} (or {color:'auto'}) or a Font {value:{font:{faceName:'Arial',height:12,bold:true}}}. Give a form list FORM ATTRIBUTE a custom dynamic-list query with a 'queryText' property (and 'customQuery' true/false, plus an optional 'mainTable' object FQN): this turns the attribute into a DynamicList and lets EDT auto-fill the available fields from the query (no manual XML; output a column with create_metadata Field dataPath 'List.<field>'). For a ROLE FQN ('Role.Name'), set access rights instead of 'properties': 'rights' (per-object right VALUES + optional per-field RLS restriction conditions), 'templates' (RLS restriction templates: add/edit/delete) and 'roleProperties' (the three role booleans). Read a role's rights matrix with get_metadata_details on the Role FQN. Edit a structured membership LIST with 'content' instead of 'properties', dispatched by the FQN's kind: a COMMON ATTRIBUTE's owners ('CommonAttribute.Name'), an EXCHANGE PLAN's content objects ('ExchangePlan.Name'), a CATALOG's owners ('Catalog.Name'), a DOCUMENT's register records / движения ('Document.Name') or a SUBSYSTEM's content objects ('Subsystem.Name', including a nested 'Subsystem.Parent.Subsystem.Child'). 'content'=[{op?:'add'|'remove' (default add), metadata:'Catalog.X', use?, autoRecord?}] adds a member (idempotent) or removes one by its metadata FQN; a CommonAttribute entry takes 'use' ('Use'|'DontUse'|'Auto'), an ExchangePlan entry takes 'autoRecord' ('Allow'|'Deny'), and a Catalog owner / Document register record / Subsystem content object is a plain reference (no flag). AUTHOR a SpreadsheetDocument (print form / макет) TEMPLATE's content with a 'template' payload instead of 'properties' on a template FQN (a common template 'CommonTemplate.<Name>' or an object-owned template '<Type>.<Owner>.Template.<Name>'): 'template'={cells:[{row, col, text?|parameter?, bold?, fontSize?, hAlign?, vAlign?, wrap?}], merges:[{fromRow, fromCol, toRow, toCol}], areas:[{name, fromRow, fromCol, toRow, toCol}], columnWidths:[{col, width}], rowHeights:[{row, height}]} writes the cells (text or a print-time parameter) with formatting, merged ranges, named areas and column / row sizes into the template's spreadsheet content; render the result with get_template_screenshot. AUTHOR a REPORT's Data Composition Schema (СКД / .dcs) with a 'dcs' payload instead of 'properties' on a Report FQN ('Report.<Name>'): 'dcs'={dataSources:[{name, type?}], dataSets:[{name, type:'query', query, dataSource?, autoFillFields?, fields:[{name?, dataPath, title?, role?}]}], parameters:[{name, valueType?, title?, use?}]} builds the report's main schema (query data sets + fields + schema parameters), creating the DCS if the report has none. Edit an XDTO package MEMBER through 'properties' on its own FQN ('XDTOPackage.<Package>.ObjectType.<Name>' or '...Property.<Name>' or '...ObjectType.<Type>.Property.<Name>'): an ObjectType takes the boolean flags 'open' / 'abstract' / 'mixed' / 'ordered' / 'sequenced'; a Property takes 'type' (a built-in XSD type name, the EXACT name of an ObjectType already in the same package, or {nsUri, name}), 'lowerBound' / 'upperBound' (integers, ObjectType-nested properties only), 'nillable' / 'fixed' (booleans, 'fixed'=true needs a 'default') and 'default' (string). Discover assignable properties + allowed values with get_metadata_details(assignable:true). To rename, use rename_metadata_object. Full parameters and examples: call get_tool_guide('modify_metadata').",
     "inputSchema": {
       "properties": {
         "content": {
@@ -4708,6 +4715,37 @@
       ],
       "type": "object"
     }
+  },
+  {
+    "annotations": {
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Validate a single XDTO package by running EDT's OWN configuration validation (the same check engine behind get_project_errors) scoped to that package, and return a pass/fail verdict plus any problems found (e.g. a dangling reference to a deleted ObjectType). It reflects the LATEST validation state already computed by EDT (reads existing markers) rather than forcing a fresh compile; run revalidate_objects first if you need up-to-the-second results. Does not implement any XDTO-specific rule itself - it is a scoped view over get_project_errors. Full parameters and examples: call get_tool_guide('validate_xdto_package').",
+    "inputSchema": {
+      "properties": {
+        "fqn": {
+          "description": "FQN of the XDTO package to validate, as 'XDTOPackage.<Name>' (required). Must already exist; check with get_metadata_objects.",
+          "type": "string"
+        },
+        "limit": {
+          "description": "Max problem rows to report; default 100, max 1000 (optional)",
+          "type": "integer"
+        },
+        "projectName": {
+          "description": "EDT project name (required).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "projectName",
+        "fqn"
+      ],
+      "type": "object"
+    },
+    "name": "validate_xdto_package",
+    "outputSchema": null
   },
   {
     "annotations": {


### PR DESCRIPTION
Closes #183.

@DitriXNew — сделал оба потока в одном PR, как обсуждали в issue: полноценное редактирование членов XDTO-пакета + функцию валидации.

## Поток 1 — редактирование членов XDTO-пакета по FQN

`create_metadata` / `modify_metadata` / `delete_metadata` / `get_metadata_details` теперь работают с содержимым XDTO-пакета, адресуемым member-FQN как остальная метадата:
- `XDTOPackage.<P>.ObjectType.<T>` — тип-объект;
- `XDTOPackage.<P>.ObjectType.<T>.Property.<N>` — свойство внутри типа;
- `XDTOPackage.<P>.Property.<N>` — свойство уровня пакета.

По твоему опасению про «30 параметров у свойства»: все параметры **опциональны**, обязательны только имя (из FQN) и `type`. Типовой кейс «добавить скалярное поле в DTO» — один короткий вызов: `type` = имя встроенного XSD-типа (`string`, `decimal`, …), либо ТОЧНОЕ имя ObjectType в этом же пакете (ссылка внутри пакета), либо `{nsUri, name}`; опционально `lowerBound`/`upperBound` (для свойств внутри ObjectType), `nillable`/`fixed`/`default`. У ObjectType — опциональные флаги `open`/`abstract`/`mixed`/`ordered`/`sequenced`. `get_metadata_details` на `XDTOPackage.<P>` рендерит типы и их свойства.

Архитектурно это зеркало СКД (#268) и макетов (#245): content-модель (`Package.xdto`) — ленивый `@ExternalProperty`, персистится тем же механизмом. Content создаётся сразу при `create_metadata XDTOPackage.<Имя>` (материализация в той же транзакции), иначе первый `Package.xdto` у свежего пакета не персистился — так дальнейшие правки идут по надёжному «существующему» пути.

Заодно устранён рассинхрон target namespace, который обнажила ранняя материализация: смена `namespace` пакета теперь пропагируется в `targetNamespace` content-ресурса `Package.xdto` (owner — единственный источник истины), а при невозможности синхронизировать правка откатывается целиком, а не оставляет `.mdo` и `.xdto` рассогласованными.

## Поток 2 — `validate_xdto_package` (твоё предложение)

Новый read-only инструмент: гоняет **собственную валидацию EDT** (тот же движок проверок, что за `get_project_errors`), но со скоупом на один XDTO-пакет, и возвращает вердикт «валиден / найдены проблемы» + список проблем (например, ссылка на удалённый ObjectType). Своих XDTO-правил не изобретает — это узкий вид поверх `get_project_errors` (как ты и заметил, «такая проверка есть в 1С»). Отражает последнее состояние валидации EDT (читает маркеры), не форсирует пересборку.

Точность скоупа: использует канонический FQN резолвнутого пакета и **точное (по границе сегмента) сопоставление** — проблемы соседнего пакета с общим префиксом (`XDTOPackage.P` vs `XDTOPackage.P2`) не приписываются, а вердикт всегда учитывает все severity (иначе «нет проблем под фильтр» ≠ «валиден»). Дефолтное поведение `get_project_errors` не тронуто — exact-scope это opt-in перегрузка.

## Проверка

- Сборка + юнит-тесты: `mvn clean verify` зелёный (3683+ теста, все ратчеты — coverage/contract/toolset/guide).
- Живой стенд EDT 2026.1: создание/модификация/удаление ObjectType+Property и рендер структуры (round-trip на диске), синхронизация namespace (3 сценария), валидатор (валидный пакет / dangling-ref / соседний пакет с общим префиксом / trailing-dot FQN / не-XDTO / несуществующий).
- `tools/list` golden перегенерирован (описания create/modify/delete + новый инструмент).
- e2e: `validate_xdto_package` + добавленные XDTO-кейсы в create/modify/delete/details — 10/10 зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
