### PR TITLE
Docs: ужать всегда-загружаемый CLAUDE.md, механику Tier 2 перенести в скилл

### DIFF
--- a/.claude/skills/edt-mcp-build-test/SKILL.md
+++ b/.claude/skills/edt-mcp-build-test/SKILL.md
@@ -28,6 +28,15 @@ bash source/compile.sh --skip-tests
 - **The first build is slow**: Tycho pulls the EDT p2 repository (`edt.1c.ru`) + the Eclipse SDK (hundreds of MB). Once the caches are warm (`~/.m2/repository/p2`, `.cache/tycho`) it runs in ~1 minute. If the caches are absent and there's no network, the build legitimately can't run — say so, don't fake "green".
 - **Unit tests need the target platform too** (Mockito/JUnit come from the p2 target, not plain Maven Central) — a green `compile.sh` is the real proof for Java edits; grep only catches anchor/text problems.
 
+## Live redeploy (Tier 2 — the only proof of runtime behaviour)
+
+A green build proves Java logic; only a redeploy proves a tool's schema, description, response and behaviour. The loop itself (non-elevated EDT copy, `edt-redeploy.ps1`, `MCP server UP on 8765`, exit 1 ≠ failure, anti-stale jar check, kill + `-clean` when EDT wedges) is in `edt-mcp-testing` and `edt-mcp-ready-to-deploy`. The traps that belong to the build:
+
+- **Redeploy without a `-Build` flag only swaps the LAST built jar** — run `compile.sh` first (or pass `-Build`), else you ship stale code and validate the previous build.
+- **Kill the whole stand before swapping**: `taskkill /IM 1cedt.exe /T /F`, plus `1cv8.exe` if an infobase is running. Terminate both again when done.
+- **Inspect payloads with `Invoke-RestMethod`** (PowerShell), not `curl` — curl mangles nested JSON. Tools with a JSON responseType put the data in `result.structuredContent`; `content[0].text` is only a `Done`/`Error` placeholder.
+- **Infobase-dependent tools** (debug / run / YAXUnit / profiling) need the infobase (or a `debug_launch`) started first.
+
 ## Unit tests — conventions
 
 - One `XxxToolTest` per tool (`tools/impl/`), JUnit4.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # EDT-MCP — code conduct (the minefield map)
 
-A 1C:EDT plugin (Maven/Tycho, Eclipse OSGi) exposing an MCP server (~62 tools) that drives EDT. This file is **what NOT to do** and **where to stop and think twice**. Claude Code loads it automatically; the "how to do it right" lives in the skills.
+A 1C:EDT plugin (Maven/Tycho, Eclipse OSGi) exposing an MCP server that drives EDT. This file is **what NOT to do** and **where to stop and think twice**. Claude Code loads it automatically; the "how to do it right" lives in the skills.
 
 > **Prime directive.** The project is mid-refactor toward shared helpers. Write new code against the **target** architecture (the skills), do NOT copy the existing duplication. Do not grow the debt.
 
@@ -10,19 +10,7 @@ A 1C:EDT plugin (Maven/Tycho, Eclipse OSGi) exposing an MCP server (~62 tools) t
 
 ## 📚 The skills (load the relevant one before working — `.claude/skills/`)
 
-The `.claude/hooks/edt-skill-router.js` hook auto-suggests these when you touch matching files.
-
-| Skill | When to load it |
-|---|---|
-| `edt-mcp-architecture` | Starting work; deciding where new code belongs; the map of shared helpers + layering. |
-| `edt-mcp-tool-conventions` | Editing any `tools/impl` class; parameter naming, error shape, output format (Markdown vs JSON), pagination. |
-| `edt-mcp-bilingual` | Any read/write/resolve/search of metadata or BSL — the ru/en correctness checklist (the #1 bug source). |
-| `edt-mcp-new-tool` | Adding/scaffolding a tool — the full contract: IMcpTool surface, schema, registration, MANIFEST, the two test ratchets, golden, README, the compile→review→redeploy→live contour. |
-| `edt-mcp-build-test` | Building the plugin + running unit/e2e tests; the test conventions. |
-| `edt-mcp-e2e-testing` | Writing/running the **automated** black-box suite `tests/e2e/` (one `test_<tool>.py` per tool). |
-| `edt-mcp-testing` | **Manual** per-tool live validation — `references/<family>/<tool>.md`: exact call, expected result, gotchas. |
-| `edt-mcp-yaxunit` | Writing/running YAXUnit 1C unit tests via `run_yaxunit_tests` / `debug_yaxunit_tests`. |
-| `edt-mcp-ready-to-deploy` | **Wrapping up — the final "definition of done" gate.** Run when a piece of work is finished, before declaring it done or merging (hygiene → tests → build → README → live redeploy → golden → full e2e → conformance → clean tree). |
+The `edt-mcp-*` skills carry the "how to do it right"; each one's description says when to load it, and the `.claude/hooks/edt-skill-router.js` hook auto-suggests the matching skill when you touch a file. **Wrapping up a piece of work is the one you must not skip: `edt-mcp-ready-to-deploy` is the final "definition of done" gate before declaring done or merging.**
 
 ---
 
@@ -75,29 +63,14 @@ The `.claude/hooks/edt-skill-router.js` hook auto-suggests these when you touch 
 
 ---
 
-## 🧪 The testing cycle (three tiers — know which one proves what)
+## 🧪 The testing cycle (four tiers — know which one proves what)
 
 Each tier proves a different layer. A green lower tier does NOT prove the higher one. Do not claim "done" by review/grep alone.
 
-**Tier 1 — compile + unit tests (Java logic + ratchets).**
-- One command, same as CI: `bash source/compile.sh` (add `--skip-tests` to skip Surefire).
-- The toolchain is **not on `PATH`** — pass it: `bash source/compile.sh --java-home "<JDK17 home>" --maven-home "<maven home>"`. CI runs `mvn clean verify --batch-mode -T 1C` in `mcp/` on JDK 17.
-- **First build is slow** (Tycho pulls the EDT p2 repo + Eclipse SDK, hundreds of MB); ~1 min once `~/.m2/repository/p2` + `.cache/tycho` are warm. No caches + no network ⇒ it legitimately can't run — say so, don't fake green.
-- Unit tests need the target platform (Mockito/JUnit come from the p2 target). A green `compile.sh` is the real proof for Java changes. Ratchets that fail the build: `BuiltInToolTestCoverageTest` (every tool has an `XxxToolTest`), `ToolContractConsistencyTest` (lowerCamelCase params), the e2e coverage ratchet.
-
-**Tier 2 — live redeploy loop (runtime behaviour + `tools/list` schema + MCP wire contract).** Only this proves anything a tool's schema/description/response/behaviour. Encapsulated in a redeploy script (e.g. `edt-redeploy.ps1`; paths are environment-specific — do NOT hardcode them into committed files).
-- **Test against a non-elevated COPY of EDT**, never the `Program Files` install (elevated → swap/relaunch triggers UAC). Copy EDT once into a writable folder + a dedicated workspace.
-- **Per change:** `compile.sh` → **kill EDT** (`taskkill /IM 1cedt.exe /T /F`; also `1cv8.exe` if an infobase runs) → **swap** the freshly built bundle jar into `<edt-copy>/plugins/` AND patch `configuration/org.eclipse.equinox.simpleconfigurator/bundles.info` (Tycho stamps a new qualifier each build → the jar filename changes) → **relaunch with `-clean`** (forces OSGi reload) → wait for `:8765` → run live checks → kill EDT (and the infobase) when done.
-- **The redeploy script exits 1 even on success** — the real signal is the log line `MCP server UP on 8765`. Don't treat exit 1 as failure.
-- **Redeploy WITHOUT a `-Build` flag only swaps the LAST built jar** — run `compile.sh` first (or pass `-Build`), else you ship stale code.
-- **Tycho p2 qualifier collision is real:** two builds can produce the SAME qualifier, and p2 then ships a STALE cached jar despite fresh compilation. **Verify the DEPLOYED jar contains your change** — `unzip -p <jar> path/To/Class.class | grep <new-literal>` (a plain `grep` on the `.jar` is useless — it's a compressed zip). If stale: **commit first** (changes the jgit qualifier) then rebuild, or clear the tycho/p2 cache.
-- **If EDT wedges** (project stuck `building`, `clean_project` never returns, a per-test TIMEOUT): kill + `-clean` relaunch autonomously, then wait for projects `ready` before a full run.
-- **Inspect payloads with `Invoke-RestMethod`** (PowerShell), not `curl` (curl mangles nested JSON). JSON-responseType tools put data in `result.structuredContent`; `content[0].text` is just a `Done`/`Error` placeholder.
-- **Infobase-dependent tools** (debug / run / YAXUnit / profiling): start the infobase (or a `debug_launch`) first; terminate it + EDT when done.
-
-**Tier 3 — automated black-box e2e (`tests/e2e/`).** Real MCP client → live server → asserts the real effect. One `test_<tool>.py` per tool; git-fixture isolation; happy + negative + error-quality; anti-cheat; a coverage ratchet fails the suite if a tool has none. Run: `python tests/e2e/run_all.py --project TestConfiguration` (needs a live `:8765`). Read `edt-mcp-e2e-testing` (full guide `tests/e2e/SKILL.md`) before adding/editing a test. The formatter/synonym and error-shape contracts are **e2e-only** — they stay "verify in EDT".
-
-**Tier 4 — protocol conformance.** The official `modelcontextprotocol/conformance` suite validates the SERVER against the MCP wire spec (handshake, capabilities, session-id, `isError`, `ping`, SSE) — a separate layer from the e2e business-logic gate. `tests/conformance/` holds `baseline.yml` (the pinned intentional gaps) + `README.md` (the layer split). Run: `npx @modelcontextprotocol/conformance@latest server --url http://127.0.0.1:8765/mcp --spec-version 2025-11-25 --expected-failures tests/conformance/baseline.yml` → green when only the pinned gaps fail; a new failure = a protocol regression. CI: `.github/workflows/conformance.yml` (needs a self-hosted runner with EDT).
+- **Tier 1 — compile + unit tests.** `bash source/compile.sh` (the same flow as CI). Proves Java logic and the build ratchets: `BuiltInToolTestCoverageTest` (every tool has an `XxxToolTest`), `ToolContractConsistencyTest` (lowerCamelCase params), the e2e coverage ratchet. Mechanics + the toolchain/cache gotchas: `edt-mcp-build-test`.
+- **Tier 2 — live redeploy.** The ONLY proof of a tool's schema/description/response/behaviour, and of the MCP wire contract. Run against a non-elevated COPY of EDT, never the `Program Files` install. Mechanics: `edt-mcp-testing` + `edt-mcp-build-test`; the anti-stale jar check: `edt-mcp-ready-to-deploy`.
+- **Tier 3 — automated black-box e2e (`tests/e2e/`).** Real MCP client → live server → asserts the real effect. The formatter/synonym and error-shape contracts are **e2e-only** — they stay "verify in EDT". Mechanics: `edt-mcp-e2e-testing`.
+- **Tier 4 — protocol conformance.** Validates the SERVER against the MCP wire spec; `tests/conformance/baseline.yml` pins the intentional gaps, so a new failure = a protocol regression. Mechanics: `edt-mcp-build-test`.
 
 **Mandatory test minimum for a change:**
 - Changed metadata/code resolution → a test for **both** languages (English `Name`, Russian `Name`, synonym). Reference: `WriteModuleSourceToolTest.testResolveRussianObjectName`.


### PR DESCRIPTION
Чистка всегда-загружаемого контекста: `CLAUDE.md` ужат с 13 813 до 9 635 символов (≈ −1 044 токена в **каждой** сессии), при этом ни одна инструкция не потеряна — механика переехала в скилл, который грузится по требованию.

## Что сделано

**`CLAUDE.md`**
- **Таблица из 10 скиллов → абзац-указатель.** Те же скиллы с описаниями и так перечислены в контексте каждой сессии автоматически, таблица была вторым экземпляром того же самого. Явно оставлено указание не пропускать `edt-mcp-ready-to-deploy`.
- **Секция тестирования сжата с 5 097 до ~1 700 символов.** Остались четыре тира как ответ на вопрос «что чем доказывается» + обязательный тестовый минимум + указатель на финальный гейт. Детали Tier 1/3/4 уже лежали в `edt-mcp-build-test` и `edt-mcp-e2e-testing` практически дословно (включая ту же команду `npx @modelcontextprotocol/conformance`).
- Убран устаревший счётчик «~62 tools» (реально 68 — цифра дрейфует и её незачем дублировать в тексте).
- Заголовок «three tiers» → «four tiers»: тиров давно четыре.

**`.claude/skills/edt-mcp-build-test/SKILL.md`**
- Добавлена секция «Live redeploy (Tier 2)» — туда перенесено то, чего **не было ни в одном скилле**: ловушка redeploy без `-Build` (иначе валидируешь прошлую сборку), `taskkill` для `1cedt.exe` + `1cv8.exe`, `Invoke-RestMethod` вместо curl и `result.structuredContent`, зависимость части инструментов от запущенной ИБ.
- Остальное из Tier 2 (non-elevated копия EDT, `edt-redeploy.ps1`, `MCP server UP on 8765`, exit 1 ≠ провал, проверка на несвежий jar, kill + `-clean` при зависании) уже описано в `edt-mcp-testing` и `edt-mcp-ready-to-deploy` — не дублировал.

## Проверка

Правки только в документации — кода и тестов не касаются, сборка не затронута. Сверено, что каждый вырезанный из `CLAUDE.md` пункт присутствует либо в `edt-mcp-build-test`, либо в `edt-mcp-testing` / `edt-mcp-e2e-testing` / `edt-mcp-ready-to-deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
