### PR TITLE
e2e: переименование, пережившее свой вызов, больше не отравляет прогон (#320)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -344,12 +344,21 @@ jobs:
           # cached, the workspace index is not), so give readiness a generous ceiling
           # before run_all aborts with a single clear error.
           E2E_PROJECT_READY_TIMEOUT: "1200"
-          # Per-CALL socket timeout. A cascading rename_metadata_object (Catalog: updates
-          # refs across BSL/forms/metadata + re-export + revalidate) can exceed the 180s
-          # default on a cold 2-core cloud runner — the call then times out and wedges the
-          # model for the next test. Give heavy mutating calls headroom (still < the 600s
-          # per-test timeout in run_all).
-          MCP_CALL_TIMEOUT: "300"
+          # Per-CALL socket timeout. A cascading rename_metadata_object can enter EDT's
+          # refactoring while the derived-data pipeline still has work; the refactoring then
+          # waits for that pipeline from inside its own BM batch session and takes ~301s
+          # (measured: "Completed tools/call: rename_metadata_object in 301090ms, outcome=ok"
+          # right after "Client connection lost: Broken pipe"). The tool now drains the
+          # pipeline first, so that path should not be reached — but 300 sat EXACTLY on the
+          # boundary, which is why every collision cost a run. Keep the budget clear of it,
+          # and below the per-test timeout below.
+          MCP_CALL_TIMEOUT: "600"
+          # Bound what reset_model may spend BEFORE and AFTER its clean_project. Left to default
+          # it inherits E2E_PROJECT_READY_TIMEOUT (1200 above, sized for the COLD first index),
+          # and reset_model can spend it twice per test - which alone exceeds the per-test cap and
+          # turns a legitimately slow cleanup into a reported hang. A post-write settle is not a
+          # cold index; 600 is generous for it.
+          E2E_MODEL_SETTLE_TIMEOUT: "600"
           # Unbuffer stdout: otherwise Python block-buffers in CI (stdout is a pipe), so
           # the readiness-wait countdown only appears when the process exits — which looks
           # like a hang during the (long) index wait. -u/PYTHONUNBUFFERED stream it live.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RenameMetadataObjectTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RenameMetadataObjectTool.java
@@ -34,6 +34,16 @@ import com.ditrix.edt.mcp.server.utils.ProjectStateChecker;
  */
 public class RenameMetadataObjectTool implements IMcpTool
 {
+    /**
+     * How long the pre-flight waits for the derived-data pipeline to drain before refusing.
+     * <p>
+     * Sized against what the alternative costs: entering the cascade with the pipeline still busy
+     * makes EDT wait for it from INSIDE its own batch session, which took 301 SECONDS on CI. Waiting
+     * here is the same wall-clock in the worst case, but it is OUR wait - bounded, logged, and
+     * ending in an actionable error instead of a silent block on the wire.
+     */
+    private static final long SETTLE_TIMEOUT_MS = 60_000L;
+
     public static final String NAME = "rename_metadata_object"; //$NON-NLS-1$
 
     /** Input param: FQN of the metadata object to rename. */
@@ -149,7 +159,15 @@ public class RenameMetadataObjectTool implements IMcpTool
         // object, miss some references, and still report success — leaving dangling old
         // references (silent partial corruption). Refuse only for that transient BUILDING
         // state; a missing/closed project falls through to the value-naming error below.
-        String building = ProjectStateChecker.buildingErrorOrNull(projectName);
+        // Drain the derived-data pipeline before the cascade rather than merely asking whether it
+        // is quiet. NB this narrows the window, it does not close it: EDT builds the refactoring
+        // INSIDE the syncExec below (saving dirty editors and running an incremental build as it
+        // goes), so fresh work can still be queued between here and perform(). Closing it properly
+        // needs an EDT-supported "quiesce then open the batch session" step; doing it ourselves -
+        // by draining between construction and perform - would mean releasing the UI thread in the
+        // middle of a rename, which drops the serialisation that keeps a concurrent write from
+        // making the built cascade stale. See issue #320.
+        String building = ProjectStateChecker.settleBeforeCascadeOrError(projectName, SETTLE_TIMEOUT_MS);
         if (building != null)
         {
             return ToolResult.error(building).toJson();

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
@@ -354,7 +354,7 @@ public final class ProjectStateChecker
             {
                 continue;
             }
-            if (base.equals(env.resolveBaseProject(candidate)))
+            if (env.isExtensionProject(candidate) && base.equals(env.resolveBaseProject(candidate)))
             {
                 participants.add(candidate);
             }
@@ -407,10 +407,23 @@ public final class ProjectStateChecker
         List<IProject> getOpenDtProjects();
 
         /**
-         * Resolves the BASE (parent) project a dependent project (e.g. a configuration extension)
-         * derives from, or {@code null} when {@code project} is not dependent on another project.
+         * Resolves the BASE (parent) project a dependent project derives from, or {@code null} when
+         * {@code project} is not dependent on another project. NB an EXTERNAL-OBJECTS project is
+         * dependent too - see {@link #isExtensionProject(IProject)} for why that matters here.
          */
         IProject resolveBaseProject(IProject project);
+
+        /**
+         * Whether {@code project} is a configuration EXTENSION (not merely dependent).
+         * <p>
+         * The cascade builds one refactoring per EXTENSION of the renamed object's configuration.
+         * An external-objects project shares the same parent and would answer
+         * {@link #resolveBaseProject(IProject)} identically, yet takes no part in that cascade -
+         * treating it as a participant would let it spend the shared drain budget and, worse,
+         * refuse the rename with an "extends ... still building" error about a project the rename
+         * never touches.
+         */
+        boolean isExtensionProject(IProject project);
 
         /** Waits, bounded by {@code timeoutMs}, for {@code project}'s derived-data pipeline to drain. */
         void waitForDerivedData(IProject project, long timeoutMs);
@@ -446,6 +459,12 @@ public final class ProjectStateChecker
             public IProject resolveBaseProject(IProject project)
             {
                 return ExtensionOriginUtils.resolveBaseProject(project);
+            }
+
+            @Override
+            public boolean isExtensionProject(IProject project)
+            {
+                return ExtensionOriginUtils.isExtensionProject(project);
             }
 
             @Override

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
@@ -280,6 +280,22 @@ public final class ProjectStateChecker
         }
         IProject project = org.eclipse.core.resources.ResourcesPlugin.getWorkspace()
             .getRoot().getProject(projectName);
+        return settleBeforeCascadeOrError(project, settleTimeoutMs, CascadeEnvironment.DEFAULT);
+    }
+
+    /**
+     * Seam-taking variant of {@link #settleBeforeCascadeOrError(String, long)}, package-visible so a
+     * unit test can drive it with a fake {@link CascadeEnvironment} and no live workspace / EDT
+     * services. Production code only ever reaches this through the {@code (String, long)} overload,
+     * which resolves {@code project} from the workspace and injects {@link CascadeEnvironment#DEFAULT}.
+     *
+     * @param project the project the cascade will mutate
+     * @param settleTimeoutMs how long to wait for the pipeline to drain
+     * @param env the seam over the workspace/derived-data services
+     * @return the building message with a retry hint, or {@code null} when the cascade may proceed
+     */
+    static String settleBeforeCascadeOrError(IProject project, long settleTimeoutMs, CascadeEnvironment env)
+    {
         if (!project.exists() || !project.isOpen())
         {
             // Nothing to drain, and asking anyway can block on a project EDT is still disposing.
@@ -294,72 +310,61 @@ public final class ProjectStateChecker
         // an EDT project at all) waitAllComputations returns immediately, so the cost is zero
         // where there is nothing to wait for.
         long deadline = System.currentTimeMillis() + settleTimeoutMs;
-        BuildUtils.waitForDerivedData(project, settleTimeoutMs);
+        env.waitForDerivedData(project, settleTimeoutMs);
         // A cascade is not confined to the named project: a rename builds one refactoring per
-        // participating project, which includes the configuration EXTENSIONS that adopt the
-        // renamed object. An extension whose pipeline is still busy collides with the batch
-        // session exactly like the base one, so drain the others too - they share ONE deadline,
-        // so this cannot multiply the wait by the number of projects in the workspace.
-        String stillBuilding = drainOtherOpenProjects(project, deadline);
-        String base = buildingErrorOrNull(project);
-        if (base != null)
+        // PARTICIPATING project, which includes the configuration EXTENSIONS that adopt the
+        // renamed object - drain those too, sharing the SAME deadline, so this cannot multiply
+        // the wait. An unrelated open project takes no part in the refactoring and cannot collide
+        // with its batch session, so it is never drained or asked about here: one slow, unrelated
+        // project must not eat the shared deadline and delay a rename of an otherwise-ready project.
+        String stillBuilding = drainParticipants(project, deadline, env);
+        if (env.isBuilding(project))
         {
-            return base;
+            // Shaped by buildingErrorOrNull, the single place that composes this message.
+            return buildingErrorOrNull(project);
         }
         // A PARTICIPATING extension that did not settle is refused like the base project would be:
-        // the cascade is about to enter its refactoring too. An UNRELATED project that happens to
-        // be indexing is not - it was drained as a courtesy, but letting it refuse would mean any
-        // busy project in the workspace blocks every rename.
+        // the cascade is about to enter its refactoring too.
         return stillBuilding;
     }
 
     /**
-     * Waits for the other open EDT projects' derived data, until the shared {@code deadline}.
+     * Waits for the PARTICIPATING open EDT projects' derived data, until the shared
+     * {@code deadline}, then verifies them unconditionally.
      * <p>
-     * PARTICIPANTS FIRST, and verified unconditionally. The projects that take part in the cascade
-     * are the ones that extend {@code base}: the rename builds a refactoring for each of them, so
-     * one that is still building is the collision this whole pre-flight exists to prevent. An
-     * unrelated project is drained only with whatever time is left over - it is a courtesy, and it
-     * must never consume the deadline a participant needed, nor decide the answer.
+     * The projects that take part in the cascade are the ones that extend {@code base} (per
+     * {@link CascadeEnvironment#resolveBaseProject(IProject)}): the rename builds a refactoring
+     * for each of them, so one that is still building is the collision this whole pre-flight
+     * exists to prevent. An unrelated open project is not a participant - it cannot collide with
+     * this cascade, so it is never drained, never asked about, and never able to consume the
+     * shared deadline or cause a refusal.
      *
      * @param base the project already drained by the caller
      * @param deadline absolute time (ms) the whole drain must not exceed
+     * @param env the seam over the workspace/derived-data services
      * @return the retryable message for a PARTICIPATING extension that is still building (naming
      *         it), or {@code null} when every participant settled
      */
-    private static String drainOtherOpenProjects(IProject base, long deadline)
+    private static String drainParticipants(IProject base, long deadline, CascadeEnvironment env)
     {
-        IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
-        if (dtProjectManager == null)
-        {
-            return null;
-        }
         List<IProject> participants = new ArrayList<>();
-        List<IProject> others = new ArrayList<>();
-        for (IProject other : org.eclipse.core.resources.ResourcesPlugin.getWorkspace().getRoot()
-            .getProjects())
+        for (IProject candidate : env.getOpenDtProjects())
         {
-            if (other.equals(base) || !other.exists() || !other.isOpen()
-                || dtProjectManager.getDtProject(other) == null)
+            if (candidate.equals(base))
             {
                 continue;
             }
-            if (base.equals(ExtensionOriginUtils.resolveBaseProject(other)))
+            if (base.equals(env.resolveBaseProject(candidate)))
             {
-                participants.add(other);
-            }
-            else
-            {
-                others.add(other);
+                participants.add(candidate);
             }
         }
-        drainAll(participants, deadline);
-        drainAll(others, deadline);
-        // Checked AFTER both drains and REGARDLESS of the remaining time: running out of deadline
+        drainAll(participants, deadline, env);
+        // Checked AFTER the drain and REGARDLESS of the remaining time: running out of deadline
         // is not a reason to stop asking whether a participant is ready - it is a reason to say so.
         for (IProject participant : participants)
         {
-            if (buildingErrorOrNull(participant) != null)
+            if (env.isBuilding(participant))
             {
                 return "Project '" + participant.getName() + "' extends '" + base.getName() //$NON-NLS-1$
                     + "' and is still building, so it takes part in this cascade with an " //$NON-NLS-1$
@@ -370,7 +375,7 @@ public final class ProjectStateChecker
     }
 
     /** Drains each project in turn, giving up as soon as the shared deadline is spent. */
-    private static void drainAll(List<IProject> projects, long deadline)
+    private static void drainAll(List<IProject> projects, long deadline, CascadeEnvironment env)
     {
         for (IProject project : projects)
         {
@@ -379,8 +384,82 @@ public final class ProjectStateChecker
             {
                 return;
             }
-            BuildUtils.waitForDerivedData(project, remaining);
+            env.waitForDerivedData(project, remaining);
         }
+    }
+
+    /**
+     * Seam over the workspace / derived-data services the cascade pre-flight needs, so a unit
+     * test can substitute a fake and exercise {@link #drainParticipants(IProject, long,
+     * CascadeEnvironment)} (and {@link #settleBeforeCascadeOrError(IProject, long,
+     * CascadeEnvironment)}) with no live workspace. {@link #DEFAULT} delegates to the same EDT
+     * services ({@link IDtProjectManager}, {@link ExtensionOriginUtils#resolveBaseProject(IProject)},
+     * {@link BuildUtils#waitForDerivedData(IProject, long)}) this pre-flight always used.
+     * <p>
+     * Public (unlike the package-visible {@code settleBeforeCascadeOrError} overload that takes
+     * it): Mockito's proxy generation cannot mock a non-public type across the fragment-test /
+     * host-bundle classloader split this test bundle runs under, so the type itself must be
+     * accessible even though only test code in this package ever implements or references it.
+     */
+    public interface CascadeEnvironment
+    {
+        /** The open EDT projects currently in the workspace (participants and unrelated alike). */
+        List<IProject> getOpenDtProjects();
+
+        /**
+         * Resolves the BASE (parent) project a dependent project (e.g. a configuration extension)
+         * derives from, or {@code null} when {@code project} is not dependent on another project.
+         */
+        IProject resolveBaseProject(IProject project);
+
+        /** Waits, bounded by {@code timeoutMs}, for {@code project}'s derived-data pipeline to drain. */
+        void waitForDerivedData(IProject project, long timeoutMs);
+
+        /** Whether {@code project}'s derived-data pipeline is still (transiently) building. */
+        boolean isBuilding(IProject project);
+
+        /** Delegates to the live, {@code Activator}-backed EDT services. */
+        CascadeEnvironment DEFAULT = new CascadeEnvironment()
+        {
+            @Override
+            public List<IProject> getOpenDtProjects()
+            {
+                List<IProject> result = new ArrayList<>();
+                IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
+                if (dtProjectManager == null)
+                {
+                    return result;
+                }
+                for (IProject candidate : org.eclipse.core.resources.ResourcesPlugin.getWorkspace()
+                    .getRoot().getProjects())
+                {
+                    if (candidate.exists() && candidate.isOpen()
+                        && dtProjectManager.getDtProject(candidate) != null)
+                    {
+                        result.add(candidate);
+                    }
+                }
+                return result;
+            }
+
+            @Override
+            public IProject resolveBaseProject(IProject project)
+            {
+                return ExtensionOriginUtils.resolveBaseProject(project);
+            }
+
+            @Override
+            public void waitForDerivedData(IProject project, long timeoutMs)
+            {
+                BuildUtils.waitForDerivedData(project, timeoutMs);
+            }
+
+            @Override
+            public boolean isBuilding(IProject project)
+            {
+                return buildingErrorOrNull(project) != null;
+            }
+        };
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
@@ -290,8 +290,48 @@ public final class ProjectStateChecker
         // skipped on the very call it exists for. With a quiet pipeline (or a name that is not
         // an EDT project at all) waitAllComputations returns immediately, so the cost is zero
         // where there is nothing to wait for.
+        long deadline = System.currentTimeMillis() + settleTimeoutMs;
         BuildUtils.waitForDerivedData(project, settleTimeoutMs);
+        // A cascade is not confined to the named project: a rename builds one refactoring per
+        // participating project, which includes the configuration EXTENSIONS that adopt the
+        // renamed object. An extension whose pipeline is still busy collides with the batch
+        // session exactly like the base one, so drain the others too - they share ONE deadline,
+        // so this cannot multiply the wait by the number of projects in the workspace.
+        drainOtherOpenProjects(project, deadline);
+        // The refusal, though, is decided on the NAMED project only. It is always a participant,
+        // while an unrelated project that happens to be indexing must not be able to refuse every
+        // rename in the workspace - for those the drain above is the whole benefit.
         return buildingErrorOrNull(project);
+    }
+
+    /**
+     * Waits for every OTHER open EDT project's derived data, until the shared {@code deadline}.
+     *
+     * @param except the project already drained by the caller
+     * @param deadline absolute time (ms) the whole drain must not exceed
+     */
+    private static void drainOtherOpenProjects(IProject except, long deadline)
+    {
+        IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
+        if (dtProjectManager == null)
+        {
+            return;
+        }
+        for (IProject other : org.eclipse.core.resources.ResourcesPlugin.getWorkspace().getRoot()
+            .getProjects())
+        {
+            long remaining = deadline - System.currentTimeMillis();
+            if (remaining <= 0)
+            {
+                return;
+            }
+            if (other.equals(except) || !other.exists() || !other.isOpen()
+                || dtProjectManager.getDtProject(other) == null)
+            {
+                continue;
+            }
+            BuildUtils.waitForDerivedData(other, remaining);
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
@@ -297,11 +297,17 @@ public final class ProjectStateChecker
         // renamed object. An extension whose pipeline is still busy collides with the batch
         // session exactly like the base one, so drain the others too - they share ONE deadline,
         // so this cannot multiply the wait by the number of projects in the workspace.
-        drainOtherOpenProjects(project, deadline);
-        // The refusal, though, is decided on the NAMED project only. It is always a participant,
-        // while an unrelated project that happens to be indexing must not be able to refuse every
-        // rename in the workspace - for those the drain above is the whole benefit.
-        return buildingErrorOrNull(project);
+        String stillBuilding = drainOtherOpenProjects(project, deadline);
+        String base = buildingErrorOrNull(project);
+        if (base != null)
+        {
+            return base;
+        }
+        // A PARTICIPATING extension that did not settle is refused like the base project would be:
+        // the cascade is about to enter its refactoring too. An UNRELATED project that happens to
+        // be indexing is not - it was drained as a courtesy, but letting it refuse would mean any
+        // busy project in the workspace blocks every rename.
+        return stillBuilding;
     }
 
     /**
@@ -309,21 +315,24 @@ public final class ProjectStateChecker
      *
      * @param except the project already drained by the caller
      * @param deadline absolute time (ms) the whole drain must not exceed
+     * @return the retryable message for a PARTICIPATING extension that is still building (naming
+     *         it), or {@code null} when every participant settled
      */
-    private static void drainOtherOpenProjects(IProject except, long deadline)
+    private static String drainOtherOpenProjects(IProject except, long deadline)
     {
         IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
         if (dtProjectManager == null)
         {
-            return;
+            return null;
         }
+        String participantStillBuilding = null;
         for (IProject other : org.eclipse.core.resources.ResourcesPlugin.getWorkspace().getRoot()
             .getProjects())
         {
             long remaining = deadline - System.currentTimeMillis();
             if (remaining <= 0)
             {
-                return;
+                return participantStillBuilding;
             }
             if (other.equals(except) || !other.exists() || !other.isOpen()
                 || dtProjectManager.getDtProject(other) == null)
@@ -331,7 +340,15 @@ public final class ProjectStateChecker
                 continue;
             }
             BuildUtils.waitForDerivedData(other, remaining);
+            if (participantStillBuilding == null && except.equals(
+                ExtensionOriginUtils.resolveBaseProject(other)) && buildingErrorOrNull(other) != null)
+            {
+                participantStillBuilding = "Project '" + other.getName() + "' extends '" //$NON-NLS-1$
+                    + except.getName() + "' and is still building, so it takes part in this " //$NON-NLS-1$
+                    + "cascade with an incomplete index. Please wait and retry."; //$NON-NLS-1$
+            }
         }
+        return participantStillBuilding;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
@@ -6,6 +6,9 @@
 
 package com.ditrix.edt.mcp.server.utils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.core.resources.IProject;
 
 import com._1c.g5.v8.derived.DerivedDataStatus;
@@ -311,44 +314,73 @@ public final class ProjectStateChecker
     }
 
     /**
-     * Waits for every OTHER open EDT project's derived data, until the shared {@code deadline}.
+     * Waits for the other open EDT projects' derived data, until the shared {@code deadline}.
+     * <p>
+     * PARTICIPANTS FIRST, and verified unconditionally. The projects that take part in the cascade
+     * are the ones that extend {@code base}: the rename builds a refactoring for each of them, so
+     * one that is still building is the collision this whole pre-flight exists to prevent. An
+     * unrelated project is drained only with whatever time is left over - it is a courtesy, and it
+     * must never consume the deadline a participant needed, nor decide the answer.
      *
-     * @param except the project already drained by the caller
+     * @param base the project already drained by the caller
      * @param deadline absolute time (ms) the whole drain must not exceed
      * @return the retryable message for a PARTICIPATING extension that is still building (naming
      *         it), or {@code null} when every participant settled
      */
-    private static String drainOtherOpenProjects(IProject except, long deadline)
+    private static String drainOtherOpenProjects(IProject base, long deadline)
     {
         IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
         if (dtProjectManager == null)
         {
             return null;
         }
-        String participantStillBuilding = null;
+        List<IProject> participants = new ArrayList<>();
+        List<IProject> others = new ArrayList<>();
         for (IProject other : org.eclipse.core.resources.ResourcesPlugin.getWorkspace().getRoot()
             .getProjects())
         {
-            long remaining = deadline - System.currentTimeMillis();
-            if (remaining <= 0)
-            {
-                return participantStillBuilding;
-            }
-            if (other.equals(except) || !other.exists() || !other.isOpen()
+            if (other.equals(base) || !other.exists() || !other.isOpen()
                 || dtProjectManager.getDtProject(other) == null)
             {
                 continue;
             }
-            BuildUtils.waitForDerivedData(other, remaining);
-            if (participantStillBuilding == null && except.equals(
-                ExtensionOriginUtils.resolveBaseProject(other)) && buildingErrorOrNull(other) != null)
+            if (base.equals(ExtensionOriginUtils.resolveBaseProject(other)))
             {
-                participantStillBuilding = "Project '" + other.getName() + "' extends '" //$NON-NLS-1$
-                    + except.getName() + "' and is still building, so it takes part in this " //$NON-NLS-1$
-                    + "cascade with an incomplete index. Please wait and retry."; //$NON-NLS-1$
+                participants.add(other);
+            }
+            else
+            {
+                others.add(other);
             }
         }
-        return participantStillBuilding;
+        drainAll(participants, deadline);
+        drainAll(others, deadline);
+        // Checked AFTER both drains and REGARDLESS of the remaining time: running out of deadline
+        // is not a reason to stop asking whether a participant is ready - it is a reason to say so.
+        for (IProject participant : participants)
+        {
+            if (buildingErrorOrNull(participant) != null)
+            {
+                return "Project '" + participant.getName() + "' extends '" + base.getName() //$NON-NLS-1$
+                    + "' and is still building, so it takes part in this cascade with an " //$NON-NLS-1$
+                    + "incomplete index. Please wait and retry."; //$NON-NLS-1$
+            }
+        }
+        return null;
+    }
+
+    /** Drains each project in turn, giving up as soon as the shared deadline is spent. */
+    private static void drainAll(List<IProject> projects, long deadline)
+    {
+        for (IProject project : projects)
+        {
+            long remaining = deadline - System.currentTimeMillis();
+            if (remaining <= 0)
+            {
+                return;
+            }
+            BuildUtils.waitForDerivedData(project, remaining);
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
@@ -250,6 +250,51 @@ public final class ProjectStateChecker
     }
 
     /**
+     * The pre-flight for a CASCADE operation (a rename / delete refactoring): actively waits for the
+     * project's derived-data pipeline to drain, then re-checks, and returns the "still building"
+     * message when it did not settle in time.
+     * <p>
+     * {@link #buildingErrorOrNull(IProject)} alone is an INSTANT probe, and a cascade needs more than
+     * that. EDT's refactoring opens a BM batch session; a derived-data task that is still pending when
+     * it does cannot run ("Unable to execute task because batch session is active") and the refactoring
+     * then waits for the pipeline from INSIDE the session - measured at 301 seconds on CI, with the
+     * call finally succeeding. Whoever is on the wire has long since timed out, which is what made
+     * this look like a flaky test rather than what it is: an unbounded wait we walked into.
+     * <p>
+     * So: drain first, on the CALLER's thread (never inside the UI-thread scope - the pipeline may
+     * need it), and if the pipeline is still busy afterwards, refuse with the same actionable,
+     * retryable message every other tool uses instead of blocking the wire for five minutes.
+     *
+     * @param projectName the project the cascade will mutate (a null/empty name skips the check)
+     * @param settleTimeoutMs how long to wait for the pipeline to drain
+     * @return the building message with a retry hint, or {@code null} when the cascade may proceed
+     */
+    public static String settleBeforeCascadeOrError(String projectName, long settleTimeoutMs)
+    {
+        if (projectName == null || projectName.isEmpty())
+        {
+            return null;
+        }
+        IProject project = org.eclipse.core.resources.ResourcesPlugin.getWorkspace()
+            .getRoot().getProject(projectName);
+        if (!project.exists() || !project.isOpen())
+        {
+            // Nothing to drain, and asking anyway can block on a project EDT is still disposing.
+            // A missing / closed project is not this method's error to report either - the caller's
+            // own resolution names the value ("Project not found: X").
+            return null;
+        }
+        // Drain UNCONDITIONALLY - do not gate this on the instant probe. On the CI run that
+        // exposed this, the probe answered READY and a derived-data task was executing one
+        // second later, so a drain that only ran when the probe said BUILDING would have been
+        // skipped on the very call it exists for. With a quiet pipeline (or a name that is not
+        // an EDT project at all) waitAllComputations returns immediately, so the cost is zero
+        // where there is nothing to wait for.
+        BuildUtils.waitForDerivedData(project, settleTimeoutMs);
+        return buildingErrorOrNull(project);
+    }
+
+    /**
      * Name-based variant of {@link #buildingErrorOrNull(IProject)}. A null/empty name
      * skips the check (returns {@code null}), leaving the caller's required-argument
      * handling to produce the proper error.

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ProjectStateCheckerTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ProjectStateCheckerTest.java
@@ -37,4 +37,15 @@ public class ProjectStateCheckerTest
         // empty name short-circuits to null before any workspace access.
         assertNull(ProjectStateChecker.buildingErrorOrNull(""));
     }
+
+    @Test
+    public void settleBeforeCascadeShortCircuitsWithoutWaitingWhenNothingIsBuilding()
+    {
+        // The cascade pre-flight drains the pipeline unconditionally for a REAL project, but a
+        // null/empty name has no project to drain: it must return before any workspace access,
+        // leaving the caller's required-argument error to speak. (A regression here would show as
+        // this test hanging on the drain rather than failing.)
+        assertNull(ProjectStateChecker.settleBeforeCascadeOrError(null, 60_000L));
+        assertNull(ProjectStateChecker.settleBeforeCascadeOrError("", 60_000L));
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ProjectStateCheckerTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ProjectStateCheckerTest.java
@@ -7,23 +7,41 @@
 package com.ditrix.edt.mcp.server.utils;
 
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.eclipse.core.resources.IProject;
 import org.junit.Test;
 
+import com.ditrix.edt.mcp.server.utils.ProjectStateChecker.CascadeEnvironment;
+
 /**
- * Tests for {@link ProjectStateChecker#buildingErrorOrNull(String)}.
+ * Tests for {@link ProjectStateChecker#buildingErrorOrNull(String)} and the cascade pre-flight
+ * {@link ProjectStateChecker#settleBeforeCascadeOrError(IProject, long, CascadeEnvironment)}.
  * <p>
- * Covers the {@code null}/empty short-circuit, which resolves WITHOUT touching the
- * workspace (the same constraint {@code ProjectContextTest} works under). The point of
- * {@code buildingErrorOrNull} is that it refuses ONLY the transient BUILDING state: a
- * null/empty/missing project must NOT yield a misleading "building, retry" message but
- * fall through to the caller's required-argument / value-naming error. The BUILDING and
- * project-not-found branches need a live workspace and are covered by the e2e suite
- * (the metadata write/rename "nonexistent project" tests assert the value-naming error,
- * not a build message).
+ * The {@code (String, long)} entry point only resolves {@code project} from the live workspace
+ * and injects {@link CascadeEnvironment#DEFAULT} - it and the BUILDING / project-not-found
+ * branches of {@link ProjectStateChecker#checkProjectState} need a live workspace and are covered
+ * by the e2e suite. The seam-taking {@code (IProject, long, CascadeEnvironment)} overload exists
+ * precisely so the participant-drain logic - which projects get waited on, whether the shared
+ * deadline is respected, and which refusal is returned - can be proven headlessly with a fake
+ * {@link CascadeEnvironment} and mocked {@link IProject} handles.
  */
 public class ProjectStateCheckerTest
 {
+    private static final long SETTLE_TIMEOUT_MS = 5_000L;
+
     @Test
     public void buildingErrorOrNullIsNullForNullName()
     {
@@ -47,5 +65,129 @@ public class ProjectStateCheckerTest
         // this test hanging on the drain rather than failing.)
         assertNull(ProjectStateChecker.settleBeforeCascadeOrError(null, 60_000L));
         assertNull(ProjectStateChecker.settleBeforeCascadeOrError("", 60_000L));
+    }
+
+    // --- settleBeforeCascadeOrError(IProject, long, CascadeEnvironment) --------------------
+    //
+    // These drive the participant-drain logic headlessly through a fake CascadeEnvironment and
+    // mocked IProject handles, so (unlike the DEFAULT environment) none of them touch Activator
+    // or the live workspace.
+
+    private static IProject mockOpenProject(String name)
+    {
+        IProject project = mock(IProject.class);
+        when(project.exists()).thenReturn(true);
+        when(project.isOpen()).thenReturn(true);
+        when(project.getName()).thenReturn(name);
+        return project;
+    }
+
+    @Test
+    public void busyParticipantIsRefusedByName()
+    {
+        // A participant (its base resolves to the renamed project) that is still building must
+        // refuse the cascade, and the message must NAME that participant - the actionable detail
+        // an agent needs to know which project to wait on.
+        IProject base = mockOpenProject("Base");
+        IProject participant = mockOpenProject("Ext1");
+
+        CascadeEnvironment env = mock(CascadeEnvironment.class);
+        when(env.getOpenDtProjects()).thenReturn(Collections.singletonList(participant));
+        when(env.resolveBaseProject(participant)).thenReturn(base);
+        when(env.isBuilding(participant)).thenReturn(true);
+
+        String result = ProjectStateChecker.settleBeforeCascadeOrError(base, SETTLE_TIMEOUT_MS, env);
+
+        assertTrue("must be a retryable refusal", result != null);
+        assertTrue("message must name the busy participant", result.contains("Ext1"));
+        assertTrue("message must name the base it extends", result.contains("Base"));
+    }
+
+    @Test
+    public void busyUnrelatedProjectIsNeverWaitedOnAndNeverCausesRefusal()
+    {
+        // An unrelated open project (its base does NOT resolve to the renamed project) takes no
+        // part in the cascade: it must never be waited on and must never cause a refusal, even
+        // while busy - draining it would only let it eat another rename's budget for nothing.
+        IProject base = mockOpenProject("Base");
+        IProject unrelated = mockOpenProject("Unrelated");
+        IProject someOtherBase = mockOpenProject("SomeOtherBase");
+
+        CascadeEnvironment env = mock(CascadeEnvironment.class);
+        when(env.getOpenDtProjects()).thenReturn(Collections.singletonList(unrelated));
+        // Not a participant: resolves to some OTHER base, not the one being renamed.
+        when(env.resolveBaseProject(unrelated)).thenReturn(someOtherBase);
+        when(env.isBuilding(unrelated)).thenReturn(true);
+
+        String result = ProjectStateChecker.settleBeforeCascadeOrError(base, SETTLE_TIMEOUT_MS, env);
+
+        assertNull("a busy unrelated project must never cause a refusal", result);
+        verify(env, never()).waitForDerivedData(eq(unrelated), anyLong());
+        verify(env, never()).isBuilding(unrelated);
+    }
+
+    @Test
+    public void settledParticipantReturnsNull()
+    {
+        // A participant that is NOT building lets the cascade proceed.
+        IProject base = mockOpenProject("Base");
+        IProject participant = mockOpenProject("Ext1");
+
+        CascadeEnvironment env = mock(CascadeEnvironment.class);
+        when(env.getOpenDtProjects()).thenReturn(Collections.singletonList(participant));
+        when(env.resolveBaseProject(participant)).thenReturn(base);
+        when(env.isBuilding(participant)).thenReturn(false);
+
+        String result = ProjectStateChecker.settleBeforeCascadeOrError(base, SETTLE_TIMEOUT_MS, env);
+
+        assertNull(result);
+        verify(env).waitForDerivedData(eq(participant), anyLong());
+    }
+
+    @Test
+    public void sharedDeadlineLeavesNothingForTheNextParticipantAfterTheFirstConsumesItAll()
+    {
+        // Both participants share ONE deadline. The first participant's drain "consumes the
+        // whole budget" (its fake wait blocks past the deadline); the second must then receive a
+        // non-positive remaining budget, or be skipped outright - either way it must not be
+        // handed the original full timeout again.
+        IProject base = mockOpenProject("Base");
+        IProject participant1 = mockOpenProject("Ext1");
+        IProject participant2 = mockOpenProject("Ext2");
+
+        long settleTimeoutMs = 30L;
+        long overrunMs = 100L;
+        AtomicLong participant2RemainingMs = new AtomicLong(Long.MIN_VALUE);
+
+        CascadeEnvironment env = mock(CascadeEnvironment.class);
+        when(env.getOpenDtProjects()).thenReturn(Arrays.asList(participant1, participant2));
+        when(env.resolveBaseProject(participant1)).thenReturn(base);
+        when(env.resolveBaseProject(participant2)).thenReturn(base);
+        when(env.isBuilding(participant1)).thenReturn(false);
+        when(env.isBuilding(participant2)).thenReturn(false);
+        doAnswer(invocation ->
+        {
+            IProject waited = invocation.getArgument(0);
+            if (waited == participant1)
+            {
+                // Simulate the first participant's drain running long enough to blow through
+                // the shared deadline before the second participant is even considered.
+                Thread.sleep(settleTimeoutMs + overrunMs);
+            }
+            else if (waited == participant2)
+            {
+                participant2RemainingMs.set(invocation.getArgument(1));
+            }
+            return null;
+        }).when(env).waitForDerivedData(any(IProject.class), anyLong());
+
+        ProjectStateChecker.settleBeforeCascadeOrError(base, settleTimeoutMs, env);
+
+        // Either participant 2 was skipped entirely (never asked to wait, budget stays at the
+        // sentinel), or it was asked with a non-positive remaining budget - never a fresh timeout.
+        long remaining = participant2RemainingMs.get();
+        assertTrue("participant 2 must not have been handed a positive remaining budget: " + remaining,
+            remaining == Long.MIN_VALUE || remaining <= 0L);
+        verify(env).waitForDerivedData(eq(participant1), anyLong());
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ProjectStateCheckerTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ProjectStateCheckerTest.java
@@ -93,6 +93,7 @@ public class ProjectStateCheckerTest
 
         CascadeEnvironment env = mock(CascadeEnvironment.class);
         when(env.getOpenDtProjects()).thenReturn(Collections.singletonList(participant));
+        when(env.isExtensionProject(participant)).thenReturn(true);
         when(env.resolveBaseProject(participant)).thenReturn(base);
         when(env.isBuilding(participant)).thenReturn(true);
 
@@ -127,6 +128,29 @@ public class ProjectStateCheckerTest
     }
 
     @Test
+    public void busyExternalObjectsProjectIsNotACascadeParticipant()
+    {
+        // An EXTERNAL-OBJECTS project is dependent on the same base (resolveBaseProject answers
+        // identically to a real participant's), but it is not an EXTENSION, so it takes no part
+        // in the rename cascade: even while busy it must never be waited on and must never cause
+        // a refusal - doing either would spend the shared drain budget, or reject the rename, over
+        // a project the rename never touches.
+        IProject base = mockOpenProject("Base");
+        IProject externalObjects = mockOpenProject("ExternalObjects");
+
+        CascadeEnvironment env = mock(CascadeEnvironment.class);
+        when(env.getOpenDtProjects()).thenReturn(Collections.singletonList(externalObjects));
+        when(env.resolveBaseProject(externalObjects)).thenReturn(base);
+        when(env.isExtensionProject(externalObjects)).thenReturn(false);
+        when(env.isBuilding(externalObjects)).thenReturn(true);
+
+        String result = ProjectStateChecker.settleBeforeCascadeOrError(base, SETTLE_TIMEOUT_MS, env);
+
+        assertNull("a busy external-objects project must never cause a refusal", result);
+        verify(env, never()).waitForDerivedData(eq(externalObjects), anyLong());
+    }
+
+    @Test
     public void settledParticipantReturnsNull()
     {
         // A participant that is NOT building lets the cascade proceed.
@@ -135,6 +159,7 @@ public class ProjectStateCheckerTest
 
         CascadeEnvironment env = mock(CascadeEnvironment.class);
         when(env.getOpenDtProjects()).thenReturn(Collections.singletonList(participant));
+        when(env.isExtensionProject(participant)).thenReturn(true);
         when(env.resolveBaseProject(participant)).thenReturn(base);
         when(env.isBuilding(participant)).thenReturn(false);
 
@@ -161,6 +186,8 @@ public class ProjectStateCheckerTest
 
         CascadeEnvironment env = mock(CascadeEnvironment.class);
         when(env.getOpenDtProjects()).thenReturn(Arrays.asList(participant1, participant2));
+        when(env.isExtensionProject(participant1)).thenReturn(true);
+        when(env.isExtensionProject(participant2)).thenReturn(true);
         when(env.resolveBaseProject(participant1)).thenReturn(base);
         when(env.resolveBaseProject(participant2)).thenReturn(base);
         when(env.isBuilding(participant1)).thenReturn(false);

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import os
 import re
+import socket
 import subprocess
 import time
 import urllib.request
@@ -104,6 +105,19 @@ _SESSION_ID = None
 # ──────────────────────────────────────────────────────────────────────────────
 class E2EAssertion(Exception):
     """Raised when an e2e assertion fails (a normal test failure)."""
+
+
+class E2ECallTimeout(Exception):
+    """One MCP call exceeded MCP_CALL_TIMEOUT.
+
+    NOT the same as a failed call: the request was never answered, so the server may still be
+    RUNNING it - a write tool keeps mutating the model after we walk away. Measured on CI: a
+    rename_metadata_object the client abandoned at 300s completed server-side at 301s
+    ("Completed tools/call: rename_metadata_object in 301090ms, outcome=ok" followed by
+    "Client connection lost: Broken pipe") and left the object renamed, so the next test failed
+    on a fixture nobody had touched. Nothing here can cancel that call, so the run must STOP
+    rather than read - or try to reset - a model somebody else is still writing.
+    """
 
 
 class E2ESkip(Exception):
@@ -214,8 +228,29 @@ def _post(method, params):
                 _SESSION_ID = sid
             text = resp.read().decode("utf-8", "replace")
     except urllib.error.HTTPError as e:
-        text = e.read().decode("utf-8", "replace")
+        try:
+            text = e.read().decode("utf-8", "replace")
+        except (TimeoutError, socket.timeout) as body_timeout:
+            # Headers arrived, the body did not - still a call we cannot account for.
+            raise E2ECallTimeout(_call_timeout_message(body_timeout))
+    except urllib.error.URLError as e:
+        # A socket read timeout arrives either bare or wrapped in URLError, depending on the
+        # Python build; only the timeout becomes E2ECallTimeout - a refused connection is a
+        # different failure and must keep its own traceback.
+        if isinstance(getattr(e, "reason", None), (TimeoutError, socket.timeout)):
+            raise E2ECallTimeout(_call_timeout_message(e))
+        raise
+    except (TimeoutError, socket.timeout) as e:
+        raise E2ECallTimeout(_call_timeout_message(e))
     return _parse_response(text)
+
+
+def _call_timeout_message(cause):
+    return ("no response in %gs (MCP_CALL_TIMEOUT). The server may still be RUNNING this call, "
+            "so the model is not safe to read or even to reset - the run stops here. Check the "
+            "EDT log for the matching 'Completed tools/call: ... in Nms' line to see whether it "
+            "finished late (raise MCP_CALL_TIMEOUT) or never finished (a real hang). %s"
+            % (CALL_TIMEOUT, cause))
 
 
 def _is_transient_building(result):
@@ -334,6 +369,11 @@ def wait_for_project_ready(timeout=None):
             text = (call("list_projects", {}).text or "").lower()
             if text and "building" not in text and "not_available" not in text:
                 return True
+        except E2ECallTimeout:
+            # The one failure a best-effort catch must NOT swallow: the server is still running
+            # that call, so retrying - or reporting success - hides it from the runner, the only
+            # place that can stop the run before the next test reads a model it is still writing.
+            raise
         except Exception:
             pass
         now = time.time()
@@ -440,6 +480,11 @@ def reset_model():
         try:
             if not call("clean_project", {"projectName": PROJECT}).is_error:
                 break
+        except E2ECallTimeout:
+            # The one failure a best-effort catch must NOT swallow: the server is still running
+            # that call, so retrying - or reporting success - hides it from the runner, the only
+            # place that can stop the run before the next test reads a model it is still writing.
+            raise
         except Exception:
             pass
     # Final settle: clean_project's revalidation re-triggers derived data; make sure the
@@ -476,6 +521,11 @@ def final_cleanup():
     for proj in (PROJECT, TESTS_PROJECT):
         try:
             call("clean_project", {"projectName": proj})
+        except E2ECallTimeout:
+            # The one failure a best-effort catch must NOT swallow: the server is still running
+            # that call, so retrying - or reporting success - hides it from the runner, the only
+            # place that can stop the run before the next test reads a model it is still writing.
+            raise
         except Exception:
             pass
     wait_for_project_ready()
@@ -771,9 +821,15 @@ def any_launch_running(config_name=None):
 def terminate_all_live_launches():
     """Teardown helper: kill EVERY live EDT launch (all=true,confirm=true). Idempotent
     and safe when nothing is running (returns the benign not_found sentinel). Best
-    effort — never raises, so it can run in a finally block."""
+    effort in a finally block: it swallows every failure EXCEPT a call timeout, which means
+    the server is still busy and must not be hidden."""
     try:
         call("terminate_launch", {"all": True, "confirm": True})
+    except E2ECallTimeout:
+        # The one failure a best-effort catch must NOT swallow: the server is still running
+        # that call, so retrying - or reporting success - hides it from the runner, the only
+        # place that can stop the run before the next test reads a model it is still writing.
+        raise
     except Exception:
         pass
 
@@ -787,6 +843,11 @@ def wait_until_no_running_launch(config_name=None, timeout=60):
         try:
             if not any_launch_running(config_name):
                 return True
+        except E2ECallTimeout:
+            # The one failure a best-effort catch must NOT swallow: the server is still running
+            # that call, so retrying - or reporting success - hides it from the runner, the only
+            # place that can stop the run before the next test reads a model it is still writing.
+            raise
         except Exception:
             pass
         time.sleep(2)

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -121,11 +121,16 @@ class E2ECallTimeout(Exception):
 
 
 class E2EModelResetFailed(Exception):
-    """reset_model exhausted its attempts without a successful clean_project.
+    """clean_project could not be gotten to succeed within its retry budget - raised by both
+    reset_model() (per-test model cleanup) and final_cleanup() (start/end-of-run sync), and by
+    either one's FINAL settle wait reporting the project still not ready afterward.
 
-    The in-memory model still carries the finished test's write, so the NEXT test would read it -
-    the exact cascade this reset exists to prevent. Silently continuing is what used to turn one
-    real failure into two, so this is raised and the runner aborts on it.
+    Either way the in-memory model may still carry an unsynchronised change (the just-finished
+    test's write, or whatever a stale session/manual edit left behind), and the next reader - the
+    next test, or a caller trusting a "clean" run - would inherit it. Silently continuing is what
+    used to turn one real failure into two (or report a run green over a model that was never
+    actually back in sync), so this is raised rather than swallowed, and callers must not treat
+    it as best-effort.
     """
 
 
@@ -528,7 +533,12 @@ def reset_model():
             "the last test's write. Continuing would hand it to the next test.")
     # Final settle: clean_project's revalidation re-triggers derived data; make sure the
     # next test starts on a fully-indexed model regardless of which branch above we took.
-    wait_for_project_ready(timeout=MODEL_SETTLE_TIMEOUT)
+    # A negative result here is the same hazard as the exhausted-retries branch above (the
+    # model is not guaranteed to be back in sync) and must not be swallowed either.
+    if not wait_for_project_ready(timeout=MODEL_SETTLE_TIMEOUT):
+        raise E2EModelResetFailed(
+            "clean_project succeeded, but the final settle did not report the project ready "
+            "within %ds, so the model is not guaranteed to be back in sync." % MODEL_SETTLE_TIMEOUT)
 
 
 def all_fixtures_status():
@@ -547,27 +557,47 @@ def final_cleanup():
     """Leave the working tree verifiably clean ('no diff' == the session passed and left
     nothing behind).
 
-    Reverts BOTH fixtures on disk, then clean_projects BOTH. The clean_project is the part
-    that defeats the autosave resurrection: it tears down EDT's in-memory model and
-    re-imports it from the now-clean disk (synchronously — the call blocks on the project
-    restart + derived-data rebuild), so a STALE model (e.g. a manual edit made in the EDT
-    editor, or a metadata write whose model change was not flushed) no longer has a pending
-    change to AUTOSAVE back and re-dirty the tree (the Compute/Goods whack-a-mole). The
-    final reset_all_fixtures() only mops up any file clean_project itself re-touched (e.g. a
-    CRLF/marker touch). Best-effort on the MCP calls (a wedged EDT must not make teardown
-    raise). Run at startup AND at the end."""
+    Reverts BOTH fixtures on disk, then clean_projects BOTH, with the SAME retry-until-synced
+    contract as reset_model() (wait for the project to settle, THEN clean_project, retried up
+    to 3 times each): call() only raises on a TIMEOUT, so a clean_project that came back with
+    isError (e.g. the derived-data pipeline outlived BUILDING_RETRY_TIMEOUT and the server
+    refused it) used to be swallowed by a bare `except Exception: pass`, silently declaring an
+    unsynchronised model clean. The clean_project is the part that defeats the autosave
+    resurrection: it tears down EDT's in-memory model and re-imports it from the now-clean disk
+    (synchronously — the call blocks on the project restart + derived-data rebuild), so a STALE
+    model (e.g. a manual edit made in the EDT editor, or a metadata write whose model change was
+    not flushed) no longer has a pending change to AUTOSAVE back and re-dirty the tree (the
+    Compute/Goods whack-a-mole). If a project still refuses after the retry budget - or the
+    final settle never reports every project ready - that must be EXPLICIT: raises
+    E2EModelResetFailed rather than let a run be reported green over a model nobody actually
+    verified is back in sync. The final reset_all_fixtures() only mops up any file clean_project
+    itself re-touched (e.g. a CRLF/marker touch). Run at startup AND at the end."""
     reset_all_fixtures()
     for proj in (PROJECT, TESTS_PROJECT):
-        try:
-            call("clean_project", {"projectName": proj})
-        except E2ECallTimeout:
-            # The one failure a best-effort catch must NOT swallow: the server is still running
-            # that call, so retrying - or reporting success - hides it from the runner, the only
-            # place that can stop the run before the next test reads a model it is still writing.
-            raise
-        except Exception:
-            pass
-    wait_for_project_ready()
+        cleaned = False
+        for _ in range(3):
+            wait_for_project_ready(timeout=MODEL_SETTLE_TIMEOUT)
+            try:
+                if not call("clean_project", {"projectName": proj}).is_error:
+                    cleaned = True
+                    break
+            except E2ECallTimeout:
+                # The one failure a best-effort catch must NOT swallow: the server is still running
+                # that call, so retrying - or reporting success - hides it from the runner, the only
+                # place that can stop the run before the next test reads a model it is still writing.
+                raise
+            except Exception:
+                pass
+        if not cleaned:
+            raise E2EModelResetFailed(
+                "clean_project did not succeed in 3 attempts for project %r, so its in-memory "
+                "model may still carry an unsynchronised change - reporting this run clean would "
+                "be a lie." % proj)
+    if not wait_for_project_ready(timeout=MODEL_SETTLE_TIMEOUT):
+        raise E2EModelResetFailed(
+            "clean_project succeeded for every project, but the final settle did not report "
+            "every project ready within %ds, so the model is not guaranteed to be back in "
+            "sync." % MODEL_SETTLE_TIMEOUT)
     reset_all_fixtures()
 
 

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -120,6 +120,15 @@ class E2ECallTimeout(Exception):
     """
 
 
+class E2EModelResetFailed(Exception):
+    """reset_model exhausted its attempts without a successful clean_project.
+
+    The in-memory model still carries the finished test's write, so the NEXT test would read it -
+    the exact cascade this reset exists to prevent. Silently continuing is what used to turn one
+    real failure into two, so this is raised and the runner aborts on it.
+    """
+
+
 class E2ESkip(Exception):
     """Raised to SKIP a test (an unmet precondition, not a failure).
 
@@ -207,6 +216,14 @@ def _parse_response(text):
     return json.loads(t)  # last resort: raise with detail
 
 
+# Set once a call times out. After that the server is still busy with work nobody can cancel,
+# so EVERY later call is refused HERE rather than at each call site: a test-level `finally` that
+# tears down its fixture (delete_project, delete_metadata, remove_breakpoint) would otherwise race
+# the request we walked away from. The run is over at that point; the latch just makes it true
+# everywhere instead of only where someone remembered to check.
+_TIMED_OUT = False
+
+
 def _post(method, params):
     global _REQUEST_ID, _SESSION_ID
     _REQUEST_ID += 1
@@ -220,6 +237,10 @@ def _post(method, params):
     }
     if _SESSION_ID:
         headers["Mcp-Session-Id"] = _SESSION_ID
+    if _TIMED_OUT:
+        raise E2ECallTimeout(
+            "refusing to send %s: an earlier call timed out and may still be running, so the run "
+            "is over. (The latch, not a new timeout - see _TIMED_OUT.)" % method)
     req = urllib.request.Request(MCP_URL, data=body, headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=CALL_TIMEOUT) as resp:
@@ -232,17 +253,26 @@ def _post(method, params):
             text = e.read().decode("utf-8", "replace")
         except (TimeoutError, socket.timeout) as body_timeout:
             # Headers arrived, the body did not - still a call we cannot account for.
+            _arm_timeout_latch()
             raise E2ECallTimeout(_call_timeout_message(body_timeout))
     except urllib.error.URLError as e:
         # A socket read timeout arrives either bare or wrapped in URLError, depending on the
         # Python build; only the timeout becomes E2ECallTimeout - a refused connection is a
         # different failure and must keep its own traceback.
         if isinstance(getattr(e, "reason", None), (TimeoutError, socket.timeout)):
+            _arm_timeout_latch()
             raise E2ECallTimeout(_call_timeout_message(e))
         raise
     except (TimeoutError, socket.timeout) as e:
+        _arm_timeout_latch()
         raise E2ECallTimeout(_call_timeout_message(e))
     return _parse_response(text)
+
+
+def _arm_timeout_latch():
+    """Remember that a call was abandoned - see _TIMED_OUT."""
+    global _TIMED_OUT
+    _TIMED_OUT = True
 
 
 def _call_timeout_message(cause):
@@ -475,10 +505,12 @@ def reset_model():
     rebuild). Retry if a late-starting recompute re-flags BUILDING between the wait and the
     call — a successful clean_project is the guarantee the model was actually reset.
     """
+    cleaned = False
     for _ in range(3):
         wait_for_project_ready(timeout=MODEL_SETTLE_TIMEOUT)
         try:
             if not call("clean_project", {"projectName": PROJECT}).is_error:
+                cleaned = True
                 break
         except E2ECallTimeout:
             # The one failure a best-effort catch must NOT swallow: the server is still running
@@ -487,6 +519,13 @@ def reset_model():
             raise
         except Exception:
             pass
+    if not cleaned:
+        # Three refusals in a row: the model still carries the finished test's write, and the next
+        # test would read it. That is the cascade this reset exists to prevent, so stop the run
+        # instead of continuing on a model we know is stale.
+        raise E2EModelResetFailed(
+            "clean_project did not succeed in 3 attempts, so the in-memory model still carries "
+            "the last test's write. Continuing would hand it to the next test.")
     # Final settle: clean_project's revalidation re-triggers derived data; make sure the
     # next test starts on a fully-indexed model regardless of which branch above we took.
     wait_for_project_ready(timeout=MODEL_SETTLE_TIMEOUT)

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -227,6 +227,7 @@ def _parse_response(text):
 # the request we walked away from. The run is over at that point; the latch just makes it true
 # everywhere instead of only where someone remembered to check.
 _TIMED_OUT = False
+_ABORT_REASON = "an earlier call timed out and may still be running"
 
 
 def _post(method, params):
@@ -244,8 +245,8 @@ def _post(method, params):
         headers["Mcp-Session-Id"] = _SESSION_ID
     if _TIMED_OUT:
         raise E2ECallTimeout(
-            "refusing to send %s: an earlier call timed out and may still be running, so the run "
-            "is over. (The latch, not a new timeout - see _TIMED_OUT.)" % method)
+            "refusing to send %s: %s, so the run is over. (The latch, not a new timeout - see "
+            "_TIMED_OUT.)" % (method, _ABORT_REASON))
     req = urllib.request.Request(MCP_URL, data=body, headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=CALL_TIMEOUT) as resp:
@@ -276,8 +277,20 @@ def _post(method, params):
 
 def _arm_timeout_latch():
     """Remember that a call was abandoned - see _TIMED_OUT."""
-    global _TIMED_OUT
+    abort_further_calls("an earlier call timed out and may still be running")
+
+
+def abort_further_calls(reason):
+    """Refuse every SUBSEQUENT MCP call, whatever is still holding the wire.
+
+    Armed by a call timeout and by the orchestrator when it abandons a timed-out worker. Both
+    mean the same thing: something we cannot cancel is still working, and every later request -
+    a test's own teardown, a reset_model still in flight on the abandoned thread - would race it.
+    Refusing at the ONE place they all pass through beats hoping each caller checks a flag.
+    """
+    global _TIMED_OUT, _ABORT_REASON
     _TIMED_OUT = True
+    _ABORT_REASON = reason
 
 
 def _call_timeout_message(cause):

--- a/tests/e2e/run_all.py
+++ b/tests/e2e/run_all.py
@@ -198,6 +198,12 @@ def main():
         # here would bury the reason.
         print("!! setup cleanup timed out: %s" % e)
         sys.exit(2)
+    except harness.E2EModelResetFailed as e:
+        # Every call RETURNED (nothing hung), but clean_project could not be gotten to succeed,
+        # so the model is not verifiably in sync before a single test has run - nothing to run
+        # against that would be trustworthy either.
+        print("!! setup cleanup could not sync the model: %s" % e)
+        sys.exit(2)
 
     # Each test (incl. its write-metadata model cleanup, see _run_test_unit) runs under a
     # per-test wall-clock timeout. If a test exceeds it, EDT is almost certainly hung (the
@@ -206,7 +212,14 @@ def main():
     # full timeout. No EDT auto-relaunch — restart it and re-run.
     results = []
     aborted_after = None
-    call_timeout_in = None
+    # Set for EITHER race that can leave a live worker behind: a per-CALL timeout (the server
+    # never answered) or a per-TEST timeout (the worker THREAD is still alive when --test-timeout
+    # elapses - it was only abandoned, never actually stopped, so it may still be blocked inside
+    # that same kind of unresponsive call, or inside its own reset_model()). Both mean the same
+    # thing to the cleanup below: a git reset now could race a write the server may still be
+    # performing. "reset-failed" is NOT one of these - every call involved already RETURNED
+    # (clean_project came back isError, not hung), so there is no live worker to race.
+    still_running_in = None
     cleanup_failed = False
     for t in tests:
         if aborted_after is not None:
@@ -229,16 +242,20 @@ def main():
         # model it is still writing.
         if timed_out or status in ("call-timeout", "reset-failed"):
             aborted_after = "%s::%s" % (t["tool"], t["name"])
-            if status == "call-timeout":
-                call_timeout_in = aborted_after
+            if timed_out or status == "call-timeout":
+                still_running_in = aborted_after
 
     # Final cleanliness guarantee across BOTH fixtures (base + extension). On a normal run,
     # full cleanup (revert + EDT model sync) so a stale model can't autosave changes back
-    # after the run. On an ABORT the EDT is wedged, so model-sync would hang — do git-only.
-    if call_timeout_in is not None and aborted_after == call_timeout_in:
-        # A CALL timeout means the server may still be writing these very files: a git reset now
-        # races EDT (it can rename/overwrite underneath us, or re-dirty right after). Leave the
-        # tree alone - the run is over, and the workspace is disposable.
+    # after the run. When a live worker may still be running (a per-CALL OR per-TEST timeout),
+    # any reset - even git-only - would race it, so leave the tree alone. Any OTHER abort (e.g.
+    # reset-failed: clean_project came back isError, not hung) has no live worker to race, so a
+    # git-only reset is still safe.
+    if still_running_in is not None and aborted_after == still_running_in:
+        # The server may still be writing these very files (or the abandoned worker may still be
+        # inside its own reset_model()): a git reset now races EDT (it can rename/overwrite
+        # underneath us, or re-dirty right after). Leave the tree alone - the run is over, and
+        # the workspace is disposable.
         print("!! left the fixtures untouched: %s may still be running server-side" % aborted_after)
     elif aborted_after:
         harness.reset_all_fixtures()
@@ -250,6 +267,12 @@ def main():
             # call the run green either: the server may still be finishing that clean_project and
             # can re-dirty the fixture right after the status check below.
             print("!! final cleanup timed out (fixtures may be dirty): %s" % e)
+            cleanup_failed = True
+        except harness.E2EModelResetFailed as e:
+            # Same idea, different failure mode: every call RETURNED (nothing hung), but
+            # clean_project kept refusing (or the final settle never reported ready), so the
+            # model may still be out of sync. Do not call the run green over that either.
+            print("!! final cleanup could not sync the model: %s" % e)
             cleanup_failed = True
     final_clean = (harness.all_fixtures_status() == "")
 

--- a/tests/e2e/run_all.py
+++ b/tests/e2e/run_all.py
@@ -32,13 +32,15 @@ def parse_args():
     ap.add_argument("--junit-xml", dest="junit", default=None)
     ap.add_argument("--filter", default=None, help="substring filter on test name or tool")
     ap.add_argument("--test-timeout", type=float,
-                    default=float(os.environ.get("MCP_TEST_TIMEOUT", "2400")),
-                    help="per-test wall-clock timeout in seconds (default 2400). Must exceed the "
+                    default=float(os.environ.get("MCP_TEST_TIMEOUT", "3600")),
+                    help="per-test wall-clock timeout in seconds (default 3600). Must exceed the "
                          "slowest LEGIT test, and that chain is long: the test call (up to "
                          "MCP_CALL_TIMEOUT, 600 on CI) plus reset_model, which can spend "
                          "MODEL_SETTLE_TIMEOUT (600 on CI, pinned there for exactly this reason) "
                          "BEFORE and after its clean_project. The old 600 - and even 1200 - could report a "
-                         "legitimately slow test as a hang, which is the one thing this timeout "
+                         "legitimately slow test as a hang - and the CI maxima already sum to 2400 "
+                         "(call 600 + settle 600 + clean_project 600 + settle 600), so the cap has "
+                         "to sit ABOVE that chain, not on it. That is the one thing this timeout "
                          "must never do: it FAILS the test and SKIPS all the rest. No auto-relaunch "
                          "- restart EDT and re-run.")
     return ap.parse_args()
@@ -124,6 +126,8 @@ def _run_with_timeout(harness, t, timeout_s):
             box["r"] = ("pass", "")
         except harness.E2ECallTimeout as e:
             box["r"] = ("call-timeout", str(e))
+        except harness.E2EModelResetFailed as e:
+            box["r"] = ("reset-failed", str(e))
         except harness.E2ESkip as e:
             box["r"] = ("skip", str(e))
         except harness.E2EAssertion as e:
@@ -203,6 +207,7 @@ def main():
     results = []
     aborted_after = None
     call_timeout_in = None
+    cleanup_failed = False
     for t in tests:
         if aborted_after is not None:
             results.append((t, "skip",
@@ -222,7 +227,7 @@ def main():
         # A per-CALL timeout aborts the run for the same reason a per-TEST one does: the server
         # is still busy with work we cannot cancel, and every later test would be reading a
         # model it is still writing.
-        if timed_out or status == "call-timeout":
+        if timed_out or status in ("call-timeout", "reset-failed"):
             aborted_after = "%s::%s" % (t["tool"], t["name"])
             if status == "call-timeout":
                 call_timeout_in = aborted_after
@@ -241,8 +246,11 @@ def main():
         try:
             harness.final_cleanup()
         except harness.E2ECallTimeout as e:
-            # Do not lose the summary and the JUnit report over a cleanup that hung.
+            # Do not lose the summary and the JUnit report over a cleanup that hung - but do not
+            # call the run green either: the server may still be finishing that clean_project and
+            # can re-dirty the fixture right after the status check below.
             print("!! final cleanup timed out (fixtures may be dirty): %s" % e)
+            cleanup_failed = True
     final_clean = (harness.all_fixtures_status() == "")
 
     npass = sum(1 for _, s, _, _ in results if s == "pass")
@@ -265,7 +273,9 @@ def main():
 
     # A skip is neither pass nor fail: the run is green when nothing FAILED and the
     # fixture is clean (skipped gated tests do not block a headless green run).
-    sys.exit(0 if (nfail == 0 and final_clean) else 1)
+    # A cleanup that timed out is a failed run even when every test passed and the tree LOOKS
+    # clean: the server may still be finishing that call and can re-dirty it after this check.
+    sys.exit(0 if (nfail == 0 and final_clean and not cleanup_failed) else 1)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/run_all.py
+++ b/tests/e2e/run_all.py
@@ -46,12 +46,16 @@ def parse_args():
     return ap.parse_args()
 
 
-def write_junit(results, path, final_clean):
+def write_junit(results, path, final_clean, cleanup_failed=False):
     # Skips are neither pass nor failure: they are reported as JUnit <skipped/> and
     # excluded from the failure count (the gated live-infobase suite skips in a
     # headless run and must not turn the report red).
-    total = len(results) + (0 if final_clean else 1)
-    fails = sum(1 for _, s, _, _ in results if s not in ("pass", "skip")) + (0 if final_clean else 1)
+    # A cleanup that failed is its own synthetic case: without it an all-green run whose
+    # final model sync never completed publishes a green report while the process exits
+    # non-zero, and the report is what the CI check reads.
+    extra = (0 if final_clean else 1) + (1 if cleanup_failed else 0)
+    total = len(results) + extra
+    fails = sum(1 for _, s, _, _ in results if s not in ("pass", "skip")) + extra
     out = ['<?xml version="1.0" encoding="UTF-8"?>',
            '<testsuite name="edt-mcp-e2e" tests="%d" failures="%d">' % (total, fails)]
     for t, status, msg, dur in results:
@@ -73,6 +77,10 @@ def write_junit(results, path, final_clean):
     if not final_clean:
         out.append('  <testcase name="fixture::final_clean">'
                    '<failure>TestConfiguration left dirty after the run</failure></testcase>')
+    if cleanup_failed:
+        out.append('  <testcase name="fixture::final_cleanup">'
+                   '<failure>the final model sync did not complete: the workspace model may still '
+                   'differ from the committed disk</failure></testcase>')
     out.append('</testsuite>')
     with open(path, "w", encoding="utf-8") as f:
         f.write("\n".join(out))
@@ -85,10 +93,19 @@ def write_junit(results, path, final_clean):
 _ABANDONED = False
 
 
-def abandon_workers():
-    """Tell any still-running worker to skip its cleanup (see _ABANDONED)."""
+def abandon_workers(harness):
+    """Give up on a worker we cannot stop: no more MCP calls, no cleanup, from anyone.
+
+    The flag alone is checked only AFTER the test function returns, which is too late for a
+    worker already inside reset_model or inside a test's own teardown - it would resume and
+    keep calling the server the moment its current request came back. So the harness latch is
+    armed as well: from here on every request is refused before it is sent.
+    """
     global _ABANDONED
     _ABANDONED = True
+    harness.abort_further_calls(
+        "the run abandoned a test that outlived its timeout, and the server may still be "
+        "working on it")
 
 
 def _run_test_unit(harness, t):
@@ -164,7 +181,7 @@ def _run_with_timeout(harness, t, timeout_s):
     if th.is_alive():
         # The worker is still running and cannot be stopped. Tell it to skip its own cleanup
         # before we return: from here on nobody may touch the fixtures, this thread included.
-        abandon_workers()
+        abandon_workers(harness)
         return ("timeout",
                 "TIMEOUT: test exceeded %gs and was considered FAILED. EDT is likely hung "
                 "(e.g. clean_project / ProjectRestartJob wedged); the remaining tests are "
@@ -317,7 +334,7 @@ def main():
         print("!! fixtures left dirty after cleanup:\n%s" % harness.all_fixtures_status()[:500])
 
     if args.junit:
-        write_junit(results, args.junit, final_clean)
+        write_junit(results, args.junit, final_clean, cleanup_failed)
         print("junit -> %s" % args.junit)
 
     # A skip is neither pass nor fail: the run is green when nothing FAILED and the

--- a/tests/e2e/run_all.py
+++ b/tests/e2e/run_all.py
@@ -32,13 +32,15 @@ def parse_args():
     ap.add_argument("--junit-xml", dest="junit", default=None)
     ap.add_argument("--filter", default=None, help="substring filter on test name or tool")
     ap.add_argument("--test-timeout", type=float,
-                    default=float(os.environ.get("MCP_TEST_TIMEOUT", "600")),
-                    help="per-test wall-clock timeout in seconds (default 600). Must exceed the "
-                         "slowest LEGIT test: a write-metadata unit chains the test call + "
-                         "clean_project + wait_for_project_ready, each bounded by MCP_CALL_TIMEOUT "
-                         "(~180s), so keep it well above ~3x that. If a test exceeds the timeout it "
-                         "is FAILED (timeout) and ALL remaining tests are SKIPPED (a hung EDT makes "
-                         "them hang too). No auto-relaunch - restart EDT and re-run.")
+                    default=float(os.environ.get("MCP_TEST_TIMEOUT", "2400")),
+                    help="per-test wall-clock timeout in seconds (default 2400). Must exceed the "
+                         "slowest LEGIT test, and that chain is long: the test call (up to "
+                         "MCP_CALL_TIMEOUT, 600 on CI) plus reset_model, which can spend "
+                         "MODEL_SETTLE_TIMEOUT (600 on CI, pinned there for exactly this reason) "
+                         "BEFORE and after its clean_project. The old 600 - and even 1200 - could report a "
+                         "legitimately slow test as a hang, which is the one thing this timeout "
+                         "must never do: it FAILS the test and SKIPS all the rest. No auto-relaunch "
+                         "- restart EDT and re-run.")
     return ap.parse_args()
 
 
@@ -80,7 +82,24 @@ def _run_test_unit(harness, t):
     clean_project refreshes the in-memory model — the step that actually hung when EDT's
     ProjectRestartJob wedged). The pre-test reset_fixture is fast local git and is done by
     the caller OUTSIDE the timeout."""
-    t["func"]()
+    try:
+        t["func"]()
+    except harness.E2ECallTimeout:
+        # Deliberately NO reset: the call may still be running server-side, and reset_model
+        # would race the very write we abandoned (clean_project against a live mutation).
+        # The runner aborts on this, so no later test inherits the state either.
+        raise
+    except BaseException:
+        # Any OTHER failure still leaves the write applied, exactly like a passing test does.
+        # Skipping the reset there is how ONE real failure became two: the next test read a
+        # model that still carried the previous test's rename and reported "object not found".
+        _reset_after_write(harness, t)
+        raise
+    _reset_after_write(harness, t)
+
+
+def _reset_after_write(harness, t):
+    """reset_fixture (disk) + reset_model (in-memory) for a write-metadata test."""
     if t.get("kind") == "write-metadata":
         harness.reset_fixture()
         harness.reset_model()
@@ -103,6 +122,8 @@ def _run_with_timeout(harness, t, timeout_s):
         try:
             _run_test_unit(harness, t)
             box["r"] = ("pass", "")
+        except harness.E2ECallTimeout as e:
+            box["r"] = ("call-timeout", str(e))
         except harness.E2ESkip as e:
             box["r"] = ("skip", str(e))
         except harness.E2EAssertion as e:
@@ -165,8 +186,14 @@ def main():
         except Exception as e:  # noqa: BLE001
             print("(could not read list_projects: %s)" % e)
         sys.exit(2)
-    harness.final_cleanup()  # clean start: revert BOTH fixtures + sync EDT model so the run
-                             # does not begin on a stale extension edit (e.g. a manual experiment)
+    try:
+        harness.final_cleanup()  # clean start: revert BOTH fixtures + sync EDT model so the run
+                                 # does not begin on a stale extension edit (e.g. a manual run)
+    except harness.E2ECallTimeout as e:
+        # The server did not answer the very first call: nothing to run against, and a traceback
+        # here would bury the reason.
+        print("!! setup cleanup timed out: %s" % e)
+        sys.exit(2)
 
     # Each test (incl. its write-metadata model cleanup, see _run_test_unit) runs under a
     # per-test wall-clock timeout. If a test exceeds it, EDT is almost certainly hung (the
@@ -175,11 +202,12 @@ def main():
     # full timeout. No EDT auto-relaunch — restart it and re-run.
     results = []
     aborted_after = None
+    call_timeout_in = None
     for t in tests:
         if aborted_after is not None:
             results.append((t, "skip",
-                            "skipped: run aborted after a TIMEOUT in %s (EDT likely hung; "
-                            "restart it and re-run)" % aborted_after, 0.0))
+                            "skipped: run aborted after a TIMEOUT in %s (EDT is still busy or "
+                            "hung; restart it and re-run)" % aborted_after, 0.0))
             print("[%-7s] %s::%s - aborted after timeout in %s"
                   % ("SKIP", t["tool"], t["name"], aborted_after))
             continue
@@ -191,16 +219,30 @@ def main():
         head = msg.splitlines()[0] if msg else ""
         print("[%-7s] %s::%s (%.2fs)%s" % (status.upper(), t["tool"], t["name"], dur,
                                            " - " + head if head else ""))
-        if timed_out:
+        # A per-CALL timeout aborts the run for the same reason a per-TEST one does: the server
+        # is still busy with work we cannot cancel, and every later test would be reading a
+        # model it is still writing.
+        if timed_out or status == "call-timeout":
             aborted_after = "%s::%s" % (t["tool"], t["name"])
+            if status == "call-timeout":
+                call_timeout_in = aborted_after
 
     # Final cleanliness guarantee across BOTH fixtures (base + extension). On a normal run,
     # full cleanup (revert + EDT model sync) so a stale model can't autosave changes back
     # after the run. On an ABORT the EDT is wedged, so model-sync would hang — do git-only.
-    if aborted_after:
+    if call_timeout_in is not None and aborted_after == call_timeout_in:
+        # A CALL timeout means the server may still be writing these very files: a git reset now
+        # races EDT (it can rename/overwrite underneath us, or re-dirty right after). Leave the
+        # tree alone - the run is over, and the workspace is disposable.
+        print("!! left the fixtures untouched: %s may still be running server-side" % aborted_after)
+    elif aborted_after:
         harness.reset_all_fixtures()
     else:
-        harness.final_cleanup()
+        try:
+            harness.final_cleanup()
+        except harness.E2ECallTimeout as e:
+            # Do not lose the summary and the JUnit report over a cleanup that hung.
+            print("!! final cleanup timed out (fixtures may be dirty): %s" % e)
     final_clean = (harness.all_fixtures_status() == "")
 
     npass = sum(1 for _, s, _, _ in results if s == "pass")

--- a/tests/e2e/run_all.py
+++ b/tests/e2e/run_all.py
@@ -78,6 +78,19 @@ def write_junit(results, path, final_clean):
         f.write("\n".join(out))
 
 
+# Set when the run is abandoning a worker (a per-test timeout). The worker thread is a daemon
+# that was never actually stopped: if its slow call returns before the process exits, it would
+# walk on into its own post-test cleanup and git-reset files the server may still be writing -
+# the very race the abort is avoiding. It checks this flag before touching anything.
+_ABANDONED = False
+
+
+def abandon_workers():
+    """Tell any still-running worker to skip its cleanup (see _ABANDONED)."""
+    global _ABANDONED
+    _ABANDONED = True
+
+
 def _run_test_unit(harness, t):
     """All EDT-touching work for ONE test, timed as a unit: the test fn plus, for a
     write-metadata test, its model cleanup (reset_fixture reverts disk; reset_model =
@@ -91,6 +104,12 @@ def _run_test_unit(harness, t):
         # would race the very write we abandoned (clean_project against a live mutation).
         # The runner aborts on this, so no later test inherits the state either.
         raise
+    except harness.E2ESkip:
+        # A skip is not a failed write - it is a test that decided there was nothing to do
+        # (an unsupported seed that committed nothing). Paying the full cleanup budget for it
+        # would be waste at best, and at worst would turn a legitimate skip into a
+        # reset-failed / call-timeout if clean_project happens to be refused just then.
+        raise
     except BaseException:
         # Any OTHER failure still leaves the write applied, exactly like a passing test does.
         # Skipping the reset there is how ONE real failure became two: the next test read a
@@ -102,6 +121,10 @@ def _run_test_unit(harness, t):
 
 def _reset_after_write(harness, t):
     """reset_fixture (disk) + reset_model (in-memory) for a write-metadata test."""
+    if _ABANDONED:
+        # This worker was given up on; the main thread has already decided the fixtures are
+        # not safe to touch. Do not undo that decision from a thread nobody is waiting for.
+        return
     if t.get("kind") == "write-metadata":
         harness.reset_fixture()
         harness.reset_model()
@@ -139,6 +162,9 @@ def _run_with_timeout(harness, t, timeout_s):
     th.start()
     th.join(timeout_s)
     if th.is_alive():
+        # The worker is still running and cannot be stopped. Tell it to skip its own cleanup
+        # before we return: from here on nobody may touch the fixtures, this thread included.
+        abandon_workers()
         return ("timeout",
                 "TIMEOUT: test exceeded %gs and was considered FAILED. EDT is likely hung "
                 "(e.g. clean_project / ProjectRestartJob wedged); the remaining tests are "

--- a/tests/e2e/tools/test_create_metadata.py
+++ b/tests/e2e/tools/test_create_metadata.py
@@ -34,6 +34,7 @@ Fixture inventory (TestConfiguration, English Names):
 import xml.etree.ElementTree as ET
 
 from harness import (
+    E2ECallTimeout,
     call,
     assert_ok,
     assert_error,
@@ -571,14 +572,25 @@ def test_create_form_object_generate_content_extension_owned_owner_gets_value_ty
         assert_contains(d.text, "DataProcessorObject.%s" % obj,
                         "the main Object attribute must carry the DataProcessorObject value type even "
                         "though the owner was created in an extension (issue #262)")
-    finally:
-        # Revert the EXTENSION fixture on disk, then re-sync ITS in-memory model from the clean disk -
-        # the same two-step final_cleanup() uses for both fixtures, scoped here to just the extension
-        # (the orchestrator's kind="write-metadata" post-test hook already handles the BASE fixture).
-        reset_all_fixtures()
-        call("clean_project", {"projectName": TESTS_PROJECT})
-        wait_for_project_ready()
-        reset_all_fixtures()
+    except E2ECallTimeout:
+        # NO cleanup here: the timed-out call may still be writing these very files, and a git
+        # reset would race it. The orchestrator aborts the run on this.
+        raise
+    except BaseException:
+        _restore_extension_fixture()
+        raise
+    else:
+        _restore_extension_fixture()
+
+
+def _restore_extension_fixture():
+    """Revert the EXTENSION fixture on disk, then re-sync ITS in-memory model from the clean disk -
+    the same two-step final_cleanup() uses for both fixtures, scoped here to just the extension
+    (the orchestrator's kind="write-metadata" post-test hook already handles the BASE fixture)."""
+    reset_all_fixtures()
+    call("clean_project", {"projectName": TESTS_PROJECT})
+    wait_for_project_ready()
+    reset_all_fixtures()
 
 
 @e2e_test(tool="create_metadata", kind="write-metadata")

--- a/tests/e2e/tools/test_list_breakpoints.py
+++ b/tests/e2e/tools/test_list_breakpoints.py
@@ -50,6 +50,7 @@ Fixture inventory used (TestConfiguration, English Names):
 """
 
 from harness import (
+    E2ECallTimeout,
     call,
     assert_ok,
     assert_no_diff,
@@ -90,6 +91,10 @@ def _remove_probe(breakpoint_id):
     manager, so we remove explicitly."""
     try:
         call("remove_breakpoint", {"breakpointId": breakpoint_id})
+    except E2ECallTimeout:
+        # A timeout here means the server is STILL running that call; swallowing it would let the
+        # run continue against state it is changing. The orchestrator aborts on it.
+        raise
     except Exception:
         pass
 

--- a/tests/e2e/tools/test_live_roundtrip.py
+++ b/tests/e2e/tools/test_live_roundtrip.py
@@ -56,6 +56,7 @@ import re
 import time
 
 from harness import (
+    E2ECallTimeout,
     call,
     assert_ok,
     assert_no_substantive_diff,
@@ -93,6 +94,10 @@ def _quiet_infobase():
     'closing' phase". Terminating only our own config keeps the blast radius minimal."""
     try:
         call("terminate_launch", {"launchConfigurationName": LIVE_LAUNCH_CONFIG})
+    except E2ECallTimeout:
+        # A timeout here means the server is STILL running that call; swallowing it would let the
+        # run continue against state it is changing. The orchestrator aborts on it.
+        raise
     except Exception:
         pass
     wait_until_no_running_launch(config_name=LIVE_LAUNCH_CONFIG, timeout=60)
@@ -402,6 +407,8 @@ def test_live_debug_breakpoint_suspend_inspect_resume():
         if bp_id:
             try:
                 call("remove_breakpoint", {"breakpointId": bp_id})
+            except E2ECallTimeout:
+                raise  # see _quiet_infobase: a timed-out call is never best-effort
             except Exception:
                 pass
         _quiet_infobase()
@@ -538,6 +545,8 @@ def test_live_profiling_start_results_stop_roundtrip():
         if bp_id:
             try:
                 call("remove_breakpoint", {"breakpointId": bp_id})
+            except E2ECallTimeout:
+                raise  # see _quiet_infobase: a timed-out call is never best-effort
             except Exception:
                 pass
         _quiet_infobase()


### PR DESCRIPTION
Closes #320.

## Что происходит на самом деле

Гипотезу из ишью удалось заменить фактом — лог EDT из упавшего прогона (артефакт `e2e-edt-log-2026.1`):

```
10:41:19.678  Processing tools/call: rename_metadata_object
10:41:20.630  com._1c.g5.v8.derived: BmBatchSessionException:
              Unable to execute task because batch session is active
              (CommandInterfaceDerivedDataComputer, DerivedDataPartBasedComputer)
   … пять минут тишины …
10:46:20.769  Completed tools/call: rename_metadata_object in 301090ms, outcome=ok
10:46:20.770  Client connection lost: Broken pipe
```

Рефакторинг EDT открывает BM-batch-сессию. Задачи конвейера производных данных, оставшиеся в очереди к этому моменту, выполниться не могут, и рефакторинг ждёт конвейер **изнутри собственной сессии** ~301 секунду, после чего спокойно доводит дело до конца (`outcome=ok`). Соседние переименования в том же прогоне заняли 6 и 8 секунд — то есть это ожидание, а не медленная машина. Клиентский бюджет CI (300 с) стоял ровно на этой границе, поэтому любое совпадение стоило целого прогона.

Второе падение в каждом прогоне было **следствием**: шаг теста в `run_all.py` не был обёрнут в `try/finally`, исключение пропускало `reset_model()`, и следующий тест читал модель с уже применённым переименованием — отсюда «Object not found: `Catalog.Catalog.Attribute.Attribute`».

## Что сделано

**Плагин.** Пред-проверка переименования теперь **дренирует** конвейер (ограниченно, вне UI-потока), а не просто спрашивает, тих ли он: мгновенная проба ответила «готов» за секунду до столкновения, так что спрашивать бесполезно. Если не устоялся — обычная ретраибельная ошибка вместо молчаливой пятиминутной блокировки провода.

**Честная граница этой правки:** окно **сужается, но не закрывается**. EDT строит рефакторинг внутри того же UI-прохода, сохраняя редакторы и запуская инкрементальную сборку, поэтому свежая работа может появиться между дренажом и `perform()`. Я пробовал развести это на две фазы (построить → дренаж → применить) и **откатил**: между фазами UI-поток свободен, а сервер обслуживает до восьми запросов, значит чужая запись может лечь между построением каскада и его применением и сделать каскад устаревшим — старый однопроходный вариант это исключал. Правильное решение требует поддержки со стороны EDT: атомарного перехода «конвейер тих → batch-сессия». Придумывать его за платформу я не стал.

**e2e-гарнесс.** Таймаут вызова стал отдельным исходом `E2ECallTimeout`, а не обычной ошибкой:
- best-effort-обработчики (`wait_for_project_ready`, `reset_model`, `final_cleanup`, теардауны запусков и брейкпоинтов в тестах) пробрасывают его, а не глотают;
- прогон на нём **останавливается** — так же, как на пер-тестовом таймауте, и по той же причине: сервер продолжает писать, отменить это нечем;
- фикстуры после него **не трогаются**: `git reset` гонялся бы с ещё идущей записью;
- любое **другое** падение теперь всегда сбрасывает модель, поэтому одно настоящее падение остаётся одним.

**Бюджеты** сведены: пер-вызов на CI 600 (в стороне от измеренных 301 с и от собственных потолков `clean_project`), `E2E_MODEL_SETTLE_TIMEOUT` закреплён на 600, чтобы сброс модели не мог превысить пер-тестовый лимит, сам лимит — 2400.

## Проверка

Сборка и юнит-тесты зелёные. Живьём на стенде EDT 2026.1: `rename_metadata_object` 15/15, `create_metadata` 92/92, `delete_metadata` 31/31, `resync_to_disk` 10/10, фикстуры чистые. Поведение гарнесса проверено напрямую (сокет, который принимает соединение и не отвечает): типизированный таймаут поднимается, при нём сброс не выполняется и исключение доходит до оркестратора; при обычном падении сброс выполняется; на чистом прогоне и на read-тесте поведение прежнее.

⚠️ Отдельно стоит знать: из пяти красных открытых PR трое падают **не** на этом, а на `resync_to_disk::test_report_only_is_the_default` (в фикстуре оказывается `M Configuration.mdo`) — это то, что чинит #325, — и трое на дрейфе golden после добавления инструментов. То есть само по себе вливание этого PR всю красноту не снимет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
