### PR TITLE
write_module_source: сохранять разделитель строк модуля (CRLF), #305

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
@@ -18,6 +18,10 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ProjectScope;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.IScopeContext;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 
 import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
 import com.ditrix.edt.mcp.server.protocol.JsonUtils;
@@ -256,15 +260,21 @@ public class WriteModuleSourceTool implements IMcpTool
         // Read current content (if file exists)
         List<String> originalLines;
         boolean hasBom;
+        String lineDelimiter;
         if (fileExists)
         {
             originalLines = BslModuleUtils.readFileLines(file);
             hasBom = detectBom(file);
+            // Preserve the module's OWN line separator (issue #305): EDT writes BSL modules with CRLF,
+            // and the raw \n write flipped every line to LF, marking the whole module changed. Detect
+            // from the raw text (readFileText keeps the original separators; readFileLines strips them).
+            lineDelimiter = resolveLineDelimiter(file.getProject(), BslModuleUtils.readFileText(file));
         }
         else
         {
             originalLines = new ArrayList<>();
             hasBom = true; // New BSL files should have BOM
+            lineDelimiter = resolveLineDelimiter(file.getProject(), null);
         }
 
         String hashError = checkExpectedHashGuard(req, file, fileExists);
@@ -293,7 +303,7 @@ public class WriteModuleSourceTool implements IMcpTool
         }
 
         // Write file (the mutating step — kept inline under the passed guards)
-        writeFile(file, newLines, hasBom, fileExists);
+        writeFile(file, newLines, hasBom, fileExists, lineDelimiter);
 
         // Return success
         return buildSuccessResponse(req.projectName, req.modulePath, req.mode, req.skipSyntaxCheck,
@@ -936,17 +946,63 @@ public class WriteModuleSourceTool implements IMcpTool
     }
 
     /**
-     * Writes lines to the file, preserving BOM if needed.
+     * The line delimiter to write the module with. An EXISTING module keeps its OWN dominant
+     * delimiter (so an edit does not flip every line to LF and mark the whole module changed —
+     * issue #305); a brand-new module (or an existing single-line one with no delimiter) uses the
+     * project's configured line separator, falling back to the platform default.
+     *
+     * @param project the module's project (for the line-separator preference scope)
+     * @param rawCurrentText the file's raw content WITH its original separators, or {@code null}
+     *     for a new file
+     * @return {@code "\r\n"} or {@code "\n"}
+     */
+    private static String resolveLineDelimiter(IProject project, String rawCurrentText)
+    {
+        String detected = detectDominantDelimiter(rawCurrentText);
+        if (detected != null)
+        {
+            return detected;
+        }
+        String pref = Platform.getPreferencesService().getString(Platform.PI_RUNTIME,
+            Platform.PREF_LINE_SEPARATOR, null,
+            new IScopeContext[] { new ProjectScope(project), InstanceScope.INSTANCE });
+        return (pref != null && !pref.isEmpty()) ? pref : System.lineSeparator();
+    }
+
+    /**
+     * The dominant line delimiter of {@code text} ({@code "\r\n"} vs {@code "\n"}), or {@code null}
+     * when the text is null/empty or has no line break at all (a single line, where the caller falls
+     * back to the project default). A tie counts as CRLF (the EDT/1C convention for BSL modules).
+     */
+    static String detectDominantDelimiter(String text)
+    {
+        if (text == null || text.isEmpty())
+        {
+            return null;
+        }
+        int crlf = countOccurrences(text, "\r\n"); //$NON-NLS-1$
+        int lf = countOccurrences(text, "\n") - crlf; // bare LF not part of a CRLF //$NON-NLS-1$
+        if (crlf == 0 && lf == 0)
+        {
+            return null;
+        }
+        return crlf >= lf ? "\r\n" : "\n"; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Writes lines to the file, preserving BOM if needed. {@code lineDelimiter} is the module's own
+     * separator (see {@link #resolveLineDelimiter}); {@code lines} are LF-normalized (no {@code \r}),
+     * so joining with it re-applies the file's convention verbatim.
      */
     private void writeFile(IFile file, List<String> lines, boolean withBom,
-        boolean fileExists) throws Exception
+        boolean fileExists, String lineDelimiter) throws Exception
     {
-        String content = String.join("\n", lines); //$NON-NLS-1$
+        String content = String.join(lineDelimiter, lines);
 
-        // Ensure file ends with newline
-        if (!content.endsWith("\n")) //$NON-NLS-1$
+        // Ensure file ends with a newline, in the file's own delimiter
+        if (!content.endsWith(lineDelimiter))
         {
-            content += "\n"; //$NON-NLS-1$
+            content += lineDelimiter;
         }
 
         byte[] contentBytes = content.getBytes("UTF-8"); //$NON-NLS-1$

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceToolTest.java
@@ -1164,4 +1164,42 @@ public class WriteModuleSourceToolTest
         String result = tool.execute(params);
         assertTrue(result.contains("Project not found")); //$NON-NLS-1$
     }
+
+    // ==================== line-delimiter detection (issue #305) ====================
+
+    @Test
+    public void testDetectDelimiterCrlfDominant()
+    {
+        assertEquals("\r\n", WriteModuleSourceTool.detectDominantDelimiter("a\r\nb\r\nc")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testDetectDelimiterLfOnly()
+    {
+        assertEquals("\n", WriteModuleSourceTool.detectDominantDelimiter("a\nb\nc")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testDetectDelimiterMixedPrefersMajority()
+    {
+        // two CRLF vs one bare LF -> CRLF wins
+        assertEquals("\r\n", WriteModuleSourceTool.detectDominantDelimiter("a\r\nb\r\nc\nd")); //$NON-NLS-1$ //$NON-NLS-2$
+        // two bare LF vs one CRLF -> LF wins
+        assertEquals("\n", WriteModuleSourceTool.detectDominantDelimiter("a\nb\nc\r\nd")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testDetectDelimiterTieIsCrlf()
+    {
+        // one CRLF, one bare LF -> tie -> CRLF (the EDT/1C BSL convention)
+        assertEquals("\r\n", WriteModuleSourceTool.detectDominantDelimiter("a\r\nb\nc")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testDetectDelimiterSingleLineOrEmptyIsNull()
+    {
+        assertNull(WriteModuleSourceTool.detectDominantDelimiter("single line, no break")); //$NON-NLS-1$
+        assertNull(WriteModuleSourceTool.detectDominantDelimiter("")); //$NON-NLS-1$
+        assertNull(WriteModuleSourceTool.detectDominantDelimiter(null));
+    }
 }


### PR DESCRIPTION
Closes #305.

## Причина
`write_module_source` при записи кодирует содержимое с **жёстко зашитым LF** (`writeFile`: `String.join("\n", lines)` + добивка `"\n"` в конце, затем сырая запись байтов в `IFile.setContents`). EDT сохраняет BSL-модули в **CRLF**, поэтому любая правка через инструмент переводила весь модуль в LF → в git весь файл помечался изменённым.

По поводу вопроса из обсуждения («мы же вроде вставляем через провайдера»): на самом деле этот инструмент пишет **не через документ-провайдер EDT, а напрямую байты в файл** — поэтому разделитель и терялся. Редактор EDT пишет через `IDocument`, который сохраняет разделитель файла. Правка ниже заставляет наш сырой путь записи делать то же самое, без большого переезда на провайдера.

## Решение
Сохраняем **собственный доминирующий разделитель** модуля при записи:
- существующий файл — берём его разделитель (детект по сырому тексту: `readFileText` сохраняет исходные `\r\n`, а `readFileLines` их срезает);
- новый файл (или однострочный без разделителя) — берём настройку разделителя строк проекта/воркспейса Eclipse (`Platform.PREF_LINE_SEPARATOR`, scope Project→Instance), с откатом на платформенный по умолчанию.

Внутри инструмент по-прежнему нормализует весь ввод в LF (устойчивый search/replace, хэш, сравнение `expectedSource`) — разделитель файла применяется **только на финальном шаге кодирования в байты**, так что lost-update-гарды остаются согласованными.

## Проверка
- Юнит-тесты на детект разделителя (CRLF / LF / смешанный / ничья→CRLF / однострочный→null).
- Сборка зелёная (`mvn clean verify`).
- Живой прогон на CRLF-модуле: правка теперь даёт **чистый однострочный git diff** вместо переворота всего файла в LF; BOM/его отсутствие тоже сохраняется.

> Отдельный CI-e2e на это намеренно не добавлял: инструмент нормализует входной EOL (CRLF нельзя «пронести» через параметр), разделитель нового файла зависит от окружения (Windows CRLF vs Linux LF на CI), а сам баг воспроизводится именно на машине с EDT-CRLF. Поэтому проверка — юнит + живой стенд.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
