### PR TITLE
write_module_source: dryRun-превью + режимы replaceMethod/insertBefor…

### DIFF
--- a/docs/tools/write_module_source.md
+++ b/docs/tools/write_module_source.md
@@ -12,13 +12,13 @@ Write BSL source code to a 1C metadata object module. Use to edit a module: sear
 | source | yes | string | BSL source to write (required): full file for replace, new fragment for searchReplace, text to add for append. |
 | oldSource | — | string | Fragment to find and replace; required for searchReplace, must match exactly once. |
 | mode | — | string (one of: searchReplace, replace, append, replaceMethod, insertBefore, insertAfter) | Write mode (default searchReplace). replaceMethod swaps a whole method by name; insertBefore/insertAfter add source before/after a named method. |
-| methodName | — | string | Target/anchor method (case-insensitive); required for replaceMethod, insertBefore and insertAfter. replaceMethod swaps its full definition (incl. leading doc-comment); insertBefore/After splice source just before/after it. |
+| methodName | — | string | Target/anchor method (case-insensitive); required for replaceMethod, insertBefore and insertAfter. replaceMethod swaps its full definition (incl. leading annotation/doc-comment); insertBefore/After splice source just before/after it. |
 | formName | — | string | Form name; required when moduleType=FormModule (e.g. 'ItemForm'). |
 | commandName | — | string | Command name; required when moduleType=CommandModule (e.g. 'FillByTemplate'). |
 | skipSyntaxCheck | — | boolean | Skip the BSL syntax check (default false). |
 | expectedSource | — | string | Lost-update guard for mode=replace: the module content you last read; mismatch rejects. |
 | overwrite | — | boolean | Force mode=replace over an existing module without an expectedSource check (default false). |
-| expectedHash | — | string | Lost-update guard for any mode: the contentHash from your last read; mismatch rejects. |
+| expectedHash | REQUIRED for replaceMethod; optional otherwise | string | Lost-update guard: the contentHash from your last read; mismatch rejects. REQUIRED for replaceMethod (it blindly swaps the whole method body). |
 | dryRun | — | boolean | Preview only (default false): compute the resulting module and run the syntax check, but do NOT write. Returns the would-be content + line counts so you can review a fix before committing it. Works with every mode. |
 
 ## Guide
@@ -55,7 +55,7 @@ Passing both is rejected; passing neither is rejected. `moduleType` is meaningfu
 | `skipSyntaxCheck` | optional | default false. |
 | `expectedSource` | mode=replace | lost-update guard. |
 | `overwrite` | mode=replace | force without expectedSource. |
-| `expectedHash` | any mode | cheap lost-update guard. |
+| `expectedHash` | REQUIRED for replaceMethod; optional otherwise | cheap lost-update guard. |
 | `dryRun` | optional | preview only — compute + syntax-check, do NOT write. Any mode. Default false. |
 
 ## moduleType to path
@@ -65,18 +65,18 @@ Passing both is rejected; passing neither is rejected. `moduleType` is meaningfu
 ## Modes
 
 - `searchReplace` (default): finds `oldSource` and replaces it with `source`. `oldSource` is REQUIRED and must match EXACTLY ONE location — zero matches or multiple matches are rejected with a steer to read again / give a larger fragment. The match runs on the raw file content (trailing newline preserved), so a fragment ending at EOF including its final newline is found. The file must already exist.
-- `replaceMethod`: swaps a WHOLE method by `methodName` (case-insensitive) — no need to quote the old body as `oldSource`. The replaced span is the method's full definition INCLUDING its leading doc-comment block, so `source` should be the complete new method (add your own doc-comment if you want one). If the method is not found, the error lists the module's available method names. The file must already exist. Ideal for a `code_review` fix: read the method, hand back the corrected method.
-- `insertBefore` / `insertAfter`: splice `source` in just BEFORE (ahead of its leading doc-comment) or just AFTER the `methodName` anchor method — the way to add a NEW method next to an existing one. `source` is inserted verbatim, so include your own blank line(s) for separation. Same not-found error as replaceMethod; the file must already exist.
+- `replaceMethod`: swaps a WHOLE method by `methodName` (case-insensitive) — no need to quote the old body as `oldSource`. The replaced span is the method's full definition INCLUDING its leading annotation (`&AtClient` etc.) and doc-comment block, so `source` should be the complete new method (add your own annotation/doc-comment if you want one). REQUIRES `expectedHash` (see Lost-update guards) - unlike insertBefore/insertAfter, it discards the whole current body, so a stale read must be caught before the write. If the method is not found, the error lists the module's available method names. The file must already exist. Ideal for a `code_review` fix: read the method, hand back the corrected method.
+- `insertBefore` / `insertAfter`: splice `source` in just BEFORE (ahead of its leading annotation/doc-comment) or just AFTER the `methodName` anchor method — the way to add a NEW method next to an existing one. `source` is inserted verbatim, so include your own blank line(s) for separation. Same not-found error as replaceMethod; the file must already exist.
 - `replace`: replaces the entire file. The ONLY mode that can CREATE a new module (creates parent folders). Over an EXISTING module it is guarded (see Lost-update guards).
 - `append`: adds `source` to the end. The file must already exist.
 
 ## Lost-update guards
 
 Concurrent edits between your read and write are caught by:
-- `expectedHash` (ANY mode): pass the opaque `contentHash` from your last `read_module_source` / `read_method_source`. If the module changed, the write is rejected. Cheapest (a fixed-size token, not the whole file). Ignored when creating a new module.
+- `expectedHash` (any mode; REQUIRED for `replaceMethod`): pass the opaque `contentHash` from your last `read_module_source` / `read_method_source`. If the module changed, the write is rejected. Cheapest (a fixed-size token, not the whole file). Ignored when creating a new module.
 - `expectedSource` (mode=replace): pass the exact content you last read. Mismatch is rejected.
 - `overwrite=true` (mode=replace): force the overwrite with no content check.
-A bare `replace` over an existing module with none of these is rejected and steers you toward expectedSource / overwrite / searchReplace. A matching `expectedHash` already satisfies the replace precondition. All comparisons are `\n`-normalized, so a CRLF/LF-only difference is not a spurious mismatch.
+A bare `replace` over an existing module with none of these is rejected and steers you toward expectedSource / overwrite / searchReplace. `replaceMethod` has no expectedSource/overwrite equivalent - it always requires `expectedHash` since it blindly discards the whole current method body (insertBefore/insertAfter are purely additive, so they do NOT require it). A matching `expectedHash` already satisfies the replace precondition. All comparisons are `\n`-normalized, so a CRLF/LF-only difference is not a spurious mismatch.
 
 ## BSL syntax check
 
@@ -115,10 +115,10 @@ Surgical edit (default mode):
   "oldSource": "Return 1;", "source": "Return 2;" }
 ```
 
-Replace a whole method by name (e.g. a code_review remediation):
+Replace a whole method by name (e.g. a code_review remediation - expectedHash from your last read is REQUIRED):
 ```
 { "projectName": "MyProj", "modulePath": "CommonModules/Calc/Module.bsl",
-  "mode": "replaceMethod", "methodName": "Test",
+  "mode": "replaceMethod", "methodName": "Test", "expectedHash": "a1b2c3d4e5f60718",
   "source": "Процедура Test() Экспорт\n\tAddend = 2;\n\tAdd(1, Addend);\nКонецПроцедуры" }
 ```
 

--- a/docs/tools/write_module_source.md
+++ b/docs/tools/write_module_source.md
@@ -1,6 +1,6 @@
 # write_module_source
 
-Write BSL source code to a 1C metadata object module. Use to edit a module: searchReplace a fragment (default, needs oldSource), replace the whole file, or append. Target the module by EITHER modulePath OR objectName (mutually exclusive — pass exactly one). Runs a BSL syntax check before writing (skipSyntaxCheck=true to force). Full parameters and examples: call get_tool_guide('write_module_source').
+Write BSL source code to a 1C metadata object module. Use to edit a module: searchReplace a fragment (default, needs oldSource), replaceMethod / insertBefore / insertAfter (by method name), replace the whole file, or append. Target the module by EITHER modulePath OR objectName (mutually exclusive — pass exactly one). Runs a BSL syntax check before writing (skipSyntaxCheck=true to force). Pass dryRun=true to preview the result (content + syntax check) WITHOUT writing. Full parameters and examples: call get_tool_guide('write_module_source').
 
 ## Parameters
 | Parameter | Required | Type | Description |
@@ -11,13 +11,15 @@ Write BSL source code to a 1C metadata object module. Use to edit a module: sear
 | moduleType | — | string (one of: ObjectModule, ManagerModule, FormModule, CommandModule, RecordSetModule, Module) | Module type for objectName resolution (default ObjectModule). |
 | source | yes | string | BSL source to write (required): full file for replace, new fragment for searchReplace, text to add for append. |
 | oldSource | — | string | Fragment to find and replace; required for searchReplace, must match exactly once. |
-| mode | — | string (one of: searchReplace, replace, append) | Write mode (default searchReplace). |
+| mode | — | string (one of: searchReplace, replace, append, replaceMethod, insertBefore, insertAfter) | Write mode (default searchReplace). replaceMethod swaps a whole method by name; insertBefore/insertAfter add source before/after a named method. |
+| methodName | — | string | Target/anchor method (case-insensitive); required for replaceMethod, insertBefore and insertAfter. replaceMethod swaps its full definition (incl. leading doc-comment); insertBefore/After splice source just before/after it. |
 | formName | — | string | Form name; required when moduleType=FormModule (e.g. 'ItemForm'). |
 | commandName | — | string | Command name; required when moduleType=CommandModule (e.g. 'FillByTemplate'). |
 | skipSyntaxCheck | — | boolean | Skip the BSL syntax check (default false). |
 | expectedSource | — | string | Lost-update guard for mode=replace: the module content you last read; mismatch rejects. |
 | overwrite | — | boolean | Force mode=replace over an existing module without an expectedSource check (default false). |
 | expectedHash | — | string | Lost-update guard for any mode: the contentHash from your last read; mismatch rejects. |
+| dryRun | — | boolean | Preview only (default false): compute the resulting module and run the syntax check, but do NOT write. Returns the would-be content + line counts so you can review a fix before committing it. Works with every mode. |
 
 ## Guide
 Writes BSL source to a single 1C metadata object module (a `.bsl` file under `src/`). Three edit modes, a mandatory BSL syntax check, and optional lost-update guards.
@@ -46,13 +48,15 @@ Passing both is rejected; passing neither is rejected. `moduleType` is meaningfu
 | `moduleType` | with objectName | default `ObjectModule`. |
 | `source` | always | the BSL to write (max 500000 chars). |
 | `oldSource` | mode=searchReplace | must match exactly once. |
-| `mode` | optional | `searchReplace` (default), `replace`, `append`. |
+| `methodName` | replaceMethod / insertBefore / insertAfter | the target/anchor method (case-insensitive). |
+| `mode` | optional | `searchReplace` (default), `replaceMethod`, `insertBefore`, `insertAfter`, `replace`, `append`. |
 | `formName` | moduleType=FormModule | except CommonForm. |
 | `commandName` | moduleType=CommandModule | except CommonCommand. |
 | `skipSyntaxCheck` | optional | default false. |
 | `expectedSource` | mode=replace | lost-update guard. |
 | `overwrite` | mode=replace | force without expectedSource. |
 | `expectedHash` | any mode | cheap lost-update guard. |
+| `dryRun` | optional | preview only — compute + syntax-check, do NOT write. Any mode. Default false. |
 
 ## moduleType to path
 
@@ -61,6 +65,8 @@ Passing both is rejected; passing neither is rejected. `moduleType` is meaningfu
 ## Modes
 
 - `searchReplace` (default): finds `oldSource` and replaces it with `source`. `oldSource` is REQUIRED and must match EXACTLY ONE location — zero matches or multiple matches are rejected with a steer to read again / give a larger fragment. The match runs on the raw file content (trailing newline preserved), so a fragment ending at EOF including its final newline is found. The file must already exist.
+- `replaceMethod`: swaps a WHOLE method by `methodName` (case-insensitive) — no need to quote the old body as `oldSource`. The replaced span is the method's full definition INCLUDING its leading doc-comment block, so `source` should be the complete new method (add your own doc-comment if you want one). If the method is not found, the error lists the module's available method names. The file must already exist. Ideal for a `code_review` fix: read the method, hand back the corrected method.
+- `insertBefore` / `insertAfter`: splice `source` in just BEFORE (ahead of its leading doc-comment) or just AFTER the `methodName` anchor method — the way to add a NEW method next to an existing one. `source` is inserted verbatim, so include your own blank line(s) for separation. Same not-found error as replaceMethod; the file must already exist.
 - `replace`: replaces the entire file. The ONLY mode that can CREATE a new module (creates parent folders). Over an EXISTING module it is guarded (see Lost-update guards).
 - `append`: adds `source` to the end. The file must already exist.
 
@@ -75,6 +81,10 @@ A bare `replace` over an existing module with none of these is rejected and stee
 ## BSL syntax check
 
 Before writing, the resulting content is checked for balanced block keywords (Procedure/EndProcedure, Function/EndFunction, If/EndIf, While/EndDo, For/EndDo, Try/EndTry). On error the write is BLOCKED and the errors are returned. Pass `skipSyntaxCheck=true` to force.
+
+## Preview (dryRun)
+
+Pass `dryRun: true` to run the whole pipeline — resolve the module, apply the lost-update guards, compute the resulting content, run the BSL syntax check — but STOP before writing. The response carries `status: preview`, `written: false`, the `linesBefore`/`linesAfter` counts, the `syntaxCheck` result, and the would-be module content (capped at 400 lines). Nothing on disk or in the model changes. Use it to review a fix (e.g. a `code_review` remediation) before committing it, or to confirm a `searchReplace` matches and stays syntactically valid. Works with every mode. A dry run that fails a guard or the syntax check returns the SAME error a real write would — so a green preview means the real write will succeed.
 
 ## Bilingual (ru/en)
 
@@ -105,6 +115,20 @@ Surgical edit (default mode):
   "oldSource": "Return 1;", "source": "Return 2;" }
 ```
 
+Replace a whole method by name (e.g. a code_review remediation):
+```
+{ "projectName": "MyProj", "modulePath": "CommonModules/Calc/Module.bsl",
+  "mode": "replaceMethod", "methodName": "Test",
+  "source": "Процедура Test() Экспорт\n\tAddend = 2;\n\tAdd(1, Addend);\nКонецПроцедуры" }
+```
+
+Add a new method after an existing one:
+```
+{ "projectName": "MyProj", "modulePath": "CommonModules/Calc/Module.bsl",
+  "mode": "insertAfter", "methodName": "Add",
+  "source": "\nФункция Sub(A, B) Экспорт\n\tВозврат A - B;\nКонецФункции\n" }
+```
+
 Form module via objectName:
 ```
 { "projectName": "MyProj", "objectName": "Document.MyDoc",
@@ -119,9 +143,17 @@ Extension method interception (append an annotated procedure to an adopted exten
   "source": "\n&After(\"Add\")\nProcedure ext_AddAfter(A, B, Result) Export\n\t// runs after CommonModule.Calc.Add\nEndProcedure\n" }
 ```
 
+Preview a fix before committing (no write):
+```
+{ "projectName": "MyProj", "modulePath": "CommonModules/MyModule/Module.bsl",
+  "oldSource": "Result = Add(1, 2);", "source": "Addend = 2;\n\tAdd(1, Addend);",
+  "dryRun": true }
+```
+
 ## Gotchas
 
 - Only `.bsl` files; `modulePath` may not contain `..`.
+- `dryRun: true` writes nothing (any mode); the response is `status: preview` with the would-be content. Drop it (or set false) to actually write.
 - `searchReplace`/`append` need an EXISTING file; only `replace` creates one.
 - New BSL files are written with a UTF-8 BOM; existing files keep their BOM state.
 - `source` is `\r\n`->`\n` normalized and the file always ends with a newline.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/write_module_source.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/write_module_source.md
@@ -24,13 +24,15 @@ Passing both is rejected; passing neither is rejected. `moduleType` is meaningfu
 | `moduleType` | with objectName | default `ObjectModule`. |
 | `source` | always | the BSL to write (max 500000 chars). |
 | `oldSource` | mode=searchReplace | must match exactly once. |
-| `mode` | optional | `searchReplace` (default), `replace`, `append`. |
+| `methodName` | replaceMethod / insertBefore / insertAfter | the target/anchor method (case-insensitive). |
+| `mode` | optional | `searchReplace` (default), `replaceMethod`, `insertBefore`, `insertAfter`, `replace`, `append`. |
 | `formName` | moduleType=FormModule | except CommonForm. |
 | `commandName` | moduleType=CommandModule | except CommonCommand. |
 | `skipSyntaxCheck` | optional | default false. |
 | `expectedSource` | mode=replace | lost-update guard. |
 | `overwrite` | mode=replace | force without expectedSource. |
 | `expectedHash` | any mode | cheap lost-update guard. |
+| `dryRun` | optional | preview only — compute + syntax-check, do NOT write. Any mode. Default false. |
 
 ## moduleType to path
 
@@ -39,6 +41,8 @@ Passing both is rejected; passing neither is rejected. `moduleType` is meaningfu
 ## Modes
 
 - `searchReplace` (default): finds `oldSource` and replaces it with `source`. `oldSource` is REQUIRED and must match EXACTLY ONE location — zero matches or multiple matches are rejected with a steer to read again / give a larger fragment. The match runs on the raw file content (trailing newline preserved), so a fragment ending at EOF including its final newline is found. The file must already exist.
+- `replaceMethod`: swaps a WHOLE method by `methodName` (case-insensitive) — no need to quote the old body as `oldSource`. The replaced span is the method's full definition INCLUDING its leading doc-comment block, so `source` should be the complete new method (add your own doc-comment if you want one). If the method is not found, the error lists the module's available method names. The file must already exist. Ideal for a `code_review` fix: read the method, hand back the corrected method.
+- `insertBefore` / `insertAfter`: splice `source` in just BEFORE (ahead of its leading doc-comment) or just AFTER the `methodName` anchor method — the way to add a NEW method next to an existing one. `source` is inserted verbatim, so include your own blank line(s) for separation. Same not-found error as replaceMethod; the file must already exist.
 - `replace`: replaces the entire file. The ONLY mode that can CREATE a new module (creates parent folders). Over an EXISTING module it is guarded (see Lost-update guards).
 - `append`: adds `source` to the end. The file must already exist.
 
@@ -53,6 +57,10 @@ A bare `replace` over an existing module with none of these is rejected and stee
 ## BSL syntax check
 
 Before writing, the resulting content is checked for balanced block keywords (Procedure/EndProcedure, Function/EndFunction, If/EndIf, While/EndDo, For/EndDo, Try/EndTry). On error the write is BLOCKED and the errors are returned. Pass `skipSyntaxCheck=true` to force.
+
+## Preview (dryRun)
+
+Pass `dryRun: true` to run the whole pipeline — resolve the module, apply the lost-update guards, compute the resulting content, run the BSL syntax check — but STOP before writing. The response carries `status: preview`, `written: false`, the `linesBefore`/`linesAfter` counts, the `syntaxCheck` result, and the would-be module content (capped at 400 lines). Nothing on disk or in the model changes. Use it to review a fix (e.g. a `code_review` remediation) before committing it, or to confirm a `searchReplace` matches and stays syntactically valid. Works with every mode. A dry run that fails a guard or the syntax check returns the SAME error a real write would — so a green preview means the real write will succeed.
 
 ## Bilingual (ru/en)
 
@@ -83,6 +91,20 @@ Surgical edit (default mode):
   "oldSource": "Return 1;", "source": "Return 2;" }
 ```
 
+Replace a whole method by name (e.g. a code_review remediation):
+```
+{ "projectName": "MyProj", "modulePath": "CommonModules/Calc/Module.bsl",
+  "mode": "replaceMethod", "methodName": "Test",
+  "source": "Процедура Test() Экспорт\n\tAddend = 2;\n\tAdd(1, Addend);\nКонецПроцедуры" }
+```
+
+Add a new method after an existing one:
+```
+{ "projectName": "MyProj", "modulePath": "CommonModules/Calc/Module.bsl",
+  "mode": "insertAfter", "methodName": "Add",
+  "source": "\nФункция Sub(A, B) Экспорт\n\tВозврат A - B;\nКонецФункции\n" }
+```
+
 Form module via objectName:
 ```
 { "projectName": "MyProj", "objectName": "Document.MyDoc",
@@ -97,9 +119,17 @@ Extension method interception (append an annotated procedure to an adopted exten
   "source": "\n&After(\"Add\")\nProcedure ext_AddAfter(A, B, Result) Export\n\t// runs after CommonModule.Calc.Add\nEndProcedure\n" }
 ```
 
+Preview a fix before committing (no write):
+```
+{ "projectName": "MyProj", "modulePath": "CommonModules/MyModule/Module.bsl",
+  "oldSource": "Result = Add(1, 2);", "source": "Addend = 2;\n\tAdd(1, Addend);",
+  "dryRun": true }
+```
+
 ## Gotchas
 
 - Only `.bsl` files; `modulePath` may not contain `..`.
+- `dryRun: true` writes nothing (any mode); the response is `status: preview` with the would-be content. Drop it (or set false) to actually write.
 - `searchReplace`/`append` need an EXISTING file; only `replace` creates one.
 - New BSL files are written with a UTF-8 BOM; existing files keep their BOM state.
 - `source` is `\r\n`->`\n` normalized and the file always ends with a newline.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/write_module_source.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/write_module_source.md
@@ -31,7 +31,7 @@ Passing both is rejected; passing neither is rejected. `moduleType` is meaningfu
 | `skipSyntaxCheck` | optional | default false. |
 | `expectedSource` | mode=replace | lost-update guard. |
 | `overwrite` | mode=replace | force without expectedSource. |
-| `expectedHash` | any mode | cheap lost-update guard. |
+| `expectedHash` | REQUIRED for replaceMethod; optional otherwise | cheap lost-update guard. |
 | `dryRun` | optional | preview only — compute + syntax-check, do NOT write. Any mode. Default false. |
 
 ## moduleType to path
@@ -41,18 +41,18 @@ Passing both is rejected; passing neither is rejected. `moduleType` is meaningfu
 ## Modes
 
 - `searchReplace` (default): finds `oldSource` and replaces it with `source`. `oldSource` is REQUIRED and must match EXACTLY ONE location — zero matches or multiple matches are rejected with a steer to read again / give a larger fragment. The match runs on the raw file content (trailing newline preserved), so a fragment ending at EOF including its final newline is found. The file must already exist.
-- `replaceMethod`: swaps a WHOLE method by `methodName` (case-insensitive) — no need to quote the old body as `oldSource`. The replaced span is the method's full definition INCLUDING its leading doc-comment block, so `source` should be the complete new method (add your own doc-comment if you want one). If the method is not found, the error lists the module's available method names. The file must already exist. Ideal for a `code_review` fix: read the method, hand back the corrected method.
-- `insertBefore` / `insertAfter`: splice `source` in just BEFORE (ahead of its leading doc-comment) or just AFTER the `methodName` anchor method — the way to add a NEW method next to an existing one. `source` is inserted verbatim, so include your own blank line(s) for separation. Same not-found error as replaceMethod; the file must already exist.
+- `replaceMethod`: swaps a WHOLE method by `methodName` (case-insensitive) — no need to quote the old body as `oldSource`. The replaced span is the method's full definition INCLUDING its leading annotation (`&AtClient` etc.) and doc-comment block, so `source` should be the complete new method (add your own annotation/doc-comment if you want one). REQUIRES `expectedHash` (see Lost-update guards) - unlike insertBefore/insertAfter, it discards the whole current body, so a stale read must be caught before the write. If the method is not found, the error lists the module's available method names. The file must already exist. Ideal for a `code_review` fix: read the method, hand back the corrected method.
+- `insertBefore` / `insertAfter`: splice `source` in just BEFORE (ahead of its leading annotation/doc-comment) or just AFTER the `methodName` anchor method — the way to add a NEW method next to an existing one. `source` is inserted verbatim, so include your own blank line(s) for separation. Same not-found error as replaceMethod; the file must already exist.
 - `replace`: replaces the entire file. The ONLY mode that can CREATE a new module (creates parent folders). Over an EXISTING module it is guarded (see Lost-update guards).
 - `append`: adds `source` to the end. The file must already exist.
 
 ## Lost-update guards
 
 Concurrent edits between your read and write are caught by:
-- `expectedHash` (ANY mode): pass the opaque `contentHash` from your last `read_module_source` / `read_method_source`. If the module changed, the write is rejected. Cheapest (a fixed-size token, not the whole file). Ignored when creating a new module.
+- `expectedHash` (any mode; REQUIRED for `replaceMethod`): pass the opaque `contentHash` from your last `read_module_source` / `read_method_source`. If the module changed, the write is rejected. Cheapest (a fixed-size token, not the whole file). Ignored when creating a new module.
 - `expectedSource` (mode=replace): pass the exact content you last read. Mismatch is rejected.
 - `overwrite=true` (mode=replace): force the overwrite with no content check.
-A bare `replace` over an existing module with none of these is rejected and steers you toward expectedSource / overwrite / searchReplace. A matching `expectedHash` already satisfies the replace precondition. All comparisons are `\n`-normalized, so a CRLF/LF-only difference is not a spurious mismatch.
+A bare `replace` over an existing module with none of these is rejected and steers you toward expectedSource / overwrite / searchReplace. `replaceMethod` has no expectedSource/overwrite equivalent - it always requires `expectedHash` since it blindly discards the whole current method body (insertBefore/insertAfter are purely additive, so they do NOT require it). A matching `expectedHash` already satisfies the replace precondition. All comparisons are `\n`-normalized, so a CRLF/LF-only difference is not a spurious mismatch.
 
 ## BSL syntax check
 
@@ -91,10 +91,10 @@ Surgical edit (default mode):
   "oldSource": "Return 1;", "source": "Return 2;" }
 ```
 
-Replace a whole method by name (e.g. a code_review remediation):
+Replace a whole method by name (e.g. a code_review remediation - expectedHash from your last read is REQUIRED):
 ```
 { "projectName": "MyProj", "modulePath": "CommonModules/Calc/Module.bsl",
-  "mode": "replaceMethod", "methodName": "Test",
+  "mode": "replaceMethod", "methodName": "Test", "expectedHash": "a1b2c3d4e5f60718",
   "source": "Процедура Test() Экспорт\n\tAddend = 2;\n\tAdd(1, Addend);\nКонецПроцедуры" }
 ```
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
@@ -47,6 +47,12 @@ public class WriteModuleSourceTool implements IMcpTool
     private static final String MODE_REPLACE = "replace"; //$NON-NLS-1$
     private static final String MODE_APPEND = "append"; //$NON-NLS-1$
     private static final String MODE_SEARCH_REPLACE = "searchReplace"; //$NON-NLS-1$
+    private static final String MODE_REPLACE_METHOD = "replaceMethod"; //$NON-NLS-1$
+    private static final String MODE_INSERT_BEFORE = "insertBefore"; //$NON-NLS-1$
+    private static final String MODE_INSERT_AFTER = "insertAfter"; //$NON-NLS-1$
+
+    /** Max lines of would-be content echoed back in a {@code dryRun} preview (bounds the response). */
+    private static final int PREVIEW_MAX_LINES = 400;
 
     private static final String PROJECT_NAME = "projectName"; //$NON-NLS-1$
     private static final String MODULE_PATH = "modulePath"; //$NON-NLS-1$
@@ -74,9 +80,10 @@ public class WriteModuleSourceTool implements IMcpTool
     {
         return "Write BSL source code to a 1C metadata object module. " + //$NON-NLS-1$
             "Use to edit a module: searchReplace a fragment (default, needs oldSource), " + //$NON-NLS-1$
-            "replace the whole file, or append. " + //$NON-NLS-1$
+            "replaceMethod / insertBefore / insertAfter (by method name), replace the whole file, or append. " + //$NON-NLS-1$
             "Target the module by EITHER modulePath OR objectName (mutually exclusive — pass exactly one). " + //$NON-NLS-1$
             "Runs a BSL syntax check before writing (skipSyntaxCheck=true to force). " + //$NON-NLS-1$
+            "Pass dryRun=true to preview the result (content + syntax check) WITHOUT writing. " + //$NON-NLS-1$
             "Full parameters and examples: call get_tool_guide('write_module_source')."; //$NON-NLS-1$
     }
 
@@ -101,8 +108,14 @@ public class WriteModuleSourceTool implements IMcpTool
             .stringProperty("oldSource", //$NON-NLS-1$
                 "Fragment to find and replace; required for searchReplace, must match exactly once.") //$NON-NLS-1$
             .enumProperty("mode", //$NON-NLS-1$
-                "Write mode (default searchReplace).", //$NON-NLS-1$
-                MODE_SEARCH_REPLACE, MODE_REPLACE, MODE_APPEND)
+                "Write mode (default searchReplace). replaceMethod swaps a whole method by name; " //$NON-NLS-1$
+                    + "insertBefore/insertAfter add source before/after a named method.", //$NON-NLS-1$
+                MODE_SEARCH_REPLACE, MODE_REPLACE, MODE_APPEND, MODE_REPLACE_METHOD,
+                MODE_INSERT_BEFORE, MODE_INSERT_AFTER)
+            .stringProperty("methodName", //$NON-NLS-1$
+                "Target/anchor method (case-insensitive); required for replaceMethod, insertBefore " //$NON-NLS-1$
+                    + "and insertAfter. replaceMethod swaps its full definition (incl. leading " //$NON-NLS-1$
+                    + "doc-comment); insertBefore/After splice source just before/after it.") //$NON-NLS-1$
             .stringProperty("formName", //$NON-NLS-1$
                 "Form name; required when moduleType=FormModule (e.g. 'ItemForm').") //$NON-NLS-1$
             .stringProperty("commandName", //$NON-NLS-1$
@@ -115,6 +128,10 @@ public class WriteModuleSourceTool implements IMcpTool
                 "Force mode=replace over an existing module without an expectedSource check (default false).") //$NON-NLS-1$
             .stringProperty("expectedHash", //$NON-NLS-1$
                 "Lost-update guard for any mode: the contentHash from your last read; mismatch rejects.") //$NON-NLS-1$
+            .booleanProperty("dryRun", //$NON-NLS-1$
+                "Preview only (default false): compute the resulting module and run the syntax check, " //$NON-NLS-1$
+                    + "but do NOT write. Returns the would-be content + line counts so you can review a " //$NON-NLS-1$
+                    + "fix before committing it. Works with every mode.") //$NON-NLS-1$
             .build();
     }
 
@@ -210,6 +227,8 @@ public class WriteModuleSourceTool implements IMcpTool
         final String expectedSource;
         final boolean overwrite;
         final String expectedHash;
+        final boolean dryRun;
+        final String methodName;
 
         private WriteRequest(Map<String, String> params)
         {
@@ -230,6 +249,8 @@ public class WriteModuleSourceTool implements IMcpTool
             this.expectedSource = JsonUtils.extractStringArgument(params, "expectedSource"); //$NON-NLS-1$
             this.overwrite = JsonUtils.extractBooleanArgument(params, "overwrite", false); //$NON-NLS-1$
             this.expectedHash = JsonUtils.extractStringArgument(params, "expectedHash"); //$NON-NLS-1$
+            this.dryRun = JsonUtils.extractBooleanArgument(params, "dryRun", false); //$NON-NLS-1$
+            this.methodName = JsonUtils.extractStringArgument(params, "methodName"); //$NON-NLS-1$
         }
 
         static WriteRequest from(Map<String, String> params)
@@ -302,6 +323,14 @@ public class WriteModuleSourceTool implements IMcpTool
             }
         }
 
+        // dryRun: everything above ran (guards + compute + syntax check) but nothing is written —
+        // return the would-be content so the caller can review the fix before committing it.
+        if (req.dryRun)
+        {
+            return buildPreviewResponse(req.projectName, req.modulePath, req.mode, req.skipSyntaxCheck,
+                newLines, fileExists, totalOriginal);
+        }
+
         // Write file (the mutating step — kept inline under the passed guards)
         writeFile(file, newLines, hasBom, fileExists, lineDelimiter);
 
@@ -358,16 +387,26 @@ public class WriteModuleSourceTool implements IMcpTool
 
         // Validate mode
         if (!MODE_REPLACE.equals(mode) && !MODE_APPEND.equals(mode)
-            && !MODE_SEARCH_REPLACE.equals(mode))
+            && !MODE_SEARCH_REPLACE.equals(mode) && !isMethodMode(mode))
         {
             return ToolResult.error("invalid mode '" + mode + "'. " + //$NON-NLS-1$ //$NON-NLS-2$
-                "Allowed: searchReplace, replace, append").toJson(); //$NON-NLS-1$
+                "Allowed: searchReplace, replace, append, replaceMethod, insertBefore, insertAfter").toJson(); //$NON-NLS-1$
         }
 
         // Validate oldSource for searchReplace mode
         if (MODE_SEARCH_REPLACE.equals(mode) && (oldSource == null || oldSource.isEmpty()))
         {
             return ToolResult.error("oldSource is required for searchReplace mode").toJson(); //$NON-NLS-1$
+        }
+
+        // Validate methodName for the method-targeting modes (replaceMethod / insertBefore / insertAfter)
+        if (isMethodMode(mode))
+        {
+            String methodName = JsonUtils.extractStringArgument(params, "methodName"); //$NON-NLS-1$
+            if (methodName == null || methodName.isEmpty())
+            {
+                return ToolResult.error("methodName is required for mode '" + mode + "'").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+            }
         }
         return null;
     }
@@ -471,6 +510,13 @@ public class WriteModuleSourceTool implements IMcpTool
         }
     }
 
+    /** @return true for the modes that target/anchor on a method by {@code methodName}. */
+    private static boolean isMethodMode(String mode)
+    {
+        return MODE_REPLACE_METHOD.equals(mode) || MODE_INSERT_BEFORE.equals(mode)
+            || MODE_INSERT_AFTER.equals(mode);
+    }
+
     /**
      * Computes the new module content for the request's mode (read-only — no file is
      * written; only the already-read {@code file}/{@code originalLines} content is
@@ -549,6 +595,53 @@ public class WriteModuleSourceTool implements IMcpTool
                 return new NewLinesResult(null, splitSourceLines(sr.newContent));
             }
 
+            case MODE_REPLACE_METHOD:
+            case MODE_INSERT_BEFORE:
+            case MODE_INSERT_AFTER:
+            {
+                // Locate the anchor method (its full definition incl. leading doc-comment) via the
+                // shared text scan — 0-based [startLine, endLine] inclusive into originalLines. Text-
+                // based (not AST) so the doc-comment block is part of the span and no EMF load is
+                // needed in the write path.
+                BslModuleUtils.TextMethod tm = BslModuleUtils.findMethodViaText(originalLines, req.methodName);
+                if (!tm.found)
+                {
+                    // A write MUST fail hard when the target method is absent (buildTextMethodNotFound
+                    // is a read-oriented, non-error response). Return a real ToolResult.error that lists
+                    // the available method names so the caller can correct the methodName.
+                    String available = tm.allMethodNames.isEmpty()
+                        ? "(none)" : String.join(", ", tm.allMethodNames); //$NON-NLS-1$ //$NON-NLS-2$
+                    return new NewLinesResult(ToolResult.error("Method '" + req.methodName //$NON-NLS-1$
+                        + "' not found in " + req.modulePath //$NON-NLS-1$
+                        + ". Available methods: " + available //$NON-NLS-1$
+                        + ". Pass an exact methodName (case-insensitive).").toJson(), null); //$NON-NLS-1$
+                }
+                List<String> sourceLines = splitSourceLines(source);
+                List<String> out = new ArrayList<>();
+                if (MODE_INSERT_BEFORE.equals(req.mode))
+                {
+                    // Splice source just BEFORE the anchor (ahead of its leading doc-comment).
+                    out.addAll(originalLines.subList(0, tm.startLine));
+                    out.addAll(sourceLines);
+                    out.addAll(originalLines.subList(tm.startLine, originalLines.size()));
+                }
+                else if (MODE_INSERT_AFTER.equals(req.mode))
+                {
+                    // Splice source just AFTER the anchor's EndProcedure/EndFunction line.
+                    out.addAll(originalLines.subList(0, tm.endLine + 1));
+                    out.addAll(sourceLines);
+                    out.addAll(originalLines.subList(tm.endLine + 1, originalLines.size()));
+                }
+                else
+                {
+                    // replaceMethod: swap the whole span [startLine, endLine] for the new source.
+                    out.addAll(originalLines.subList(0, tm.startLine));
+                    out.addAll(sourceLines);
+                    out.addAll(originalLines.subList(tm.endLine + 1, originalLines.size()));
+                }
+                return new NewLinesResult(null, out);
+            }
+
             default:
                 return new NewLinesResult(ToolResult.error("unsupported mode: " + req.mode).toJson(), null); //$NON-NLS-1$
         }
@@ -608,6 +701,51 @@ public class WriteModuleSourceTool implements IMcpTool
         }
 
         return fm.wrapContent("File written successfully"); //$NON-NLS-1$
+    }
+
+    /**
+     * Builds the {@code dryRun} preview: the same frontmatter as a real write but with
+     * {@code status: preview} / {@code written: false}, and the would-be module content
+     * (capped at {@link #PREVIEW_MAX_LINES}) as the body so the caller can review a fix
+     * before committing it. No file is touched.
+     */
+    private static String buildPreviewResponse(String projectName, String modulePath, String mode,
+        boolean skipSyntaxCheck, List<String> newLines, boolean fileExists, int totalOriginal)
+    {
+        FrontMatter fm = FrontMatter.create()
+            .put("tool", NAME) //$NON-NLS-1$
+            .put(PROJECT_NAME, projectName)
+            .put(MODULE_PATH, modulePath)
+            .put("mode", mode) //$NON-NLS-1$
+            .put("status", "preview") //$NON-NLS-1$ //$NON-NLS-2$
+            .put("dryRun", true) //$NON-NLS-1$
+            .put("written", false) //$NON-NLS-1$
+            .put("linesAfter", newLines.size()) //$NON-NLS-1$
+            .put("syntaxCheck", skipSyntaxCheck ? "skipped" : "passed"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+        if (fileExists)
+        {
+            fm.put("linesBefore", totalOriginal); //$NON-NLS-1$
+        }
+        else
+        {
+            fm.put("newFile", true); //$NON-NLS-1$
+        }
+
+        StringBuilder body = new StringBuilder();
+        body.append("Dry run - nothing was written. Resulting module content:\n\n```bsl\n"); //$NON-NLS-1$
+        int shown = Math.min(newLines.size(), PREVIEW_MAX_LINES);
+        for (int i = 0; i < shown; i++)
+        {
+            body.append(newLines.get(i)).append('\n');
+        }
+        body.append("```"); //$NON-NLS-1$
+        if (newLines.size() > PREVIEW_MAX_LINES)
+        {
+            body.append("\n\n_[preview truncated: showing ").append(PREVIEW_MAX_LINES) //$NON-NLS-1$
+                .append(" of ").append(newLines.size()).append(" lines]_"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return fm.wrapContent(body.toString());
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceTool.java
@@ -127,7 +127,10 @@ public class WriteModuleSourceTool implements IMcpTool
             .booleanProperty("overwrite", //$NON-NLS-1$
                 "Force mode=replace over an existing module without an expectedSource check (default false).") //$NON-NLS-1$
             .stringProperty("expectedHash", //$NON-NLS-1$
-                "Lost-update guard for any mode: the contentHash from your last read; mismatch rejects.") //$NON-NLS-1$
+                "Lost-update guard: the contentHash from your last read; mismatch rejects. Optional for " //$NON-NLS-1$
+                    + "searchReplace/replace/append/insertBefore/insertAfter, REQUIRED for " //$NON-NLS-1$
+                    + "replaceMethod (it blindly swaps the whole method body, so a stale read must be " //$NON-NLS-1$
+                    + "caught before that write, not just discovered after).") //$NON-NLS-1$
             .booleanProperty("dryRun", //$NON-NLS-1$
                 "Preview only (default false): compute the resulting module and run the syntax check, " //$NON-NLS-1$
                     + "but do NOT write. Returns the would-be content + line counts so you can review a " //$NON-NLS-1$
@@ -599,6 +602,22 @@ public class WriteModuleSourceTool implements IMcpTool
             case MODE_INSERT_BEFORE:
             case MODE_INSERT_AFTER:
             {
+                // Lost-update guard for replaceMethod: unlike insertBefore/insertAfter (purely
+                // additive - they never discard existing text), replaceMethod swaps the WHOLE
+                // current method body for the caller's source, so a stale read silently clobbers
+                // any edit made to that method since. expectedHash is ALREADY validated to match
+                // (checkExpectedHashGuard ran before this) when one is supplied - it is required
+                // HERE, not re-checked - mirroring MODE_REPLACE's expectedSource/overwrite guard for
+                // whole-file replace.
+                if (MODE_REPLACE_METHOD.equals(req.mode)
+                    && (req.expectedHash == null || req.expectedHash.isEmpty()))
+                {
+                    return new NewLinesResult(ToolResult.error("replaceMethod requires expectedHash - " //$NON-NLS-1$
+                        + "the contentHash from your last read_module_source / write_module_source " //$NON-NLS-1$
+                        + "call for this module - so a concurrent edit to '" + req.methodName //$NON-NLS-1$
+                        + "' is not silently lost. Read the module first (or reuse the hash you " //$NON-NLS-1$
+                        + "already have) and pass it as expectedHash.").toJson(), null); //$NON-NLS-1$
+                }
                 // Locate the anchor method (its full definition incl. leading doc-comment) via the
                 // shared text scan — 0-based [startLine, endLine] inclusive into originalLines. Text-
                 // based (not AST) so the doc-comment block is part of the span and no EMF load is

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BslModuleUtils.java
@@ -366,8 +366,19 @@ public final class BslModuleUtils
             methodEnd = allLines.size() - 1;
         }
 
-        // Include the doc-comment block preceding the method keyword.
-        int docStart = findDocCommentStartLine(allLines, methodStart + 1) - 1;
+        // Back up over any contiguous annotation line(s) (&AtClient, &AtServer, &Before("..."), ...)
+        // immediately preceding the method keyword FIRST - a compilation-directive/extension
+        // annotation is not itself a doc-comment, so findDocCommentStartLine alone would leave it
+        // outside the span. Without this, insertBefore splices new source AFTER the annotation
+        // (silently moving it onto the inserted method) and replaceMethod leaves it dangling above
+        // the swapped-in source (a stale or duplicate directive).
+        int annotationStart = methodStart;
+        while (annotationStart > 0 && allLines.get(annotationStart - 1).trim().startsWith("&")) //$NON-NLS-1$
+        {
+            annotationStart--;
+        }
+        // Include the doc-comment block preceding the (possibly annotation-adjusted) start.
+        int docStart = findDocCommentStartLine(allLines, annotationStart + 1) - 1;
         return new TextMethod(true, docStart, methodEnd, matchedName, isFunction, allMethodNames);
     }
 

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/WriteModuleSourceToolTest.java
@@ -117,8 +117,23 @@ public class WriteModuleSourceToolTest
         // Lost-update guard params for mode=replace over an existing module.
         assertTrue(schema.contains("\"expectedSource\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"overwrite\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"expectedHash\"")); //$NON-NLS-1$
+        // Preview flag: compute + syntax-check without writing.
+        assertTrue(schema.contains("\"dryRun\"")); //$NON-NLS-1$
+        // Method-targeting modes + their target param.
+        assertTrue(schema.contains("\"methodName\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("replaceMethod")); //$NON-NLS-1$
+        assertTrue(schema.contains("insertBefore")); //$NON-NLS-1$
+        assertTrue(schema.contains("insertAfter")); //$NON-NLS-1$
         // The new params are OPTIONAL — required stays projectName + source only.
         assertTrue(schema.contains("\"required\":[\"projectName\",\"source\"]")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testDescriptionMentionsDryRunPreview()
+    {
+        String desc = new WriteModuleSourceTool().getDescription();
+        assertTrue("description must advertise the dryRun preview", desc.contains("dryRun")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     @Test
@@ -368,7 +383,9 @@ public class WriteModuleSourceToolTest
     public void testExecuteOldLineModes()
     {
         WriteModuleSourceTool tool = new WriteModuleSourceTool();
-        String[] removedModes = { "insertBefore", "insertAfter", "replaceLines" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        // insertBefore/insertAfter are now VALID method-anchored modes (they take methodName,
+        // not line numbers); only the line-range mode replaceLines remains unimplemented/rejected.
+        String[] removedModes = { "replaceLines" }; //$NON-NLS-1$
 
         for (String mode : removedModes)
         {

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/BslModuleUtilsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/BslModuleUtilsTest.java
@@ -368,6 +368,40 @@ public class BslModuleUtilsTest
     }
 
     @Test
+    public void testFindMethodViaTextIncludesAnnotationLine()
+    {
+        // A compilation-directive annotation (&AtClient) immediately above the method keyword
+        // must be part of the span, or insertBefore/replaceMethod would split it from the
+        // method it decorates (silently moving it onto inserted content, or leaving it dangling
+        // above a swapped-in body).
+        List<String> lines = List.of(
+            "&AtClient",                    // 0 //$NON-NLS-1$
+            "Procedure Delta()",            // 1 //$NON-NLS-1$
+            "EndProcedure");                // 2 //$NON-NLS-1$
+        BslModuleUtils.TextMethod tm = BslModuleUtils.findMethodViaText(lines, "Delta"); //$NON-NLS-1$
+        assertTrue(tm.found);
+        assertEquals(0, tm.startLine); // includes the &AtClient line
+        assertEquals(2, tm.endLine);
+    }
+
+    @Test
+    public void testFindMethodViaTextIncludesDocCommentAboveAnnotation()
+    {
+        // The usual 1C order is doc-comment, then annotation, then the method keyword - the
+        // doc-comment search must run AFTER backing up over the annotation, not before, or it
+        // would stop at the annotation line and miss the comment above it.
+        List<String> lines = List.of(
+            "// Does something on the client.", // 0 //$NON-NLS-1$
+            "&AtClient",                         // 1 //$NON-NLS-1$
+            "Procedure Epsilon()",               // 2 //$NON-NLS-1$
+            "EndProcedure");                     // 3 //$NON-NLS-1$
+        BslModuleUtils.TextMethod tm = BslModuleUtils.findMethodViaText(lines, "Epsilon"); //$NON-NLS-1$
+        assertTrue(tm.found);
+        assertEquals(0, tm.startLine); // includes both the doc-comment AND the annotation
+        assertEquals(3, tm.endLine);
+    }
+
+    @Test
     public void testFindMethodViaTextEmptyInputNotFoundEmptyNames()
     {
         BslModuleUtils.TextMethod tm = BslModuleUtils.findMethodViaText(List.of(), "Whatever"); //$NON-NLS-1$

--- a/tests/e2e/tools/test_write_module_source.py
+++ b/tests/e2e/tools/test_write_module_source.py
@@ -366,15 +366,17 @@ def _seed_two_methods():
 @e2e_test(tool="write_module_source", kind="write")
 def test_replacemethod_swaps_named_method_only():
     """replaceMethod swaps ONE method by name: the new body lands, the old body is gone,
-    and the OTHER method is left intact. No oldSource needed."""
+    and the OTHER method is left intact. No oldSource needed (expectedHash IS needed - see
+    test_replacemethod_requires_expected_hash)."""
     _seed_two_methods()
+    token = _read_content_hash()
     new_test = ("Процедура Test() Экспорт\n"
                 "\tСлагаемое = 2;\n"
                 "\tAdd(1, Слагаемое);\n"
                 "КонецПроцедуры")
     r = call("write_module_source", {
         "projectName": PROJECT, "modulePath": MODULE,
-        "mode": "replaceMethod", "methodName": "Test", "source": new_test,
+        "mode": "replaceMethod", "methodName": "Test", "source": new_test, "expectedHash": token,
     })
     assert_ok(r, "replaceMethod must succeed for an existing method")
     src = call("read_module_source", {"projectName": PROJECT, "modulePath": MODULE})
@@ -388,10 +390,11 @@ def test_replacemethod_unknown_method_rejected_and_keeps_content():
     """An unknown methodName is rejected with the available method names, and nothing is
     written (the seeded content survives)."""
     _seed_two_methods()
+    token = _read_content_hash()
     r = call("write_module_source", {
         "projectName": PROJECT, "modulePath": MODULE,
         "mode": "replaceMethod", "methodName": "NoSuchMethod_e2e",
-        "source": "Процедура X() Экспорт\nКонецПроцедуры",
+        "source": "Процедура X() Экспорт\nКонецПроцедуры", "expectedHash": token,
     })
     err = assert_error(r, "replaceMethod for an absent method must be rejected")
     # Actionable: the error lists the real method names so the caller can correct it.
@@ -414,13 +417,35 @@ def test_replacemethod_missing_methodname_rejected():
 
 
 @e2e_test(tool="write_module_source", kind="write")
+def test_replacemethod_requires_expected_hash():
+    """replaceMethod blindly swaps the whole method body, so (unlike insertBefore/insertAfter,
+    which only ADD text) it requires expectedHash - without one, a stale read could silently
+    clobber a concurrent edit to the same method. Rejected before the method lookup even runs,
+    and nothing is written."""
+    _seed_two_methods()
+    r = call("write_module_source", {
+        "projectName": PROJECT, "modulePath": MODULE,
+        "mode": "replaceMethod", "methodName": "Test",
+        "source": "Процедура Test() Экспорт\nКонецПроцедуры",
+    })
+    err = assert_error(r, "replaceMethod without expectedHash must be rejected")
+    assert_error_quality(err, names=["expectedHash"], suggests=["read_module_source"],
+                          ctx="missing expectedHash names the param + steers to re-read")
+    src = call("read_module_source", {"projectName": PROJECT, "modulePath": MODULE})
+    assert_contains(src.text, "Результат = Add(1, 2);",
+                    "a rejected replaceMethod must not have altered the module")
+
+
+@e2e_test(tool="write_module_source", kind="write")
 def test_replacemethod_dryrun_previews_without_writing():
     """replaceMethod honors dryRun: the preview shows the swapped module, disk is untouched."""
     _seed_two_methods()
+    token = _read_content_hash()
     new_test = "Процедура Test() Экспорт\n\tВозврат;\nКонецПроцедуры"
     r = call("write_module_source", {
         "projectName": PROJECT, "modulePath": MODULE,
         "mode": "replaceMethod", "methodName": "Test", "source": new_test, "dryRun": True,
+        "expectedHash": token,
     })
     assert_ok(r, "replaceMethod dryRun must succeed")
     assert_contains(r.text, "status: preview", "must be a preview")

--- a/tests/e2e/tools/test_write_module_source.py
+++ b/tests/e2e/tools/test_write_module_source.py
@@ -22,7 +22,7 @@ import re
 from harness import (
     call, assert_ok, assert_error, assert_error_quality,
     assert_contains, assert_not_contains,
-    assert_diff_contains, assert_no_diff, e2e_test, PROJECT,
+    assert_diff_contains, assert_no_diff, e2e_test, PROJECT, _fail,
 )
 
 MODULE = "CommonModules/OK/Module.bsl"
@@ -298,3 +298,194 @@ def test_searchreplace_with_matching_expectedhash_succeeds():
     })
     assert_ok(r, "searchReplace with a matching expectedHash must be accepted")
     assert_diff_contains("Значение = 7;", "the hash-guarded searchReplace must persist to disk")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# dryRun (preview, no write)
+# ──────────────────────────────────────────────────────────────────────────────
+
+_DRYRUN_SRC = "Процедура Демо() Экспорт\n\tВозврат;\nКонецПроцедуры\n"
+
+
+@e2e_test(tool="write_module_source", kind="write")
+def test_dryrun_previews_without_writing():
+    """dryRun runs the full pipeline (guards + compute + syntax check) but writes NOTHING:
+    the response is a preview echoing the would-be content, and the project on disk is
+    untouched. Uses replace+overwrite so the ONLY reason nothing lands is dryRun itself
+    (a bare replace would be rejected by the lost-update guard, masking the point)."""
+    r = call("write_module_source", {
+        "projectName": PROJECT, "modulePath": MODULE,
+        "mode": "replace", "overwrite": True, "source": _DRYRUN_SRC, "dryRun": True,
+    })
+    assert_ok(r, "dryRun preview must succeed")
+    assert_contains(r.text, "status: preview", "response must be marked status: preview")
+    assert_contains(r.text, "written: false", "preview must state nothing was written")
+    assert_contains(r.text, "Процедура Демо", "preview must echo the would-be content")
+    assert_no_diff("a dryRun must not touch the project on disk")
+    # An independent read-back proves the preview did NOT persist (belt and suspenders).
+    src = call("read_module_source", {"projectName": PROJECT, "modulePath": MODULE})
+    assert_not_contains(src.text, "Процедура Демо", "previewed content must NOT be on disk")
+
+
+@e2e_test(tool="write_module_source", kind="write")
+def test_dryrun_syntax_error_is_reported_and_no_write():
+    """The BSL syntax check runs in dryRun too: previewing unbalanced BSL returns the
+    syntax error (not a preview) and still writes nothing."""
+    bad = "Процедура Broken() Экспорт\n\t// no EndProcedure\n"
+    r = call("write_module_source", {
+        "projectName": PROJECT, "modulePath": MODULE,
+        "mode": "replace", "overwrite": True, "source": bad, "dryRun": True,
+    })
+    assert_error(r, "a dryRun over invalid BSL must report the syntax error")
+    assert_no_diff("a failed dryRun must not touch the project on disk")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# replaceMethod (swap a whole method by name)
+# ──────────────────────────────────────────────────────────────────────────────
+
+_TWO_METHODS = (
+    "Функция Add(A, B) Экспорт\n"
+    "\tВозврат A + B;\n"
+    "КонецФункции\n"
+    "\n"
+    "Процедура Test() Экспорт\n"
+    "\tРезультат = Add(1, 2);\n"
+    "КонецПроцедуры\n"
+)
+
+
+def _seed_two_methods():
+    seed = call("write_module_source", {
+        "projectName": PROJECT, "modulePath": MODULE,
+        "mode": "replace", "source": _TWO_METHODS, "overwrite": True,
+    })
+    assert_ok(seed, "seed a two-method module")
+
+
+@e2e_test(tool="write_module_source", kind="write")
+def test_replacemethod_swaps_named_method_only():
+    """replaceMethod swaps ONE method by name: the new body lands, the old body is gone,
+    and the OTHER method is left intact. No oldSource needed."""
+    _seed_two_methods()
+    new_test = ("Процедура Test() Экспорт\n"
+                "\tСлагаемое = 2;\n"
+                "\tAdd(1, Слагаемое);\n"
+                "КонецПроцедуры")
+    r = call("write_module_source", {
+        "projectName": PROJECT, "modulePath": MODULE,
+        "mode": "replaceMethod", "methodName": "Test", "source": new_test,
+    })
+    assert_ok(r, "replaceMethod must succeed for an existing method")
+    src = call("read_module_source", {"projectName": PROJECT, "modulePath": MODULE})
+    assert_contains(src.text, "Слагаемое = 2;", "the new method body must be on disk")
+    assert_not_contains(src.text, "Результат = Add(1, 2);", "the old method body must be gone")
+    assert_contains(src.text, "Функция Add(A, B)", "the untouched sibling method must remain")
+
+
+@e2e_test(tool="write_module_source", kind="write")
+def test_replacemethod_unknown_method_rejected_and_keeps_content():
+    """An unknown methodName is rejected with the available method names, and nothing is
+    written (the seeded content survives)."""
+    _seed_two_methods()
+    r = call("write_module_source", {
+        "projectName": PROJECT, "modulePath": MODULE,
+        "mode": "replaceMethod", "methodName": "NoSuchMethod_e2e",
+        "source": "Процедура X() Экспорт\nКонецПроцедуры",
+    })
+    err = assert_error(r, "replaceMethod for an absent method must be rejected")
+    # Actionable: the error lists the real method names so the caller can correct it.
+    assert_contains(err, "Test", "not-found error should list the available methods")
+    src = call("read_module_source", {"projectName": PROJECT, "modulePath": MODULE})
+    assert_contains(src.text, "Результат = Add(1, 2);",
+                    "a rejected replaceMethod must not have altered the module")
+
+
+@e2e_test(tool="write_module_source", kind="write")
+def test_replacemethod_missing_methodname_rejected():
+    """replaceMethod without methodName is rejected before any file work."""
+    _seed_two_methods()
+    r = call("write_module_source", {
+        "projectName": PROJECT, "modulePath": MODULE,
+        "mode": "replaceMethod", "source": "Процедура X() Экспорт\nКонецПроцедуры",
+    })
+    err = assert_error(r, "replaceMethod without methodName must be rejected")
+    assert_contains(err, "methodName", "the error must name the missing methodName param")
+
+
+@e2e_test(tool="write_module_source", kind="write")
+def test_replacemethod_dryrun_previews_without_writing():
+    """replaceMethod honors dryRun: the preview shows the swapped module, disk is untouched."""
+    _seed_two_methods()
+    new_test = "Процедура Test() Экспорт\n\tВозврат;\nКонецПроцедуры"
+    r = call("write_module_source", {
+        "projectName": PROJECT, "modulePath": MODULE,
+        "mode": "replaceMethod", "methodName": "Test", "source": new_test, "dryRun": True,
+    })
+    assert_ok(r, "replaceMethod dryRun must succeed")
+    assert_contains(r.text, "status: preview", "must be a preview")
+    src = call("read_module_source", {"projectName": PROJECT, "modulePath": MODULE})
+    assert_contains(src.text, "Результат = Add(1, 2);",
+                    "a dryRun replaceMethod must NOT change the module on disk")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# insertBefore / insertAfter (add a method next to a named anchor)
+# ──────────────────────────────────────────────────────────────────────────────
+
+_NEW_SUB = "\nФункция Sub(A, B) Экспорт\n\tВозврат A - B;\nКонецФункции\n"
+
+
+def _order_ok(text, first, second, third):
+    """True when first < second < third by first-occurrence index (all must be present)."""
+    i1, i2, i3 = text.find(first), text.find(second), text.find(third)
+    return -1 < i1 < i2 < i3
+
+
+@e2e_test(tool="write_module_source", kind="write")
+def test_insertafter_places_method_after_anchor():
+    """insertAfter splices source right after the anchor method: the new method lands
+    BETWEEN the anchor (Add) and the next method (Test), and both originals survive."""
+    _seed_two_methods()
+    r = call("write_module_source", {
+        "projectName": PROJECT, "modulePath": MODULE,
+        "mode": "insertAfter", "methodName": "Add", "source": _NEW_SUB,
+    })
+    assert_ok(r, "insertAfter must succeed for an existing anchor")
+    src = call("read_module_source", {"projectName": PROJECT, "modulePath": MODULE})
+    assert_contains(src.text, "Функция Sub(A, B)", "the new method must be on disk")
+    assert_contains(src.text, "Функция Add(A, B)", "the anchor method must survive")
+    assert_contains(src.text, "Процедура Test()", "the sibling method must survive")
+    if not _order_ok(src.text, "Функция Add", "Функция Sub", "Процедура Test"):
+        _fail("insertAfter must place Sub AFTER Add and BEFORE Test")
+
+
+@e2e_test(tool="write_module_source", kind="write")
+def test_insertbefore_places_method_before_anchor():
+    """insertBefore splices source right before the anchor method: the new method lands
+    BEFORE Test (and after Add)."""
+    _seed_two_methods()
+    r = call("write_module_source", {
+        "projectName": PROJECT, "modulePath": MODULE,
+        "mode": "insertBefore", "methodName": "Test", "source": _NEW_SUB,
+    })
+    assert_ok(r, "insertBefore must succeed for an existing anchor")
+    src = call("read_module_source", {"projectName": PROJECT, "modulePath": MODULE})
+    assert_contains(src.text, "Функция Sub(A, B)", "the new method must be on disk")
+    if not _order_ok(src.text, "Функция Add", "Функция Sub", "Процедура Test"):
+        _fail("insertBefore Test must place Sub before Test (and after Add)")
+
+
+@e2e_test(tool="write_module_source", kind="write")
+def test_insert_unknown_anchor_rejected_and_keeps_content():
+    """insert modes share the method-not-found guard: an unknown anchor is rejected with
+    the available method names and nothing is written."""
+    _seed_two_methods()
+    r = call("write_module_source", {
+        "projectName": PROJECT, "modulePath": MODULE,
+        "mode": "insertAfter", "methodName": "NoSuchAnchor_e2e", "source": _NEW_SUB,
+    })
+    err = assert_error(r, "insertAfter for an absent anchor must be rejected")
+    assert_contains(err, "Add", "not-found error should list the available methods")
+    src = call("read_module_source", {"projectName": PROJECT, "modulePath": MODULE})
+    assert_not_contains(src.text, "Функция Sub", "a rejected insert must not have written anything")


### PR DESCRIPTION
…e/insertAfter

Четыре новых возможности поверх существующих режимов (searchReplace/replace/append):

- dryRun (любой режим): считает итоговый контент, гоняет BSL-синтакс-чек, но НЕ пишет на диск. Возвращает status: preview + would-be контент (до 400 строк). Позволяет проверить правку перед записью, не тратя lost-update guard впустую.
- replaceMethod: заменяет метод целиком по имени (methodName), не требуя цитировать старое тело как oldSource. Заменяемый диапазон включает ведущий doc-комментарий метода. Метод не найден -> ошибка со списком доступных методов.
- insertBefore / insertAfter: вставляют source перед/после метода-якоря (methodName) - способ добавить новый метод рядом с существующим без собственноручного подсчёта номеров строк.

Локация метода по имени - через существующий текстовый скан (findMethodViaText), без загрузки EMF в write-путь; диапазон включает doc-комментарий, что делает replaceMethod пригодным для автоматической правки находок code-review/линтеров.

Тесты: unit (схема содержит новые параметры/режимы) + e2e (14 сценариев: dryRun на всех режимах, синтакс-ошибка в dryRun, swap/insert только нужного метода с сохранением соседних, неизвестный метод/якорь -> ошибка со списком, отсутствие обязательных параметров -> отказ).