### PR TITLE
get_project_errors: вопрос о владельце адресуется метамодели платформы (продолжение #342)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -1600,7 +1600,30 @@ public class GetProjectErrorsTool implements IMcpTool
         String ownerFqn = ref.ownerFqn();
         int dot = ownerFqn.indexOf('.');
         String ownerType = dot < 0 ? ownerFqn : ownerFqn.substring(0, dot);
-        return MetadataTypeUtils.typeCanContain(ownerType, PREDEFINED_FEATURE);
+        return ownerTypeCanContain(ownerType, PREDEFINED_FEATURE);
+    }
+
+    /**
+     * THE owner question, asked as one thing: {@code typeToken} must name a metadata type that
+     * exists at all, AND that type must really carry {@code featureName}.
+     *
+     * <p>Two separate pieces of model-independent knowledge, deliberately joined here because every
+     * caller needs both and none needs one alone. {@link MetadataTypeUtils#typeCanContain} is
+     * permissive on tokens it does not recognize - on purpose, so it can never turn a real address
+     * into a false miss - which means it cannot rule out an unknown leading type. That second half
+     * lived inline at two of the three call sites, in two different spellings, and was simply
+     * missing at the third: {@code NoSuchType.X.Predefined.Item} passed the gate and was carried
+     * into the projects, where a closed or still-indexing one made it undecided instead of absent.
+     * A single entry means a fourth caller inherits both halves instead of remembering them.</p>
+     *
+     * @param typeToken the OWNER's metadata type token (English/Russian, singular/plural, any case)
+     * @param featureName the EMF containment feature the address needs on that owner
+     * @return {@code true} only when the type is known and can hold that feature
+     */
+    private static boolean ownerTypeCanContain(String typeToken, String featureName)
+    {
+        return MetadataTypeUtils.resolve(typeToken) != null
+            && MetadataTypeUtils.typeCanContain(typeToken, featureName);
     }
 
     /** The EMF containment feature holding a type's predefined items. */
@@ -1629,12 +1652,9 @@ public class GetProjectErrorsTool implements IMcpTool
         {
             return true;
         }
-        // An owned form needs a real owner TYPE. The mdclass chain has always rejected an unknown
-        // leading token, but the form grammars never looked at it, so 'NoSuchType.X.Form.F' parsed
-        // cleanly. typeCanContain cannot answer this: it is permissive on tokens it does not know,
-        // exactly so it never turns a real address into a false miss.
-        return MetadataTypeUtils.resolve(p[0]) != null
-            && MetadataTypeUtils.typeCanContain(p[0], FORMS_FEATURE);
+        // An owned form needs a real owner TYPE: the form grammars never looked at the leading
+        // token, so 'NoSuchType.X.Form.F' parsed cleanly.
+        return ownerTypeCanContain(p[0], FORMS_FEATURE);
     }
 
     /**
@@ -1671,7 +1691,7 @@ public class GetProjectErrorsTool implements IMcpTool
             // names nothing in any configuration. Only the first level is checked because deeper
             // owners are not named by a type token (the owner of an Attribute under a TabularSection
             // is the tabular section, which no segment types), and a gap here is the safe direction.
-            if (i == 2 && !MetadataTypeUtils.typeCanContain(parts[0], feature))
+            if (i == 2 && !ownerTypeCanContain(parts[0], feature))
             {
                 return false;
             }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -1541,10 +1541,6 @@ public class GetProjectErrorsTool implements IMcpTool
      * exist" - and a lenient answer HERE is a false gap: the address gets carried into the model as
      * if a project might hold it, and an impossible string ends up undecided instead of absent.</p>
      *
-     * <p>Each grammar is asked in its STRICT form. Several of the parsers below are deliberately
-     * lenient for their own callers - they answer "close enough to report on" rather than "could
-     * exist" - and a lenient answer HERE is a false gap: the address gets carried into the model as
-     * if a project might hold it, and an impossible string ends up undecided instead of absent.</p>
      *
      * <p>Single source for the shape question: the enumeration gate above asks it too, so the two
      * cannot drift into disagreeing about what a supported address looks like.</p>

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -1541,6 +1541,21 @@ public class GetProjectErrorsTool implements IMcpTool
      * exist" - and a lenient answer HERE is a false gap: the address gets carried into the model as
      * if a project might hold it, and an impossible string ends up undecided instead of absent.</p>
      *
+     * <p><b>This filter is SOUND but deliberately NOT COMPLETE, and the direction is not a
+     * compromise.</b> Saying "possible" about something impossible costs only the WORDING of the
+     * answer when no project could be read: the caller is told "could not decide" instead of "no
+     * such address". Saying "impossible" about something real costs a confident "No Errors Found"
+     * for an address that has problems - the false all-clear this whole filter exists to prevent.
+     * So every question here errs towards possible, and gaps are left open on purpose.</p>
+     *
+     * <p>Concretely: the owner question below is asked of the mdclass metamodel, which answers for
+     * mdclass containment only. Combinations forbidden INSIDE a form - an attribute owning an event
+     * handler, a command carrying an event other than its single Action slot - are NOT ruled out
+     * here. The form metamodel cannot be imported (the form layer is reflective by canon), so that
+     * knowledge is not available without a model, and inventing a parallel copy of it is exactly the
+     * duplicated grammar this design refuses. Those addresses stay possible and the model decides
+     * them, correctly, as soon as any project can be read.</p>
+     *
      *
      * <p>Single source for the shape question: the enumeration gate above asks it too, so the two
      * cannot drift into disagreeing about what a supported address looks like.</p>
@@ -1557,12 +1572,69 @@ public class GetProjectErrorsTool implements IMcpTool
         }
         String normFqn = MetadataTypeUtils.normalizeFqn(canonical);
         return SubsystemUtils.parseSubsystemPath(normFqn) != null
-            || PredefinedWriter.parseRef(normFqn) != null
-            || FormElementWriter.parseFormPath(normFqn) != null
+            || predefinedOwnerCanHoldItems(normFqn)
+            || (FormElementWriter.parseFormPath(normFqn) != null && formOwnerCanHoldForms(normFqn))
             // The STRICT form question, not the lenient parse: parse accepts any Kind.Name tail, so
             // asking it would call a misspelled kind a shape some configuration might hold.
-            || FormElementWriter.addressesKnownKinds(FormElementWriter.parse(normFqn))
+            || (FormElementWriter.addressesKnownKinds(FormElementWriter.parse(normFqn))
+                && formOwnerCanHoldForms(normFqn))
             || isMdclassChain(normFqn);
+    }
+
+    /**
+     * Whether {@code normFqn} is a predefined-item address whose OWNER type can hold predefined
+     * items at all. Predefined items are a containment of only a few types, and the metamodel says
+     * which - so {@code Document.Invoice.Predefined.Sample} names nothing anywhere, however well it
+     * parses.
+     *
+     * @param normFqn the type-normalized, canonical address
+     * @return {@code true} when the address is a predefined reference on a type that can hold them
+     */
+    private static boolean predefinedOwnerCanHoldItems(String normFqn)
+    {
+        PredefinedWriter.PredefinedRef ref = PredefinedWriter.parseRef(normFqn);
+        if (ref == null)
+        {
+            return false;
+        }
+        String ownerFqn = ref.ownerFqn();
+        int dot = ownerFqn.indexOf('.');
+        String ownerType = dot < 0 ? ownerFqn : ownerFqn.substring(0, dot);
+        return MetadataTypeUtils.typeCanContain(ownerType, PREDEFINED_FEATURE);
+    }
+
+    /** The EMF containment feature holding a type's predefined items. */
+    private static final String PREDEFINED_FEATURE = "predefined"; //$NON-NLS-1$
+
+    /** The EMF containment feature holding a type's owned forms. */
+    private static final String FORMS_FEATURE = "forms"; //$NON-NLS-1$
+
+    /**
+     * Whether an OWNED-form address names an owner type that can hold forms. The form grammars look
+     * at the {@code .Form.} segment and the member kind but never at the leading TYPE, so
+     * {@code NoSuchType.X.Form.F} parsed cleanly.
+     *
+     * <p>A {@code CommonForm.Name} address has no owner to ask - the form IS the top object - so it
+     * is passed through untouched.</p>
+     *
+     * @param normFqn the type-normalized, canonical address
+     * @return {@code true} unless the leading type is modelled and provably cannot own forms
+     */
+    private static boolean formOwnerCanHoldForms(String normFqn)
+    {
+        String[] p = normFqn.split("\\.", -1); //$NON-NLS-1$
+        MetadataTypeUtils.NestedKindInfo kind =
+            p.length >= 4 ? MetadataTypeUtils.resolveNestedKind(p[2]) : null;
+        if (kind == null || !"Form".equals(kind.getEnglish())) //$NON-NLS-1$
+        {
+            return true;
+        }
+        // An owned form needs a real owner TYPE. The mdclass chain has always rejected an unknown
+        // leading token, but the form grammars never looked at it, so 'NoSuchType.X.Form.F' parsed
+        // cleanly. typeCanContain cannot answer this: it is permissive on tokens it does not know,
+        // exactly so it never turns a real address into a false miss.
+        return MetadataTypeUtils.resolve(p[0]) != null
+            && MetadataTypeUtils.typeCanContain(p[0], FORMS_FEATURE);
     }
 
     /**
@@ -1589,7 +1661,17 @@ public class GetProjectErrorsTool implements IMcpTool
             // pass as a shape some configuration might hold. Nothing can: the mdclass metamodel has
             // no such containment. Form / Handler are absent here on purpose; they lead out of the
             // mdclass model and the two form grammars above own them.
-            if (MetadataNodeResolver.featureNameForKind(parts[i]) == null)
+            String feature = MetadataNodeResolver.featureNameForKind(parts[i]);
+            if (feature == null)
+            {
+                return false;
+            }
+            // ...and, at the FIRST level, whether THIS owner can hold that child at all: 'Column' is
+            // a real kind but a containment of DocumentJournal, so 'Catalog.Products.Column.Number'
+            // names nothing in any configuration. Only the first level is checked because deeper
+            // owners are not named by a type token (the owner of an Attribute under a TabularSection
+            // is the tabular section, which no segment types), and a gap here is the safe direction.
+            if (i == 2 && !MetadataTypeUtils.typeCanContain(parts[0], feature))
             {
                 return false;
             }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataNodeResolver.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataNodeResolver.java
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * MCP Server for EDT
  * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
  * Licensed under AGPL-3.0-or-later
@@ -254,6 +254,22 @@ public final class MetadataNodeResolver
         {
             return new CreateTarget(owner, topObject, feature, elementType, childName);
         }
+    }
+
+    /**
+     * The child-kind grammar itself: an unmodifiable {@code lowercase token -> EMF feature name}
+     * view of THE map {@link #featureNameForKind} answers from.
+     *
+     * <p>Exposed so a regression check can walk the SOURCE of the first-step grammar rather than a
+     * catalogue that mirrors it. A pin taken from a mirror is vacuous: a token added here alone is
+     * live in address resolution while the mirror - and therefore the check - knows nothing about
+     * it.</p>
+     *
+     * @return the token to feature map, unmodifiable
+     */
+    public static Map<String, String> childFeatureByToken()
+    {
+        return CHILD_FEATURE_BY_TOKEN;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtils.java
@@ -15,9 +15,12 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EReference;
 
 import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
+import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
 import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
 
 /**
@@ -499,6 +502,41 @@ public final class MetadataTypeUtils
      * @param typeName type name in any recognized form (e.g. "Catalogs", "Справочник", "document")
      * @return canonical English singular form (e.g. "Catalog"), or {@code null} if not recognized
      */
+    /**
+     * Whether the metadata TYPE named by {@code typeToken} really carries a containment feature
+     * called {@code featureName} - asked of the EDT metamodel itself, with NO model loaded.
+     *
+     * <p>{@link MdClassPackage} is a static EMF registry, so this is knowledge available before any
+     * project is read: a {@code Catalog} has no {@code columns}, a {@code Document} has no
+     * {@code predefined}, and no configuration anywhere can change that. Asking the metamodel keeps
+     * this class's token tables out of the existence business - they translate a bilingual token to
+     * a feature NAME, which is genuinely their knowledge, while whether that feature EXISTS on a
+     * given type stays the metamodel's.</p>
+     *
+     * <p>PERMISSIVE on anything it cannot answer: an unknown token, or a type EMF does not model,
+     * returns {@code true}. Callers use this to rule addresses OUT, so a confident wrong "no" would
+     * turn a real address into a false "not found" - the failure that matters. A wrong "yes" only
+     * means the model gets consulted, which decides it correctly anyway.</p>
+     *
+     * @param typeToken the metadata type token (English/Russian, singular/plural, any case)
+     * @param featureName the EMF containment feature name (e.g. {@code "columns"})
+     * @return {@code false} only when the type is modelled AND provably lacks the feature
+     */
+    public static boolean typeCanContain(String typeToken, String featureName)
+    {
+        String english = toEnglishSingular(typeToken);
+        if (english == null || featureName == null)
+        {
+            return true;
+        }
+        EClassifier classifier = MdClassPackage.eINSTANCE.getEClassifier(english);
+        if (!(classifier instanceof EClass))
+        {
+            return true;
+        }
+        return ((EClass)classifier).getEStructuralFeature(featureName) != null;
+    }
+
     public static String toEnglishSingular(String typeName)
     {
         if (typeName == null || typeName.isEmpty())

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtils.java
@@ -18,6 +18,7 @@ import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
 
 import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
 import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
@@ -526,7 +527,11 @@ public final class MetadataTypeUtils
         {
             return true;
         }
-        return ((EClass)classifier).getEStructuralFeature(featureName) != null;
+        EStructuralFeature feature = ((EClass)classifier).getEStructuralFeature(featureName);
+        // A CONTAINMENT reference, as the contract says - not any feature. A scalar like
+        // Catalog.uuid is a real EStructuralFeature but can never be a step in an address,
+        // and answering yes for it wrote the contract wider than the truth.
+        return feature instanceof EReference && ((EReference)feature).isContainment();
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtils.java
@@ -495,14 +495,6 @@ public final class MetadataTypeUtils
     }
 
     /**
-     * Resolves any recognized form of a metadata type name to its canonical English singular form.
-     * Supports English singular/plural and Russian singular/plural forms.
-     * Case-insensitive.
-     *
-     * @param typeName type name in any recognized form (e.g. "Catalogs", "Справочник", "document")
-     * @return canonical English singular form (e.g. "Catalog"), or {@code null} if not recognized
-     */
-    /**
      * Whether the metadata TYPE named by {@code typeToken} really carries a containment feature
      * called {@code featureName} - asked of the EDT metamodel itself, with NO model loaded.
      *
@@ -537,6 +529,14 @@ public final class MetadataTypeUtils
         return ((EClass)classifier).getEStructuralFeature(featureName) != null;
     }
 
+    /**
+     * Resolves any recognized form of a metadata type name to its canonical English singular form.
+     * Supports English singular/plural and Russian singular/plural forms.
+     * Case-insensitive.
+     *
+     * @param typeName type name in any recognized form (e.g. "Catalogs", "Справочник", "document")
+     * @return canonical English singular form (e.g. "Catalog"), or {@code null} if not recognized
+     */
     public static String toEnglishSingular(String typeName)
     {
         if (typeName == null || typeName.isEmpty())

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
@@ -1441,54 +1441,55 @@ public class GetProjectErrorsToolTest
     }
 
     @Test
-    public void testTheOwnerQuestionSeesFeaturesInHERITedFromABaseEClass()
+    public void testTheOwnerQuestionIsAboutCONTAINMENT()
+    {
+        // The contract says CONTAINMENT feature. A scalar such as Catalog.uuid is a real
+        // EStructuralFeature, so a plain getEStructuralFeature answered yes for it - a contract
+        // written wider than the truth, and an address step that can never exist.
+        assertFalse("a scalar feature must NOT satisfy the owner question", //$NON-NLS-1$
+            MetadataTypeUtils.typeCanContain("Catalog", "uuid")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        // ...and every containment the gate really asks about must still answer yes, or the
+        // tightening would turn real addresses into false misses.
+        String[][] gateAsks = { {"Catalog", "attributes"}, {"Catalog", "tabularSections"}, //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            {"Catalog", "forms"}, {"Catalog", "templates"}, {"Catalog", "commands"}, //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+            {"Catalog", "predefined"}, {"DocumentJournal", "columns"} }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        for (String[] pair : gateAsks)
+        {
+            EClass owner = (EClass)MdClassPackage.eINSTANCE.getEClassifier(pair[0]);
+            assertNotNull("the metamodel must model " + pair[0], owner); //$NON-NLS-1$
+            EStructuralFeature feature = owner.getEStructuralFeature(pair[1]);
+            assertTrue("the gate asks about it, so it must be a CONTAINMENT reference: " //$NON-NLS-1$
+                + pair[0] + "." + pair[1], //$NON-NLS-1$
+                feature instanceof EReference && ((EReference)feature).isContainment());
+            assertTrue("a real gate containment must still answer yes: " //$NON-NLS-1$
+                + pair[0] + "." + pair[1], //$NON-NLS-1$
+                MetadataTypeUtils.typeCanContain(pair[0], pair[1]));
+        }
+    }
+
+    @Test
+    public void testTheOwnerQuestionSeesAnInheritedCONTAINMENT()
     {
         // The whole owner gate rests on one unstated assumption: that asking an EClass for a feature
-        // finds features declared on its ANCESTORS too, not only its own. Nothing tested it. If it
-        // were false, every type that inherits 'forms' or 'attributes' from a base class would be
-        // judged unable to hold them, and real addresses would be reported as not found.
-        // Which of the gate's features is inherited is the metamodel's business, not ours, so the
-        // control DISCOVERS one instead of assuming. Written the other way round it passed
-        // vacuously: 'forms' turns out to be declared on Catalog itself.
-        // Measured 2026-08-03: EVERY containment the gate currently asks about (attributes,
-        // tabularSections, forms, templates, commands, columns, predefined) is declared on the
-        // owner's own EClass, so no pair among them can exercise inheritance. The assumption still
-        // has to hold for the next feature that isn't, so the control tests the MECHANISM: find any
-        // type token the gate can be asked about whose feature is inherited, and prove it is seen.
-        String[] tokens = {"Catalog", "Document", "DocumentJournal", "ChartOfAccounts", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-            "InformationRegister", "AccumulationRegister", "Report", "DataProcessor", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-            "BusinessProcess", "Task", "Enum", "ExchangePlan"}; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-        String inheritedType = null;
-        String inheritedFeature = null;
-        for (String token : tokens)
-        {
-            EClass owner = (EClass)MdClassPackage.eINSTANCE.getEClassifier(token);
-            if (owner == null)
-            {
-                continue;
-            }
-            for (EStructuralFeature feature : owner.getEAllStructuralFeatures())
-            {
-                if (feature.getEContainingClass() != owner)
-                {
-                    inheritedType = token;
-                    inheritedFeature = feature.getName();
-                    break;
-                }
-            }
-            if (inheritedFeature != null)
-            {
-                break;
-            }
-        }
-        // Self-check: if the metamodel ever declares every one of these locally, this control stops
-        // testing inheritance - and says so, instead of passing on nothing.
-        assertNotNull("the metamodel has no inherited feature on any gate-addressable type - control is vacuous", //$NON-NLS-1$
-            inheritedFeature);
+        // reaches containments declared on its ANCESTORS, not only its own. The MdClass metamodel
+        // does have such pairs on gate-addressable types (measured 2026-08-03: Catalog.
+        // standardAttributes, Catalog.characteristics, ChartOfAccounts.tabularParts and others), so
+        // this control is built on a real one - no synthetic hierarchy and, deliberately, no scalar
+        // stand-in: a scalar would prove the opposite of the contract.
+        EClass catalog = (EClass)MdClassPackage.eINSTANCE.getEClassifier("Catalog"); //$NON-NLS-1$
+        assertNotNull("the metamodel must model Catalog", catalog); //$NON-NLS-1$
+        EStructuralFeature inherited = catalog.getEStructuralFeature("standardAttributes"); //$NON-NLS-1$
+        assertNotNull("Catalog must reach 'standardAttributes' at all", inherited); //$NON-NLS-1$
+        // Self-checks: the control means nothing unless the feature really is BOTH inherited and a
+        // containment. If the metamodel ever moves or re-kinds it, these say so instead of passing.
+        assertNotSame("'standardAttributes' must be INHERITED for this control to test anything", //$NON-NLS-1$
+            catalog, inherited.getEContainingClass());
+        assertTrue("'standardAttributes' must be a CONTAINMENT reference", //$NON-NLS-1$
+            inherited instanceof EReference && ((EReference)inherited).isContainment());
 
-        assertTrue("an inherited feature must satisfy the owner question: " //$NON-NLS-1$
-            + inheritedType + "." + inheritedFeature, //$NON-NLS-1$
-            MetadataTypeUtils.typeCanContain(inheritedType, inheritedFeature));
+        assertTrue("an inherited containment must satisfy the owner question", //$NON-NLS-1$
+            MetadataTypeUtils.typeCanContain("Catalog", "standardAttributes")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
@@ -34,6 +34,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
@@ -60,6 +61,7 @@ import com.e1c.g5.v8.dt.check.settings.ICheckRepository;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
 import com.ditrix.edt.mcp.server.tools.impl.GetProjectErrorsTool.ErrorInfo;
 import com.ditrix.edt.mcp.server.utils.FormElementWriter;
+import com.ditrix.edt.mcp.server.utils.MetadataNodeResolver;
 import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils;
 import com.ditrix.edt.mcp.server.utils.PredefinedWriter;
 
@@ -1439,6 +1441,74 @@ public class GetProjectErrorsToolTest
         // The owner is in the scope as well - that is where EDT reports a predefined item's problem.
         assertTrue(scope.contains("Catalog.C")); //$NON-NLS-1$
     }
+
+    @Test
+    public void testEveryValidFirstStepIsAContainmentAndStaysPossible()
+    {
+        // The table of valid first steps is DERIVED from the grammar catalogue, not hand-written:
+        // every nested kind the catalogue publishes, mapped through the resolver's own token ->
+        // feature map, crossed with every type the gate can address. A new putTokens entry is
+        // therefore covered the moment it is added - it cannot slip past a list someone forgot to
+        // extend. (An earlier version of this check pinned SEVEN hand-picked pairs while the map
+        // holds many more: dimensions, resources, enumValues, accountingFlags, recalculations and
+        // the rest were never checked at all.)
+        int checked = 0;
+        for (String token : MetadataTypeUtils.nestedKindCanonicalTokens())
+        {
+            String feature = MetadataNodeResolver.featureNameForKind(token);
+            if (feature == null)
+            {
+                // Form / Handler / Predefined / Subsystem and the form-only item kinds: owned by
+                // other grammars, never a mdclass first step.
+                continue;
+            }
+            for (EClassifier classifier : MdClassPackage.eINSTANCE.getEClassifiers())
+            {
+                if (!(classifier instanceof EClass)
+                    || MetadataTypeUtils.toEnglishSingular(classifier.getName()) == null)
+                {
+                    continue;
+                }
+                EStructuralFeature f = ((EClass)classifier).getEStructuralFeature(feature);
+                if (f == null)
+                {
+                    continue;
+                }
+                String type = classifier.getName();
+                assertTrue("a valid first step must be a CONTAINMENT reference: " //$NON-NLS-1$
+                    + type + "." + feature, //$NON-NLS-1$
+                    f instanceof EReference && ((EReference)f).isContainment());
+                assertTrue("the owner question must accept it: " + type + "." + feature, //$NON-NLS-1$ //$NON-NLS-2$
+                    MetadataTypeUtils.typeCanContain(type, feature));
+                String address = type + ".X." + token + ".Y"; //$NON-NLS-1$ //$NON-NLS-2$
+                assertTrue("a valid first step must stay POSSIBLE: " + address, //$NON-NLS-1$
+                    GetProjectErrorsTool.possibleAddressShape(address));
+                checked++;
+            }
+        }
+        assertTrue("the derived table must not be empty - the catalogue walk broke", checked > 50); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testKindsThatAreLegalOnlyDeeperAreNotValidFirstSteps()
+    {
+        // Method lives on an HTTPService URLTemplate and Parameter on a WebService Operation, so
+        // neither is a first step. They must NOT be swept into the derived table above just because
+        // the catalogue publishes their tokens.
+        for (String address : new String[] {
+            "HTTPService.Service.Method.Get",        // Method belongs to a URLTemplate //$NON-NLS-1$
+            "WebService.Service.Parameter.Value"})   // Parameter belongs to an Operation //$NON-NLS-1$
+        {
+            assertFalse("legal only deeper, so not a valid first step: " + address, //$NON-NLS-1$
+                GetProjectErrorsTool.possibleAddressShape(address));
+        }
+        // ...and the legitimate deeper shapes they belong to must still be possible.
+        assertTrue(GetProjectErrorsTool.possibleAddressShape(
+            "HTTPService.Service.URLTemplate.Root.Method.Get")); //$NON-NLS-1$
+        assertTrue(GetProjectErrorsTool.possibleAddressShape(
+            "WebService.Service.Operation.Calc.Parameter.Value")); //$NON-NLS-1$
+    }
+
 
     @Test
     public void testTheOwnerQuestionIsAboutCONTAINMENT()

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
@@ -1447,62 +1447,6 @@ public class GetProjectErrorsToolTest
     }
 
     @Test
-    public void testEveryCatalogueKindMatchesItsConsumersEXACTLY()
-    {
-        // Three rounds running, the pin was weaker than claimed for the SAME reason: it asked
-        // whether a token EXISTS somewhere rather than whether the sets are EQUAL. "Some consumer
-        // accepts this kind" let the first matching consumer fill the slot, so an alias published by
-        // the catalogue and accepted by the form writer - but unknown to the mdclass resolver - was
-        // invisible. Equality per consumer is the only shape that cannot hide that.
-
-        // 1. Resolver group -> catalogue: every canonical kind the resolver knows must accept
-        //    EXACTLY the catalogue's aliases for it, and all of them must mean ONE feature.
-        Map<String, Set<String>> tokensByCanonical = new LinkedHashMap<>();
-        Map<String, Set<String>> featuresByCanonical = new LinkedHashMap<>();
-        for (Map.Entry<String, String> entry : MetadataNodeResolver.childFeatureByToken().entrySet())
-        {
-            MetadataTypeUtils.NestedKindInfo info =
-                MetadataTypeUtils.resolveNestedKind(entry.getKey());
-            assertNotNull("resolver token is not published by the catalogue: " + entry.getKey(), //$NON-NLS-1$
-                info);
-            tokensByCanonical.computeIfAbsent(info.getEnglish(), k -> new LinkedHashSet<>())
-                .add(entry.getKey());
-            featuresByCanonical.computeIfAbsent(info.getEnglish(), k -> new LinkedHashSet<>())
-                .add(entry.getValue());
-        }
-        for (Map.Entry<String, Set<String>> entry : tokensByCanonical.entrySet())
-        {
-            assertEquals("every alias of one kind must resolve to ONE feature: " + entry.getKey(), //$NON-NLS-1$
-                1, featuresByCanonical.get(entry.getKey()).size());
-            assertEquals("resolver and catalogue must accept EXACTLY the same tokens for " //$NON-NLS-1$
-                + entry.getKey(), lower(MetadataTypeUtils.nestedKindAliases(entry.getKey())),
-                lower(entry.getValue()));
-        }
-
-        // 2. Catalogue -> the FORM consumer, for every kind it publishes. Same equality, asked of
-        //    the other applicable consumer instead of whichever one answered first.
-        for (FormElementWriter.Kind kind : FormElementWriter.Kind.values())
-        {
-            List<String> tokens = FormElementWriter.tokensForKind(kind);
-            assertFalse("a form kind must publish tokens: " + kind, tokens.isEmpty()); //$NON-NLS-1$
-            String canonical = MetadataTypeUtils.resolveNestedKind(tokens.get(0)).getEnglish();
-            assertEquals("form writer and catalogue must accept EXACTLY the same tokens for " //$NON-NLS-1$
-                + kind, lower(MetadataTypeUtils.nestedKindAliases(canonical)), lower(tokens));
-        }
-    }
-
-    /** Lowercased set, so a spelling difference in case never reads as a set difference. */
-    private static Set<String> lower(Collection<String> tokens)
-    {
-        Set<String> out = new TreeSet<>();
-        for (String token : tokens)
-        {
-            out.add(token.toLowerCase(Locale.ROOT));
-        }
-        return out;
-    }
-
-    @Test
     public void testEveryValidFirstStepIsAContainmentAndStaysPossible()
     {
         // Walks THE grammar the gate resolves against - MetadataNodeResolver's own token -> feature

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
@@ -2218,6 +2218,9 @@ public class GetProjectErrorsToolTest
             "NoSuchType_e2e.X",                     // unknown leading TYPE token //$NON-NLS-1$
             "Catalog.Products.Fom.ItemForm",        // misspelt nested KIND //$NON-NLS-1$
             "Catalog.Products.Field.Code",          // form-only kind on a mdclass object //$NON-NLS-1$
+            "Catalog.Products.Column.Number",       // Column is a DocumentJournal containment //$NON-NLS-1$
+            "Document.Invoice.Predefined.Sample",   // Documents hold no predefined items //$NON-NLS-1$
+            "NoSuchType.X.Form.F",                  // form grammar never checked the leading TYPE //$NON-NLS-1$
             "Catalog.Products.Form.ItemForm.Fielld.Code", // misspelt form-element KIND //$NON-NLS-1$
             "Catalog.Products.Module"})             // odd arity: no grammar has it //$NON-NLS-1$
         {
@@ -2236,6 +2239,9 @@ public class GetProjectErrorsToolTest
             "Catalog.Products.Form.ItemForm.Field.Code.Handler.OnChange", //$NON-NLS-1$
             "Catalog.Products.Form.ItemForm.Handler.OnOpen", // form-LEVEL handler //$NON-NLS-1$
             "DocumentJournal.Sales.Column.Number", // a real mdclass Column //$NON-NLS-1$
+            "Catalog.Products.TabularSection.Goods", // the owner question must not swallow this //$NON-NLS-1$
+            "Catalog.Products.Predefined.Sample", // Catalogs DO hold predefined items //$NON-NLS-1$
+            "ChartOfAccounts.Main.Predefined.Cash", // ...and so do charts of accounts //$NON-NLS-1$
             "Subsystem.Sales.Subsystem.Orders", //$NON-NLS-1$
             "Catalog.Products.Predefined.Sample", //$NON-NLS-1$
             "XDTOPackage.Exchange"}) //$NON-NLS-1$

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
@@ -9,6 +9,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -36,6 +37,7 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.junit.Test;
@@ -48,6 +50,7 @@ import com._1c.g5.v8.dt.metadata.mdclass.CatalogAttribute;
 import com._1c.g5.v8.dt.metadata.mdclass.CatalogForm;
 import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
 import com._1c.g5.v8.dt.metadata.mdclass.MdClassFactory;
+import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
 import com._1c.g5.v8.dt.metadata.mdclass.Subsystem;
 import com._1c.g5.v8.dt.validation.marker.IExtraInfoMap;
 import com._1c.g5.v8.dt.validation.marker.Marker;
@@ -1438,6 +1441,57 @@ public class GetProjectErrorsToolTest
     }
 
     @Test
+    public void testTheOwnerQuestionSeesFeaturesInHERITedFromABaseEClass()
+    {
+        // The whole owner gate rests on one unstated assumption: that asking an EClass for a feature
+        // finds features declared on its ANCESTORS too, not only its own. Nothing tested it. If it
+        // were false, every type that inherits 'forms' or 'attributes' from a base class would be
+        // judged unable to hold them, and real addresses would be reported as not found.
+        // Which of the gate's features is inherited is the metamodel's business, not ours, so the
+        // control DISCOVERS one instead of assuming. Written the other way round it passed
+        // vacuously: 'forms' turns out to be declared on Catalog itself.
+        // Measured 2026-08-03: EVERY containment the gate currently asks about (attributes,
+        // tabularSections, forms, templates, commands, columns, predefined) is declared on the
+        // owner's own EClass, so no pair among them can exercise inheritance. The assumption still
+        // has to hold for the next feature that isn't, so the control tests the MECHANISM: find any
+        // type token the gate can be asked about whose feature is inherited, and prove it is seen.
+        String[] tokens = {"Catalog", "Document", "DocumentJournal", "ChartOfAccounts", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            "InformationRegister", "AccumulationRegister", "Report", "DataProcessor", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            "BusinessProcess", "Task", "Enum", "ExchangePlan"}; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        String inheritedType = null;
+        String inheritedFeature = null;
+        for (String token : tokens)
+        {
+            EClass owner = (EClass)MdClassPackage.eINSTANCE.getEClassifier(token);
+            if (owner == null)
+            {
+                continue;
+            }
+            for (EStructuralFeature feature : owner.getEAllStructuralFeatures())
+            {
+                if (feature.getEContainingClass() != owner)
+                {
+                    inheritedType = token;
+                    inheritedFeature = feature.getName();
+                    break;
+                }
+            }
+            if (inheritedFeature != null)
+            {
+                break;
+            }
+        }
+        // Self-check: if the metamodel ever declares every one of these locally, this control stops
+        // testing inheritance - and says so, instead of passing on nothing.
+        assertNotNull("the metamodel has no inherited feature on any gate-addressable type - control is vacuous", //$NON-NLS-1$
+            inheritedFeature);
+
+        assertTrue("an inherited feature must satisfy the owner question: " //$NON-NLS-1$
+            + inheritedType + "." + inheritedFeature, //$NON-NLS-1$
+            MetadataTypeUtils.typeCanContain(inheritedType, inheritedFeature));
+    }
+
+    @Test
     public void testEveryOwnerAPredefinedAddressCanMeanIsScoped()
     {
         // Both spellings of the owner AND of the item exist, in the crossed arrangement: M[yo]d
@@ -2244,7 +2298,14 @@ public class GetProjectErrorsToolTest
             "Catalog.Products.Predefined.Sample", // Catalogs DO hold predefined items //$NON-NLS-1$
             "ChartOfAccounts.Main.Predefined.Cash", // ...and so do charts of accounts //$NON-NLS-1$
             "Subsystem.Sales.Subsystem.Orders", //$NON-NLS-1$
-            "Catalog.Products.Predefined.Sample", //$NON-NLS-1$
+            // The owner question must survive a RUSSIAN owner token and a Russian nested kind: it
+            // resolves the type through the bilingual catalogue before asking the metamodel, and a
+            // regression there would reject a legitimate address written the other way round.
+            fromCp(0x0421, 0x043f, 0x0440, 0x0430, 0x0432, 0x043e, 0x0447, 0x043d, 0x0438, 0x043a)
+                + ".Products." //$NON-NLS-1$
+                + fromCp(0x0422, 0x0430, 0x0431, 0x043b, 0x0438, 0x0447, 0x043d, 0x0430, 0x044f,
+                    0x0427, 0x0430, 0x0441, 0x0442, 0x044c)
+                + ".Goods", //$NON-NLS-1$
             "XDTOPackage.Exchange"}) //$NON-NLS-1$
         {
             assertTrue("a documented grammar must stay possible: " + possible, //$NON-NLS-1$

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
@@ -24,9 +24,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Locale;
+import java.util.Collection;
+import java.util.TreeSet;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -1443,6 +1447,62 @@ public class GetProjectErrorsToolTest
     }
 
     @Test
+    public void testEveryCatalogueKindMatchesItsConsumersEXACTLY()
+    {
+        // Three rounds running, the pin was weaker than claimed for the SAME reason: it asked
+        // whether a token EXISTS somewhere rather than whether the sets are EQUAL. "Some consumer
+        // accepts this kind" let the first matching consumer fill the slot, so an alias published by
+        // the catalogue and accepted by the form writer - but unknown to the mdclass resolver - was
+        // invisible. Equality per consumer is the only shape that cannot hide that.
+
+        // 1. Resolver group -> catalogue: every canonical kind the resolver knows must accept
+        //    EXACTLY the catalogue's aliases for it, and all of them must mean ONE feature.
+        Map<String, Set<String>> tokensByCanonical = new LinkedHashMap<>();
+        Map<String, Set<String>> featuresByCanonical = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : MetadataNodeResolver.childFeatureByToken().entrySet())
+        {
+            MetadataTypeUtils.NestedKindInfo info =
+                MetadataTypeUtils.resolveNestedKind(entry.getKey());
+            assertNotNull("resolver token is not published by the catalogue: " + entry.getKey(), //$NON-NLS-1$
+                info);
+            tokensByCanonical.computeIfAbsent(info.getEnglish(), k -> new LinkedHashSet<>())
+                .add(entry.getKey());
+            featuresByCanonical.computeIfAbsent(info.getEnglish(), k -> new LinkedHashSet<>())
+                .add(entry.getValue());
+        }
+        for (Map.Entry<String, Set<String>> entry : tokensByCanonical.entrySet())
+        {
+            assertEquals("every alias of one kind must resolve to ONE feature: " + entry.getKey(), //$NON-NLS-1$
+                1, featuresByCanonical.get(entry.getKey()).size());
+            assertEquals("resolver and catalogue must accept EXACTLY the same tokens for " //$NON-NLS-1$
+                + entry.getKey(), lower(MetadataTypeUtils.nestedKindAliases(entry.getKey())),
+                lower(entry.getValue()));
+        }
+
+        // 2. Catalogue -> the FORM consumer, for every kind it publishes. Same equality, asked of
+        //    the other applicable consumer instead of whichever one answered first.
+        for (FormElementWriter.Kind kind : FormElementWriter.Kind.values())
+        {
+            List<String> tokens = FormElementWriter.tokensForKind(kind);
+            assertFalse("a form kind must publish tokens: " + kind, tokens.isEmpty()); //$NON-NLS-1$
+            String canonical = MetadataTypeUtils.resolveNestedKind(tokens.get(0)).getEnglish();
+            assertEquals("form writer and catalogue must accept EXACTLY the same tokens for " //$NON-NLS-1$
+                + kind, lower(MetadataTypeUtils.nestedKindAliases(canonical)), lower(tokens));
+        }
+    }
+
+    /** Lowercased set, so a spelling difference in case never reads as a set difference. */
+    private static Set<String> lower(Collection<String> tokens)
+    {
+        Set<String> out = new TreeSet<>();
+        for (String token : tokens)
+        {
+            out.add(token.toLowerCase(Locale.ROOT));
+        }
+        return out;
+    }
+
+    @Test
     public void testEveryValidFirstStepIsAContainmentAndStaysPossible()
     {
         // Walks THE grammar the gate resolves against - MetadataNodeResolver's own token -> feature
@@ -1454,9 +1514,6 @@ public class GetProjectErrorsToolTest
         {
             String token = entry.getKey();
             String feature = entry.getValue();
-            // PARITY with the catalogue the object filters advertise. A token live in the resolver
-            // but unpublished there is drift: addresses resolve through it that the filter never
-            // offers, and no bilingual expansion exists for it.
             assertNotNull("resolver token is not published by the kind catalogue - the two have " //$NON-NLS-1$
                 + "drifted apart: " + token, MetadataTypeUtils.resolveNestedKind(token)); //$NON-NLS-1$
 

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
@@ -1445,23 +1445,22 @@ public class GetProjectErrorsToolTest
     @Test
     public void testEveryValidFirstStepIsAContainmentAndStaysPossible()
     {
-        // The table of valid first steps is DERIVED from the grammar catalogue, not hand-written:
-        // every nested kind the catalogue publishes, mapped through the resolver's own token ->
-        // feature map, crossed with every type the gate can address. A new putTokens entry is
-        // therefore covered the moment it is added - it cannot slip past a list someone forgot to
-        // extend. (An earlier version of this check pinned SEVEN hand-picked pairs while the map
-        // holds many more: dimensions, resources, enumValues, accountingFlags, recalculations and
-        // the rest were never checked at all.)
-        int checked = 0;
-        for (String token : MetadataTypeUtils.nestedKindCanonicalTokens())
+        // Walks THE grammar the gate resolves against - MetadataNodeResolver's own token -> feature
+        // map - not a catalogue that mirrors it. Pinning the mirror was vacuous: a token added to
+        // the resolver alone is live in address resolution while the mirror, and so the check,
+        // knows nothing about it.
+        Map<String, Integer> ownersPerFeature = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : MetadataNodeResolver.childFeatureByToken().entrySet())
         {
-            String feature = MetadataNodeResolver.featureNameForKind(token);
-            if (feature == null)
-            {
-                // Form / Handler / Predefined / Subsystem and the form-only item kinds: owned by
-                // other grammars, never a mdclass first step.
-                continue;
-            }
+            String token = entry.getKey();
+            String feature = entry.getValue();
+            // PARITY with the catalogue the object filters advertise. A token live in the resolver
+            // but unpublished there is drift: addresses resolve through it that the filter never
+            // offers, and no bilingual expansion exists for it.
+            assertNotNull("resolver token is not published by the kind catalogue - the two have " //$NON-NLS-1$
+                + "drifted apart: " + token, MetadataTypeUtils.resolveNestedKind(token)); //$NON-NLS-1$
+
+            ownersPerFeature.putIfAbsent(feature, Integer.valueOf(0));
             for (EClassifier classifier : MdClassPackage.eINSTANCE.getEClassifiers())
             {
                 if (!(classifier instanceof EClass)
@@ -1483,11 +1482,35 @@ public class GetProjectErrorsToolTest
                 String address = type + ".X." + token + ".Y"; //$NON-NLS-1$ //$NON-NLS-2$
                 assertTrue("a valid first step must stay POSSIBLE: " + address, //$NON-NLS-1$
                     GetProjectErrorsTool.possibleAddressShape(address));
-                checked++;
+                ownersPerFeature.put(feature, Integer.valueOf(ownersPerFeature.get(feature) + 1));
             }
         }
-        assertTrue("the derived table must not be empty - the catalogue walk broke", checked > 50); //$NON-NLS-1$
+
+        // PER KIND, not in aggregate. A total floor lets a whole family fall to zero - a renamed
+        // feature, or an owner that lost its containment - while the other families hold the count
+        // up and nothing is reported.
+        for (Map.Entry<String, Integer> entry : ownersPerFeature.entrySet())
+        {
+            if (DEEPER_ONLY_FEATURES.contains(entry.getKey()))
+            {
+                assertEquals("legal only deeper, so it must have NO first-step owner: " //$NON-NLS-1$
+                    + entry.getKey(), Integer.valueOf(0), entry.getValue());
+                continue;
+            }
+            assertTrue("no owner type carries this first-step feature any more: " + entry.getKey(), //$NON-NLS-1$
+                entry.getValue().intValue() > 0);
+        }
     }
+
+    /**
+     * Features whose kinds are legal only DEEPER in an address: {@code methods} hangs off an
+     * HTTPService URLTemplate and {@code parameters} off a WebService Operation, so neither may have
+     * a first-step owner. Named explicitly so a new kind that resolves to nothing is a failure
+     * rather than another silent zero.
+     */
+    private static final Set<String> DEEPER_ONLY_FEATURES =
+        new HashSet<>(Arrays.asList("methods", "parameters")); //$NON-NLS-1$ //$NON-NLS-2$
+
 
     @Test
     public void testKindsThatAreLegalOnlyDeeperAreNotValidFirstSteps()
@@ -1519,23 +1542,15 @@ public class GetProjectErrorsToolTest
         assertFalse("a scalar feature must NOT satisfy the owner question", //$NON-NLS-1$
             MetadataTypeUtils.typeCanContain("Catalog", "uuid")); //$NON-NLS-1$ //$NON-NLS-2$
 
-        // ...and every containment the gate really asks about must still answer yes, or the
-        // tightening would turn real addresses into false misses.
-        String[][] gateAsks = { {"Catalog", "attributes"}, {"Catalog", "tabularSections"}, //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-            {"Catalog", "forms"}, {"Catalog", "templates"}, {"Catalog", "commands"}, //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
-            {"Catalog", "predefined"}, {"DocumentJournal", "columns"} }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-        for (String[] pair : gateAsks)
-        {
-            EClass owner = (EClass)MdClassPackage.eINSTANCE.getEClassifier(pair[0]);
-            assertNotNull("the metamodel must model " + pair[0], owner); //$NON-NLS-1$
-            EStructuralFeature feature = owner.getEStructuralFeature(pair[1]);
-            assertTrue("the gate asks about it, so it must be a CONTAINMENT reference: " //$NON-NLS-1$
-                + pair[0] + "." + pair[1], //$NON-NLS-1$
-                feature instanceof EReference && ((EReference)feature).isContainment());
-            assertTrue("a real gate containment must still answer yes: " //$NON-NLS-1$
-                + pair[0] + "." + pair[1], //$NON-NLS-1$
-                MetadataTypeUtils.typeCanContain(pair[0], pair[1]));
-        }
+        // The mdclass first steps are covered exhaustively by the derived walk above. These two are
+        // NOT in that table - forms and predefined are reached by their own grammars, never through
+        // the resolver's child-feature map - so they are pinned here.
+        assertTrue("Catalog must be able to own forms", //$NON-NLS-1$
+            MetadataTypeUtils.typeCanContain("Catalog", "forms")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("Catalog must be able to own predefined items", //$NON-NLS-1$
+            MetadataTypeUtils.typeCanContain("Catalog", "predefined")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("a Document holds no predefined items", //$NON-NLS-1$
+            MetadataTypeUtils.typeCanContain("Document", "predefined")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
@@ -2221,6 +2221,7 @@ public class GetProjectErrorsToolTest
             "Catalog.Products.Column.Number",       // Column is a DocumentJournal containment //$NON-NLS-1$
             "Document.Invoice.Predefined.Sample",   // Documents hold no predefined items //$NON-NLS-1$
             "NoSuchType.X.Form.F",                  // form grammar never checked the leading TYPE //$NON-NLS-1$
+            "NoSuchType.X.Predefined.Item",         // ...nor did the predefined grammar //$NON-NLS-1$
             "Catalog.Products.Form.ItemForm.Fielld.Code", // misspelt form-element KIND //$NON-NLS-1$
             "Catalog.Products.Module"})             // odd arity: no grammar has it //$NON-NLS-1$
         {

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtilsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtilsTest.java
@@ -710,10 +710,7 @@ public class MetadataTypeUtilsTest
             resolverFeatures.computeIfAbsent(info.getEnglish(), k -> new LinkedHashSet<>())
                 .add(e.getValue());
         }
-        for (String canonical : resolverTokens.keySet())
-        {
-            addOwner(owners, canonical, t -> MetadataNodeResolver.featureNameForKind(t) != null);
-        }
+
         // Applicability of the mdclass resolver is DECLARED, not inferred from the map under test.
         // Deriving it from resolverTokens.keySet() still let the subject opt out: deleting the whole
         // Attribute block made the group vanish, so the exact-equality branch never ran, and the
@@ -721,10 +718,15 @@ public class MetadataTypeUtilsTest
         // regression this test exists to catch, so the set below is written by hand ON PURPOSE -
         // the alternative is not inference but self-confirmation. Adding an mdclass kind requires
         // adding it here, and that is the step that must not be silent.
+        // EQUALITY, both ways. Registering owners from resolverTokens.keySet() as well left the
+        // declaration optional: an existing group could not vanish, but a NEW undeclared group
+        // switched its own check on, so "adding a kind requires declaring it here" was not true.
+        // Self-confirmation had simply moved one floor down.
+        assertEquals("the declared mdclass kinds and the resolver's groups must match EXACTLY - " //$NON-NLS-1$
+            + "a missing entry means a group vanished, an extra group means it was never declared", //$NON-NLS-1$
+            MDCLASS_RESOLVED_KINDS, new LinkedHashSet<>(resolverTokens.keySet()));
         for (String canonical : MDCLASS_RESOLVED_KINDS)
         {
-            assertTrue("the mdclass resolver must still map the kind '" + canonical //$NON-NLS-1$
-                + "' - its whole token group disappeared", resolverTokens.containsKey(canonical)); //$NON-NLS-1$
             addOwner(owners, canonical, t -> MetadataNodeResolver.featureNameForKind(t) != null);
         }
 
@@ -1072,12 +1074,6 @@ public class MetadataTypeUtilsTest
             boolean sawCyrillic = false;
             for (String token : tokens)
             {
-                // Kept, NOT delegated: absorption of this one is UNPROVEN. The mutation meant to
-                // test it was invalid (it referenced a map before its declaration, so it never
-                // compiled), and a mutation that cannot run proves nothing. Deleting an assertion
-                // on an unproven absorption is exactly how a guarantee is lost.
-                assertEquals("the form parser must read '" + token + "' as " + kind, //$NON-NLS-1$ //$NON-NLS-2$
-                    kind, FormElementWriter.kindForToken(token));
                 MetadataTypeUtils.NestedKindInfo info = MetadataTypeUtils.resolveNestedKind(token);
                 if (info == null)
                 {

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtilsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtilsTest.java
@@ -1018,16 +1018,19 @@ public class MetadataTypeUtilsTest
         Collections.emptyMap();
 
     @Test
-    public void testEveryFormKindAliasAgreesWithTheFormParser()
+    public void testEveryFormKindIsSpelledInBothLanguagesAndPairedConsistently()
     {
-        // Two token tables describe the same form kinds: this one (for FILTER variants) and
-        // FormElementWriter's (for FQN parsing). They are separate on purpose - the parser maps a
-        // token to an EMF feature, this map to a bilingual canon - so pin them against each other.
+        // SCOPE - read this before adding to it. Token-SET parity between the catalogue and the form
+        // parser (both directions), and that every alias reads back as its kind, are owned by
+        // testEveryPublishedNestedKindTokenIsAcceptedByItsExactResolver. Duplicating them here is
+        // what left one invariant split across two methods.
         //
-        // The pin walks Kind.values() and every token the parser ACCEPTS for each kind (exported by
-        // tokensForKind) instead of a hand-written list of pairs: a hand-written list keeps passing
-        // when a kind is added to one table only, which is the very drift this test claims to
-        // prevent. Adding a Kind now REQUIRES its bilingual alias here, or this test fails.
+        // What is NOT covered there, and is the only reason this test still exists:
+        //   - BILINGUAL COVERAGE: a kind must have at least one Latin AND one Cyrillic spelling.
+        //     Set equality cannot see this - two catalogues can agree on a purely English set.
+        //   - The RUSSIAN half of the canonical pair: set equality compares tokens, never that all
+        //     spellings of a kind carry the same canonical Russian.
+        //   - Standalone aliases that belong to no form Kind (Column, Handler).
         for (FormElementWriter.Kind kind : FormElementWriter.Kind.values())
         {
             if (KINDS_NOT_ADDRESSED_AS_FQN_SEGMENT.containsKey(kind))
@@ -1042,6 +1045,10 @@ public class MetadataTypeUtilsTest
             boolean sawCyrillic = false;
             for (String token : tokens)
             {
+                // Kept, NOT delegated: absorption of this one is UNPROVEN. The mutation meant to
+                // test it was invalid (it referenced a map before its declaration, so it never
+                // compiled), and a mutation that cannot run proves nothing. Deleting an assertion
+                // on an unproven absorption is exactly how a guarantee is lost.
                 assertEquals("the form parser must read '" + token + "' as " + kind, //$NON-NLS-1$ //$NON-NLS-2$
                     kind, FormElementWriter.kindForToken(token));
                 MetadataTypeUtils.NestedKindInfo info = MetadataTypeUtils.resolveNestedKind(token);
@@ -1051,10 +1058,10 @@ public class MetadataTypeUtilsTest
                 {
                     canon = info;
                 }
+                // The RUSSIAN half of the pair - the part token-set equality cannot check.
                 assertEquals("every accepted spelling of " + kind //$NON-NLS-1$
-                    + " must resolve to the SAME canonical pair", //$NON-NLS-1$
-                    canon.getEnglish(), info.getEnglish());
-                assertEquals(canon.getRussian(), info.getRussian());
+                    + " must resolve to the SAME canonical Russian", //$NON-NLS-1$
+                    canon.getRussian(), info.getRussian());
                 if (isCyrillic(token))
                 {
                     sawCyrillic = true;
@@ -1066,34 +1073,15 @@ public class MetadataTypeUtilsTest
             }
             assertTrue("the form parser must accept an English spelling of " + kind, sawLatin); //$NON-NLS-1$
             assertTrue("the form parser must accept a Russian spelling of " + kind, sawCyrillic); //$NON-NLS-1$
-            // Both canonical spellings must be readable back by the parser as the same kind, so an
-            // address translated through this map stays addressable.
-            assertEquals(kind, FormElementWriter.kindForToken(canon.getEnglish()));
-            assertEquals(kind, FormElementWriter.kindForToken(canon.getRussian()));
-
-            // THE REVERSE DIRECTION. Walking only the parser's own tokens proves that what it
-            // ACCEPTS is translatable here - never that everything this catalogue ADVERTISES is
-            // accepted there. That gap let the PLURAL spellings (Fields.Price and its Russian twin)
-            // be advertised by the filter and rejected by the form parser on the KIND check, so a
-            // real field came back as objectsNotFound. Every alias this map publishes for the kind
-            // must therefore be readable by the parser as that same kind.
-            for (String alias : MetadataTypeUtils.nestedKindAliases(canon.getEnglish()))
-            {
-                assertEquals("this map advertises '" + alias + "' for " + kind //$NON-NLS-1$ //$NON-NLS-2$
-                    + ", so the form parser must accept it too", //$NON-NLS-1$
-                    kind, FormElementWriter.kindForToken(alias));
-            }
         }
-        // Column is a nested kind of the MDCLASS model (a DocumentJournal column), which this map
-        // must translate; whether the form parser knows it is decided by the loop above, so this
-        // only pins that the alias itself never disappears.
+        // Aliases belonging to no form Kind, so no loop above can pin them: Column is a mdclass
+        // nested kind (a DocumentJournal column) and Handler routes to its own branch.
         assertNotNull(MetadataTypeUtils.resolveNestedKind("Column")); //$NON-NLS-1$
         assertNotNull(MetadataTypeUtils.resolveNestedKind(
-            "\u041A\u043E\u043B\u043E\u043D\u043A\u0430")); //$NON-NLS-1$
-        // Handler is not a Kind (it routes to its own branch), but it IS a structural segment.
+            "Колонка")); //$NON-NLS-1$
         assertNotNull(MetadataTypeUtils.resolveNestedKind("Handler")); //$NON-NLS-1$
         assertTrue(FormElementWriter.isHandlerToken(
-            "\u043E\u0431\u0440\u0430\u0431\u043E\u0442\u0447\u0438\u043A")); //$NON-NLS-1$
+            "обработчик")); //$NON-NLS-1$
     }
 
     /** Whether {@code token} is written in Cyrillic (its first letter decides). */

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtilsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtilsTest.java
@@ -9,6 +9,7 @@ package com.ditrix.edt.mcp.server.utils;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -713,6 +714,19 @@ public class MetadataTypeUtilsTest
         {
             addOwner(owners, canonical, t -> MetadataNodeResolver.featureNameForKind(t) != null);
         }
+        // Applicability of the mdclass resolver is DECLARED, not inferred from the map under test.
+        // Deriving it from resolverTokens.keySet() still let the subject opt out: deleting the whole
+        // Attribute block made the group vanish, so the exact-equality branch never ran, and the
+        // form owner kept the "no owner declared" assertion quiet. A vanished group is exactly the
+        // regression this test exists to catch, so the set below is written by hand ON PURPOSE -
+        // the alternative is not inference but self-confirmation. Adding an mdclass kind requires
+        // adding it here, and that is the step that must not be silent.
+        for (String canonical : MDCLASS_RESOLVED_KINDS)
+        {
+            assertTrue("the mdclass resolver must still map the kind '" + canonical //$NON-NLS-1$
+                + "' - its whole token group disappeared", resolverTokens.containsKey(canonical)); //$NON-NLS-1$
+            addOwner(owners, canonical, t -> MetadataNodeResolver.featureNameForKind(t) != null);
+        }
 
         // Every OTHER kind is an mdclass member, and its exact resolver is MetadataNodeResolver:
         // it maps the kind token to the EMF child feature. That is a real owner, not an excuse -
@@ -778,6 +792,19 @@ public class MetadataTypeUtilsTest
             }
         }
     }
+
+    /**
+     * Canonical kinds the mdclass resolver MUST map, declared explicitly.
+     *
+     * <p>The one place in this file where a hand-written list is the right answer. Everything else
+     * is derived from a catalogue so a new entry cannot slip past; here derivation would mean asking
+     * the map under test whether it still contains the group, which is self-confirmation - losing a
+     * group would switch off the check that a group must not be lost.</p>
+     */
+    private static final Set<String> MDCLASS_RESOLVED_KINDS = new LinkedHashSet<>(Arrays.asList(
+        "Attribute", "TabularSection", "Dimension", "Resource", "EnumValue", "Command",
+        "AccountingFlag", "ExtDimensionAccountingFlag", "AddressingAttribute", "Column",
+        "Template", "Recalculation", "URLTemplate", "Method", "Operation", "Parameter"));
 
     /** Registers one more applicable consumer for a canonical kind. */
     private static void addOwner(Map<String, List<Predicate<String>>> owners, String canonical,
@@ -1052,8 +1079,13 @@ public class MetadataTypeUtilsTest
                 assertEquals("the form parser must read '" + token + "' as " + kind, //$NON-NLS-1$ //$NON-NLS-2$
                     kind, FormElementWriter.kindForToken(token));
                 MetadataTypeUtils.NestedKindInfo info = MetadataTypeUtils.resolveNestedKind(token);
-                assertNotNull("this map must know the form-kind token '" + token + "' (" + kind //$NON-NLS-1$ //$NON-NLS-2$
-                    + ")", info); //$NON-NLS-1$
+                if (info == null)
+                {
+                    // NOT this test's business: whether the catalogue publishes every token the
+                    // parser accepts is set parity, owned by the consolidated test. Asserting it
+                    // here too made one mutation raise two identical signals.
+                    continue;
+                }
                 if (canon == null)
                 {
                     canon = info;

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtilsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtilsTest.java
@@ -1110,10 +1110,10 @@ public class MetadataTypeUtilsTest
         // nested kind (a DocumentJournal column) and Handler routes to its own branch.
         assertNotNull(MetadataTypeUtils.resolveNestedKind("Column")); //$NON-NLS-1$
         assertNotNull(MetadataTypeUtils.resolveNestedKind(
-            "Колонка")); //$NON-NLS-1$
+            "\u041A\u043E\u043B\u043E\u043D\u043A\u0430")); //$NON-NLS-1$
         assertNotNull(MetadataTypeUtils.resolveNestedKind("Handler")); //$NON-NLS-1$
         assertTrue(FormElementWriter.isHandlerToken(
-            "обработчик")); //$NON-NLS-1$
+            "\u043E\u0431\u0440\u0430\u0431\u043E\u0442\u0447\u0438\u043A")); //$NON-NLS-1$
     }
 
     /** Whether {@code token} is written in Cyrillic (its first letter decides). */

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtilsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtilsTest.java
@@ -10,6 +10,10 @@ import static org.junit.Assert.*;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.TreeSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -663,7 +667,11 @@ public class MetadataTypeUtilsTest
     @Test
     public void testEveryPublishedNestedKindTokenIsAcceptedByItsExactResolver()
     {
-        Map<String, Predicate<String>> owners = new LinkedHashMap<>();
+        // EVERY applicable consumer, not one. A single-owner map let the FIRST consumer fill the
+        // slot: for Attribute and Command that was the form parser, so the catalogue ->
+        // MetadataNodeResolver direction went unchecked for them and an alias published here and
+        // accepted by the form writer, but unknown to the resolver, passed green.
+        Map<String, List<Predicate<String>>> owners = new LinkedHashMap<>();
         // Form-content kinds: the form parser resolves the element and then checks the KIND token.
         for (FormElementWriter.Kind kind : FormElementWriter.Kind.values())
         {
@@ -676,13 +684,23 @@ public class MetadataTypeUtilsTest
                 MetadataTypeUtils.resolveNestedKind(tokens.get(0));
             assertNotNull("the form parser accepts '" + tokens.get(0) + "' but this map does not",
                 info);
-            owners.put(info.getEnglish(), t -> FormElementWriter.kindForToken(t) == kind);
+            owners.computeIfAbsent(info.getEnglish(), k -> new ArrayList<>())
+                .add(t -> FormElementWriter.kindForToken(t) == kind);
         }
         // The structural tokens that route an address to a branch rather than to an element kind.
-        owners.put("Form", FormElementWriter::isFormToken);
-        owners.put("Handler", FormElementWriter::isHandlerToken);
-        owners.put("Subsystem", SubsystemUtils::isSubsystemTypeToken);
-        owners.put("Predefined", MetadataTypeUtilsTest::predefinedTokenAccepted);
+        addOwner(owners, "Form", FormElementWriter::isFormToken);
+        addOwner(owners, "Handler", FormElementWriter::isHandlerToken);
+        addOwner(owners, "Subsystem", SubsystemUtils::isSubsystemTypeToken);
+        addOwner(owners, "Predefined", MetadataTypeUtilsTest::predefinedTokenAccepted);
+        // The mdclass resolver is an owner of EVERY kind it maps - including ones a form consumer
+        // also claims. This is the line whose absence made the guarantee false.
+        for (String canonical : MetadataTypeUtils.nestedKindCanonicalTokens())
+        {
+            if (MetadataNodeResolver.featureNameForKind(canonical) != null)
+            {
+                addOwner(owners, canonical, t -> MetadataNodeResolver.featureNameForKind(t) != null);
+            }
+        }
 
         // Every OTHER kind is an mdclass member, and its exact resolver is MetadataNodeResolver:
         // it maps the kind token to the EMF child feature. That is a real owner, not an excuse -
@@ -698,27 +716,60 @@ public class MetadataTypeUtilsTest
 
         for (String canonical : MetadataTypeUtils.nestedKindCanonicalTokens())
         {
-            Predicate<String> owner = owners.get(canonical);
-            if (owner == null && !notAddressed.containsKey(canonical))
+            List<Predicate<String>> applicable = owners.get(canonical);
+            if (applicable == null)
             {
-                // An mdclass member kind: its exact resolver is the child-feature mapping.
-                owner = t -> MetadataNodeResolver.featureNameForKind(t) != null;
-            }
-            if (owner == null)
-            {
-                continue; // a documented content-only segment
+                assertTrue("a published kind must declare an owner or be documented as content-only: "
+                    + canonical, notAddressed.containsKey(canonical));
+                continue;
             }
             Set<String> aliases = MetadataTypeUtils.nestedKindAliases(canonical);
             assertFalse("a published kind must have spellings: " + canonical, aliases.isEmpty());
-            for (String alias : aliases)
+            for (Predicate<String> owner : applicable)
             {
-                assertTrue("the catalogue advertises '" + alias + "' for " + canonical
-                    + ", so the exact resolver must accept it", owner.test(alias));
-                // ...and case must not matter: a marker location renders these capitalized.
-                assertTrue("case must not matter for '" + alias + "'",
-                    owner.test(alias.substring(0, 1).toUpperCase() + alias.substring(1)));
+                for (String alias : aliases)
+                {
+                    assertTrue("the catalogue advertises '" + alias + "' for " + canonical
+                        + ", so the exact resolver must accept it", owner.test(alias));
+                    // ...and case must not matter: a marker location renders these capitalized.
+                    assertTrue("case must not matter for '" + alias + "'",
+                        owner.test(alias.substring(0, 1).toUpperCase() + alias.substring(1)));
+                }
+            }
+            // ...and the reverse direction for the mdclass resolver: its token group for this kind
+            // must equal the catalogue's aliases EXACTLY, and all of them must mean one feature.
+            if (MetadataNodeResolver.featureNameForKind(canonical) != null)
+            {
+                Set<String> resolverTokens = new TreeSet<>();
+                Set<String> features = new LinkedHashSet<>();
+                for (Map.Entry<String, String> e : MetadataNodeResolver.childFeatureByToken().entrySet())
+                {
+                    MetadataTypeUtils.NestedKindInfo i = MetadataTypeUtils.resolveNestedKind(e.getKey());
+                    assertNotNull("resolver token is not published by the catalogue: " + e.getKey(), i);
+                    if (canonical.equals(i.getEnglish()))
+                    {
+                        resolverTokens.add(e.getKey().toLowerCase(Locale.ROOT));
+                        features.add(e.getValue());
+                    }
+                }
+                Set<String> published = new TreeSet<>();
+                for (String alias : aliases)
+                {
+                    published.add(alias.toLowerCase(Locale.ROOT));
+                }
+                assertEquals("resolver and catalogue must accept EXACTLY the same tokens for "
+                    + canonical, published, resolverTokens);
+                assertEquals("every alias of one kind must resolve to ONE feature: " + canonical,
+                    1, features.size());
             }
         }
+    }
+
+    /** Registers one more applicable consumer for a canonical kind. */
+    private static void addOwner(Map<String, List<Predicate<String>>> owners, String canonical,
+        Predicate<String> owner)
+    {
+        owners.computeIfAbsent(canonical, k -> new ArrayList<>()).add(owner);
     }
 
     /** The predefined-item token predicate, which is private to its writer - probed through parseRef. */

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtilsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtilsTest.java
@@ -8,15 +8,15 @@ package com.ditrix.edt.mcp.server.utils;
 
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.Locale;
-import java.util.TreeSet;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import java.util.function.Predicate;
 import org.junit.Test;
@@ -692,14 +692,26 @@ public class MetadataTypeUtilsTest
         addOwner(owners, "Handler", FormElementWriter::isHandlerToken);
         addOwner(owners, "Subsystem", SubsystemUtils::isSubsystemTypeToken);
         addOwner(owners, "Predefined", MetadataTypeUtilsTest::predefinedTokenAccepted);
-        // The mdclass resolver is an owner of EVERY kind it maps - including ones a form consumer
-        // also claims. This is the line whose absence made the guarantee false.
-        for (String canonical : MetadataTypeUtils.nestedKindCanonicalTokens())
+        // Resolver groups are built by a FULL pass over the resolver's own map, and its
+        // applicability is decided by THAT, never by asking the resolver about the canonical token.
+        // Deriving applicability from the thing under test let it opt out: deleting just the
+        // canonical "attribute" token made featureNameForKind("Attribute") null, the resolver
+        // dropped out of the owners, the reverse-equality block was skipped, and the form owner
+        // kept the "no owner declared" assertion quiet. Losing a token switched off its own check.
+        Map<String, Set<String>> resolverTokens = new LinkedHashMap<>();
+        Map<String, Set<String>> resolverFeatures = new LinkedHashMap<>();
+        for (Map.Entry<String, String> e : MetadataNodeResolver.childFeatureByToken().entrySet())
         {
-            if (MetadataNodeResolver.featureNameForKind(canonical) != null)
-            {
-                addOwner(owners, canonical, t -> MetadataNodeResolver.featureNameForKind(t) != null);
-            }
+            MetadataTypeUtils.NestedKindInfo info = MetadataTypeUtils.resolveNestedKind(e.getKey());
+            assertNotNull("resolver token is not published by the catalogue: " + e.getKey(), info);
+            resolverTokens.computeIfAbsent(info.getEnglish(), k -> new TreeSet<>())
+                .add(e.getKey().toLowerCase(Locale.ROOT));
+            resolverFeatures.computeIfAbsent(info.getEnglish(), k -> new LinkedHashSet<>())
+                .add(e.getValue());
+        }
+        for (String canonical : resolverTokens.keySet())
+        {
+            addOwner(owners, canonical, t -> MetadataNodeResolver.featureNameForKind(t) != null);
         }
 
         // Every OTHER kind is an mdclass member, and its exact resolver is MetadataNodeResolver:
@@ -738,29 +750,31 @@ public class MetadataTypeUtilsTest
             }
             // ...and the reverse direction for the mdclass resolver: its token group for this kind
             // must equal the catalogue's aliases EXACTLY, and all of them must mean one feature.
-            if (MetadataNodeResolver.featureNameForKind(canonical) != null)
+            Set<String> published = new TreeSet<>();
+            for (String alias : aliases)
             {
-                Set<String> resolverTokens = new TreeSet<>();
-                Set<String> features = new LinkedHashSet<>();
-                for (Map.Entry<String, String> e : MetadataNodeResolver.childFeatureByToken().entrySet())
-                {
-                    MetadataTypeUtils.NestedKindInfo i = MetadataTypeUtils.resolveNestedKind(e.getKey());
-                    assertNotNull("resolver token is not published by the catalogue: " + e.getKey(), i);
-                    if (canonical.equals(i.getEnglish()))
-                    {
-                        resolverTokens.add(e.getKey().toLowerCase(Locale.ROOT));
-                        features.add(e.getValue());
-                    }
-                }
-                Set<String> published = new TreeSet<>();
-                for (String alias : aliases)
-                {
-                    published.add(alias.toLowerCase(Locale.ROOT));
-                }
+                published.add(alias.toLowerCase(Locale.ROOT));
+            }
+            if (resolverTokens.containsKey(canonical))
+            {
                 assertEquals("resolver and catalogue must accept EXACTLY the same tokens for "
-                    + canonical, published, resolverTokens);
+                    + canonical, published, resolverTokens.get(canonical));
                 assertEquals("every alias of one kind must resolve to ONE feature: " + canonical,
-                    1, features.size());
+                    1, resolverFeatures.get(canonical).size());
+            }
+            // 2. The FORM consumer, in the SAME place and in the reverse direction too: its token
+            // list must equal the catalogue's aliases exactly, so a token the form parser accepts
+            // but the catalogue does not publish is caught here rather than in a second test.
+            FormElementWriter.Kind formKind = FormElementWriter.kindForToken(canonical);
+            if (formKind != null)
+            {
+                Set<String> formTokens = new TreeSet<>();
+                for (String token : FormElementWriter.tokensForKind(formKind))
+                {
+                    formTokens.add(token.toLowerCase(Locale.ROOT));
+                }
+                assertEquals("form parser and catalogue must accept EXACTLY the same tokens for "
+                    + canonical, published, formTokens);
             }
         }
     }


### PR DESCRIPTION
Продолжение #342. Эта половина работы была выложена **после** мержа, поэтому в master не попала: влита голова `c3577def`, а `2fd80d63` остался в ветке. Здесь она перенесена на свежий master.

## Суть

Гейт «возможной формы адреса» в `get_project_errors` спрашивал, **знаком ли токен кому-нибудь**, а не **допускает ли грамматика это сочетание у ЭТОГО владельца**. Из-за этого адреса, которые не может содержать ни одна конфигурация, уезжали в модель как «возможные» и при нечитаемых проектах возвращались как «не смогли решить» вместо «нет такого»:

* `Catalog.Products.Column.Number` — `Column` реальный вид, но это containment `DocumentJournal`;
* `Document.Invoice.Predefined.Sample` — предопределённые бывают не у всех типов;
* `NoSuchType.X.Form.F` — форменные грамматики смотрели на сегмент `.Form.` и вид члена, но никогда на ведущий тип.

Вместо перечисления запрещённых сочетаний вопрос делегирован **настоящей метамодели**. `MetadataTypeUtils.typeCanContain` спрашивает `MdClassPackage.eINSTANCE` — это статический EMF-реестр, поэтому ответ доступен без загрузки модели и без BM-транзакции.

Ключевое: это **убирает** знание, а не добавляет. Раньше список токенов в `MetadataTypeUtils` работал оракулом существования; теперь он снова только переводит двуязычный токен в имя фичи, а вопрос «есть ли такая фича у такого типа» принадлежит платформе. Факт «предопределённые бывают у четырёх типов» здесь больше не поддерживается вообще.

Проверяется только **первый** вложенный уровень: глубже владелец не называется типовым сегментом (владелец реквизита под табличной частью — сама табличная часть), и пробел там — безопасное направление.

## Надёжный, но намеренно НЕ полный

Это записано в javadoc `possibleAddressShape`, чтобы следующий ревьюер читал заявленную границу, а не подозревал дефект.

Асимметрия цены здесь решающая:

* ложное «возможно» стоит только **формулировки** ответа и лишь когда ни один проект не удалось прочитать;
* ложное «невозможно» стоит уверенного **«No Errors Found»** на адресе, у которого есть проблемы — ровно того ложного «всё чисто», против которого заведена #312.

Поэтому каждый вопрос здесь ошибается в разрешающую сторону. Запреты **внутри формы** (реквизит формы не бывает владельцем обработчика; у команды единственный слот `Action`) не отсекаются: импорт `com._1c.g5.v8.dt.form.model` запрещён каноном проекта, форменный слой рефлективный, значит статически этот ответ недоступен — а параллельная копия форменной грамматики это ровно то дублирование, которое данный дизайн отказывается заводить. Такие адреса остаются возможными, и модель решает их правильно, как только читается хоть один проект.

@DitriXNew — в #342 остался открытым вопрос по контракту: **должен ли `possibleAddressShape` быть надёжным-но-неполным по замыслу?** Если да, оставшиеся находки бота по этому гейту становятся «не чиним, вот причина». Ответ на него определяет, нужно ли что-то ещё в этой области.

## Границы регрессионного пина каталога

Пины грамматики в этом PR переведены с проверки **существования** на проверку **точного равенства множеств** у каждого применимого потребителя — именно слабое «существует хотя бы один» трижды подряд делало пин слабее заявленного. Ниже — два места, где равенства сознательно **нет**. Это заявленные границы, а не недосмотр: обе найдены и названы нами, а не мутацией на ревью.

**1. Проверка «у вида есть владелец первого шага» осталась проверкой существования.**
В проходе по первым шагам стоит `matchesForKind > 0`, а не равенство. Причина не в недосмотре: множество типов-владельцев для вида **нигде не опубликовано** — оно выводится из платформенной метамодели, а не из наших каталогов, поэтому сравнивать не с чем. Ввести равенство можно только заведя **ожидаемую таблицу владельцев на вид** и сверяя её с метамоделью, то есть ровно ту ручную таблицу, от которой этот PR уходит. Делаю только по отдельному решению.

**2. Обратное направление для `Subsystem` и `Predefined`.**

> ⚠️ **Поправка (была ошибка в этом разделе).** Здесь ранее утверждалось, что виды `Form`, `Handler`, `Predefined`, `Subsystem`, `Module`, `Package` «не проверяются вовсе», и что **«алиас, добавленный к `Subsystem` только в каталог, прошёл бы сегодня зелёным»**. Это **неверно**. Проверено мутацией, а не чтением: алиас, добавленный к `Subsystem` только в каталог, **краснеет уже сегодня** —
> `the catalogue advertises 'reviewsubsysalias' for Subsystem, so the exact resolver must accept it`.
> То же для `Predefined` (`reviewpredefalias`). Оценка была завышена, и это ровно тот дефект, который мы ловим у других: утверждение шире кода.

Как на самом деле:

* `Form` и `Handler` — дрейф **невозможен по конструкции**: `isFormToken`/`isHandlerToken` читают тот же каталог через `isNestedKind → resolveNestedKind`, отдельные множества токенов не существуют, сверять нечего.
* `Subsystem` и `Predefined` — направление **каталог → потребитель уже покрыто** (`SubsystemUtils::isSubsystemTypeToken` и проба через `PredefinedWriter.parseRef`).
* `Module` и `Package` — потребителями грамматики не являются и помечены как `notAddressed` явно: это content-сегменты location маркера (`CommonModule.X.Module`, `XDTOPackage.P.Package`).

**Реальный остаток — только обратное направление** для `Subsystem` и `Predefined`: токен, принимаемый потребителем, но не опубликованный каталогом, не ловится. Здесь не чиню: предикаты потребителей не отдают своих множеств токенов, нужны аксессоры, и это за пределами темы владельческого гейта.

## Отдельный коммит: дублированный абзац

`39cced48` убирает абзац javadoc, продублированный в `possibleAddressShape`. Он приехал таким вместе с #342: патч-скрипт повторно применил правку, чья замена **сохраняла собственный якорь**, и вставил вторую копию. Компилятор ловит дублированный код, но не дублированную прозу. Поведение не меняется.

## Проверка

* `BUILD SUCCESS`, **4174** юнит-теста зелёные.
* Обратная дыра проверена — возможный адрес не должен стать невозможным. Таблица валидных первых шагов **выводится из каталога грамматики**, а не пишется руками: каждый вложенный вид из каталога, отображённый через собственную карту `MetadataNodeResolver` «токен → фича», перекрёстно со всеми типами, у которых есть токен типа. Новый `putTokens` попадает под тест в момент добавления, а не когда кто-то вспомнит расширить список.

  ⚠️ **Поправка.** Раньше здесь утверждалось, что проверены «все семь containment'ов, которые гейт спрашивает». Это было **неверно**: первый уровень идёт через `CHILD_FEATURE_BY_TOKEN`, где фич заметно больше (`dimensions`, `resources`, `enumValues`, `accountingFlags`, `extDimensionAccountingFlags`, `addressingAttributes`, `recalculations`, `urlTemplates`, `operations`). Замерено перебором до внесения правок: среди **всех** пар «адресуемый тип × фича каталога» нет ни одной не-containment и ни одной, которую ужесточённый хелпер отвергает, — то есть регрессии ужесточение не внесло. Теперь это закреплено выведенной таблицей, а не семёркой.
* `Method` и `Parameter` законны только глубже (на `URLTemplate` и на `Operation`), поэтому их верхнеуровневые формы закреплены **отрицательно**, а настоящие глубокие — положительно.
* Откат каждой из трёх правок по отдельности, с проверкой **текста** падения:
  * без mdclass-вопроса → `must be impossible by shape alone: Catalog.Products.Column.Number`
  * без вопроса про предопределённые → `must be impossible by shape alone: Document.Invoice.Predefined.Sample`
  * без вопроса про владельца формы → `must be impossible by shape alone: NoSuchType.X.Form.F`
* Живая проверка на стенде 2026.1 — по очереди, доложу отдельно.

## Открытые вопросы из #342

PR влит, но эти вопросы не сняты; переношу сюда, чтобы не потерялись:

1. **Схема машинного вывода.** `get_project_errors` не объявляет `outputSchema`, хотя отдаёт `structuredContent` (прецедент — `list_projects`). Нужно ли объявлять?
2. **Расхождение markdown и `structuredContent`.** Часть сведений о нерешённых адресах видна только в одном из двух представлений. Какое считать основным?
3. **Четвёртая корзина `objectsUndecided`.** Заведена как отдельное поле; подтвердить, что это тот контракт, который нужен.
4. **Тексты XDTO и кросс-парсерный пин** — договорённость о том, где проходит граница поддерживаемых адресов XDTO.


---

## ⏳ Ждём вашего решения — сводка

@DitriXNew, ниже всё, что требует вашего слова: перенесённое из влитого #342 плюс вопрос, который родился здесь. **У каждого указано, что будет, если вы промолчите.**

| # | Вопрос | Если промолчите |
|---|---|---|
| 1 | **Отбор «невозможных по форме» адресов — надёжный, но намеренно неполный?** Обзор третий заход подряд просит ужесточать его, и каждый раз находится сочетание уровнем глубже. Но все эти замечания — про **неполноту, а не про неверность**: ни одно не утверждает, что возможный адрес назван невозможным. Цена ошибок несимметрична — ложное «возможно» стоит формулировки ответа, ложное «невозможно» стоит уверенного `# No Errors Found` на существующем адресе, то есть ровно того, против чего заведена #312. | Считаю зафиксированным: отбор надёжный-но-неполный, граница описана в javadoc, дальнейшие замечания по этому месту закрываю как «не чиним, вот причина». |
| 2 | **Схема машинного вывода.** Инструмент отдаёт `structuredContent` при `objectFqns`, но `outputSchema` не объявляет. Ратчет этому **не мешает** (проверено: он фильтрует по безаргументному `getResponseType()`, который здесь `MARKDOWN`). Мешает другое: `getOutputSchema()` безаргументный, поэтому схема рекламировалась бы на **каждом** вызове, включая те, где структурной части нет вовсе. Развилка: либо всегда отдавать `structuredContent`, либо завести `getOutputSchema(Map)` рядом с `getResponseType(Map)` — правка `IMcpTool`, задевающая все инструменты. Прецедент `list_projects` ведёт себя так же и схемы не объявляет. | Не объявляю — следую существующему прецеденту. |
| 3 | **Расхождение markdown и `structuredContent`.** Неполнота ответа (адрес разрешился, но другой проект опросить не смогли) видна как предупреждение в markdown, а машинные поля отдают «полный успех». Программный вызывающий примет частичный скан за полный. | Оставляю предупреждение в markdown; менять проволочный контракт без вашего слова не буду. |
| 4 | **Четвёртая корзина `objectsUndecided`.** Внутренняя модель различает все четыре исхода; вопрос только в том, публиковать ли третье состояние наружу отдельным полем. Это и есть чистое решение пункта 3. | Не публикую. |
| 5 | **Тексты XDTO и кросс-парсерный пин.** Граница поддерживаемых XDTO-адресов описана; автоматически сверяется пока только парсер форм, остальные грамматики сверены вручную. | Оставляю как есть; при вашем «да» добавлю пин отдельной задачей. |

### Заявленная граница, а не пробел

Форменная половина владельческих проверок (обработчик на реквизите формы; событие кроме `Action` у команды) **намеренно** оставлена разрешающей. Эквивалента `MdClassPackage` для форм нет — импорт `com._1c.g5.v8.dt.form.model` запрещён каноном проекта, — поэтому закрывать эти случаи значило бы реконструировать правила форменной метамодели рефлексивно и держать их в согласии с настоящими. Это ровно тот класс дублирования, который в #342 дал серию однотипных дефектов. Ответ на вопрос 1 определяет, нужно ли здесь что-то ещё.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



