### PR TITLE
MCP usability: BSL-чекер (async/многострочные литералы), типо-свойства в get_metadata_details, фильтр имён типов в get_metadata_objects (#286–#289)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/get_metadata_details.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/get_metadata_details.md
@@ -19,6 +19,7 @@ Return the detailed properties of one or more 1C metadata objects. By default yo
 - Markdown, one section per resolved object, separated by `---`.
 - A form FQN renders the enriched form structure instead of an mdclass object section: an Items outline (each item with its visibility, bound `dataPath` and per-kind extras), an Attributes table (with the `Main`/`SavedData` columns), a Commands table and an Event handlers section.
 - A template FQN whose content is a Data Composition Schema renders the schema's structure (see above) instead of an mdclass object section, headed `# Data Composition Schema: <fqn>`.
+- Type-specific properties are appended for a few kinds whose behaviour the basic view otherwise hid: a **ScheduledJob** gets a Properties table (methodName, use, predefined, restartCountOnFailure / restartIntervalOnFailure, key, and whether a Schedule is set), a **CommonModule** gets its context-availability flags (server / serverCall / clientManagedApplication / clientOrdinaryApplication / externalConnection / global / privileged) and returnValuesReuse, and an **InformationRegister**'s Dimensions additionally show their `Indexing`. These render in both the default and `full: true` views.
 - Per-object failures (malformed FQN or object not found) do NOT fail the whole call. They are collected into a dedicated `## Errors` table at the end with an `ERROR` status row carrying the FQN and reason, so a client can tell a failed object from data.
 
 ## Examples

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/get_metadata_objects.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/get_metadata_objects.md
@@ -7,7 +7,11 @@ List the metadata objects of a 1C configuration as a flat Markdown table. Each r
 
 ## Parameter details
 - `projectName` (required) - EDT project name.
-- `metadataType` - which kind to list; default `all`. Matching is case-insensitive. Supported values: `all`, `documents`, `catalogs`, `informationRegisters`, `accumulationRegisters`, `commonModules`, `enums`, `constants`, `reports`, `dataProcessors`, `exchangePlans`, `businessProcesses`, `tasks`, `commonAttributes`, `eventSubscriptions`, `scheduledJobs`. An unknown value returns an error listing the supported types.
+- `metadataType` - which kind to list; default `all`. Matching is case-insensitive, and it's a single string, not an array. Accepts EITHER form:
+  - a category token: `all`, `documents`, `catalogs`, `informationRegisters`, `accumulationRegisters`, `commonModules`, `enums`, `constants`, `reports`, `dataProcessors`, `exchangePlans`, `businessProcesses`, `tasks`, `commonAttributes`, `eventSubscriptions`, `scheduledJobs`;
+  - OR a standard metadata type name - the same FQN token used elsewhere in the API, English or its Russian equivalent (e.g. `ScheduledJob`, `Document`, `Справочник`). This is the natural form to reach for; it maps onto the category above internally.
+
+  An unrecognized value (including a type name this tool has no collector for, e.g. `Subsystem`) returns an error naming the bad value and listing the supported categories. Note the parameter is `metadataType` (a single value) - there is no `types` array parameter.
 - `nameFilter` - case-insensitive substring matched against the object **Name only**, never the Synonym. Omit to list everything of the chosen type.
 - `limit` - max rows returned; default from preferences (100), clamped to 1000. A truncation notice is appended when results are capped, while **Total** still reports the full count.
 - `language` - language code for the Synonym column (e.g. `en`, `ru`). Defaults to the configuration's default language.
@@ -23,6 +27,7 @@ List the metadata objects of a 1C configuration as a flat Markdown table. Each r
 ## Examples
 - Everything: `{projectName: "MyProject"}`.
 - Only documents: `{projectName: "MyProject", metadataType: "documents"}`.
+- Only scheduled jobs, via the type-name token: `{projectName: "MyProject", metadataType: "ScheduledJob"}` (equivalent to `metadataType: "scheduledJobs"`).
 - Filter by name: `{projectName: "MyProject", nameFilter: "Order"}`.
 - Russian synonyms: `{projectName: "MyProject", language: "ru"}`.
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/modify_metadata.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/modify_metadata.md
@@ -3,6 +3,14 @@ Sets one or more properties of a metadata node addressed by a 1C full-name FQN (
 ## Validation (errors are help)
 - A property that is NOT assignable on this node is rejected with the list of assignable properties - discover them with get_metadata_details(assignable:true).
 - An ENUM value that is not one of the allowed literals is rejected WITH the allowed values; a non-boolean for a boolean property, or a non-integer for an integer property, is rejected too. Nothing is written unless EVERY property validates.
+- A ScheduledJob's `methodName` and an EventSubscription's `handler` are VALIDATED against the target CommonModule method - see [Binding a ScheduledJob / EventSubscription to a method](#binding-a-scheduledjob--eventsubscription-to-a-method-methodname--handler).
+
+## Binding a ScheduledJob / EventSubscription to a method (methodName / handler)
+Setting a ScheduledJob's `methodName` or an EventSubscription's `handler` is VALIDATED against the target CommonModule method BEFORE it is accepted - the referenced method must already EXIST, be `Export`ed, and live in a module with the Server flag (a scheduled job / event-subscription handler always runs server-side). This catches the "bound the job/subscription to a method BEFORE writing it" mistake at validation time, with an actionable error naming the fix, instead of only surfacing it later at update_database as an opaque "no such function" failure.
+- A ScheduledJob's `methodName` takes `<CommonModuleName>.<MethodName>` (e.g. `Calc.Add`); an EventSubscription's `handler` takes `CommonModule.<ModuleName>.<MethodName>` (e.g. `CommonModule.Calc.Add`, matching how mdclass stores it). Both forms also accept an optional leading `CommonModule` / `ОбщийМодуль` type-token prefix (stripped before resolving the module), and a value with no dot is rejected with the expected `Module.Method` shape.
+- Checks run in order, failing fast on the first that does not hold: the value parses (a module part + a method name); the CommonModule exists (`get_metadata_objects` lists the available ones); the method exists in that module's source (create it first with `write_module_source` - an `Export`ed SERVER procedure/function - then set `methodName` / `handler`); the method is marked `Export` (`Экспорт`); the module has the Server property.
+- An EMPTY value is NOT validated by this guard (it falls through to the standard "a property needs a non-empty value" rejection - modify_metadata never clears a property on an empty value).
+- Scoped to exactly these two properties (`ScheduledJob.methodName`, `EventSubscription.handler`) - every other property on every other FQN is unaffected.
 
 ## Parameter details
 - `projectName` (required) - EDT project name.
@@ -148,6 +156,8 @@ A malformed entry (a missing dataset `name` / `query`, a missing calculated fiel
 - Set a comment: `{projectName:'P', fqn:'Catalog.Products', properties:[{name:'comment', value:'Goods'}]}`
 - Set a synonym: `{projectName:'P', fqn:'Catalog.Products', properties:[{name:'synonym', value:'Goods', language:'en'}]}`
 - Set an enum on an attribute: `{projectName:'P', fqn:'Catalog.Products.Attribute.Weight', properties:[{name:'indexing', value:'Index'}]}`
+- Bind a scheduled job to an existing Exported server method (validated): `{projectName:'P', fqn:'ScheduledJob.NightlyRecalc', properties:[{name:'methodName', value:'Calc.Add'}]}`
+- Bind an event-subscription handler (validated, `CommonModule.` prefix form): `{projectName:'P', fqn:'EventSubscription.OnWrite', properties:[{name:'handler', value:'CommonModule.Calc.Add'}]}`
 - Set a type: `{projectName:'P', fqn:'Catalog.Products.Attribute.Weight', properties:[{name:'type', value:{types:[{kind:'Number', precision:10, scale:2}]}}]}`
 - Set a list reference: `{projectName:'P', fqn:'Subsystem.Sales', properties:[{name:'content', value:['Catalog.Products', 'Document.Order']}]}`
 - Set a DataProcessor's default form by the full member FQN: `{projectName:'P', fqn:'DataProcessor.Invoices', properties:[{name:'defaultForm', value:'DataProcessor.Invoices.Form.ItemForm'}]}`

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataDetailsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataDetailsTool.java
@@ -23,9 +23,14 @@ import com._1c.g5.v8.dt.core.platform.IBmModelManager;
 import com._1c.g5.v8.dt.dcs.model.schema.DataCompositionSchema;
 import com._1c.g5.v8.dt.metadata.mdclass.AbstractRoleDescription;
 import com._1c.g5.v8.dt.metadata.mdclass.BasicTemplate;
+import com._1c.g5.v8.dt.metadata.mdclass.CommonModule;
 import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
+import com._1c.g5.v8.dt.metadata.mdclass.InformationRegister;
+import com._1c.g5.v8.dt.metadata.mdclass.InformationRegisterDimension;
+import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
 import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
 import com._1c.g5.v8.dt.metadata.mdclass.Role;
+import com._1c.g5.v8.dt.metadata.mdclass.ScheduledJob;
 import com.ditrix.edt.mcp.server.Activator;
 import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
 import com.ditrix.edt.mcp.server.protocol.JsonUtils;
@@ -57,6 +62,9 @@ public class GetMetadataDetailsTool implements IMcpTool
     /** Markdown separator between rendered object sections. */
     private static final String SECTION_SEPARATOR = "\n---\n\n"; //$NON-NLS-1$
 
+    /** Placeholder for an absent/empty value in the type-specific property tables below. */
+    private static final String DASH = "-"; //$NON-NLS-1$
+
     @Override
     public String getName()
     {
@@ -75,6 +83,10 @@ public class GetMetadataDetailsTool implements IMcpTool
                "ACCESS RIGHTS - the object->right matrix, RLS restrictions, RLS templates and the role " + //$NON-NLS-1$
                "properties ('full: true' shows every object, otherwise only the non-default rows, the " + //$NON-NLS-1$
                "first 100 by default - page past them with 'roleObjectOffset' or use 'full: true'). " + //$NON-NLS-1$
+               "In the default (non-full) view a ScheduledJob or CommonModule also renders a " + //$NON-NLS-1$
+               "type-specific Properties table (e.g. methodName/schedule/use for a job; " + //$NON-NLS-1$
+               "server/serverCall/global/returnValuesReuse for a module), and an InformationRegister's " + //$NON-NLS-1$
+               "Dimensions additionally show their Indexing. " + //$NON-NLS-1$
                "Use this for the full properties of one named object; to list objects by type use get_metadata_objects. " + //$NON-NLS-1$
                "Full parameters and examples: call get_tool_guide('get_metadata_details')."; //$NON-NLS-1$
     }
@@ -306,6 +318,9 @@ public class GetMetadataDetailsTool implements IMcpTool
         }
 
         sb.append(MetadataFormatterRegistry.format(mdObject, ctx.full, ctx.effectiveLanguage));
+        // Type-specific properties the universal reflective formatter's default view omits
+        // (issue #288): ScheduledJob / CommonModule / an InformationRegister's dimension Indexing.
+        sb.append(formatTypeSpecificProperties(mdObject, ctx.full));
         // ORIGIN footer: core / core (adopted) / extension. For a base
         // configuration this is always "core"; for an extension it distinguishes
         // an adopted base object from one the extension itself owns.
@@ -468,6 +483,168 @@ public class GetMetadataDetailsTool implements IMcpTool
             sb.append(MarkdownUtils.tableRow(p.name, p.valueKind.toString(), p.currentValue, allowed));
         }
         return sb.toString();
+    }
+
+    /**
+     * Renders TYPE-SPECIFIC properties that the universal reflective formatter's DEFAULT
+     * (non-{@code full}) view does not surface (issue #288): {@code modify_metadata} already WRITES
+     * a ScheduledJob's execution properties (Schedule presence via {@code eIsSet} - EXPLICITLY set,
+     * not a non-null default), a CommonModule's context-availability flags, and an
+     * InformationRegister dimension's Indexing, but the basic details view rendered only Name /
+     * Synonym for the first two, and no Indexing at all for the third - reading them back was
+     * impossible. Appended right after the universal object section, before the ORIGIN footer.
+     * <p>
+     * The ScheduledJob/CommonModule "Properties" table is skipped when {@code full} is {@code true}:
+     * {@code UniversalMetadataFormatter}'s full-mode "All Properties" reflective dump already lists
+     * every plain {@code EAttribute} of both types (methodName / use / predefined /
+     * restartCountOnFailure / restartIntervalOnFailure / key; server / serverCall / ... /
+     * returnValuesReuse), so a second table here would only duplicate it.
+     * <p>
+     * The InformationRegister "Dimension Indexing" table is emitted regardless of {@code full}: the
+     * generic attributes-table Indexing column (in {@code UniversalMetadataFormatter}) only
+     * recognizes {@code com._1c.g5.v8.dt.metadata.mdclass.DbObjectAttribute}, while a register
+     * dimension is a {@code com._1c.g5.v8.dt.metadata.mdclass.RegisterDimension} - a SEPARATE
+     * sub-interface of {@code BasicFeature} - so a dimension never gets an Indexing value there in
+     * EITHER mode; this is the only place Indexing is visible for a dimension.
+     *
+     * @param mdObject the resolved top object (a type this method does not handle is a no-op)
+     * @param full the request's full-mode flag
+     * @return the Markdown section to append (possibly empty)
+     */
+    static String formatTypeSpecificProperties(MdObject mdObject, boolean full)
+    {
+        StringBuilder sb = new StringBuilder();
+        // Render in BOTH basic and full mode. It would be tempting to skip these in full mode
+        // (the generic "All Properties" dump repeats the scalar getters), but that dump does NOT
+        // include the transient Schedule reference, so skipping in full mode silently LOSES the
+        // Schedule row that basic mode shows (codex #288). A little overlap in full mode is
+        // preferable to full mode carrying LESS information than basic.
+        if (mdObject instanceof ScheduledJob)
+        {
+            appendScheduledJobProperties(sb, (ScheduledJob)mdObject);
+        }
+        else if (mdObject instanceof CommonModule)
+        {
+            appendCommonModuleProperties(sb, (CommonModule)mdObject);
+        }
+        else if (mdObject instanceof InformationRegister)
+        {
+            appendDimensionIndexing(sb, (InformationRegister)mdObject);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Renders a ScheduledJob's execution properties as a Property/Value table: the method it calls,
+     * whether it is enabled/predefined, its failure-restart policy, its (import) key, and whether a
+     * Schedule is attached. The Schedule is rendered as mere PRESENCE ("set" / {@link #DASH}), never a
+     * {@code toString()} dump - a {@code Schedule} is a cross-model {@code EObject} (not an
+     * {@code MdObject}), so dumping it would print an unhelpful implementation-detail string instead of
+     * a meaningful value. Presence is read via {@link #scheduledJobHasSchedule(ScheduledJob)}.
+     */
+    private static void appendScheduledJobProperties(StringBuilder sb, ScheduledJob job)
+    {
+        sb.append("\n### Properties\n\n"); //$NON-NLS-1$
+        sb.append(MarkdownUtils.tableHeader("Property", "Value")); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append(MarkdownUtils.tableRow("Method Name", valueOrDash(job.getMethodName()))); //$NON-NLS-1$
+        sb.append(MarkdownUtils.tableRow("Use", yesNo(job.isUse()))); //$NON-NLS-1$
+        sb.append(MarkdownUtils.tableRow("Predefined", yesNo(job.isPredefined()))); //$NON-NLS-1$
+        sb.append(MarkdownUtils.tableRow("Restart Count On Failure", //$NON-NLS-1$
+            String.valueOf(job.getRestartCountOnFailure())));
+        sb.append(MarkdownUtils.tableRow("Restart Interval On Failure", //$NON-NLS-1$
+            String.valueOf(job.getRestartIntervalOnFailure())));
+        sb.append(MarkdownUtils.tableRow("Key", valueOrDash(job.getKey()))); //$NON-NLS-1$
+        sb.append(MarkdownUtils.tableRow("Schedule", scheduledJobHasSchedule(job) ? "set" : DASH)); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Returns whether the job has an EXPLICITLY-configured Schedule, via EMF {@code eIsSet} on the
+     * {@code SCHEDULED_JOB__SCHEDULE} feature. This deliberately does NOT use {@code getSchedule() != null}:
+     * a {@code create_metadata}-made job carries a non-null DEFAULT schedule, so a null-check would
+     * always report "set". {@code eIsSet} needs only the EMF feature literal, so it avoids importing the
+     * {@code com._1c.g5.v8.dt.schedule.model} package (which this bundle's {@code MANIFEST.MF} does not
+     * declare) and needs no reflection.
+     */
+    private static boolean scheduledJobHasSchedule(ScheduledJob job)
+    {
+        // eIsSet (EXPLICITLY configured), NOT getSchedule() != null: a create_metadata-made job
+        // carries a non-null DEFAULT schedule, so a plain null-check would always render "set".
+        // eIsSet is true only once a schedule is actually assigned - and it takes the EMF feature
+        // literal, so it needs no import of the schedule model package (which this bundle does not
+        // declare in its MANIFEST).
+        return job.eIsSet(MdClassPackage.Literals.SCHEDULED_JOB__SCHEDULE);
+    }
+
+    /**
+     * Renders a CommonModule's context-availability flags and its return-values-reuse mode as a
+     * Property/Value table. Every boolean is rendered directly (Yes/No) - {@code false} is a valid,
+     * meaningful value here (the user wants to see e.g. server=No), not an "absent" marker. The
+     * {@code returnValuesReuse} enum is rendered by its LITERAL name (via {@link #enumLiteral(Object)}),
+     * never a raw object dump.
+     */
+    private static void appendCommonModuleProperties(StringBuilder sb, CommonModule module)
+    {
+        sb.append("\n### Properties\n\n"); //$NON-NLS-1$
+        sb.append(MarkdownUtils.tableHeader("Property", "Value")); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append(MarkdownUtils.tableRow("Server", yesNo(module.isServer()))); //$NON-NLS-1$
+        sb.append(MarkdownUtils.tableRow("Server Call", yesNo(module.isServerCall()))); //$NON-NLS-1$
+        sb.append(MarkdownUtils.tableRow("Client (Managed Application)", //$NON-NLS-1$
+            yesNo(module.isClientManagedApplication())));
+        sb.append(MarkdownUtils.tableRow("Client (Ordinary Application)", //$NON-NLS-1$
+            yesNo(module.isClientOrdinaryApplication())));
+        sb.append(MarkdownUtils.tableRow("External Connection", yesNo(module.isExternalConnection()))); //$NON-NLS-1$
+        sb.append(MarkdownUtils.tableRow("Global", yesNo(module.isGlobal()))); //$NON-NLS-1$
+        sb.append(MarkdownUtils.tableRow("Privileged", yesNo(module.isPrivileged()))); //$NON-NLS-1$
+        sb.append(MarkdownUtils.tableRow("Return Values Reuse", //$NON-NLS-1$
+            enumLiteral(module.getReturnValuesReuse())));
+    }
+
+    /**
+     * Renders an InformationRegister's dimensions' Indexing as a small Dimension/Indexing table. A
+     * no-op when the register has no dimensions. See {@link #formatTypeSpecificProperties} for why this
+     * cannot be folded into the shared attributes table.
+     */
+    private static void appendDimensionIndexing(StringBuilder sb, InformationRegister register)
+    {
+        List<InformationRegisterDimension> dimensions = register.getDimensions();
+        if (dimensions == null || dimensions.isEmpty())
+        {
+            return;
+        }
+        sb.append("\n### Dimension Indexing\n\n"); //$NON-NLS-1$
+        sb.append(MarkdownUtils.tableHeader("Dimension", "Indexing")); //$NON-NLS-1$ //$NON-NLS-2$
+        for (InformationRegisterDimension dimension : dimensions)
+        {
+            sb.append(MarkdownUtils.tableRow(dimension.getName(), enumLiteral(dimension.getIndexing())));
+        }
+    }
+
+    /**
+     * Renders a possibly-{@code null}/empty string, or {@link #DASH} when absent.
+     */
+    private static String valueOrDash(String value)
+    {
+        return value != null && !value.isEmpty() ? value : DASH;
+    }
+
+    /**
+     * Renders a boolean as {@code Yes}/{@code No}, matching the Yes/No Markdown convention the rest of
+     * get_metadata_details uses. {@code false} is rendered as {@code No}, not omitted - it is a real,
+     * meaningful value for these flags.
+     */
+    private static String yesNo(boolean value)
+    {
+        return value ? "Yes" : "No"; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Renders an EMF enum's LITERAL name (its {@code toString()}, which the generated enum overrides to
+     * return the literal), or {@link #DASH} when {@code null}. Never used on a plain {@link EObject}
+     * (e.g. a ScheduledJob's Schedule) - only on an actual enum value.
+     */
+    private static String enumLiteral(Object enumValue)
+    {
+        return enumValue != null ? enumValue.toString() : DASH;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataObjectsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataObjectsTool.java
@@ -7,8 +7,11 @@
 package com.ditrix.edt.mcp.server.tools.impl;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.resources.IProject;
@@ -44,6 +47,7 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool;
 import com.ditrix.edt.mcp.server.utils.ExtensionOriginUtils;
 import com.ditrix.edt.mcp.server.utils.MarkdownUtils;
 import com.ditrix.edt.mcp.server.utils.MetadataLanguageUtils;
+import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils;
 import com.ditrix.edt.mcp.server.utils.Pagination;
 import com.ditrix.edt.mcp.server.utils.ProjectContext;
 
@@ -73,6 +77,20 @@ public class GetMetadataObjectsTool implements IMcpTool
     private static final String TYPE_EVENT_SUBSCRIPTIONS = "eventsubscriptions"; //$NON-NLS-1$
     private static final String TYPE_SCHEDULED_JOBS = "scheduledjobs"; //$NON-NLS-1$
 
+    /**
+     * The category tokens this tool actually collects (lowercase). Used both as the
+     * legacy vocabulary of {@code metadataType} and as the target of the type-name-token
+     * normalization in {@link #normalizeMetadataType(String)}: {@code MetadataTypeUtils}
+     * recognizes far more type names (e.g. Role, Subsystem, XDTOPackage) than this tool
+     * has collectors for, so a resolved type name is only accepted when its category is
+     * a member of this set.
+     */
+    private static final Set<String> SUPPORTED_CATEGORIES = new HashSet<>(Arrays.asList(
+        TYPE_DOCUMENTS, TYPE_CATALOGS, TYPE_INFORMATION_REGISTERS, TYPE_ACCUMULATION_REGISTERS,
+        TYPE_COMMON_MODULES, TYPE_ENUMS, TYPE_CONSTANTS, TYPE_REPORTS, TYPE_DATA_PROCESSORS,
+        TYPE_EXCHANGE_PLANS, TYPE_BUSINESS_PROCESSES, TYPE_TASKS, TYPE_COMMON_ATTRIBUTES,
+        TYPE_EVENT_SUBSCRIPTIONS, TYPE_SCHEDULED_JOBS));
+
     private static final String LIMIT = "limit"; //$NON-NLS-1$
 
     @Override
@@ -98,10 +116,13 @@ public class GetMetadataObjectsTool implements IMcpTool
             .stringProperty(McpKeys.PROJECT_NAME,
                 "EDT project name (required)", true) //$NON-NLS-1$
             .stringProperty("metadataType", //$NON-NLS-1$
-                "Type filter (case-insensitive), default 'all'. One of: all, documents, catalogs, " + //$NON-NLS-1$
-                "informationRegisters, accumulationRegisters, commonModules, enums, constants, reports, " + //$NON-NLS-1$
-                "dataProcessors, exchangePlans, businessProcesses, tasks, commonAttributes, " + //$NON-NLS-1$
-                "eventSubscriptions, scheduledJobs") //$NON-NLS-1$
+                "Type filter (case-insensitive), default 'all'. Accepts EITHER a category token - all, " + //$NON-NLS-1$
+                "documents, catalogs, informationRegisters, accumulationRegisters, commonModules, enums, " + //$NON-NLS-1$
+                "constants, reports, dataProcessors, exchangePlans, businessProcesses, tasks, " + //$NON-NLS-1$
+                "commonAttributes, eventSubscriptions, scheduledJobs - OR a single standard metadata " + //$NON-NLS-1$
+                "type name (the FQN token, English or its Russian equivalent, e.g. 'ScheduledJob', " + //$NON-NLS-1$
+                "'Document'). Single value only - not an array. An unrecognized value returns an error " + //$NON-NLS-1$
+                "listing the supported options.") //$NON-NLS-1$
             .stringProperty("nameFilter", //$NON-NLS-1$
                 "Case-insensitive substring matched against Name only (not Synonym)") //$NON-NLS-1$
             .integerProperty(LIMIT,
@@ -198,11 +219,27 @@ public class GetMetadataObjectsTool implements IMcpTool
         // e.g. "ru"/"en", not by the Language object's name). May be null when the
         // configuration has no languages; getSynonymForLanguage tolerates that.
         String effectiveLanguage = MetadataLanguageUtils.resolveLanguageCode(config, language);
-        
+
+        // Normalize metadataType to the internal category token: either it already IS
+        // one (legacy vocabulary, back-compat), or it is a standard type-name token
+        // (FQN form, English/Russian, singular/plural - e.g. "ScheduledJob") resolved
+        // via the shared MetadataTypeUtils resolver. See normalizeMetadataType javadoc.
+        String category = normalizeMetadataType(metadataType);
+        if (category == null)
+        {
+            return ToolResult.error("Unknown metadata type: " + metadataType + ". " + //$NON-NLS-1$ //$NON-NLS-2$
+                   "Supported categories (case-insensitive): all, documents, catalogs, informationRegisters, " + //$NON-NLS-1$
+                   "accumulationRegisters, commonModules, enums, constants, reports, dataProcessors, " + //$NON-NLS-1$
+                   "exchangePlans, businessProcesses, tasks, commonAttributes, eventSubscriptions, " + //$NON-NLS-1$
+                   "scheduledJobs. Also accepts a standard metadata type name (the FQN token, English " + //$NON-NLS-1$
+                   "or Russian, singular or plural, e.g. 'ScheduledJob', 'Document') for one of these " + //$NON-NLS-1$
+                   "categories.").toJson(); //$NON-NLS-1$
+        }
+
         // Collect metadata objects
         List<MetadataInfo> objects = new ArrayList<>();
-        
-        switch (metadataType.toLowerCase())
+
+        switch (category)
         {
             case TYPE_ALL:
                 collectDocuments(config, objects, nameFilter);
@@ -267,20 +304,84 @@ public class GetMetadataObjectsTool implements IMcpTool
                 collectScheduledJobs(config, objects, nameFilter);
                 break;
             default:
-                return ToolResult.error("Unknown metadata type: " + metadataType + ". " + //$NON-NLS-1$ //$NON-NLS-2$
-                       "Supported (case-insensitive): all, documents, catalogs, informationRegisters, accumulationRegisters, " + //$NON-NLS-1$
-                       "commonModules, enums, constants, reports, dataProcessors, exchangePlans, " + //$NON-NLS-1$
-                       "businessProcesses, tasks, commonAttributes, eventSubscriptions, scheduledJobs").toJson(); //$NON-NLS-1$
+                // Unreachable: normalizeMetadataType only ever returns TYPE_ALL or a
+                // member of SUPPORTED_CATEGORIES, both fully covered above. Kept as a
+                // defensive net against the two enumerations drifting apart.
+                return ToolResult.error("Unknown metadata type: " + metadataType).toJson(); //$NON-NLS-1$
         }
-        
+
         // An object's ORIGIN (core vs extension-adopted vs extension-own) is only
         // meaningful for an EXTENSION project, where adopted base objects are listed
         // alongside the extension's own. Resolve the project type once and surface an
         // Origin column only then; a base configuration keeps its original columns.
         boolean isExtensionProject = ExtensionOriginUtils.isExtensionProject(project);
 
-        // Format output
+        // Format output. Show the caller's ORIGINAL filter value in the "Filter:" line (what
+        // they typed - a category token, a type name, whatever casing), not the internal
+        // lowercased category token; the TYPE_ALL comparison in formatOutput is case-insensitive.
         return formatOutput(projectName, objects, limit, effectiveLanguage, metadataType, isExtensionProject);
+    }
+
+    /**
+     * Normalizes the {@code metadataType} filter value to the internal category token
+     * used by the collection switch above. Accepted forms, checked in this order:
+     * <ol>
+     *   <li>{@code "all"} (special, always wins);</li>
+     *   <li>an existing category token ({@code documents}, {@code catalogs}, ...,
+     *       {@code scheduledJobs}), case-insensitive - checked BEFORE type-name
+     *       resolution so a category token can never be shadowed by it;</li>
+     *   <li>a standard metadata type name in any form {@code MetadataTypeUtils}
+     *       recognizes (English/Russian, singular/plural, e.g. "ScheduledJob",
+     *       "РегламентноеЗадание"),
+     *       mapped to its category token via {@link MetadataTypeUtils.MetadataTypeInfo#getConfigReferenceName()}
+     *       IF that category is one this tool actually collects
+     *       ({@link #SUPPORTED_CATEGORIES}) - a type MetadataTypeUtils recognizes but
+     *       this tool has no collector for (e.g. Role, Subsystem, XDTOPackage) falls
+     *       through to "not recognized" here, same as an unknown value.</li>
+     * </ol>
+     * This reuses the shared bilingual resolver (do NOT hand-roll type resolution,
+     * see CLAUDE.md #4) rather than adding a second Russian-token table.
+     *
+     * Package-private (not {@code private}) so it can be unit-tested directly: unlike
+     * the rest of {@code getMetadataObjectsInternal}, this method touches neither the
+     * workbench nor a live {@code Configuration} - it is pure string/lookup logic
+     * against {@code MetadataTypeUtils}, which {@code MetadataTypeUtilsTest} already
+     * proves runs standalone.
+     *
+     * @param metadataType raw filter value as supplied by the caller
+     * @return the category token to switch on ({@link #TYPE_ALL} or a member of
+     *         {@link #SUPPORTED_CATEGORIES}), or {@code null} if not recognized in any form
+     */
+    String normalizeMetadataType(String metadataType)
+    {
+        if (metadataType == null || metadataType.isEmpty())
+        {
+            return null;
+        }
+
+        String lower = metadataType.toLowerCase();
+        if (TYPE_ALL.equals(lower) || SUPPORTED_CATEGORIES.contains(lower))
+        {
+            return lower;
+        }
+
+        // Not a category token - try resolving it as a standard metadata type name
+        // (FQN token, English or Russian, singular or plural) via the shared resolver.
+        MetadataTypeUtils.MetadataTypeInfo typeInfo = MetadataTypeUtils.resolve(metadataType);
+        if (typeInfo != null)
+        {
+            String configReferenceName = typeInfo.getConfigReferenceName();
+            if (configReferenceName != null)
+            {
+                String category = configReferenceName.toLowerCase();
+                if (SUPPORTED_CATEGORIES.contains(category))
+                {
+                    return category;
+                }
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -296,7 +397,7 @@ public class GetMetadataObjectsTool implements IMcpTool
         int total = objects.size();
         int shown = Math.min(total, limit);
         
-        if (!TYPE_ALL.equals(metadataType))
+        if (!TYPE_ALL.equalsIgnoreCase(metadataType))
         {
             sb.append("**Filter:** ").append(metadataType).append("\n"); //$NON-NLS-1$ //$NON-NLS-2$
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -3615,6 +3615,11 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         {
             return methodRefErr;
         }
+        // A VALID reference is re-written to its canonical stored form (resolved module casing;
+        // methodName without a type prefix, handler with the English CommonModule prefix) so a
+        // tolerated variant like 'CommonModule.Calc.Add' / 'ОбщийМодуль.Calc.Add' never serializes
+        // verbatim into the model where the platform's own resolution would miss it.
+        value = canonicalMethodReference(ctx.config, target, name, value);
 
         // findFeature classifies ONLY the matched feature and skips the current-value rendering
         // (eGet + proxy + type rendering) that the full introspect() performs for EVERY assignable
@@ -3688,6 +3693,31 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 "'CommonModule.ModuleName.MethodName'", "CommonModule.Calc.Add"); //$NON-NLS-1$ //$NON-NLS-2$
         }
         return null;
+    }
+
+    /**
+     * Canonicalizes an ALREADY-VALIDATED method reference for the two guarded combos (see
+     * {@link #validateMethodReference}): a ScheduledJob's {@code methodName} stores
+     * {@code Module.Method} (no type prefix), an EventSubscription's {@code handler} stores
+     * {@code CommonModule.Module.Method}, both with the RESOLVED module's exact metadata name.
+     * Any other target/property - or a defensive resolution failure - returns the value unchanged.
+     */
+    static String canonicalMethodReference(Configuration config, EObject target, String name, String value)
+    {
+        if (value == null || value.isEmpty())
+        {
+            return value;
+        }
+        String canonical = null;
+        if (target instanceof ScheduledJob && PROP_METHOD_NAME.equalsIgnoreCase(name))
+        {
+            canonical = MethodReferenceValidator.canonicalReference(config, value, false);
+        }
+        else if (target instanceof EventSubscription && PROP_HANDLER.equalsIgnoreCase(name))
+        {
+            canonical = MethodReferenceValidator.canonicalReference(config, value, true);
+        }
+        return canonical != null ? canonical : value;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.EMap;
 import org.eclipse.emf.ecore.EClass;
@@ -39,11 +40,13 @@ import com._1c.g5.v8.dt.metadata.mdclass.Catalog;
 import com._1c.g5.v8.dt.metadata.mdclass.CommonAttribute;
 import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
 import com._1c.g5.v8.dt.metadata.mdclass.Document;
+import com._1c.g5.v8.dt.metadata.mdclass.EventSubscription;
 import com._1c.g5.v8.dt.metadata.mdclass.ExchangePlan;
 import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
 import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
 import com._1c.g5.v8.dt.metadata.mdclass.Report;
 import com._1c.g5.v8.dt.metadata.mdclass.Role;
+import com._1c.g5.v8.dt.metadata.mdclass.ScheduledJob;
 import com._1c.g5.v8.dt.metadata.mdclass.StyleElementType;
 import com._1c.g5.v8.dt.metadata.mdclass.Subsystem;
 import com._1c.g5.v8.dt.metadata.mdclass.Template;
@@ -75,6 +78,7 @@ import com.ditrix.edt.mcp.server.utils.MetadataPropertyIntrospector;
 import com.ditrix.edt.mcp.server.utils.MetadataPropertyIntrospector.PropertyInfo;
 import com.ditrix.edt.mcp.server.utils.MetadataTypeBuilder;
 import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils;
+import com.ditrix.edt.mcp.server.utils.MethodReferenceValidator;
 import com.ditrix.edt.mcp.server.utils.ReferenceMembershipWriter;
 import com.ditrix.edt.mcp.server.utils.RoleRightsWriter;
 import com.ditrix.edt.mcp.server.utils.SpreadsheetTemplateWriter;
@@ -159,6 +163,9 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
 
     /** The form attribute's value-type feature / property alias. */
     private static final String PROP_VALUE_TYPE = "valueType"; //$NON-NLS-1$
+
+    /** A ScheduledJob's method-reference property (guarded by {@link MethodReferenceValidator}). */
+    private static final String PROP_METHOD_NAME = "methodName"; //$NON-NLS-1$
 
     /** Confirmation-message prefix for a completed modify. */
     private static final String MSG_MODIFIED_PREFIX = "Modified "; //$NON-NLS-1$
@@ -1841,8 +1848,8 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         // once so an unresolved 'type' reference can append the extension-adopt hint (issue #262).
         boolean isExtensionProject = ExtensionOriginUtils.isExtensionProject(ctx.project);
         List<PreparedChange> changes = new ArrayList<>();
-        String prepErr = validateAndPrepare(config, version, target, properties, changes, normReport,
-            isExtensionProject);
+        String prepErr = validateAndPrepare(ctx.project, config, version, target, properties, changes,
+            normReport, isExtensionProject);
         if (prepErr != null)
         {
             return prepErr;
@@ -2477,13 +2484,15 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
      * mutation), appending a {@link PreparedChange} for each. Returns the first property's JSON error,
      * or {@code null} when all validated. Side-effect-free apart from populating {@code changes};
      * extracted verbatim from {@link #executeOnUiThread} so a failure returns the SAME error in the
-     * SAME case, before the BM transaction runs.
+     * SAME case, before the BM transaction runs. {@code project} is threaded through only so
+     * {@link #validateMethodReference} can read a CommonModule's source when the target is a
+     * ScheduledJob / EventSubscription; every other property ignores it.
      */
-    private String validateAndPrepare(Configuration config, Version version, MdObject target,
+    private String validateAndPrepare(IProject project, Configuration config, Version version, MdObject target,
         List<JsonObject> properties, List<PreparedChange> changes, MdNameNormalizer.Report normReport,
         boolean isExtensionProject)
     {
-        PrepareContext ctx = new PrepareContext(config, version);
+        PrepareContext ctx = new PrepareContext(project, config, version);
         for (JsonObject prop : properties)
         {
             // The mdclass path has no <extInfo> (extInfo == null): findFeature then classifies only the
@@ -3059,9 +3068,10 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         // The extension-adopt hint (issue #262) is scoped to the mdclass 'type' property path
         // (validateAndPrepare, which threads the project's extension status through); a form member's
         // 'type' is a platform-type classifier (group/field/decoration kind), never a metadata reference,
-        // so there is no unresolved-reference case here to hint.
-        String pErr = prepare(new PrepareContext(config, version), member, holder.classifyExtInfo, normProp, built,
-            normReport, false);
+        // so there is no unresolved-reference case here to hint. `project` is null: a form member is
+        // never a ScheduledJob / EventSubscription, so validateMethodReference never dereferences it.
+        String pErr = prepare(new PrepareContext(null, config, version), member, holder.classifyExtInfo, normProp,
+            built, normReport, false);
         if (pErr != null)
         {
             throw new FormValidationException(pErr);
@@ -3166,7 +3176,9 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
     }
 
     /** The rebind property names. {@code procedure} (alias {@code handler}) rebinds a handler's BSL
-     * procedure; {@code command} (alias {@code commandName}) re-points a button at a form command. */
+     * procedure; {@code command} (alias {@code commandName}) re-points a button at a form command.
+     * {@code PROP_HANDLER} doubles as an EventSubscription's method-reference property (guarded by
+     * {@link MethodReferenceValidator} on the mdclass path). */
     private static final String PROP_PROCEDURE = "procedure"; //$NON-NLS-1$
     private static final String PROP_HANDLER = "handler"; //$NON-NLS-1$
     private static final String PROP_COMMAND = "command"; //$NON-NLS-1$
@@ -3553,16 +3565,21 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
      * Immutable bundle of {@link #prepare}'s {@link Configuration} + {@link Version} parameters - the
      * model context every {@code ValueKind} branch resolves references / types against. Folded together
      * purely to bring {@link #prepare}'s parameter count under the 7-parameter threshold (S107); no
-     * behaviour change.
+     * behaviour change. {@code project} is nullable: it is {@code null} on the form-member path (a form
+     * member is never a ScheduledJob / EventSubscription, so {@link #validateMethodReference} never
+     * dereferences it there) and only non-null on the mdclass path.
      */
     private static final class PrepareContext
     {
+        final IProject project;
+
         final Configuration config;
 
         final Version version;
 
-        PrepareContext(Configuration config, Version version)
+        PrepareContext(IProject project, Configuration config, Version version)
         {
+            this.project = project;
             this.config = config;
             this.version = version;
         }
@@ -3584,6 +3601,20 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 + "metadata. modify_metadata only sets non-identity properties.").toJson(); //$NON-NLS-1$
         }
         String value = asString(prop.get(KEY_VALUE));
+
+        // Guard (scoped to exactly two type+property combos - a no-op for everything else, including
+        // every property on the form-member path where ctx.project is null): a ScheduledJob's
+        // methodName / an EventSubscription's handler must reference an EXISTING, Exported, Server-side
+        // CommonModule method BEFORE it is accepted, so binding a job/subscription at a function that
+        // does not exist yet fails HERE with an actionable error instead of only at update_database
+        // ("no such function"). An empty value is left to the pre-existing generic-STRING policy below
+        // (requireValueError: modify_metadata never "clears" a property on an empty value) rather than
+        // being reported as a method-reference failure.
+        String methodRefErr = validateMethodReference(ctx.project, ctx.config, target, name, value);
+        if (methodRefErr != null)
+        {
+            return methodRefErr;
+        }
 
         // findFeature classifies ONLY the matched feature and skips the current-value rendering
         // (eGet + proxy + type rendering) that the full introspect() performs for EVERY assignable
@@ -3626,6 +3657,37 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             default:
                 return prepareString(name, value, info, out, normReport);
         }
+    }
+
+    /**
+     * Dispatches the maintainer-requested method-reference guard (a job/subscription must be bound to a
+     * method that already EXISTS, is EXPORTED and lives in a SERVER module) to {@link
+     * MethodReferenceValidator}, scoped to exactly the two type+property combos it covers. Every other
+     * target/property - including any property on the form-member path, where {@code project} is
+     * {@code null} - returns {@code null} immediately without touching {@code project} / {@code config}.
+     * An empty value is NOT validated here (it falls through to the pre-existing generic-STRING policy,
+     * which itself rejects an empty value rather than "clearing" the property). Package-visible (takes
+     * the plain {@code project}/{@code config} pair rather than the private {@link PrepareContext}) so
+     * the dispatch is unit-testable headlessly, mirroring {@link #formTypeExtInfoComboError}.
+     */
+    static String validateMethodReference(IProject project, Configuration config, EObject target, String name,
+        String value)
+    {
+        if (value == null || value.isEmpty())
+        {
+            return null;
+        }
+        if (target instanceof ScheduledJob && PROP_METHOD_NAME.equalsIgnoreCase(name))
+        {
+            return MethodReferenceValidator.validate(project, config, value, PROP_METHOD_NAME,
+                "'CommonModuleName.MethodName'", "Calc.Add"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        if (target instanceof EventSubscription && PROP_HANDLER.equalsIgnoreCase(name))
+        {
+            return MethodReferenceValidator.validate(project, config, value, PROP_HANDLER,
+                "'CommonModule.ModuleName.MethodName'", "CommonModule.Calc.Add"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return null;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
@@ -55,9 +55,10 @@ public final class BslModuleUtils
     /** Dummy BSL URI for IResourceServiceProvider lookup */
     public static final URI BSL_LOOKUP_URI = URI.createURI("/nopr/module.bsl"); //$NON-NLS-1$
 
-    /** Regex for BSL method start (Процедура/Функция / Procedure/Function). Group 1 = method name, group 2 = params text after '(' */
+    /** Regex for BSL method start (Процедура/Функция / Procedure/Function, with an optional leading
+     * Асинх/Async modifier - platform async methods). Group 1 = method name, group 2 = params text after '(' */
     public static final Pattern METHOD_START_PATTERN = Pattern.compile(
-        "^\\s*(?:\u041F\u0440\u043E\u0446\u0435\u0434\u0443\u0440\u0430|\u0424\u0443\u043D\u043A\u0446\u0438\u044F|Procedure|Function)\\s+([^\\s(]+)\\s*\\((.*)$", //$NON-NLS-1$
+        "^\\s*(?:\u0410\u0441\u0438\u043D\u0445\\s+|Async\\s+)?(?:\u041F\u0440\u043E\u0446\u0435\u0434\u0443\u0440\u0430|\u0424\u0443\u043D\u043A\u0446\u0438\u044F|Procedure|Function)\\s+([^\\s(]+)\\s*\\((.*)$", //$NON-NLS-1$
         Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
 
     /** Regex for BSL method end (КонецПроцедуры/КонецФункции / EndProcedure/EndFunction) */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
@@ -66,9 +66,9 @@ public final class BslModuleUtils
         "^\\s*(?:\u041A\u043E\u043D\u0435\u0446\u041F\u0440\u043E\u0446\u0435\u0434\u0443\u0440\u044B|\u041A\u043E\u043D\u0435\u0446\u0424\u0443\u043D\u043A\u0446\u0438\u0438|EndProcedure|EndFunction)", //$NON-NLS-1$
         Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
 
-    /** Regex for function keyword check (Функция / Function) */
+    /** Regex for function keyword check (Функция / Function, optional leading Асинх/Async) */
     public static final Pattern FUNC_KEYWORD_PATTERN = Pattern.compile(
-        "^\\s*(?:\u0424\u0443\u043D\u043A\u0446\u0438\u044F|Function)\\s", //$NON-NLS-1$
+        "^\\s*(?:\u0410\u0441\u0438\u043D\u0445\\s+|Async\\s+)?(?:\u0424\u0443\u043D\u043A\u0446\u0438\u044F|Function)\\s", //$NON-NLS-1$
         Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
 
     /** Regex for region start (#Область / #Region) */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslSyntaxChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslSyntaxChecker.java
@@ -51,13 +51,15 @@ public final class BslSyntaxChecker
         "^\\s*(?:\u041A\u043E\u043D\u0435\u0446\u041F\u043E\u043F\u044B\u0442\u043A\u0438|EndTry)\\b", //$NON-NLS-1$
         Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
 
-    // Opening keywords
+    // Opening keywords. An optional "\u0410\u0441\u0438\u043D\u0445"/"Async" prefix is allowed before
+    // Procedure/Function (async procedures/functions, #287); "\u0416\u0434\u0430\u0442\u044C"/"Await" is
+    // an expression keyword and introduces no block of its own, so it is intentionally not matched here.
     private static final Pattern PROCEDURE_START = Pattern.compile(
-        "^\\s*(?:\u041F\u0440\u043E\u0446\u0435\u0434\u0443\u0440\u0430|Procedure)\\b", //$NON-NLS-1$
+        "^\\s*(?:\u0410\u0441\u0438\u043D\u0445\\s+|Async\\s+)?(?:\u041F\u0440\u043E\u0446\u0435\u0434\u0443\u0440\u0430|Procedure)\\b", //$NON-NLS-1$
         Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
 
     private static final Pattern FUNCTION_START = Pattern.compile(
-        "^\\s*(?:\u0424\u0443\u043D\u043A\u0446\u0438\u044F|Function)\\b", //$NON-NLS-1$
+        "^\\s*(?:\u0410\u0441\u0438\u043D\u0445\\s+|Async\\s+)?(?:\u0424\u0443\u043D\u043A\u0446\u0438\u044F|Function)\\b", //$NON-NLS-1$
         Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
 
     // If but NOT ElsIf/ElseIf/ИначеЕсли
@@ -118,12 +120,24 @@ public final class BslSyntaxChecker
         List<String> errors = new ArrayList<>();
         // Stack of (tag, lineNumber as string)
         Deque<String[]> stack = new ArrayDeque<>();
+        // Carries whether a string literal is still open across physical lines
+        StringLiteralState stringState = new StringLiteralState();
 
         for (int i = 0; i < lines.size(); i++) // NOSONAR intentional multiple loop exits; restructuring with flags would reduce readability
         {
             int lineNum = i + 1;
 
-            String trimmed = preprocessLine(lines.get(i));
+            // A double-quote string only continues onto the next physical line via a leading '|'
+            // continuation. If the previous line ended still inside a string but THIS line is not a
+            // continuation, the literal was not a valid multi-line string (a mis-tracked quote or a
+            // genuinely unclosed string) - reset so it does not mask the real code that follows,
+            // which would hide real block keywords (and their imbalance).
+            if (stringState.insideString && !lines.get(i).trim().startsWith("|")) //$NON-NLS-1$
+            {
+                stringState.insideString = false;
+            }
+
+            String trimmed = preprocessLine(lines.get(i), stringState);
             if (trimmed == null)
             {
                 continue;
@@ -145,43 +159,132 @@ public final class BslSyntaxChecker
     }
 
     /**
-     * Normalize a source line for keyword matching: trims it, skips blank/comment/string
-     * continuation lines, and strips any inline comment.
+     * Carries whether a string literal opened on an earlier physical line is still
+     * open when the next line starts. BSL string literals can span several lines,
+     * each continuation line starting with a leading {@code |}.
+     */
+    private static final class StringLiteralState
+    {
+        private boolean insideString;
+    }
+
+    /**
+     * Normalize a source line for keyword matching: masks any string-literal (and
+     * comment) content via {@link #maskStringLiterals}, then drops leading
+     * whitespace and stray statement separators.
+     * <p>
+     * The leftover leading {@code ;} case shows up when a string literal closes
+     * mid-line and the assignment's trailing {@code ;} is the only unmasked
+     * character before the next real statement — e.g. a closing continuation line
+     * such as {@code |tail"; If x Then} masks to a run of spaces followed by
+     * {@code ; If x Then}; skipping that separator lets {@code If} still be
+     * recognized "at line start".
      *
      * @param line the raw source line
-     * @return the trimmed line ready for matching, or {@code null} if the line must be skipped
+     * @param state carries whether a string literal is already open when this
+     *     line starts; updated in place to reflect the state after this line
+     * @return the masked line ready for keyword matching, or {@code null} if there
+     *     is no real code left on the line (blank, a full comment, a pure string
+     *     continuation line, or only statement separators)
      */
-    private static String preprocessLine(String line)
+    private static String preprocessLine(String line, StringLiteralState state)
     {
-        // Skip empty lines
-        if (line.trim().isEmpty())
+        String masked = maskStringLiterals(line, state);
+
+        int start = 0;
+        int len = masked.length();
+        while (start < len && (Character.isWhitespace(masked.charAt(start)) || masked.charAt(start) == ';'))
         {
-            return null;
+            start++;
+        }
+        return start >= len ? null : masked.substring(start);
+    }
+
+    /**
+     * Masks the parts of a line that are lexically inside a string literal so that
+     * keyword-looking text embedded in query or message text can never match a
+     * block keyword, while any real code on the same physical line — including
+     * code that follows the string's closing quote — is left untouched.
+     * <p>
+     * Walks the line character by character, toggling {@code state.insideString}
+     * on every double quote, EXCEPT a doubled {@code ""} which is an escaped quote
+     * inside the literal and does not close it. Masked characters are replaced
+     * with a space (not removed), so the column position of any real code after
+     * the string is preserved. An inline {@code //} comment is only recognized
+     * while NOT inside a string, so a {@code //} inside a URL or message text no
+     * longer truncates the line. {@code state.insideString} is updated in place so
+     * the flag carries across lines for a literal that spans several physical
+     * lines (each continuation masks to blank and is effectively skipped, same
+     * outcome as before, but now for the correct reason).
+     *
+     * @param line the raw source line
+     * @param state carries whether a string literal is already open when this
+     *     line starts; updated in place to reflect the state after this line
+     * @return the line with string-literal content (and any trailing comment)
+     *     replaced by spaces or dropped
+     */
+    private static String maskStringLiterals(String line, StringLiteralState state)
+    {
+        int len = line.length();
+        StringBuilder masked = new StringBuilder(len);
+        boolean insideString = state.insideString; // double-quote "..." string, CARRIED across lines
+        boolean insideDate = false;                 // single-quote '...' date literal, intra-line only
+
+        for (int i = 0; i < len; i++)
+        {
+            char c = line.charAt(i);
+            if (insideString)
+            {
+                if (c == '"' && i + 1 < len && line.charAt(i + 1) == '"')
+                {
+                    // Doubled quote: an escaped quote inside the literal, string stays open
+                    masked.append(' ').append(' ');
+                    i++;
+                    continue;
+                }
+                if (c == '"')
+                {
+                    insideString = false;
+                }
+                masked.append(' ');
+                continue;
+            }
+            if (insideDate)
+            {
+                // A single-quote '...' date literal. A double-quote inside it is CONTENT, not a
+                // string toggle - masking it here is what stops a stray '"' inside a date/'...'
+                // token from flipping insideString and swallowing the rest of the module.
+                if (c == '\'')
+                {
+                    insideDate = false;
+                }
+                masked.append(' ');
+                continue;
+            }
+            if (c == '"')
+            {
+                insideString = true;
+                masked.append(' ');
+                continue;
+            }
+            if (c == '\'')
+            {
+                insideDate = true;
+                masked.append(' ');
+                continue;
+            }
+            if (c == '/' && i + 1 < len && line.charAt(i + 1) == '/')
+            {
+                break; // inline comment - the rest of the line is not code
+            }
+            masked.append(c);
         }
 
-        // Skip lines that are entirely a comment
-        String trimmed = line.trim();
-        if (trimmed.startsWith("//")) //$NON-NLS-1$
-        {
-            return null;
-        }
-
-        // Skip multiline string continuation lines (start with |)
-        if (trimmed.startsWith("|")) //$NON-NLS-1$
-        {
-            return null;
-        }
-
-        // Remove inline comment (everything after //)
-        // Known limitation: // inside string literals (e.g. URLs like "https://...")
-        // will be treated as a comment start. This is acceptable because keywords
-        // are matched at line start (^\s*keyword\b), so truncation does not affect results.
-        int commentIdx = trimmed.indexOf("//"); //$NON-NLS-1$
-        if (commentIdx > 0)
-        {
-            trimmed = trimmed.substring(0, commentIdx);
-        }
-        return trimmed;
+        // A single-quote date literal never spans physical lines, so insideDate is intentionally
+        // NOT persisted; only the double-quote string carries (via the '|'-continuation rule the
+        // caller applies before the next line - see check()).
+        state.insideString = insideString;
+        return masked.toString();
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MethodReferenceValidator.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MethodReferenceValidator.java
@@ -236,10 +236,10 @@ public final class MethodReferenceValidator
         int declLine = findDeclarationLine(lines, found);
         for (int i = declLine; i <= found.endLine && i < lines.size(); i++)
         {
-            // Strip a trailing inline comment BEFORE matching: a signature such as
-            // `Procedure Foo() // TODO: Export` must NOT count as exported (the keyword lives in the
-            // comment, not the modifier position).
-            String line = stripInlineComment(lines.get(i));
+            // Mask string literals and strip a trailing inline comment BEFORE matching: neither a
+            // signature comment (`Procedure Foo() // TODO: Export`) nor a parameter default carrying
+            // the word (`Procedure Foo(P = "Export")`) may count as the Export modifier.
+            String line = maskStringsAndStripComment(lines.get(i));
             if (EXPORT_KEYWORD_PATTERN.matcher(line).find())
             {
                 return true;
@@ -256,12 +256,16 @@ public final class MethodReferenceValidator
     }
 
     /**
-     * Truncates {@code line} at the first {@code //} that is OUTSIDE a double-quoted string literal
-     * (a {@code //} inside a parameter's default string value stays). Quote tracking is the minimal
-     * intra-line kind a declaration header needs; it does not attempt multi-line literals.
+     * MASKS double-quoted string-literal content (each in-string char becomes a space, so a parameter
+     * default like {@code P = "Export"} can never look like the Export modifier, and a {@code ")"}
+     * inside a string cannot fake the header's end) and truncates at the first {@code //} that is
+     * OUTSIDE a string (a {@code //} inside a default string value stays masked, not treated as a
+     * comment). Quote tracking is the minimal intra-line kind a declaration header needs; it does not
+     * attempt multi-line literals.
      */
-    static String stripInlineComment(String line)
+    static String maskStringsAndStripComment(String line)
     {
+        StringBuilder masked = new StringBuilder(line.length());
         boolean inString = false;
         for (int i = 0; i < line.length(); i++)
         {
@@ -269,13 +273,21 @@ public final class MethodReferenceValidator
             if (c == '"')
             {
                 inString = !inString;
+                masked.append(' ');
+                continue;
             }
-            else if (!inString && c == '/' && i + 1 < line.length() && line.charAt(i + 1) == '/')
+            if (inString)
             {
-                return line.substring(0, i);
+                masked.append(' ');
+                continue;
             }
+            if (c == '/' && i + 1 < line.length() && line.charAt(i + 1) == '/')
+            {
+                break;
+            }
+            masked.append(c);
         }
-        return line;
+        return masked.toString();
     }
 
     private static int findDeclarationLine(List<String> lines, BslModuleUtils.TextMethod found)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MethodReferenceValidator.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MethodReferenceValidator.java
@@ -236,7 +236,10 @@ public final class MethodReferenceValidator
         int declLine = findDeclarationLine(lines, found);
         for (int i = declLine; i <= found.endLine && i < lines.size(); i++)
         {
-            String line = lines.get(i);
+            // Strip a trailing inline comment BEFORE matching: a signature such as
+            // `Procedure Foo() // TODO: Export` must NOT count as exported (the keyword lives in the
+            // comment, not the modifier position).
+            String line = stripInlineComment(lines.get(i));
             if (EXPORT_KEYWORD_PATTERN.matcher(line).find())
             {
                 return true;
@@ -250,6 +253,29 @@ public final class MethodReferenceValidator
             }
         }
         return false;
+    }
+
+    /**
+     * Truncates {@code line} at the first {@code //} that is OUTSIDE a double-quoted string literal
+     * (a {@code //} inside a parameter's default string value stays). Quote tracking is the minimal
+     * intra-line kind a declaration header needs; it does not attempt multi-line literals.
+     */
+    static String stripInlineComment(String line)
+    {
+        boolean inString = false;
+        for (int i = 0; i < line.length(); i++)
+        {
+            char c = line.charAt(i);
+            if (c == '"')
+            {
+                inString = !inString;
+            }
+            else if (!inString && c == '/' && i + 1 < line.length() && line.charAt(i + 1) == '/')
+            {
+                return line.substring(0, i);
+            }
+        }
+        return line;
     }
 
     private static int findDeclarationLine(List<String> lines, BslModuleUtils.TextMethod found)
@@ -298,8 +324,41 @@ public final class MethodReferenceValidator
         }
         CommonModule module = (CommonModule)moduleObj;
 
-        List<String> lines = readModuleLines(project, parsed.moduleName);
+        // Read the source by the RESOLVED metadata name, not the raw input: findObject resolves the
+        // module tolerantly (e.g. a case difference), but the folder on disk carries the metadata
+        // name's exact casing - building the path from the raw input would miss the file on a
+        // case-sensitive filesystem and mis-report the method as missing.
+        List<String> lines = readModuleLines(project, module.getName());
         return decide(module, parsed.moduleName, lines, parsed.methodName, propertyLabel);
+    }
+
+    /**
+     * Returns the CANONICAL stored form of a VALID reference, or {@code null} when the value does not
+     * parse/resolve (callers run {@link #validate} first, so {@code null} is only a defensive fallback -
+     * they then keep the raw value). The canonical form uses the RESOLVED module's exact metadata name
+     * (so a tolerated case/prefix variant is not serialized verbatim into the model, where the
+     * platform's own resolution would then miss it):
+     * <ul>
+     * <li>{@code withTypePrefix == false} (a ScheduledJob's {@code methodName}):
+     * {@code <ModuleName>.<MethodName>};</li>
+     * <li>{@code withTypePrefix == true} (an EventSubscription's {@code handler}):
+     * {@code CommonModule.<ModuleName>.<MethodName>}.</li>
+     * </ul>
+     */
+    public static String canonicalReference(Configuration config, String rawValue, boolean withTypePrefix)
+    {
+        ParsedReference parsed = parse(rawValue, "", "", ""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        if (parsed.error != null)
+        {
+            return null;
+        }
+        MdObject moduleObj = MetadataTypeUtils.findObject(config, COMMON_MODULE_TYPE, parsed.moduleName);
+        if (!(moduleObj instanceof CommonModule))
+        {
+            return null;
+        }
+        String base = moduleObj.getName() + "." + parsed.methodName; //$NON-NLS-1$
+        return withTypePrefix ? COMMON_MODULE_TYPE + "." + base : base; //$NON-NLS-1$
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MethodReferenceValidator.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MethodReferenceValidator.java
@@ -1,0 +1,328 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2026 Diversus (https://github.com/Diversus23)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+
+import com._1c.g5.v8.dt.metadata.mdclass.CommonModule;
+import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
+import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
+import com.ditrix.edt.mcp.server.Activator;
+import com.ditrix.edt.mcp.server.protocol.ToolResult;
+
+/**
+ * Validates a "method reference" value BEFORE it is written to a
+ * {@link com._1c.g5.v8.dt.metadata.mdclass.ScheduledJob ScheduledJob}'s {@code methodName} or an
+ * {@link com._1c.g5.v8.dt.metadata.mdclass.EventSubscription EventSubscription}'s {@code handler}
+ * property, so {@code modify_metadata} refuses a job/subscription pointed at a method that does not
+ * exist yet - a real authoring mistake reported by a maintainer: an AI bound a ScheduledJob's
+ * {@code methodName} at a function it had not created yet, and EDT accepted the value silently; the
+ * mistake surfaced only at {@code update_database}, with an opaque "no such function" failure. This
+ * guard forces the correct order (create the module + Exported method first, THEN bind it) by failing
+ * fast, at validation time, with an actionable error.
+ *
+ * <p>Both properties reference a {@link CommonModule} method as {@code <ModuleName>.<MethodName>},
+ * optionally prefixed with the {@code CommonModule} type token (mdclass stores an EventSubscription's
+ * {@code handler} as {@code CommonModule.<ModuleName>.<MethodName>}; a bare
+ * {@code <ModuleName>.<MethodName>} is the live-verified ScheduledJob {@code methodName} form, e.g.
+ * {@code "Calc.Add"}). {@link #validate} runs four checks, in order, failing fast on the first that does
+ * not hold:</p>
+ * <ol>
+ * <li>the value parses as a module/method reference (has a dot separating a module part from a method
+ * name);</li>
+ * <li>the referenced {@link CommonModule} exists (resolved through the shared bilingual resolver
+ * {@link MetadataTypeUtils#findObject});</li>
+ * <li>the referenced method exists in that module's {@code Module.bsl} source (a missing method OR a
+ * missing module file are reported the same way: create the method first);</li>
+ * <li>the method is {@code Export}ed;</li>
+ * <li>the module has the {@code Server} flag ({@link CommonModule#isServer()}) - a scheduled job /
+ * event-subscription handler always runs server-side.</li>
+ * </ol>
+ *
+ * <p>The parse ({@link #parse}) and decision ({@link #decide}) logic is pure (no {@link IProject}, no
+ * workspace access) so it is unit-testable in-JVM; only {@link #validate} touches the workspace
+ * (resolving + reading the module's source file through {@link BslModuleUtils}).</p>
+ */
+public final class MethodReferenceValidator
+{
+    private MethodReferenceValidator()
+    {
+        // Utility class
+    }
+
+    /** The CommonModule metadata type token (canonical English), reused to detect/strip a leading prefix. */
+    private static final String COMMON_MODULE_TYPE = "CommonModule"; //$NON-NLS-1$
+
+    /**
+     * Matches the BSL {@code Export} / {@code Экспорт} keyword as a
+     * standalone token (never a substring of a longer identifier), case-insensitively.
+     */
+    // The Cyrillic keyword is written as backslash-u escapes (matches the BslModuleUtils /
+    // MetadataTypeUtils convention for a REGEX, which a non-UTF-8 Tycho build could otherwise
+    // corrupt). NOTE: never spell a literal backslash-u sequence inside a comment - javac
+    // processes unicode escapes in comments too and a malformed one is a compile error.
+    private static final Pattern EXPORT_KEYWORD_PATTERN = Pattern.compile(
+        "(?:^|[^\\p{L}\\p{Nd}_])(?:" //$NON-NLS-1$
+            + "\u042D\u043A\u0441\u043F\u043E\u0440\u0442" // Экспорт //$NON-NLS-1$
+            + "|Export)(?:[^\\p{L}\\p{Nd}_]|$)", //$NON-NLS-1$
+        Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+
+    // ---- parse (pure) -----------------------------------------------------------------------------
+
+    /**
+     * The outcome of {@link #parse}: either a ready JSON {@link #error} (the value is not a well-formed
+     * module/method reference) or the split {@link #moduleName} / {@link #methodName}. Exactly one side
+     * is non-null.
+     */
+    public static final class ParsedReference
+    {
+        /** A ready {@link ToolResult#error} JSON when the value does not parse, else {@code null}. */
+        public final String error;
+
+        /** The module name (type-token prefix already stripped), or {@code null} on error. */
+        public final String moduleName;
+
+        /** The method name, or {@code null} on error. */
+        public final String methodName;
+
+        private ParsedReference(String error, String moduleName, String methodName)
+        {
+            this.error = error;
+            this.moduleName = moduleName;
+            this.methodName = methodName;
+        }
+
+        static ParsedReference ofError(String error)
+        {
+            return new ParsedReference(error, null, null);
+        }
+
+        static ParsedReference of(String moduleName, String methodName)
+        {
+            return new ParsedReference(null, moduleName, methodName);
+        }
+    }
+
+    /**
+     * Parses a {@code <ModuleName>.<MethodName>} reference value (optionally prefixed with the
+     * {@code CommonModule} / {@code ОбщийМодуль}
+     * type token, e.g. {@code "CommonModule.Calc.Add"}): splits on the LAST dot into a module part and
+     * the method name, then strips a leading {@code CommonModule} type-token prefix from the module part
+     * when present. The prefix is detected + normalized through
+     * {@link MetadataTypeUtils#toEnglishSingular} - the SAME bilingual-token resolver every type token
+     * in this plugin goes through - never hand-rolled.
+     *
+     * @param rawValue the raw property value (the caller only invokes this for a non-empty value)
+     * @param propertyLabel the property name to name in the error (e.g. {@code "methodName"} / {@code "handler"})
+     * @param expectedFormat a human-readable description of the expected shape, quoted (e.g.
+     *     {@code "'CommonModuleName.MethodName'"})
+     * @param exampleValue a concrete example value for the error hint (e.g. {@code "Calc.Add"})
+     * @return a {@link ParsedReference}; check {@link ParsedReference#error} first
+     */
+    public static ParsedReference parse(String rawValue, String propertyLabel, String expectedFormat,
+        String exampleValue)
+    {
+        int dotIdx = rawValue == null ? -1 : rawValue.lastIndexOf('.');
+        if (rawValue == null || dotIdx <= 0 || dotIdx == rawValue.length() - 1)
+        {
+            return ParsedReference.ofError(formatError(rawValue, propertyLabel, expectedFormat, exampleValue));
+        }
+        String modulePart = rawValue.substring(0, dotIdx);
+        String methodName = rawValue.substring(dotIdx + 1);
+        String moduleName = stripCommonModuleTypeToken(modulePart);
+        if (moduleName.isEmpty())
+        {
+            return ParsedReference.ofError(formatError(rawValue, propertyLabel, expectedFormat, exampleValue));
+        }
+        return ParsedReference.of(moduleName, methodName);
+    }
+
+    private static String formatError(String rawValue, String propertyLabel, String expectedFormat,
+        String exampleValue)
+    {
+        return ToolResult.error("'" + rawValue + "' is not a valid '" + propertyLabel //$NON-NLS-1$ //$NON-NLS-2$
+            + "' reference: expected " + expectedFormat + " (e.g. '" + exampleValue + "').").toJson(); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    /**
+     * Strips a leading {@code CommonModule} /
+     * {@code ОбщийМодуль} type-token prefix from a
+     * module-part string (e.g. {@code "CommonModule.Calc"} -&gt; {@code "Calc"}), reusing
+     * {@link MetadataTypeUtils#toEnglishSingular} rather than hand-rolling the bilingual match. A module
+     * part with no embedded dot (nothing to strip, e.g. plain {@code "Calc"}) is returned unchanged.
+     */
+    private static String stripCommonModuleTypeToken(String modulePart)
+    {
+        int firstDot = modulePart.indexOf('.');
+        if (firstDot <= 0)
+        {
+            return modulePart;
+        }
+        String prefixCandidate = modulePart.substring(0, firstDot);
+        String rest = modulePart.substring(firstDot + 1);
+        return COMMON_MODULE_TYPE.equals(MetadataTypeUtils.toEnglishSingular(prefixCandidate)) ? rest : modulePart;
+    }
+
+    // ---- decide (pure: module + source lines already resolved) ------------------------------------
+
+    /**
+     * Decides whether a parsed reference is a VALID, bindable method: it must exist in the module's
+     * source, be {@code Export}ed, and the module must have the {@code Server} flag (a scheduled job /
+     * event-subscription handler always runs server-side). Pure - takes the already-resolved
+     * {@link CommonModule} + its source lines (or {@code null} lines when the source could not be read,
+     * reported the SAME as "method not found": a missing file cannot host the method either) - so it is
+     * unit-testable without an {@link IProject}.
+     *
+     * @param module the resolved common module (its {@link CommonModule#isServer()} flag is checked)
+     * @param moduleName the module name, for the error text
+     * @param moduleLines the module's source lines, or {@code null} when the source could not be read
+     * @param methodName the method name to find
+     * @param propertyLabel the property name to name in the error
+     * @return a ready JSON error, or {@code null} when the reference is valid
+     */
+    public static String decide(CommonModule module, String moduleName, List<String> moduleLines,
+        String methodName, String propertyLabel)
+    {
+        BslModuleUtils.TextMethod found =
+            moduleLines == null ? null : BslModuleUtils.findMethodViaText(moduleLines, methodName);
+        if (found == null || !found.found)
+        {
+            return methodNotFoundError(moduleName, methodName, propertyLabel);
+        }
+        if (!isExported(moduleLines, found))
+        {
+            return ToolResult.error("Method '" + methodName + "' in CommonModule '" + moduleName //$NON-NLS-1$ //$NON-NLS-2$
+                + "' must be marked Export ('Экспорт') before it can " //$NON-NLS-1$
+                + "be used as '" + propertyLabel + "'.").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        if (module != null && !module.isServer())
+        {
+            return ToolResult.error("CommonModule '" + moduleName + "' does not have the Server flag: " //$NON-NLS-1$ //$NON-NLS-2$
+                + "a scheduled job / event-subscription handler always runs server-side, so give the " //$NON-NLS-1$
+                + "module the Server property (set 'server' to true) before setting '" + propertyLabel //$NON-NLS-1$
+                + "'.").toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    private static String methodNotFoundError(String moduleName, String methodName, String propertyLabel)
+    {
+        return ToolResult.error("Method '" + methodName + "' not found in CommonModule '" + moduleName //$NON-NLS-1$ //$NON-NLS-2$
+            + "'. Create it first with write_module_source (an Exported server procedure/function), " //$NON-NLS-1$
+            + "then set '" + propertyLabel + "'.").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Detects whether the found method's declaration carries {@code Export} /
+     * {@code Экспорт}. {@link BslModuleUtils.TextMethod} carries no
+     * export flag of its own (and its {@link BslModuleUtils.TextMethod#startLine startLine} may include
+     * an adjacent doc-comment block), so the ACTUAL declaration line is re-located within
+     * {@code [startLine, endLine]} via the shared {@link BslModuleUtils#METHOD_START_PATTERN}; every
+     * line from there up to (and including) the first line that closes the parameter list ({@code ")"})
+     * is then scanned for the keyword - covering both a single-line signature and one whose parameter
+     * list wraps across multiple lines.
+     */
+    static boolean isExported(List<String> lines, BslModuleUtils.TextMethod found)
+    {
+        int declLine = findDeclarationLine(lines, found);
+        for (int i = declLine; i <= found.endLine && i < lines.size(); i++)
+        {
+            String line = lines.get(i);
+            if (EXPORT_KEYWORD_PATTERN.matcher(line).find())
+            {
+                return true;
+            }
+            if (line.indexOf(')') >= 0)
+            {
+                // The parameter list (and so the declaration header) is closed on this line: Export, if
+                // present, must be here too (already checked above) - stop before the method BODY, so a
+                // body line mentioning the word is never mistaken for the Export modifier.
+                break;
+            }
+        }
+        return false;
+    }
+
+    private static int findDeclarationLine(List<String> lines, BslModuleUtils.TextMethod found)
+    {
+        for (int i = found.startLine; i <= found.endLine && i < lines.size(); i++)
+        {
+            Matcher matcher = BslModuleUtils.METHOD_START_PATTERN.matcher(lines.get(i));
+            if (matcher.find() && found.matchedName.equalsIgnoreCase(matcher.group(1)))
+            {
+                return i;
+            }
+        }
+        return found.startLine;
+    }
+
+    // ---- validate (the IProject-touching seam) -----------------------------------------------------
+
+    /**
+     * Full validation: parses the reference, resolves the {@link CommonModule} through the shared
+     * bilingual resolver {@link MetadataTypeUtils#findObject}, reads its {@code Module.bsl} source, and
+     * decides via {@link #decide}. This is the ONLY method here that touches the workspace.
+     *
+     * @param project the EDT project (for resolving the module's source file)
+     * @param config the project's configuration (for resolving the module object)
+     * @param rawValue the raw property value (the caller only invokes this for a non-empty value)
+     * @param propertyLabel the property name to name in the error (e.g. {@code "methodName"} / {@code "handler"})
+     * @param expectedFormat a human-readable description of the expected shape, quoted
+     * @param exampleValue a concrete example value for the format-error hint
+     * @return a ready JSON error, or {@code null} when the reference is valid
+     */
+    public static String validate(IProject project, Configuration config, String rawValue, String propertyLabel,
+        String expectedFormat, String exampleValue)
+    {
+        ParsedReference parsed = parse(rawValue, propertyLabel, expectedFormat, exampleValue);
+        if (parsed.error != null)
+        {
+            return parsed.error;
+        }
+
+        MdObject moduleObj = MetadataTypeUtils.findObject(config, COMMON_MODULE_TYPE, parsed.moduleName);
+        if (!(moduleObj instanceof CommonModule))
+        {
+            return ToolResult.error("Common module '" + parsed.moduleName + "' not found (from '" + rawValue //$NON-NLS-1$ //$NON-NLS-2$
+                + "'). Use get_metadata_objects to see the available common modules, or create it " //$NON-NLS-1$
+                + "first.").toJson(); //$NON-NLS-1$
+        }
+        CommonModule module = (CommonModule)moduleObj;
+
+        List<String> lines = readModuleLines(project, parsed.moduleName);
+        return decide(module, parsed.moduleName, lines, parsed.methodName, propertyLabel);
+    }
+
+    /**
+     * Reads a common module's {@code Module.bsl} source lines, or {@code null} when the file is missing
+     * / unreadable (the caller then reports the SAME "method not found" error as an existing-but-empty
+     * source would).
+     */
+    private static List<String> readModuleLines(IProject project, String moduleName)
+    {
+        IFile file = BslModuleUtils.resolveModuleFile(project,
+            "CommonModules/" + moduleName + "/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (file == null || !file.exists())
+        {
+            return null;
+        }
+        try
+        {
+            return BslModuleUtils.readFileLines(file);
+        }
+        catch (Exception e)
+        {
+            Activator.logError("MethodReferenceValidator: failed to read " + moduleName + "/Module.bsl", e); //$NON-NLS-1$ //$NON-NLS-2$
+            return null;
+        }
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/BslSyntaxCheckerTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/BslSyntaxCheckerTest.java
@@ -615,4 +615,243 @@ public class BslSyntaxCheckerTest
         assertFalse(result.isValid());
         assertTrue(result.getErrors().get(0).contains("Unexpected")); //$NON-NLS-1$
     }
+
+    // ==================== Async procedures/functions (#287) ====================
+
+    @Test
+    public void testAsyncProcedureRussian()
+    {
+        List<String> lines = Arrays.asList(
+            "\u0410\u0441\u0438\u043D\u0445 \u041F\u0440\u043E\u0446\u0435\u0434\u0443\u0440\u0430 \u0424(\u041A\u043E\u043C\u0430\u043D\u0434\u0430)", //$NON-NLS-1$
+            "    \u0445 = 1;", //$NON-NLS-1$
+            "\u041A\u043E\u043D\u0435\u0446\u041F\u0440\u043E\u0446\u0435\u0434\u0443\u0440\u044B" //$NON-NLS-1$
+        );
+        CheckResult result = BslSyntaxChecker.check(lines);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testAsyncFunctionRussian()
+    {
+        List<String> lines = Arrays.asList(
+            "\u0410\u0441\u0438\u043D\u0445 \u0424\u0443\u043D\u043A\u0446\u0438\u044F \u0424(\u041A\u043E\u043C\u0430\u043D\u0434\u0430)", //$NON-NLS-1$
+            "    \u0412\u043E\u0437\u0432\u0440\u0430\u0442 1;", //$NON-NLS-1$
+            "\u041A\u043E\u043D\u0435\u0446\u0424\u0443\u043D\u043A\u0446\u0438\u0438" //$NON-NLS-1$
+        );
+        CheckResult result = BslSyntaxChecker.check(lines);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testAsyncProcedureEnglish()
+    {
+        List<String> lines = Arrays.asList(
+            "Async Procedure DoSomethingAsync(Command)", //$NON-NLS-1$
+            "    x = 1;", //$NON-NLS-1$
+            "EndProcedure" //$NON-NLS-1$
+        );
+        CheckResult result = BslSyntaxChecker.check(lines);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testAsyncFunctionEnglish()
+    {
+        List<String> lines = Arrays.asList(
+            "Async Function GetValueAsync()", //$NON-NLS-1$
+            "    Return 1;", //$NON-NLS-1$
+            "EndFunction" //$NON-NLS-1$
+        );
+        CheckResult result = BslSyntaxChecker.check(lines);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testAsyncProcedureWithAwaitInBody()
+    {
+        List<String> lines = Arrays.asList(
+            "\u0410\u0441\u0438\u043D\u0445 \u041F\u0440\u043E\u0446\u0435\u0434\u0443\u0440\u0430 \u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C(\u041A\u043E\u043C\u0430\u043D\u0434\u0430)", //$NON-NLS-1$
+            "    \u0420\u0435\u0437\u0443\u043B\u044C\u0442\u0430\u0442 = \u0416\u0434\u0430\u0442\u044C \u041F\u043E\u043B\u0443\u0447\u0438\u0442\u044C\u0414\u0430\u043D\u043D\u044B\u0435\u0410\u0441\u0438\u043D\u0445();", //$NON-NLS-1$
+            "\u041A\u043E\u043D\u0435\u0446\u041F\u0440\u043E\u0446\u0435\u0434\u0443\u0440\u044B" //$NON-NLS-1$
+        );
+        CheckResult result = BslSyntaxChecker.check(lines);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testAsyncProcedureWithClientAnnotation()
+    {
+        List<String> lines = Arrays.asList(
+            "&\u041D\u0430\u041A\u043B\u0438\u0435\u043D\u0442\u0435", //$NON-NLS-1$
+            "\u0410\u0441\u0438\u043D\u0445 \u041F\u0440\u043E\u0446\u0435\u0434\u0443\u0440\u0430 \u041E\u0431\u0440\u0430\u0431\u043E\u0442\u0430\u0442\u044C(\u041A\u043E\u043C\u0430\u043D\u0434\u0430)", //$NON-NLS-1$
+            "    \u0416\u0434\u0430\u0442\u044C \u041F\u0430\u0443\u0437\u0430(1000);", //$NON-NLS-1$
+            "\u041A\u043E\u043D\u0435\u0446\u041F\u0440\u043E\u0446\u0435\u0434\u0443\u0440\u044B" //$NON-NLS-1$
+        );
+        CheckResult result = BslSyntaxChecker.check(lines);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testUnclosedAsyncProcedureStillInvalid()
+    {
+        List<String> lines = Arrays.asList(
+            "\u0410\u0441\u0438\u043D\u0445 \u041F\u0440\u043E\u0446\u0435\u0434\u0443\u0440\u0430 \u0424()", //$NON-NLS-1$
+            "    \u0445 = 1;" //$NON-NLS-1$
+        );
+        CheckResult result = BslSyntaxChecker.check(lines);
+        assertFalse(result.isValid());
+        assertTrue(result.getErrors().get(0).contains("Unclosed")); //$NON-NLS-1$
+    }
+
+    // ==================== Multi-line string literals (#286) ====================
+
+    @Test
+    public void testMultilineStringWithCodeAfterClosingQuote()
+    {
+        // The reported trigger: a multi-line string's LAST continuation line also
+        // carries post-string code with a block keyword (If). The old blunt "skip
+        // any line starting with |" logic dropped this whole line - including the
+        // If opener - while its EndIf on a later non-| line was still matched.
+        List<String> lines = Arrays.asList(
+            "Procedure Test()", //$NON-NLS-1$
+            "    Text = \"start", //$NON-NLS-1$
+            "    |end\"; If X Then", //$NON-NLS-1$
+            "        Return;", //$NON-NLS-1$
+            "    EndIf;", //$NON-NLS-1$
+            "EndProcedure" //$NON-NLS-1$
+        );
+        CheckResult result = BslSyntaxChecker.check(lines);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testMultilineNStrLiteralInsideTryBlock()
+    {
+        List<String> lines = Arrays.asList(
+            "Procedure Test()", //$NON-NLS-1$
+            "    Try", //$NON-NLS-1$
+            "        Message = NStr(\"ru = '\u0421\u0442\u0440\u043E\u043A\u0430 \u043F\u0435\u0440\u0432\u0430\u044F", //$NON-NLS-1$
+            "        |\u0421\u0442\u0440\u043E\u043A\u0430 \u0432\u0442\u043E\u0440\u0430\u044F'; en = 'Line one", //$NON-NLS-1$
+            "        |Line two'\");", //$NON-NLS-1$
+            "        If Message <> \"\" Then", //$NON-NLS-1$
+            "            Return;", //$NON-NLS-1$
+            "        EndIf;", //$NON-NLS-1$
+            "    Except", //$NON-NLS-1$
+            "        Raise;", //$NON-NLS-1$
+            "    EndTry;", //$NON-NLS-1$
+            "EndProcedure" //$NON-NLS-1$
+        );
+        CheckResult result = BslSyntaxChecker.check(lines);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testMultilineQueryTextWithPipeLines()
+    {
+        List<String> lines = Arrays.asList(
+            "Procedure Test()", //$NON-NLS-1$
+            "    Query = New Query;", //$NON-NLS-1$
+            "    Query.Text =", //$NON-NLS-1$
+            "        \"SELECT", //$NON-NLS-1$
+            "        |    Ref", //$NON-NLS-1$
+            "        |FROM", //$NON-NLS-1$
+            "        |    Catalog.Items", //$NON-NLS-1$
+            "        |WHERE", //$NON-NLS-1$
+            "        |    Ref.Code = &Code\";", //$NON-NLS-1$
+            "    Result = Query.Execute();", //$NON-NLS-1$
+            "EndProcedure" //$NON-NLS-1$
+        );
+        CheckResult result = BslSyntaxChecker.check(lines);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testDoubleSlashInsideMultilineStringIsNotTreatedAsComment()
+    {
+        // The "//" inside the URL (opened on the first line, still inside the
+        // string on the continuation line) must not be mistaken for a comment
+        // start, and the trailing If on the closing continuation line must still
+        // be recognized.
+        List<String> lines = Arrays.asList(
+            "Procedure Test()", //$NON-NLS-1$
+            "    Url = \"https://example.com/", //$NON-NLS-1$
+            "    |path\"; If Url <> \"\" Then", //$NON-NLS-1$
+            "        Return;", //$NON-NLS-1$
+            "    EndIf;", //$NON-NLS-1$
+            "EndProcedure" //$NON-NLS-1$
+        );
+        CheckResult result = BslSyntaxChecker.check(lines);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testGenuinelyUnbalancedModuleWithMultilineStringStillInvalid()
+    {
+        // A correctly-masked multi-line string must not hide a REAL imbalance
+        // elsewhere in the module (the If below is genuinely never closed).
+        List<String> lines = Arrays.asList(
+            "Procedure Test()", //$NON-NLS-1$
+            "    Text = \"start", //$NON-NLS-1$
+            "    |end\";", //$NON-NLS-1$
+            "    If X Then", //$NON-NLS-1$
+            "        Return;", //$NON-NLS-1$
+            "EndProcedure" //$NON-NLS-1$
+        );
+        CheckResult result = BslSyntaxChecker.check(lines);
+        assertFalse(result.isValid());
+    }
+
+    @Test
+    public void testDoubledQuoteInsideStringIsEscapedNotClosing()
+    {
+        // A doubled "" inside an already-open string is an escaped quote and must
+        // NOT close the literal early; keyword-looking words inside the string
+        // ("If", "EndIf") must stay masked so they cannot be mistaken for the real
+        // If/EndIf block that follows on later lines.
+        List<String> lines = Arrays.asList(
+            "Procedure Test()", //$NON-NLS-1$
+            "    Text = \"say \"\"hello\"\" to If EndIf\";", //$NON-NLS-1$
+            "    If X Then", //$NON-NLS-1$
+            "        Return;", //$NON-NLS-1$
+            "    EndIf;", //$NON-NLS-1$
+            "EndProcedure" //$NON-NLS-1$
+        );
+        CheckResult result = BslSyntaxChecker.check(lines);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testDoubleQuoteInsideSingleQuoteDateLiteralDoesNotOpenAString()
+    {
+        // A single-quote '...' date/token literal that happens to contain a double quote must
+        // NOT flip the string state (otherwise the unmatched " sticks and masks the whole rest
+        // of the module, hiding EndIf/EndProcedure and yielding a false "unclosed" - codex #286).
+        List<String> lines = Arrays.asList(
+            "Procedure Test()", //$NON-NLS-1$
+            "    D = '2024\"0101';", //$NON-NLS-1$
+            "    If X Then", //$NON-NLS-1$
+            "        Return;", //$NON-NLS-1$
+            "    EndIf;", //$NON-NLS-1$
+            "EndProcedure" //$NON-NLS-1$
+        );
+        CheckResult result = BslSyntaxChecker.check(lines);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void testUnclosedStringNotFollowedByContinuationDoesNotSwallowRealCode()
+    {
+        // An unclosed " opens a string, but the NEXT line is real code (not a '|' continuation),
+        // so the literal was not a valid multi-line string. The checker must NOT keep masking:
+        // the following (genuinely unclosed) If block must still be detected (codex #286 - without
+        // the reset the sticky string masks the If and the module is wrongly reported valid).
+        List<String> lines = Arrays.asList(
+            "x = \"broken", //$NON-NLS-1$
+            "If X Then", //$NON-NLS-1$
+            "    Return;" //$NON-NLS-1$
+        );
+        CheckResult result = BslSyntaxChecker.check(lines);
+        assertFalse("an unclosed If after a broken (non-continued) string must still be caught", //$NON-NLS-1$
+            result.isValid());
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataDetailsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataDetailsToolTest.java
@@ -29,6 +29,14 @@ import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.junit.Test;
 
+import com._1c.g5.v8.dt.metadata.mdclass.Catalog;
+import com._1c.g5.v8.dt.metadata.mdclass.CommonModule;
+import com._1c.g5.v8.dt.metadata.mdclass.Indexing;
+import com._1c.g5.v8.dt.metadata.mdclass.InformationRegister;
+import com._1c.g5.v8.dt.metadata.mdclass.InformationRegisterDimension;
+import com._1c.g5.v8.dt.metadata.mdclass.MdClassFactory;
+import com._1c.g5.v8.dt.metadata.mdclass.ReturnValuesReuse;
+import com._1c.g5.v8.dt.metadata.mdclass.ScheduledJob;
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 
 /**
@@ -482,5 +490,194 @@ public class GetMetadataDetailsToolTest
         literal.setValue(value);
         literal.setLiteral(name);
         eEnum.getELiterals().add(literal);
+    }
+
+    // ==================== Type-specific properties: ScheduledJob / CommonModule / InformationRegister
+    // dimension Indexing (issue #288) ====================
+    //
+    // get_metadata_details WRITES these via modify_metadata but used to render only Name/Synonym for
+    // ScheduledJob/CommonModule in the default (non-full) view, and never showed a register dimension's
+    // Indexing at all - reading them back was impossible. formatTypeSpecificProperties is the pure
+    // rendering hook (package-private, called from processFqn right after the universal formatter and
+    // before the ORIGIN footer); it needs only in-memory MdClassFactory objects, no live workbench.
+
+    @Test
+    public void testScheduledJobPropertiesRenderedInBasicMode()
+    {
+        ScheduledJob job = MdClassFactory.eINSTANCE.createScheduledJob();
+        job.setMethodName("CommonModule.MyJob.Execute"); //$NON-NLS-1$
+        job.setUse(true);
+        job.setPredefined(false);
+        job.setRestartCountOnFailure(3);
+        job.setRestartIntervalOnFailure(60);
+        job.setKey("JobKey"); //$NON-NLS-1$
+
+        String md = GetMetadataDetailsTool.formatTypeSpecificProperties(job, false);
+
+        assertTrue("must render the Properties section", md.contains("### Properties")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("methodName must be present", //$NON-NLS-1$
+            md.contains("Method Name") && md.contains("CommonModule.MyJob.Execute")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("use=true must render as Yes", md.contains("| Use | Yes |")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("predefined=false must render as No, not be omitted", //$NON-NLS-1$
+            md.contains("| Predefined | No |")); //$NON-NLS-1$
+        assertTrue("restartCountOnFailure must render its int value", //$NON-NLS-1$
+            md.contains("| Restart Count On Failure | 3 |")); //$NON-NLS-1$
+        assertTrue("restartIntervalOnFailure must render its int value", //$NON-NLS-1$
+            md.contains("| Restart Interval On Failure | 60 |")); //$NON-NLS-1$
+        assertTrue("key must be present", md.contains("| Key | JobKey |")); //$NON-NLS-1$ //$NON-NLS-2$
+        // No Schedule was set on this job, so its presence row must show the dash placeholder,
+        // never a raw toString() dump of an absent/unresolvable cross-model object.
+        assertTrue("an unset Schedule must render as the dash placeholder", //$NON-NLS-1$
+            md.contains("| Schedule | - |")); //$NON-NLS-1$
+    }
+
+    /**
+     * A blank {@code methodName}/{@code key} must render as the dash placeholder, not an empty cell
+     * (which would look identical to a table-formatting bug rather than "not set").
+     */
+    @Test
+    public void testScheduledJobBlankStringsRenderAsDash()
+    {
+        ScheduledJob job = MdClassFactory.eINSTANCE.createScheduledJob();
+        // methodName/key left unset (EMF default for an unset String feature is null/empty).
+
+        String md = GetMetadataDetailsTool.formatTypeSpecificProperties(job, false);
+
+        assertTrue("an unset Method Name must render as the dash placeholder", //$NON-NLS-1$
+            md.contains("| Method Name | - |")); //$NON-NLS-1$
+        assertTrue("an unset Key must render as the dash placeholder", //$NON-NLS-1$
+            md.contains("| Key | - |")); //$NON-NLS-1$
+    }
+
+    /**
+     * The type-specific Properties table renders in FULL mode too. The generic "All Properties" dump
+     * repeats the plain scalar attributes, but it omits the transient Schedule reference, so full mode
+     * must keep this table or it would carry LESS than basic mode (codex #288).
+     */
+    @Test
+    public void testScheduledJobPropertiesRenderedInFullMode()
+    {
+        // Full mode must ALSO render the type-specific table: the generic "All Properties" dump
+        // does not include the transient Schedule reference, so skipping here would make full mode
+        // lose information present in basic mode (codex #288).
+        ScheduledJob job = MdClassFactory.eINSTANCE.createScheduledJob();
+        job.setMethodName("CommonModule.MyJob.Execute"); //$NON-NLS-1$
+
+        String md = GetMetadataDetailsTool.formatTypeSpecificProperties(job, true);
+
+        assertTrue("full mode must still render the ScheduledJob Properties table", //$NON-NLS-1$
+            md.contains("### Properties") && md.contains("Method Name")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testCommonModulePropertiesRenderedInBasicMode()
+    {
+        CommonModule module = MdClassFactory.eINSTANCE.createCommonModule();
+        module.setServer(true);
+        module.setServerCall(false);
+        module.setClientManagedApplication(true);
+        module.setClientOrdinaryApplication(false);
+        module.setExternalConnection(false);
+        module.setGlobal(true);
+        module.setPrivileged(false);
+        module.setReturnValuesReuse(ReturnValuesReuse.DURING_SESSION);
+
+        String md = GetMetadataDetailsTool.formatTypeSpecificProperties(module, false);
+
+        assertTrue("must render the Properties section", md.contains("### Properties")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("server=true must render as Yes", md.contains("| Server | Yes |")); //$NON-NLS-1$ //$NON-NLS-2$
+        // false is a real, meaningful value for these flags - it must render as No, never be omitted.
+        assertTrue("serverCall=false must render as No, not be omitted", //$NON-NLS-1$
+            md.contains("| Server Call | No |")); //$NON-NLS-1$
+        assertTrue("clientManagedApplication=true must render as Yes", //$NON-NLS-1$
+            md.contains("| Client (Managed Application) | Yes |")); //$NON-NLS-1$
+        assertTrue("clientOrdinaryApplication=false must render as No", //$NON-NLS-1$
+            md.contains("| Client (Ordinary Application) | No |")); //$NON-NLS-1$
+        assertTrue("externalConnection=false must render as No", md.contains("| External Connection | No |")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("global=true must render as Yes", md.contains("| Global | Yes |")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("privileged=false must render as No", md.contains("| Privileged | No |")); //$NON-NLS-1$ //$NON-NLS-2$
+        // The enum must render its LITERAL name (whatever ReturnValuesReuse.DURING_SESSION.toString()
+        // is), never a raw Java object dump (e.g. containing '@' + a hashcode).
+        assertTrue("returnValuesReuse must render its literal name", //$NON-NLS-1$
+            md.contains(ReturnValuesReuse.DURING_SESSION.toString()));
+        assertFalse("the enum cell must not be a raw object dump", md.contains("@")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Mirrors {@link #testScheduledJobPropertiesRenderedInFullMode} for CommonModule: the
+     * type-specific table renders in full mode too, so full output never carries less than basic.
+     */
+    @Test
+    public void testCommonModulePropertiesRenderedInFullMode()
+    {
+        CommonModule module = MdClassFactory.eINSTANCE.createCommonModule();
+        module.setServer(true);
+
+        String md = GetMetadataDetailsTool.formatTypeSpecificProperties(module, true);
+
+        assertTrue("full mode must still render the CommonModule Properties table", //$NON-NLS-1$
+            md.contains("### Properties") && md.contains("| Server | Yes |")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * An InformationRegister's dimension Indexing must be visible in BOTH the default and full views:
+     * the shared attributes-table Indexing column only recognizes DbObjectAttribute, and a register
+     * dimension is a separate RegisterDimension sub-interface, so it never gets a value there in either
+     * mode - this dedicated table is the only place it is visible.
+     */
+    @Test
+    public void testInformationRegisterDimensionIndexingRenderedInBothModes()
+    {
+        InformationRegister register = MdClassFactory.eINSTANCE.createInformationRegister();
+        InformationRegisterDimension indexed = MdClassFactory.eINSTANCE.createInformationRegisterDimension();
+        indexed.setName("Indexed"); //$NON-NLS-1$
+        indexed.setIndexing(Indexing.INDEX);
+        InformationRegisterDimension notIndexed = MdClassFactory.eINSTANCE.createInformationRegisterDimension();
+        notIndexed.setName("NotIndexed"); //$NON-NLS-1$
+        notIndexed.setIndexing(Indexing.DONT_INDEX);
+        register.getDimensions().add(indexed);
+        register.getDimensions().add(notIndexed);
+
+        String basic = GetMetadataDetailsTool.formatTypeSpecificProperties(register, false);
+        String full = GetMetadataDetailsTool.formatTypeSpecificProperties(register, true);
+
+        for (String md : new String[] { basic, full })
+        {
+            assertTrue("must render the Dimension Indexing section", md.contains("### Dimension Indexing")); //$NON-NLS-1$ //$NON-NLS-2$
+            assertTrue("the indexed dimension's row must carry its Indexing literal", //$NON-NLS-1$
+                md.contains("Indexed") && md.contains(Indexing.INDEX.toString())); //$NON-NLS-1$
+            assertTrue("the non-indexed dimension's row must carry its Indexing literal", //$NON-NLS-1$
+                md.contains("NotIndexed") && md.contains(Indexing.DONT_INDEX.toString())); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * A register with no dimensions renders no Dimension Indexing section (and, since an
+     * InformationRegister is neither a ScheduledJob nor a CommonModule, no Properties table either) -
+     * the whole type-specific section is empty.
+     */
+    @Test
+    public void testInformationRegisterWithNoDimensionsRendersNothing()
+    {
+        InformationRegister register = MdClassFactory.eINSTANCE.createInformationRegister();
+
+        String md = GetMetadataDetailsTool.formatTypeSpecificProperties(register, false);
+
+        assertEquals("a register with no dimensions must add no section", "", md); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * A type this method does not special-case (e.g. Catalog) must add nothing, in either mode - the
+     * hook must be a true no-op for everything else, matching the ratchet other section-formatter tests
+     * apply.
+     */
+    @Test
+    public void testUnrelatedTypeRendersNothing()
+    {
+        Catalog catalog = MdClassFactory.eINSTANCE.createCatalog();
+        catalog.setName("Products"); //$NON-NLS-1$
+
+        assertEquals("", GetMetadataDetailsTool.formatTypeSpecificProperties(catalog, false)); //$NON-NLS-1$
+        assertEquals("", GetMetadataDetailsTool.formatTypeSpecificProperties(catalog, true)); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataObjectsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataObjectsToolTest.java
@@ -228,4 +228,65 @@ public class GetMetadataObjectsToolTest
         assertTrue("an invalid metadataType must NOT leak through before the projectName guard", //$NON-NLS-1$
             !result.contains("Unknown metadata type")); //$NON-NLS-1$
     }
+
+    // ==================== issue #289: metadataType normalization (pure logic, no ======
+    // ==================== EDT/workbench dependency - see normalizeMetadataType javadoc)
+
+    @Test
+    public void testNormalizeMetadataTypeAcceptsLegacyCategoryTokens()
+    {
+        GetMetadataObjectsTool tool = new GetMetadataObjectsTool();
+        assertEquals("all", tool.normalizeMetadataType("all")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("scheduledjobs", tool.normalizeMetadataType("scheduledJobs")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("catalogs", tool.normalizeMetadataType("Catalogs")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("commonmodules", tool.normalizeMetadataType("COMMONMODULES")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testNormalizeMetadataTypeAcceptsEnglishTypeNameToken()
+    {
+        // The core #289 fix: a standard FQN type-name token (singular, as an AI would
+        // naturally send it) now resolves to the same category as the legacy plural.
+        GetMetadataObjectsTool tool = new GetMetadataObjectsTool();
+        assertEquals("scheduledjobs", tool.normalizeMetadataType("ScheduledJob")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("scheduledjobs", tool.normalizeMetadataType("scheduledjob")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("documents", tool.normalizeMetadataType("Document")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("commonmodules", tool.normalizeMetadataType("CommonModule")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testNormalizeMetadataTypeAcceptsRussianTypeNameToken()
+    {
+        // Bilingual side of the resolver (MetadataTypeUtils), both singular forms.
+        // Escaped so the RU tokens survive a non-UTF-8 Tycho build (see CLAUDE.md hard
+        // don't #7); same escape sequences as MetadataTypeUtils.MetadataTypeInfo.
+        String ruScheduledJob = // РегламентноеЗадание (ScheduledJob)
+            "\u0420\u0435\u0433\u043B\u0430\u043C\u0435\u043D\u0442\u043D\u043E\u0435\u0417\u0430\u0434\u0430\u043D\u0438\u0435"; //$NON-NLS-1$
+        String ruCatalog = // Справочник (Catalog)
+            "\u0421\u043F\u0440\u0430\u0432\u043E\u0447\u043D\u0438\u043A"; //$NON-NLS-1$
+        GetMetadataObjectsTool tool = new GetMetadataObjectsTool();
+        assertEquals("scheduledjobs", tool.normalizeMetadataType(ruScheduledJob)); //$NON-NLS-1$
+        assertEquals("catalogs", tool.normalizeMetadataType(ruCatalog)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNormalizeMetadataTypeRejectsRecognizedButUncollectedTypeName()
+    {
+        // MetadataTypeUtils recognizes far more type names than this tool has
+        // collectors for; a type it does NOT collect (Subsystem, XDTOPackage) must
+        // fall through to "not recognized" here rather than silently mis-mapping.
+        GetMetadataObjectsTool tool = new GetMetadataObjectsTool();
+        assertNull(tool.normalizeMetadataType("Subsystem")); //$NON-NLS-1$
+        assertNull(tool.normalizeMetadataType("XDTOPackage")); //$NON-NLS-1$
+        assertNull(tool.normalizeMetadataType("Role")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNormalizeMetadataTypeRejectsUnrecognizedValue()
+    {
+        GetMetadataObjectsTool tool = new GetMetadataObjectsTool();
+        assertNull(tool.normalizeMetadataType("bogusType_e2e")); //$NON-NLS-1$
+        assertNull(tool.normalizeMetadataType("")); //$NON-NLS-1$
+        assertNull(tool.normalizeMetadataType(null));
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
@@ -35,8 +35,10 @@ import com._1c.g5.v8.dt.metadata.mdclass.CommandGroup;
 import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
 import com._1c.g5.v8.dt.metadata.mdclass.DataProcessor;
 import com._1c.g5.v8.dt.metadata.mdclass.DataProcessorForm;
+import com._1c.g5.v8.dt.metadata.mdclass.EventSubscription;
 import com._1c.g5.v8.dt.metadata.mdclass.MdClassFactory;
 import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
+import com._1c.g5.v8.dt.metadata.mdclass.ScheduledJob;
 import com._1c.g5.v8.dt.metadata.mdclass.TemplateType;
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 import com.ditrix.edt.mcp.server.tools.impl.ModifyMetadataTool.FormHolder;
@@ -1126,5 +1128,78 @@ public class ModifyMetadataToolTest
         assertNull("a well-formed 'dcs' arg carries no error", valid.error); //$NON-NLS-1$
         assertNotNull("a well-formed 'dcs' object must parse", valid.spec); //$NON-NLS-1$
         assertTrue("the parsed object must carry its members", valid.spec.has("dataSets")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    // ===== method-reference guard dispatch (a job/subscription must be bound to an EXISTING, Exported,
+    // Server method) =================================================================================
+    //
+    // validateMethodReference is scoped to exactly two type+property combos (ScheduledJob.methodName /
+    // EventSubscription.handler); the actual parse/resolve/decide logic lives in MethodReferenceValidator
+    // (covered by MethodReferenceValidatorTest) - these tests only prove the DISPATCH: which target/property
+    // combo triggers the guard, which is a no-op, and that an empty value (clearing) is never validated.
+
+    @Test
+    public void testMethodReferenceGuardTriggersOnScheduledJobMethodName()
+    {
+        ScheduledJob job = MdClassFactory.eINSTANCE.createScheduledJob();
+        String err = ModifyMetadataTool.validateMethodReference(null, null, job, "methodName", "NoDotHere"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNotNull("a methodName value with no dot must be rejected", err); //$NON-NLS-1$
+        assertTrue("the refusal must be a ToolResult error json", err.contains("\"error\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the refusal must name the bad value", err.contains("NoDotHere")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testMethodReferenceGuardTriggersOnEventSubscriptionHandler()
+    {
+        EventSubscription sub = MdClassFactory.eINSTANCE.createEventSubscription();
+        String err = ModifyMetadataTool.validateMethodReference(null, null, sub, "handler", "NoDotHere"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNotNull("a handler value with no dot must be rejected", err); //$NON-NLS-1$
+        assertTrue("the refusal must name the bad value", err.contains("NoDotHere")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testMethodReferenceGuardIsNoOpForOtherTargetTypes()
+    {
+        // Even a garbage (no-dot) value on a 'methodName'-NAMED property must be IGNORED on a non
+        // -ScheduledJob target: the guard is scoped by TYPE first.
+        DataProcessor dp = MdClassFactory.eINSTANCE.createDataProcessor();
+        assertNull("the guard must not fire on a non-ScheduledJob/EventSubscription target", //$NON-NLS-1$
+            ModifyMetadataTool.validateMethodReference(null, null, dp, "methodName", "NoDotHere")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testMethodReferenceGuardIsNoOpForOtherPropertyNames()
+    {
+        // A ScheduledJob's 'comment' (or any property other than methodName) is not the guarded one.
+        ScheduledJob job = MdClassFactory.eINSTANCE.createScheduledJob();
+        assertNull("the guard must only fire on 'methodName', not any other property", //$NON-NLS-1$
+            ModifyMetadataTool.validateMethodReference(null, null, job, "comment", "NoDotHere")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testMethodReferenceGuardSkipsEmptyOrNullValue()
+    {
+        // An empty/null value is NEVER validated by this guard - it falls through to the pre-existing
+        // generic-STRING policy (which itself rejects an empty value rather than "clearing" the
+        // property; modify_metadata never clears a property on an empty value).
+        ScheduledJob job = MdClassFactory.eINSTANCE.createScheduledJob();
+        assertNull("an empty methodName value must not be validated by this guard", //$NON-NLS-1$
+            ModifyMetadataTool.validateMethodReference(null, null, job, "methodName", "")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNull("a null methodName value must not be validated by this guard", //$NON-NLS-1$
+            ModifyMetadataTool.validateMethodReference(null, null, job, "methodName", null)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMethodReferenceGuardReportsMissingModule()
+    {
+        // A well-formed reference ("Module.Method") whose module does not exist in the (empty)
+        // configuration must be rejected naming the module - end-to-end through
+        // MethodReferenceValidator.validate, proving the dispatch threads project/config correctly.
+        Configuration config = MdClassFactory.eINSTANCE.createConfiguration();
+        ScheduledJob job = MdClassFactory.eINSTANCE.createScheduledJob();
+        String err =
+            ModifyMetadataTool.validateMethodReference(null, config, job, "methodName", "NoSuchModule.Foo"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNotNull("a reference to a non-existent module must be rejected", err); //$NON-NLS-1$
+        assertTrue("the refusal must name the missing module", err.contains("NoSuchModule")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import com._1c.g5.v8.dt.metadata.mdclass.BasicTemplate;
 import com._1c.g5.v8.dt.metadata.mdclass.CommandGroup;
+import com._1c.g5.v8.dt.metadata.mdclass.CommonModule;
 import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
 import com._1c.g5.v8.dt.metadata.mdclass.DataProcessor;
 import com._1c.g5.v8.dt.metadata.mdclass.DataProcessorForm;
@@ -1201,5 +1202,22 @@ public class ModifyMetadataToolTest
             ModifyMetadataTool.validateMethodReference(null, config, job, "methodName", "NoSuchModule.Foo"); //$NON-NLS-1$ //$NON-NLS-2$
         assertNotNull("a reference to a non-existent module must be rejected", err); //$NON-NLS-1$
         assertTrue("the refusal must name the missing module", err.contains("NoSuchModule")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testCanonicalMethodReferenceNormalizesGuardedCombos()
+    {
+        Configuration config = MdClassFactory.eINSTANCE.createConfiguration();
+        CommonModule module = MdClassFactory.eINSTANCE.createCommonModule();
+        module.setName("Calc"); //$NON-NLS-1$
+        config.getCommonModules().add(module);
+        ScheduledJob job = MdClassFactory.eINSTANCE.createScheduledJob();
+        assertEquals("a validated methodName must serialize WITHOUT the type prefix", //$NON-NLS-1$
+            "Calc.Add", ModifyMetadataTool.canonicalMethodReference(config, job, "methodName", "CommonModule.Calc.Add")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        EventSubscription sub = MdClassFactory.eINSTANCE.createEventSubscription();
+        assertEquals("a validated handler must serialize WITH the English CommonModule prefix", //$NON-NLS-1$
+            "CommonModule.Calc.Add", ModifyMetadataTool.canonicalMethodReference(config, sub, "handler", "Calc.Add")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        // Unguarded combo: value passes through unchanged.
+        assertEquals("x.y", ModifyMetadataTool.canonicalMethodReference(config, module, "methodName", "x.y")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/BslModuleUtilsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/BslModuleUtilsTest.java
@@ -715,4 +715,26 @@ public class BslModuleUtilsTest
         // empty source: the loop never runs and the method returns null
         assertNull(BslModuleUtils.findRegionForLine(List.of(), 1));
     }
+
+    // ---- async declarations (Async/\u0410\u0441\u0438\u043D\u0445 prefix) --------------------------------
+
+    @Test
+    public void testFindMethodViaTextAsyncProcedureEnglish()
+    {
+        List<String> lines = List.of(
+            "Async Procedure Foo() Export", //$NON-NLS-1$
+            "EndProcedure"); //$NON-NLS-1$
+        BslModuleUtils.TextMethod tm = BslModuleUtils.findMethodViaText(lines, "Foo"); //$NON-NLS-1$
+        assertTrue("an Async Procedure declaration must be discoverable", tm.found); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindMethodViaTextAsyncFunctionRussian()
+    {
+        List<String> lines = List.of(
+            "\u0410\u0441\u0438\u043D\u0445 \u0424\u0443\u043D\u043A\u0446\u0438\u044F Bar() \u042D\u043A\u0441\u043F\u043E\u0440\u0442", //$NON-NLS-1$
+            "\u041A\u043E\u043D\u0435\u0446\u0424\u0443\u043D\u043A\u0446\u0438\u0438"); //$NON-NLS-1$
+        BslModuleUtils.TextMethod tm = BslModuleUtils.findMethodViaText(lines, "Bar"); //$NON-NLS-1$
+        assertTrue("an async (Russian) Function declaration must be discoverable", tm.found); //$NON-NLS-1$
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/BslModuleUtilsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/BslModuleUtilsTest.java
@@ -737,4 +737,18 @@ public class BslModuleUtilsTest
         BslModuleUtils.TextMethod tm = BslModuleUtils.findMethodViaText(lines, "Bar"); //$NON-NLS-1$
         assertTrue("an async (Russian) Function declaration must be discoverable", tm.found); //$NON-NLS-1$
     }
+
+    @Test
+    public void testFuncKeywordPatternAcceptsAsyncPrefix()
+    {
+        // The classifier must agree with METHOD_START_PATTERN on async declarations, or an
+        // `Async Function` found by the text fallback would be reported as a procedure.
+        assertTrue(BslModuleUtils.FUNC_KEYWORD_PATTERN.matcher("Async Function Foo(") //$NON-NLS-1$
+            .find());
+        assertTrue(BslModuleUtils.FUNC_KEYWORD_PATTERN.matcher(
+            "\u0410\u0441\u0438\u043D\u0445 \u0424\u0443\u043D\u043A\u0446\u0438\u044F Bar(") //$NON-NLS-1$
+            .find());
+        assertFalse("a procedure must still not classify as a function", //$NON-NLS-1$
+            BslModuleUtils.FUNC_KEYWORD_PATTERN.matcher("Async Procedure Baz(").find()); //$NON-NLS-1$
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MethodReferenceValidatorTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MethodReferenceValidatorTest.java
@@ -307,12 +307,30 @@ public class MethodReferenceValidatorTest
     }
 
     @Test
-    public void testStripInlineCommentKeepsSlashesInsideStrings()
+    public void testMaskStringsAndStripComment()
     {
-        assertEquals("Procedure Foo(A = \"http://x\") Export ", //$NON-NLS-1$
-            MethodReferenceValidator.stripInlineComment("Procedure Foo(A = \"http://x\") Export // note")); //$NON-NLS-1$
+        // String content is MASKED (spaces), a // inside a string is NOT a comment start, and a real
+        // trailing // comment is cut. Structure (quotes' positions, parens) survives for the header scan.
+        assertEquals("Procedure Foo(A =           ) Export ", //$NON-NLS-1$
+            MethodReferenceValidator.maskStringsAndStripComment(
+                "Procedure Foo(A = \"http://x\") Export // note")); //$NON-NLS-1$
         assertEquals("Procedure Foo() ", //$NON-NLS-1$
-            MethodReferenceValidator.stripInlineComment("Procedure Foo() // Export")); //$NON-NLS-1$
+            MethodReferenceValidator.maskStringsAndStripComment("Procedure Foo() // Export")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExportInsideParameterDefaultStringIsNotExported()
+    {
+        // `Procedure Foo(P = "Export")` - the keyword lives INSIDE a string default, not the
+        // modifier position, and must NOT count as exported.
+        List<String> lines = List.of(
+            "Procedure Foo(P = \"Export\")", //$NON-NLS-1$
+            "  Return;", //$NON-NLS-1$
+            "EndProcedure"); //$NON-NLS-1$
+        BslModuleUtils.TextMethod found = BslModuleUtils.findMethodViaText(lines, "Foo"); //$NON-NLS-1$
+        assertTrue(found.found);
+        assertFalse("Export inside a string default must NOT count as the modifier", //$NON-NLS-1$
+            MethodReferenceValidator.isExported(lines, found));
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MethodReferenceValidatorTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MethodReferenceValidatorTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.junit.Test;
 
 import com._1c.g5.v8.dt.metadata.mdclass.CommonModule;
+import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
 import com._1c.g5.v8.dt.metadata.mdclass.MdClassFactory;
 import com.google.gson.JsonParser;
 
@@ -286,5 +287,49 @@ public class MethodReferenceValidatorTest
         List<String> lines = List.of("Function Add(A, B)", "  Return A + B;", "EndFunction"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         String json = MethodReferenceValidator.decide(moduleWithServerFlag(false), "Calc", lines, "Add", LABEL); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue(errorOf(json).contains("Export")); //$NON-NLS-1$
+    }
+
+    // ---- review round: comment-stripping + canonical form ---------------------------------------
+
+    @Test
+    public void testTrailingCommentExportIsNotExported()
+    {
+        // `Procedure Foo() // TODO: Export` - the keyword lives in a trailing comment, not the
+        // modifier position, and must NOT count as exported.
+        List<String> lines = List.of(
+            "Procedure Foo() // TODO: Export", //$NON-NLS-1$
+            "  Return;", //$NON-NLS-1$
+            "EndProcedure"); //$NON-NLS-1$
+        BslModuleUtils.TextMethod found = BslModuleUtils.findMethodViaText(lines, "Foo"); //$NON-NLS-1$
+        assertTrue(found.found);
+        assertFalse("Export inside a trailing comment must NOT count as the modifier", //$NON-NLS-1$
+            MethodReferenceValidator.isExported(lines, found));
+    }
+
+    @Test
+    public void testStripInlineCommentKeepsSlashesInsideStrings()
+    {
+        assertEquals("Procedure Foo(A = \"http://x\") Export ", //$NON-NLS-1$
+            MethodReferenceValidator.stripInlineComment("Procedure Foo(A = \"http://x\") Export // note")); //$NON-NLS-1$
+        assertEquals("Procedure Foo() ", //$NON-NLS-1$
+            MethodReferenceValidator.stripInlineComment("Procedure Foo() // Export")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testCanonicalReferenceResolvedCasingAndPrefixes()
+    {
+        Configuration config = MdClassFactory.eINSTANCE.createConfiguration();
+        CommonModule module = MdClassFactory.eINSTANCE.createCommonModule();
+        module.setName("Calc"); //$NON-NLS-1$
+        config.getCommonModules().add(module);
+        // methodName form: no type prefix, resolved metadata casing (findObject is case-insensitive).
+        assertEquals("Calc.Add", MethodReferenceValidator.canonicalReference(config, "CommonModule.Calc.Add", false)); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("Calc.Add", MethodReferenceValidator.canonicalReference(config, "calc.Add", false)); //$NON-NLS-1$ //$NON-NLS-2$
+        // handler form: English CommonModule prefix restored regardless of the input variant.
+        assertEquals("CommonModule.Calc.Add", MethodReferenceValidator.canonicalReference(config, "Calc.Add", true)); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("CommonModule.Calc.Add", //$NON-NLS-1$
+            MethodReferenceValidator.canonicalReference(config, "\u041E\u0431\u0449\u0438\u0439\u041C\u043E\u0434\u0443\u043B\u044C.Calc.Add", true)); //$NON-NLS-1$
+        // Defensive: an unresolvable module yields null (caller keeps the raw value).
+        assertNull(MethodReferenceValidator.canonicalReference(config, "NoSuch.Add", false)); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MethodReferenceValidatorTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MethodReferenceValidatorTest.java
@@ -1,0 +1,290 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2026 Diversus (https://github.com/Diversus23)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com._1c.g5.v8.dt.metadata.mdclass.CommonModule;
+import com._1c.g5.v8.dt.metadata.mdclass.MdClassFactory;
+import com.google.gson.JsonParser;
+
+/**
+ * Tests the pure, model-independent logic of {@link MethodReferenceValidator}: parsing a
+ * {@code <ModuleName>.<MethodName>} reference (with/without a bilingual {@code CommonModule} type-token
+ * prefix), the {@code Export} keyword detection from raw source lines (single-line signature / a
+ * parameter list spanning multiple lines / not exported at all), and the {@link
+ * MethodReferenceValidator#decide} decision (method missing, not exported, module not Server, valid).
+ * The {@link org.eclipse.core.resources.IProject}-touching {@link MethodReferenceValidator#validate}
+ * seam (module resolution + {@code Module.bsl} reading) is covered by the e2e suite against a live
+ * ScheduledJob / EventSubscription.
+ */
+public class MethodReferenceValidatorTest
+{
+    private static final String LABEL = "methodName"; //$NON-NLS-1$
+    private static final String FORMAT = "'CommonModuleName.MethodName'"; //$NON-NLS-1$
+    private static final String EXAMPLE = "Calc.Add"; //$NON-NLS-1$
+
+    private static String errorOf(String json)
+    {
+        return JsonParser.parseString(json).getAsJsonObject().get("error").getAsString(); //$NON-NLS-1$
+    }
+
+    private static String fromCp(int... codePoints)
+    {
+        return new String(codePoints, 0, codePoints.length);
+    }
+
+    private static CommonModule moduleWithServerFlag(boolean server)
+    {
+        CommonModule module = MdClassFactory.eINSTANCE.createCommonModule();
+        module.setServer(server);
+        return module;
+    }
+
+    // ---- parse --------------------------------------------------------------------------------
+
+    @Test
+    public void testParsePlainModuleDotMethod()
+    {
+        MethodReferenceValidator.ParsedReference r =
+            MethodReferenceValidator.parse("Calc.Add", LABEL, FORMAT, EXAMPLE); //$NON-NLS-1$
+        assertNull(r.error);
+        assertEquals("Calc", r.moduleName); //$NON-NLS-1$
+        assertEquals("Add", r.methodName); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testParseStripsEnglishCommonModulePrefix()
+    {
+        MethodReferenceValidator.ParsedReference r =
+            MethodReferenceValidator.parse("CommonModule.Calc.Add", LABEL, FORMAT, EXAMPLE); //$NON-NLS-1$
+        assertNull(r.error);
+        assertEquals("Calc", r.moduleName); //$NON-NLS-1$
+        assertEquals("Add", r.methodName); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testParseStripsRussianCommonModulePrefix()
+    {
+        // ОбщийМодуль (= CommonModule) built from code points, so the assertion verifies the REAL
+        // Cyrillic mapping through MetadataTypeUtils, not a round-trip of the same literal (the
+        // bilingual-test convention: see CommonAttributeContentWriterTest).
+        String ru = fromCp(0x041e, 0x0431, 0x0449, 0x0438, 0x0439, 0x041c, 0x043e, 0x0434, 0x0443, 0x043b,
+            0x044c);
+        MethodReferenceValidator.ParsedReference r =
+            MethodReferenceValidator.parse(ru + ".Calc.Add", LABEL, FORMAT, EXAMPLE); //$NON-NLS-1$
+        assertNull(r.error);
+        assertEquals("Calc", r.moduleName); //$NON-NLS-1$
+        assertEquals("Add", r.methodName); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testParseNoDotIsActionableError()
+    {
+        MethodReferenceValidator.ParsedReference r =
+            MethodReferenceValidator.parse("JustAName", LABEL, FORMAT, EXAMPLE); //$NON-NLS-1$
+        assertNotNull(r.error);
+        String msg = errorOf(r.error);
+        assertTrue("must name the bad value", msg.contains("JustAName")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("must name the property", msg.contains(LABEL)); //$NON-NLS-1$
+        assertTrue("must show an example", msg.contains(EXAMPLE)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testParseTrailingDotIsActionableError()
+    {
+        MethodReferenceValidator.ParsedReference r =
+            MethodReferenceValidator.parse("Calc.", LABEL, FORMAT, EXAMPLE); //$NON-NLS-1$
+        assertNotNull(r.error);
+        assertTrue(errorOf(r.error).contains("Calc.")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testParseLeadingDotIsActionableError()
+    {
+        MethodReferenceValidator.ParsedReference r =
+            MethodReferenceValidator.parse(".Add", LABEL, FORMAT, EXAMPLE); //$NON-NLS-1$
+        assertNotNull(r.error);
+    }
+
+    @Test
+    public void testParseNullValueIsActionableError()
+    {
+        MethodReferenceValidator.ParsedReference r = MethodReferenceValidator.parse(null, LABEL, FORMAT, EXAMPLE);
+        assertNotNull(r.error);
+    }
+
+    @Test
+    public void testParseNonPrefixModulePartWithDotIsKeptVerbatim()
+    {
+        // "Foo.Calc.Add": the segment before the module part's own first dot ("Foo") does NOT resolve
+        // to CommonModule, so nothing is stripped - the whole module part is kept, proving the prefix
+        // strip is a real type-token lookup, not "drop anything before the last dot".
+        MethodReferenceValidator.ParsedReference r =
+            MethodReferenceValidator.parse("Foo.Calc.Add", LABEL, FORMAT, EXAMPLE); //$NON-NLS-1$
+        assertNull(r.error);
+        assertEquals("Foo.Calc", r.moduleName); //$NON-NLS-1$
+        assertEquals("Add", r.methodName); //$NON-NLS-1$
+    }
+
+    // ---- isExported -----------------------------------------------------------------------------
+
+    @Test
+    public void testIsExportedSingleLineSignature()
+    {
+        List<String> lines = List.of(
+            "Function Add(A, B) Export", //$NON-NLS-1$
+            "  Return A + B;", //$NON-NLS-1$
+            "EndFunction"); //$NON-NLS-1$
+        BslModuleUtils.TextMethod found = BslModuleUtils.findMethodViaText(lines, "Add"); //$NON-NLS-1$
+        assertTrue(found.found);
+        assertTrue(MethodReferenceValidator.isExported(lines, found));
+    }
+
+    @Test
+    public void testIsExportedParamsSpanMultipleLines()
+    {
+        List<String> lines = List.of(
+            "Procedure Foo(", //$NON-NLS-1$
+            "    A,", //$NON-NLS-1$
+            "    B) Export", //$NON-NLS-1$
+            "  DoSomething();", //$NON-NLS-1$
+            "EndProcedure"); //$NON-NLS-1$
+        BslModuleUtils.TextMethod found = BslModuleUtils.findMethodViaText(lines, "Foo"); //$NON-NLS-1$
+        assertTrue(found.found);
+        assertTrue(MethodReferenceValidator.isExported(lines, found));
+    }
+
+    @Test
+    public void testIsExportedFalseWhenNoExportKeyword()
+    {
+        List<String> lines = List.of(
+            "Procedure Foo(A, B)", //$NON-NLS-1$
+            "  DoSomething();", //$NON-NLS-1$
+            "EndProcedure"); //$NON-NLS-1$
+        BslModuleUtils.TextMethod found = BslModuleUtils.findMethodViaText(lines, "Foo"); //$NON-NLS-1$
+        assertTrue(found.found);
+        assertFalse(MethodReferenceValidator.isExported(lines, found));
+    }
+
+    @Test
+    public void testIsExportedFalseWhenNotExportedButBodyMentionsTheWord()
+    {
+        // The body (past the closing paren) mentions "Export" in a comment - must NOT be mistaken
+        // for the modifier: the scan stops at the line that closes the parameter list.
+        List<String> lines = List.of(
+            "Procedure Foo(A, B)", //$NON-NLS-1$
+            "  // Export note: not the real modifier", //$NON-NLS-1$
+            "EndProcedure"); //$NON-NLS-1$
+        BslModuleUtils.TextMethod found = BslModuleUtils.findMethodViaText(lines, "Foo"); //$NON-NLS-1$
+        assertTrue(found.found);
+        assertFalse(MethodReferenceValidator.isExported(lines, found));
+    }
+
+    @Test
+    public void testIsExportedRussianKeyword()
+    {
+        // Функция Сумма(А, Б) Экспорт / Возврат А + Б; / КонецФункции - built from code points.
+        String func = fromCp(0x0424, 0x0443, 0x043d, 0x043a, 0x0446, 0x0438, 0x044f); // Функция
+        String sum = fromCp(0x0421, 0x0443, 0x043c, 0x043c, 0x0430); // Сумма
+        String export = fromCp(0x042d, 0x043a, 0x0441, 0x043f, 0x043e, 0x0440, 0x0442); // Экспорт
+        String endFunc =
+            fromCp(0x041a, 0x043e, 0x043d, 0x0435, 0x0446, 0x0424, 0x0443, 0x043d, 0x043a, 0x0446, 0x0438,
+                0x0438); // КонецФункции
+        List<String> lines = List.of(
+            func + " " + sum + "(A, B) " + export, //$NON-NLS-1$ //$NON-NLS-2$
+            "  Return A + B;", //$NON-NLS-1$
+            endFunc);
+        BslModuleUtils.TextMethod found = BslModuleUtils.findMethodViaText(lines, sum);
+        assertTrue(found.found);
+        assertTrue(MethodReferenceValidator.isExported(lines, found));
+    }
+
+    @Test
+    public void testIsExportedIncludesAdjacentDocCommentInScanRange()
+    {
+        // startLine (from findMethodViaText) points at the doc comment, not the declaration; isExported
+        // must still locate the REAL declaration line and detect Export there.
+        List<String> lines = List.of(
+            "// Adds two numbers.", //$NON-NLS-1$
+            "Function Add(A, B) Export", //$NON-NLS-1$
+            "  Return A + B;", //$NON-NLS-1$
+            "EndFunction"); //$NON-NLS-1$
+        BslModuleUtils.TextMethod found = BslModuleUtils.findMethodViaText(lines, "Add"); //$NON-NLS-1$
+        assertTrue(found.found);
+        assertEquals(0, found.startLine); // doc-comment line, not the declaration
+        assertTrue(MethodReferenceValidator.isExported(lines, found));
+    }
+
+    // ---- decide ---------------------------------------------------------------------------------
+
+    @Test
+    public void testDecideMethodNotFoundWhenLinesNull()
+    {
+        String json = MethodReferenceValidator.decide(moduleWithServerFlag(true), "Calc", null, "Add", LABEL); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNotNull(json);
+        String msg = errorOf(json);
+        assertTrue(msg.contains("Add")); //$NON-NLS-1$
+        assertTrue(msg.contains("Calc")); //$NON-NLS-1$
+        assertTrue("must point at write_module_source", msg.contains("write_module_source")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testDecideMethodNotFoundWhenMissingFromSource()
+    {
+        List<String> lines = List.of("Function Other() Export", "EndFunction"); //$NON-NLS-1$ //$NON-NLS-2$
+        String json = MethodReferenceValidator.decide(moduleWithServerFlag(true), "Calc", lines, "Add", LABEL); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(errorOf(json).contains("not found")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testDecideNotExported()
+    {
+        List<String> lines = List.of("Function Add(A, B)", "  Return A + B;", "EndFunction"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        String json = MethodReferenceValidator.decide(moduleWithServerFlag(true), "Calc", lines, "Add", LABEL); //$NON-NLS-1$ //$NON-NLS-2$
+        String msg = errorOf(json);
+        assertTrue(msg.contains("Export")); //$NON-NLS-1$
+        assertTrue(msg.contains("Calc")); //$NON-NLS-1$
+        assertTrue(msg.contains("Add")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testDecideNotServer()
+    {
+        List<String> lines = List.of("Function Add(A, B) Export", "  Return A + B;", "EndFunction"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        String json = MethodReferenceValidator.decide(moduleWithServerFlag(false), "Calc", lines, "Add", LABEL); //$NON-NLS-1$ //$NON-NLS-2$
+        String msg = errorOf(json);
+        assertTrue(msg.contains("Server")); //$NON-NLS-1$
+        assertTrue(msg.contains("Calc")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testDecideValidReturnsNull()
+    {
+        List<String> lines = List.of("Function Add(A, B) Export", "  Return A + B;", "EndFunction"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        String json = MethodReferenceValidator.decide(moduleWithServerFlag(true), "Calc", lines, "Add", LABEL); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNull(json);
+    }
+
+    @Test
+    public void testDecideChecksExportBeforeServer()
+    {
+        // A non-exported method on a non-server module must report the EXPORT problem first (fix one
+        // thing at a time - matches the checklist order: exists -> exported -> server).
+        List<String> lines = List.of("Function Add(A, B)", "  Return A + B;", "EndFunction"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        String json = MethodReferenceValidator.decide(moduleWithServerFlag(false), "Calc", lines, "Add", LABEL); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(errorOf(json).contains("Export")); //$NON-NLS-1$
+    }
+}

--- a/tests/e2e/tools/test_get_metadata_details.py
+++ b/tests/e2e/tools/test_get_metadata_details.py
@@ -408,3 +408,158 @@ def test_non_dcs_template_fqn_renders_basic_info_unchanged():
         "a non-DCS template must NOT render the DCS structure heading")
     assert_contains(r.text, "PrintForm", "the template's own name must still appear")
     assert_no_diff("a non-DCS template read must not change the project")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# TYPE-SPECIFIC PROPERTIES (issue #288) — a ScheduledJob / CommonModule / an
+# InformationRegister dimension's Indexing render in the DEFAULT (non-full) view.
+# modify_metadata already WRITES these; before this fix, get_metadata_details rendered
+# only Name/Synonym for the first two and never showed a dimension's Indexing at all -
+# reading them back was impossible. The fixture ships no ScheduledJob and no
+# InformationRegister, and its CommonModules (Calc/Error/OK) are reused by many other
+# e2e tests, so - mirroring the DCS-template test's "seed a FRESH object rather than
+# perturb a shared fixture" pattern - each test here seeds its OWN top object via
+# create_metadata (kind="write-metadata" resets the tree afterward).
+# ──────────────────────────────────────────────────────────────────────────────
+
+@e2e_test(tool="get_metadata_details", kind="write-metadata")
+def test_scheduled_job_properties_rendered_in_basic_view():
+    job = "GMDJob"
+    fqn = "ScheduledJob." + job
+    r0 = call("create_metadata", {"projectName": PROJECT, "fqn": fqn})
+    assert_ok(r0, "seed " + fqn)
+    wait_for_project_ready()
+
+    r1 = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": fqn,
+        "properties": [
+            {"name": "methodName", "value": "Calc.Add"},
+            {"name": "use", "value": True},
+            {"name": "restartCountOnFailure", "value": 3},
+            {"name": "restartIntervalOnFailure", "value": 60},
+            {"name": "key", "value": "GMDJobKey"},
+        ],
+    })
+    assert_ok(r1, "set ScheduledJob execution properties")
+    wait_for_project_ready()
+
+    r = call("get_metadata_details", {"projectName": PROJECT, "objectFqns": [fqn]})
+    assert_ok(r, "get_metadata_details on the seeded ScheduledJob")
+    if "## Errors" in r.text:
+        raise AssertionError(fqn + " should resolve, but a ## Errors section was emitted:\n" + r.text[:400])
+    # The type-specific Properties table (issue #288) - the details view used to show only
+    # Name/Synonym for a ScheduledJob; modify_metadata already wrote these back.
+    assert_contains(r.text, "### Properties", "must render the type-specific Properties section")
+    assert_contains(r.text, "Method Name", "the Method Name property must be labeled")
+    assert_contains(r.text, "Calc.Add", "the written methodName value must round-trip")
+    assert_contains(r.text, "| Use | Yes |", "use=true must render as Yes")
+    assert_contains(r.text, "| Restart Count On Failure | 3 |", "the written restart count must round-trip")
+    assert_contains(r.text, "| Restart Interval On Failure | 60 |",
+        "the written restart interval must round-trip")
+    assert_contains(r.text, "| Key | GMDJobKey |", "the written key must round-trip")
+    # Schedule is rendered as presence ("set"/"-") via eIsSet, never a raw dump. Whether a
+    # create_metadata-seeded job counts as having an explicitly-set schedule is platform-dependent,
+    # so assert only that the row is present with one of the two presence tokens (never an object dump).
+    assert_contains(r.text, "| Schedule |", "the Schedule row (presence) must be rendered")
+    assert_not_contains(r.text, "@", "the Schedule cell must never be a raw object dump")
+    # Full mode must ALSO keep the type-specific table (the universal reflective dump omits the
+    # transient Schedule reference, so full mode would otherwise lose information - see issue #288).
+    r_full = call("get_metadata_details", {"projectName": PROJECT, "objectFqns": [fqn], "full": True})
+    assert_ok(r_full, "get_metadata_details on the seeded ScheduledJob (full)")
+    assert_contains(r_full.text, "### Properties",
+        "full mode must still render the type-specific Properties table (no info loss)")
+
+
+@e2e_test(tool="get_metadata_details", kind="write-metadata")
+def test_common_module_properties_rendered_in_basic_view():
+    # A FRESH module (not the shared CommonModule.Calc/Error/OK fixture many other tests depend on).
+    module = "GMDMod"
+    fqn = "CommonModule." + module
+    r0 = call("create_metadata", {"projectName": PROJECT, "fqn": fqn})
+    assert_ok(r0, "seed " + fqn)
+    wait_for_project_ready()
+
+    r1 = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": fqn,
+        "properties": [
+            {"name": "server", "value": True},
+            {"name": "serverCall", "value": False},
+            {"name": "global", "value": True},
+            # The EMF enum LITERAL (as modify_metadata's validator reports: "Allowed: DontUse,
+            # DuringRequest, DuringSession") - NOT the Java constant name DURING_SESSION.
+            {"name": "returnValuesReuse", "value": "DuringSession"},
+        ],
+    })
+    assert_ok(r1, "set CommonModule context-availability flags")
+    wait_for_project_ready()
+
+    r = call("get_metadata_details", {"projectName": PROJECT, "objectFqns": [fqn]})
+    assert_ok(r, "get_metadata_details on the seeded CommonModule")
+    if "## Errors" in r.text:
+        raise AssertionError(fqn + " should resolve, but a ## Errors section was emitted:\n" + r.text[:400])
+    assert_contains(r.text, "### Properties", "must render the type-specific Properties section")
+    assert_contains(r.text, "| Server | Yes |", "server=true must round-trip as Yes")
+    # false is a real, meaningful value here - it must render as No, never be omitted from the table.
+    assert_contains(r.text, "| Server Call | No |", "serverCall=false must round-trip as No, not be omitted")
+    assert_contains(r.text, "| Global | Yes |", "global=true must round-trip as Yes")
+    assert_contains(r.text, "Return Values Reuse", "the enum property must be labeled")
+    # Never a raw Java object dump of the enum (would contain '@' + a hashcode).
+    assert_not_contains(r.text, "@", "the enum cell must never be a raw object dump")
+    # Full mode must ALSO render the type-specific table (no information loss vs basic - issue #288).
+    r_full = call("get_metadata_details", {"projectName": PROJECT, "objectFqns": [fqn], "full": True})
+    assert_ok(r_full, "get_metadata_details on the seeded CommonModule (full)")
+    assert_contains(r_full.text, "### Properties",
+        "full mode must still render the type-specific Properties table (no info loss)")
+
+
+@e2e_test(tool="get_metadata_details", kind="write-metadata")
+def test_information_register_dimension_indexing_rendered():
+    # No InformationRegister ships in the baseline fixture (test_create_metadata.py's
+    # test_create_register_then_resource_member: "No register in the baseline") -> seed one + a
+    # Dimension member, mirroring test_create_dimension_member_on_register.
+    reg = "GMDReg"
+    reg_fqn = "InformationRegister." + reg
+    r0 = call("create_metadata", {"projectName": PROJECT, "fqn": reg_fqn})
+    assert_ok(r0, "seed " + reg_fqn)
+    wait_for_project_ready()
+
+    dim = "GMDDim"
+    r1 = call("create_metadata", {
+        "projectName": PROJECT, "fqn": "%s.Dimension.%s" % (reg_fqn, dim)})
+    assert_ok(r1, "seed Dimension member on the register")
+    wait_for_project_ready()
+
+    # Read BEFORE setting a non-default Indexing - the section must already render (dimensions
+    # exist), just with whatever the platform default is.
+    r_before = call("get_metadata_details", {"projectName": PROJECT, "objectFqns": [reg_fqn]})
+    assert_ok(r_before, "get_metadata_details on the register before setting Indexing")
+    assert_contains(r_before.text, "### Dimension Indexing",
+        "the Dimension Indexing section must render as soon as a dimension exists")
+    assert_contains(r_before.text, dim, "the seeded dimension must be listed by name")
+
+    r2 = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": "%s.Dimension.%s" % (reg_fqn, dim),
+        # The Java enum constant name (case-insensitive match against either the EMF literal or the
+        # constant name, per MetadataPropertyIntrospector.resolveEnumLiteral).
+        "properties": [{"name": "indexing", "value": "INDEX"}],
+    })
+    assert_ok(r2, "set the dimension's indexing")
+    wait_for_project_ready()
+
+    r_after = call("get_metadata_details", {"projectName": PROJECT, "objectFqns": [reg_fqn]})
+    assert_ok(r_after, "get_metadata_details on the register after setting Indexing")
+    assert_contains(r_after.text, "### Dimension Indexing", "the section must still render")
+    assert_contains(r_after.text, dim, "the seeded dimension must still be listed by name")
+    # The write must be OBSERVABLE: the rendered Indexing cell for this dimension must differ from
+    # its pre-write rendering (avoids hard-coding the exact enum literal string, which is an internal
+    # EMF codegen detail this test should not need to know).
+    if r_before.text == r_after.text:
+        raise AssertionError(
+            "setting the dimension's indexing must change the rendered details, but the "
+            "before/after output is byte-identical:\n" + r_after.text[:600])
+    # Indexing is emitted in BOTH modes (the shared attributes-table Indexing column never
+    # recognizes a register dimension in either mode, so this dedicated table always renders).
+    r_full = call("get_metadata_details", {"projectName": PROJECT, "objectFqns": [reg_fqn], "full": True})
+    assert_ok(r_full, "get_metadata_details on the register (full)")
+    assert_contains(r_full.text, "### Dimension Indexing", "the section must also render in full mode")
+    assert_contains(r_full.text, dim, "the seeded dimension must be listed in full mode too")

--- a/tests/e2e/tools/test_get_metadata_objects.py
+++ b/tests/e2e/tools/test_get_metadata_objects.py
@@ -12,7 +12,15 @@ with assert_no_diff() because a read tool must never mutate the project on disk.
 Negative matrix targets the tool's REAL execute() error paths:
   - missing required projectName  -> "projectName is required"  (JsonUtils.requireArgument)
   - non-existent project          -> "Project not found: <name>"
-  - invalid metadataType enum     -> "Unknown metadata type: <type>. Supported ..."
+  - invalid metadataType enum     -> "Unknown metadata type: <type>. Supported categories ..."
+
+issue #289: metadataType now ALSO accepts a standard type-name token (the FQN form, as
+used elsewhere in the API - English or Russian, singular or plural, e.g. "CommonModule",
+"Справочник"), resolved via the shared MetadataTypeUtils resolver, IN ADDITION TO the
+legacy lowercase-plural category tokens (documents/catalogs/.../scheduledJobs) which stay
+supported for back-compat. Separately, an AI naturally sending an undeclared
+types=["ScheduledJob"] array (instead of the declared metadataType) is now caught and
+rejected with an actionable error instead of being silently ignored.
 
 Fixture inventory used (TestConfiguration, English Names):
   Catalog.Catalog, CommonModule.Error, CommonModule.OK,
@@ -81,6 +89,40 @@ def test_namefilter_narrows_results():
     assert_no_diff("a read tool must not touch the project on disk")
 
 
+@e2e_test(tool="get_metadata_objects", kind="read")
+def test_filter_by_english_type_name_token_returns_only_that_type():
+    # issue #289 fix: metadataType now ALSO accepts a standard type-name token (the FQN
+    # form, e.g. "CommonModule"), not just the legacy category token ("commonModules").
+    # Must behave identically to test_filter_commonmodules_returns_both_fixture_modules -
+    # both resolve to the same internal category via MetadataTypeUtils.
+    r = call("get_metadata_objects",
+             {"projectName": PROJECT, "metadataType": "CommonModule"})
+    assert_ok(r, "get_metadata_objects metadataType=CommonModule (type-name token)")
+    assert_contains(r.text, "Error", "type-name filter must list CommonModule 'Error'")
+    assert_contains(r.text, "OK", "type-name filter must list CommonModule 'OK'")
+    # Mutation guard: a broken (ignored) filter would leak in the fixture Catalog row -
+    # the ONLY object in the fixture whose Name/Type is "Catalog", so its total absence
+    # proves the filter narrowed to common modules only.
+    assert_not_contains(r.text, "Catalog",
+                        "CommonModule type-name filter must EXCLUDE the fixture Catalog")
+    assert_no_diff("a read tool must not touch the project on disk")
+
+
+@e2e_test(tool="get_metadata_objects", kind="read")
+def test_filter_by_russian_type_name_token_returns_only_that_type():
+    # Bilingual side of the same fix: the Russian singular "Справочник" (Catalog) must
+    # resolve to the same category as the English "Catalog"/"catalogs" token, via the
+    # shared MetadataTypeUtils resolver (not a second hand-rolled Russian table).
+    r = call("get_metadata_objects",
+             {"projectName": PROJECT, "metadataType": "Справочник"})
+    assert_ok(r, "get_metadata_objects metadataType=Справочник (Russian type-name token)")
+    assert_contains(r.text, "Catalog", "Russian type-name filter must list the fixture Catalog")
+    # Mutation guard: a broken (ignored) filter would leak in CommonModule rows.
+    assert_not_contains(r.text, "CommonModule",
+                        "Russian type-name filter must EXCLUDE common modules")
+    assert_no_diff("a read tool must not touch the project on disk")
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Negative matrix (mandatory)
 # ──────────────────────────────────────────────────────────────────────────────
@@ -113,9 +155,10 @@ def test_nonexistent_project_errors_and_names_value():
 
 @e2e_test(tool="get_metadata_objects", kind="read")
 def test_invalid_metadatatype_enum_errors_actionably():
-    # metadataType is an enum; an unknown value -> "Unknown metadata type: <type>.
-    # Supported (case-insensitive): all, documents, catalogs, ...". This error IS
-    # actionable: it enumerates the valid values.
+    # metadataType accepts EITHER a category token OR a standard type-name token; a
+    # value recognized as NEITHER -> "Unknown metadata type: <type>. Supported
+    # categories (case-insensitive): all, documents, catalogs, ...". This error IS
+    # actionable: it enumerates the valid category values.
     bad = "bogusType_e2e"
     r = call("get_metadata_objects", {"projectName": PROJECT, "metadataType": bad})
     err = assert_error(r, "invalid metadataType enum")
@@ -123,4 +166,17 @@ def test_invalid_metadatatype_enum_errors_actionably():
     # listed supported values) -> the message is genuinely actionable.
     assert_error_quality(err, names=[bad], suggests=["catalogs"],
                          ctx="invalid metadataType names value and lists valid ones")
+    assert_no_diff("an invalid call must not touch the project on disk")
+
+
+@e2e_test(tool="get_metadata_objects", kind="read")
+def test_unrecognized_type_name_token_still_errors():
+    # A value that IS a metadata type name MetadataTypeUtils recognizes, but that this
+    # tool has NO collector for (e.g. Subsystem - see SUPPORTED_CATEGORIES), must still
+    # fall through to the actionable "Unknown metadata type" error, same as a totally
+    # bogus value - not silently succeed with an empty/wrong result.
+    r = call("get_metadata_objects", {"projectName": PROJECT, "metadataType": "Subsystem"})
+    err = assert_error(r, "recognized-but-uncollected type name")
+    assert_error_quality(err, names=["Subsystem"], suggests=["catalogs"],
+                         ctx="uncollected type name still names the value and lists valid ones")
     assert_no_diff("an invalid call must not touch the project on disk")

--- a/tests/e2e/tools/test_modify_metadata.py
+++ b/tests/e2e/tools/test_modify_metadata.py
@@ -1270,3 +1270,208 @@ def test_extension_unresolved_ref_gets_adopt_hint():
         e, names=["Cannot resolve the reference target"], suggests=["adopt_metadata_object"],
         ctx="an unresolved ref inside an extension must keep the sentinel AND hint at adopt_metadata_object")
     assert_tree_unchanged(before, "a rejected type set must change nothing on the base project")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Method-reference guard — a ScheduledJob.methodName / an EventSubscription.handler must
+# reference an EXISTING, Exported, Server-side CommonModule method (maintainer report on PR
+# #292: an AI bound a job's methodName at a function it had not created yet; EDT accepted it
+# silently and update_database later failed with an opaque "no such function"). Fixture
+# CommonModule.Calc.Add ("Функция Add(A, B) Экспорт" in a <server>true</server> module) is the
+# live-verified happy-path target; each negative test seeds its own fresh module/job/subscription
+# so it never perturbs the shared Calc/OK/Error fixtures other tests depend on.
+# ──────────────────────────────────────────────────────────────────────────────
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_scheduled_job_method_name_accepts_existing_exported_server_method():
+    job = "E2EMrvJobOk"
+    fqn = "ScheduledJob." + job
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": fqn}), "seed " + fqn)
+    wait_for_project_ready()
+
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": fqn,
+        "properties": [{"name": "methodName", "value": "Calc.Add"}],
+    })
+    assert_ok(r, "bind methodName to the existing exported server method Calc.Add")
+    assert r.structured.get("action") == "modified", "must report modified: %r" % (r.structured,)
+    assert "methodName" in (r.structured.get("applied") or []), \
+        "methodName must be applied: %r" % (r.structured,)
+    poll_diff_contains("Calc.Add", ctx="the methodName must land in the ScheduledJob .mdo on disk")
+
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_scheduled_job_method_name_missing_module_is_error():
+    job = "E2EMrvJobNoMod"
+    fqn = "ScheduledJob." + job
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": fqn}), "seed " + fqn)
+    wait_for_project_ready()
+    before = tree_snapshot()
+
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": fqn,
+        "properties": [{"name": "methodName", "value": "E2EMrvNoSuchModule.Foo"}],
+    })
+    e = assert_error(r, "methodName referencing a non-existent CommonModule")
+    assert_error_quality(e, names=["E2EMrvNoSuchModule"],
+                         suggests=["get_metadata_objects"],
+                         ctx="a missing module must be named with a discovery hint")
+    assert_tree_unchanged(before, "a rejected methodName must not touch the project")
+
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_scheduled_job_method_name_missing_method_is_error():
+    job = "E2EMrvJobNoMethod"
+    fqn = "ScheduledJob." + job
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": fqn}), "seed " + fqn)
+    wait_for_project_ready()
+    before = tree_snapshot()
+
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": fqn,
+        "properties": [{"name": "methodName", "value": "Calc.E2EMrvNoSuchMethod"}],
+    })
+    e = assert_error(r, "methodName referencing a method that does not exist in an existing module")
+    # The error must name the missing method + point at the fix: create it first, THEN bind it
+    # (the exact maintainer-requested order-forcing behaviour).
+    assert_error_quality(e, names=["E2EMrvNoSuchMethod", "Calc"],
+                         suggests=["write_module_source"],
+                         ctx="a missing method must be named with a create-it-first hint")
+    assert_tree_unchanged(before, "a rejected methodName must not touch the project")
+
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_scheduled_job_method_name_not_exported_is_error():
+    module = "E2EMrvNoExpMod"
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": "CommonModule." + module}),
+              "seed a fresh (default Server-kind) CommonModule")
+    wait_for_project_ready()
+    assert_ok(call("write_module_source", {
+        "projectName": PROJECT, "modulePath": "CommonModules/%s/Module.bsl" % module,
+        "mode": "replace", "overwrite": True,
+        "source": "Procedure Foo()\nEndProcedure\n",
+    }), "seed a NON-exported procedure")
+    wait_for_project_ready()
+
+    job = "E2EMrvJobNoExp"
+    fqn = "ScheduledJob." + job
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": fqn}), "seed " + fqn)
+    wait_for_project_ready()
+    before = tree_snapshot()
+
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": fqn,
+        "properties": [{"name": "methodName", "value": module + ".Foo"}],
+    })
+    e = assert_error(r, "methodName referencing a non-exported method")
+    assert_error_quality(e, names=["Foo", module], suggests=["Export"],
+                         ctx="a non-exported method must be rejected naming the Export fix")
+    assert_tree_unchanged(before, "a rejected methodName must not touch the project")
+
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_scheduled_job_method_name_non_server_module_is_error():
+    module = "E2EMrvNotSrvMod"
+    assert_ok(call("create_metadata", {
+        "projectName": PROJECT, "fqn": "CommonModule." + module,
+        "commonModuleKind": "ClientManaged",
+    }), "seed a CLIENT (non-server) CommonModule")
+    wait_for_project_ready()
+    assert_ok(call("write_module_source", {
+        "projectName": PROJECT, "modulePath": "CommonModules/%s/Module.bsl" % module,
+        "mode": "replace", "overwrite": True,
+        "source": "Procedure Foo() Export\nEndProcedure\n",
+    }), "seed an EXPORTED procedure on the non-server module")
+    wait_for_project_ready()
+
+    job = "E2EMrvJobNotSrv"
+    fqn = "ScheduledJob." + job
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": fqn}), "seed " + fqn)
+    wait_for_project_ready()
+    before = tree_snapshot()
+
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": fqn,
+        "properties": [{"name": "methodName", "value": module + ".Foo"}],
+    })
+    e = assert_error(r, "methodName referencing an exported method in a non-server module")
+    assert_error_quality(e, names=[module], suggests=["Server"],
+                         ctx="a non-server module must be rejected naming the Server fix")
+    assert_tree_unchanged(before, "a rejected methodName must not touch the project")
+
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_scheduled_job_method_name_no_dot_is_error():
+    job = "E2EMrvJobNoDot"
+    fqn = "ScheduledJob." + job
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": fqn}), "seed " + fqn)
+    wait_for_project_ready()
+    before = tree_snapshot()
+
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": fqn,
+        "properties": [{"name": "methodName", "value": "JustAName"}],
+    })
+    e = assert_error(r, "methodName with no dot")
+    assert_error_quality(e, names=["JustAName"], suggests=["Module", "Method"],
+                         ctx="a value with no dot must explain the expected Module.Method shape")
+    assert_tree_unchanged(before, "a rejected methodName must not touch the project")
+
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_scheduled_job_method_name_empty_value_skips_the_guard():
+    # An EMPTY value is NOT validated by the method-reference guard (it only fires for a
+    # non-empty binding) - modify_metadata's PRE-EXISTING, unrelated generic-STRING policy is
+    # that an empty value never "clears" a property (see requireValueError: "does not clear a
+    # property on an empty value"). So the call still errors, but it must be THAT generic
+    # error, never a method-reference one (no "Export"/"Server"/"not found in CommonModule"),
+    # proving the guard was skipped rather than firing on the empty value.
+    job = "E2EMrvJobEmpty"
+    fqn = "ScheduledJob." + job
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": fqn}), "seed " + fqn)
+    wait_for_project_ready()
+
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": fqn,
+        "properties": [{"name": "methodName", "value": ""}],
+    })
+    e = assert_error(r, "an empty methodName value")
+    assert_error_quality(e, suggests=["non-empty"],
+                         ctx="an empty value must hit the generic non-empty-value error")
+    assert "CommonModule" not in e, \
+        "an empty value must NOT be routed through the method-reference guard: %r" % (e,)
+
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_event_subscription_handler_accepts_existing_exported_server_method():
+    sub = "E2EMrvSubOk"
+    fqn = "EventSubscription." + sub
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": fqn}), "seed " + fqn)
+    wait_for_project_ready()
+
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": fqn,
+        "properties": [{"name": "handler", "value": "CommonModule.Calc.Add"}],
+    })
+    assert_ok(r, "bind handler to the existing exported server method CommonModule.Calc.Add")
+    assert "handler" in (r.structured.get("applied") or []), \
+        "handler must be applied: %r" % (r.structured,)
+    poll_diff_contains("Calc.Add", ctx="the handler must land in the EventSubscription .mdo on disk")
+
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_event_subscription_handler_missing_method_is_error():
+    sub = "E2EMrvSubNoMethod"
+    fqn = "EventSubscription." + sub
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": fqn}), "seed " + fqn)
+    wait_for_project_ready()
+    before = tree_snapshot()
+
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": fqn,
+        "properties": [{"name": "handler", "value": "CommonModule.Calc.E2EMrvSubNoSuchMethod"}],
+    })
+    e = assert_error(r, "handler referencing a method that does not exist")
+    assert_error_quality(e, names=["E2EMrvSubNoSuchMethod", "Calc"], suggests=["write_module_source"],
+                         ctx="a missing handler method must be named with a create-it-first hint")
+    assert_tree_unchanged(before, "a rejected handler must not touch the project")

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -2168,7 +2168,7 @@
       "openWorldHint": false,
       "readOnlyHint": true
     },
-    "description": "Get detailed properties of one or more 1C metadata objects (basic info by default, or every reflected section with 'full: true'). Use it after get_metadata_objects to inspect a known object's attributes/forms/commands; in full mode each section is capped so request fewer FQNs to keep the response small. A FORM FQN ('Catalog.X.Form.ItemForm' or 'CommonForm.Name') renders that form's STRUCTURE (items / attributes / commands). A ROLE FQN ('Role.FullAccess') renders that role's ACCESS RIGHTS - the object->right matrix, RLS restrictions, RLS templates and the role properties ('full: true' shows every object, otherwise only the non-default rows, the first 100 by default - page past them with 'roleObjectOffset' or use 'full: true'). Use this for the full properties of one named object; to list objects by type use get_metadata_objects. Full parameters and examples: call get_tool_guide('get_metadata_details').",
+    "description": "Get detailed properties of one or more 1C metadata objects (basic info by default, or every reflected section with 'full: true'). Use it after get_metadata_objects to inspect a known object's attributes/forms/commands; in full mode each section is capped so request fewer FQNs to keep the response small. A FORM FQN ('Catalog.X.Form.ItemForm' or 'CommonForm.Name') renders that form's STRUCTURE (items / attributes / commands). A ROLE FQN ('Role.FullAccess') renders that role's ACCESS RIGHTS - the object->right matrix, RLS restrictions, RLS templates and the role properties ('full: true' shows every object, otherwise only the non-default rows, the first 100 by default - page past them with 'roleObjectOffset' or use 'full: true'). In the default (non-full) view a ScheduledJob or CommonModule also renders a type-specific Properties table (e.g. methodName/schedule/use for a job; server/serverCall/global/returnValuesReuse for a module), and an InformationRegister's Dimensions additionally show their Indexing. Use this for the full properties of one named object; to list objects by type use get_metadata_objects. Full parameters and examples: call get_tool_guide('get_metadata_details').",
     "inputSchema": {
       "properties": {
         "assignable": {
@@ -2226,7 +2226,7 @@
           "type": "integer"
         },
         "metadataType": {
-          "description": "Type filter (case-insensitive), default 'all'. One of: all, documents, catalogs, informationRegisters, accumulationRegisters, commonModules, enums, constants, reports, dataProcessors, exchangePlans, businessProcesses, tasks, commonAttributes, eventSubscriptions, scheduledJobs",
+          "description": "Type filter (case-insensitive), default 'all'. Accepts EITHER a category token - all, documents, catalogs, informationRegisters, accumulationRegisters, commonModules, enums, constants, reports, dataProcessors, exchangePlans, businessProcesses, tasks, commonAttributes, eventSubscriptions, scheduledJobs - OR a single standard metadata type name (the FQN token, English or its Russian equivalent, e.g. 'ScheduledJob', 'Document'). Single value only - not an array. An unrecognized value returns an error listing the supported options.",
           "type": "string"
         },
         "nameFilter": {


### PR DESCRIPTION
Closes #286, closes #287, closes #288, closes #289.

@DitriXNew — четыре юзабилити-фикса по MCP, о которые споткнулись при работе (репортил другой ИИ через воркспейс). Каждый перепроверил по коду и на живом стенде 2026.1. Три логических коммита по компонентам.

## #286 + #287 — `write_module_source`: ложные отказы BSL-чекера

Встроенный лёгкий чекер баланса блоков блокировал запись валидного кода:
- **#287 (async):** `Асинх Процедура` / `Асинх Функция` — строка начинается с `Асинх`, поэтому открытие процедуры не матчилось (`^\s*(?:Процедура|Procedure)\b`), а `КонецПроцедуры` матчился → мнимый дисбаланс. Добавил опциональный префикс `Асинх`/`Async` в паттерны открытия. `Ждать`/`Await` — выражение, блока не вводит.
- **#286 (многострочный литерал с `|`):** чекер не трекал состояние строкового литерала — только пропускал строки, начинающиеся с `|`. `|`-строка с кодом после закрытия строки (`|хвост"; Если Х Тогда`) отбрасывалась целиком вместе с ключевым словом, а `"` внутри одинарно-кавыченного токена-даты `'…'` «залипал». Заменил на quote-aware маскирование содержимого строк (двойные кавычки со `""`-экранированием, одинарные `'…'`-даты, `//` только вне строк), переносимое между строками только при реальном `|`-продолжении — так незакрытая строка больше не «съедает» последующий код, а реальные дисбалансы по-прежнему ловятся (проверено live: несбалансированный модуль отвергается).

## #288 — `get_metadata_details`: типо-специфичные свойства

Раньше для ряда типов возвращались только Name/Synonym, хотя `modify_metadata` эти свойства пишет — асимметрия. Добавил:
- **ScheduledJob:** methodName, use, predefined, restartCountOnFailure/restartIntervalOnFailure, key, наличие расписания (через EMF `eIsSet` — именно ЯВНО заданное, не непустой дефолт).
- **CommonModule:** флаги контекста (server/serverCall/clientManagedApplication/clientOrdinaryApplication/externalConnection/global/privileged) и returnValuesReuse.
- **InformationRegister:** колонка `Indexing` (Индексировать) у измерений.

Рендерится в обоих режимах (default и `full:true`) — иначе в full терялось расписание, которого нет в общем reflective-дампе.

## #289 — `get_metadata_objects`: фильтр `metadataType` принимает имена типов

Фильтр понимал только собственные категорийные токены (documents/catalogs/…/scheduledJobs), а естественный вызов по имени типа как в FQN (`ScheduledJob`) падал в «Unknown metadata type». Теперь `metadataType` принимает и стандартный токен имени типа (англ. или рус. эквивалент), резолвится через общий `MetadataTypeUtils` и маппится на нужную категорию; старые категорийные токены проверяются первыми и не затеняются; нераспознанное значение (или тип без коллектора — Role/Subsystem/XDTOPackage) даёт ту же actionable-ошибку. Заодно вернул в шапку «Filter:» исходный ввод (протекал нормализованный нижний регистр).

Про сам параметр: по репорту ИИ передавал `types=["ScheduledJob"]`. Жёстко ловить необъявленный `types` явной ошибкой не стал — это конфликтует с ратчетом `SchemaExecuteParamParityTest` (execute() не должен читать необъявленные параметры). Вместо этого `metadataType` теперь понимает имя типа, а описание/guide явно указывают имя параметра. Если хочешь жёсткую ловлю `types` — могу добавить через объявленный rejection-параметр, скажи.

## Проверка
- Сборка + юнит-тесты: `mvn clean verify` зелёный (все ратчеты).
- Живой стенд EDT 2026.1: write_module_source принимает async+многострочный литерал и по-прежнему отвергает несбалансированный код; get_metadata_details отдаёт свойства ScheduledJob/CommonModule/indexing; get_metadata_objects фильтрует по имени типа (англ./рус.), отвергает мусор.
- e2e: get_metadata_objects + get_metadata_details — 33/33 зелёные; BSL-чекер покрыт юнит-тестами (async/многострочный/дата/незакрытая строка + сохранённая детекция дисбаланса).
- `tools/list` golden перегенерирован (описания get_metadata_objects + get_metadata_details).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
