### PR TITLE
clean_project: предел на clean build, чтобы зависание платформы не съедало весь прогон (#349)

### DIFF
--- a/docs/tools/clean_project.md
+++ b/docs/tools/clean_project.md
@@ -6,7 +6,7 @@ Clean EDT project and trigger full revalidation. Direction: DISK -> MODEL - re-i
 | Parameter | Required | Type | Description |
 | --- | --- | --- | --- |
 | projectName | — | string | Name of the project to clean (optional, cleans all EDT projects if not specified) |
-| timeout | — | integer | How long to wait for the clean build itself, in seconds (default 120, clamped to 10..3600). On expiry the call fails with a timeout error instead of waiting forever; the clean may still be running in EDT afterwards. Does not cover the subsequent revalidation wait. |
+| timeout | — | integer | How long to wait for the clean build itself, per project, in seconds (default 120, clamped to 10..3600). On expiry the call fails with a timeout error instead of waiting forever; the clean may still be running in EDT afterwards. Does not cover the subsequent revalidation wait. |
 
 ## Guide
 Force EDT to fully rebuild and re-validate a project: refreshes its files from disk, drops every existing validation marker, re-imports the model, and BLOCKS until EDT has finished recomputing derived data. Use it to recover from a stuck or stale validation state.
@@ -23,7 +23,9 @@ Force EDT to fully rebuild and re-validate a project: refreshes its files from d
 - `timeout` - how long to wait for the clean build itself, in seconds (default 120, clamped to 10..3600). It bounds only the clean build, not the revalidation waits that follow. Raise it for a very large configuration; the default can also be changed in Preferences > MCP Server > Tools > `clean_project`.
 
 ## What you get
-JSON: `success`, `projectsCleaned` (count), `projects` (the names cleaned), and a human-readable `message`. The call returns only after three sequential waits **per project**: the clean build (`timeout`, default 120s), the project-context restart (up to 3 min) and the derived-data recomputation (up to 5 min). On a large configuration one call can therefore take several minutes, and cleaning ALL projects multiplies that - budget the client-side call timeout accordingly.
+JSON: `success`, `projectsCleaned` (count), `projects` (the names cleaned), and a human-readable `message`. The call returns only after three waits: the clean build (bounded by `timeout` **per project**, default 120s), the project-context restart and the derived-data recomputation (up to 5 min per project). On a large configuration one call can therefore take several minutes, and cleaning ALL projects multiplies that - budget the client-side call timeout accordingly.
+
+One subtlety about the restart wait: its 3-minute allowance is counted from the moment the lifecycle listener is registered, which happens **before** the clean build starts (that ordering is what keeps the restart event from being missed). A slow clean therefore eats into it, and on a clean-all so do the projects cleaned earlier. The allowance bounds the whole wait, not each phase separately.
 
 Two honest caveats about "settled":
 - If the clean build does not finish within `timeout`, the call fails with a timeout error instead of waiting indefinitely. Cancellation is requested, but EDT may still be working on it - poll `list_projects` until the project reports `ready` before relying on the model.

--- a/docs/tools/clean_project.md
+++ b/docs/tools/clean_project.md
@@ -6,6 +6,7 @@ Clean EDT project and trigger full revalidation. Direction: DISK -> MODEL - re-i
 | Parameter | Required | Type | Description |
 | --- | --- | --- | --- |
 | projectName | — | string | Name of the project to clean (optional, cleans all EDT projects if not specified) |
+| timeout | — | integer | How long to wait for the clean build itself, in seconds (default 120, clamped to 10..3600). On expiry the call fails with a timeout error instead of waiting forever; the clean may still be running in EDT afterwards. Does not cover the subsequent revalidation wait. |
 
 ## Guide
 Force EDT to fully rebuild and re-validate a project: refreshes its files from disk, drops every existing validation marker, re-imports the model, and BLOCKS until EDT has finished recomputing derived data. Use it to recover from a stuck or stale validation state.
@@ -19,9 +20,14 @@ Force EDT to fully rebuild and re-validate a project: refreshes its files from d
 
 ## Parameter details
 - `projectName` - the project to clean. **Omit to clean every EDT project** in the workspace.
+- `timeout` - how long to wait for the clean build itself, in seconds (default 120, clamped to 10..3600). It bounds only the clean build, not the revalidation waits that follow. Raise it for a very large configuration; the default can also be changed in Preferences > MCP Server > Tools > `clean_project`.
 
 ## What you get
-JSON: `success`, `projectsCleaned` (count), `projects` (the names cleaned), and a human-readable `message`. The call returns only AFTER the rebuild + re-validation finish (it waits up to ~3 min per project), so the project is fully settled when it returns.
+JSON: `success`, `projectsCleaned` (count), `projects` (the names cleaned), and a human-readable `message`. The call returns only after three sequential waits **per project**: the clean build (`timeout`, default 120s), the project-context restart (up to 3 min) and the derived-data recomputation (up to 5 min). On a large configuration one call can therefore take several minutes, and cleaning ALL projects multiplies that - budget the client-side call timeout accordingly.
+
+Two honest caveats about "settled":
+- If the clean build does not finish within `timeout`, the call fails with a timeout error instead of waiting indefinitely. Cancellation is requested, but EDT may still be working on it - poll `list_projects` until the project reports `ready` before relying on the model.
+- If the restart or derived-data wait runs out, that is only logged: the call still reports success. So a `success` means "the clean was driven to completion", not "EDT has certainly finished recomputing". When it matters, confirm with `list_projects`.
 
 ## Notes & gotchas
 - This is a rebuild, not a destructive action - but it **discards UNSAVED in-memory model edits** (they are recomputed from disk). Save pending changes first.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/clean_project.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/clean_project.md
@@ -12,7 +12,9 @@ Force EDT to fully rebuild and re-validate a project: refreshes its files from d
 - `timeout` - how long to wait for the clean build itself, in seconds (default 120, clamped to 10..3600). It bounds only the clean build, not the revalidation waits that follow. Raise it for a very large configuration; the default can also be changed in Preferences > MCP Server > Tools > `clean_project`.
 
 ## What you get
-JSON: `success`, `projectsCleaned` (count), `projects` (the names cleaned), and a human-readable `message`. The call returns only after three sequential waits **per project**: the clean build (`timeout`, default 120s), the project-context restart (up to 3 min) and the derived-data recomputation (up to 5 min). On a large configuration one call can therefore take several minutes, and cleaning ALL projects multiplies that - budget the client-side call timeout accordingly.
+JSON: `success`, `projectsCleaned` (count), `projects` (the names cleaned), and a human-readable `message`. The call returns only after three waits: the clean build (bounded by `timeout` **per project**, default 120s), the project-context restart and the derived-data recomputation (up to 5 min per project). On a large configuration one call can therefore take several minutes, and cleaning ALL projects multiplies that - budget the client-side call timeout accordingly.
+
+One subtlety about the restart wait: its 3-minute allowance is counted from the moment the lifecycle listener is registered, which happens **before** the clean build starts (that ordering is what keeps the restart event from being missed). A slow clean therefore eats into it, and on a clean-all so do the projects cleaned earlier. The allowance bounds the whole wait, not each phase separately.
 
 Two honest caveats about "settled":
 - If the clean build does not finish within `timeout`, the call fails with a timeout error instead of waiting indefinitely. Cancellation is requested, but EDT may still be working on it - poll `list_projects` until the project reports `ready` before relying on the model.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/clean_project.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/clean_project.md
@@ -9,9 +9,14 @@ Force EDT to fully rebuild and re-validate a project: refreshes its files from d
 
 ## Parameter details
 - `projectName` - the project to clean. **Omit to clean every EDT project** in the workspace.
+- `timeout` - how long to wait for the clean build itself, in seconds (default 120, clamped to 10..3600). It bounds only the clean build, not the revalidation waits that follow. Raise it for a very large configuration; the default can also be changed in Preferences > MCP Server > Tools > `clean_project`.
 
 ## What you get
-JSON: `success`, `projectsCleaned` (count), `projects` (the names cleaned), and a human-readable `message`. The call returns only AFTER the rebuild + re-validation finish (it waits up to ~3 min per project), so the project is fully settled when it returns.
+JSON: `success`, `projectsCleaned` (count), `projects` (the names cleaned), and a human-readable `message`. The call returns only after three sequential waits **per project**: the clean build (`timeout`, default 120s), the project-context restart (up to 3 min) and the derived-data recomputation (up to 5 min). On a large configuration one call can therefore take several minutes, and cleaning ALL projects multiplies that - budget the client-side call timeout accordingly.
+
+Two honest caveats about "settled":
+- If the clean build does not finish within `timeout`, the call fails with a timeout error instead of waiting indefinitely. Cancellation is requested, but EDT may still be working on it - poll `list_projects` until the project reports `ready` before relying on the model.
+- If the restart or derived-data wait runs out, that is only logged: the call still reports success. So a `success` means "the clean was driven to completion", not "EDT has certainly finished recomputing". When it matters, confirm with `list_projects`.
 
 ## Notes & gotchas
 - This is a rebuild, not a destructive action - but it **discards UNSAVED in-memory model edits** (they are recomputed from disk). Save pending changes first.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolParameterSettings.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolParameterSettings.java
@@ -131,6 +131,12 @@ public final class ToolParameterSettings // NOSONAR intentional singleton (Eclip
                     + "reporting timeout (or escalating to force-kill when force=true)", //$NON-NLS-1$
                 10, 1, 120)));
 
+        map.put("clean_project", Collections.singletonList( //$NON-NLS-1$
+            new ParameterDef("timeout", "Clean build timeout (sec)", //$NON-NLS-1$ //$NON-NLS-2$
+                "How long to wait for the clean build itself before failing with a timeout " //$NON-NLS-1$
+                    + "instead of holding the call open. Raise it for very large configurations", //$NON-NLS-1$
+                120, 10, 3600)));
+
         TOOL_PARAMETERS = Collections.unmodifiableMap(map);
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CleanProjectTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CleanProjectTool.java
@@ -9,21 +9,23 @@ package com.ditrix.edt.mcp.server.tools.impl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
 
 import com._1c.g5.v8.dt.core.platform.IDtProject;
 import com._1c.g5.v8.dt.core.platform.IDtProjectManager;
 import com.ditrix.edt.mcp.server.Activator;
+import com.ditrix.edt.mcp.server.preferences.ToolParameterSettings;
 import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
 import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.BoundedJob;
 import com.ditrix.edt.mcp.server.utils.BuildUtils;
 import com.ditrix.edt.mcp.server.utils.LifecycleWaiter;
 import com.ditrix.edt.mcp.server.utils.LifecycleWaiter.ProjectRestartWaiter;
@@ -37,10 +39,27 @@ import com.ditrix.edt.mcp.server.utils.ProjectStateChecker;
 public class CleanProjectTool implements IMcpTool
 {
     public static final String NAME = "clean_project"; //$NON-NLS-1$
-    
+
     /** Default timeout for waiting project lifecycle restart (3 minutes) */
     private static final long DEFAULT_LIFECYCLE_TIMEOUT_MS = 3L * 60 * 1000;
-    
+
+    /** Input key: bound on the clean-build phase, in seconds. */
+    static final String KEY_TIMEOUT = "timeout"; //$NON-NLS-1$
+
+    /**
+     * Default bound on the clean-build phase (2 minutes). A healthy clean of the whole
+     * phase takes seconds; the bound only has to be far above that, because its job is to
+     * turn a wedged platform call into an honest error instead of an endless MCP request.
+     * Raise it (parameter or preference) for very large configurations.
+     */
+    static final int DEFAULT_CLEAN_TIMEOUT_SECONDS = 120;
+
+    /** Smallest accepted clean-build bound, in seconds. */
+    private static final int MIN_CLEAN_TIMEOUT_SECONDS = 10;
+
+    /** Largest accepted clean-build bound, in seconds. */
+    private static final int MAX_CLEAN_TIMEOUT_SECONDS = 3600;
+
     @Override
     public String getName()
     {
@@ -66,6 +85,11 @@ public class CleanProjectTool implements IMcpTool
     {
         return JsonSchemaBuilder.object()
             .stringProperty("projectName", "Name of the project to clean (optional, cleans all EDT projects if not specified)") //$NON-NLS-1$ //$NON-NLS-2$
+            .integerProperty(KEY_TIMEOUT, "How long to wait for the clean build itself, in seconds (default " //$NON-NLS-1$
+                + DEFAULT_CLEAN_TIMEOUT_SECONDS + ", clamped to " + MIN_CLEAN_TIMEOUT_SECONDS + ".." //$NON-NLS-1$ //$NON-NLS-2$
+                + MAX_CLEAN_TIMEOUT_SECONDS + "). On expiry the call fails with a timeout error instead of " //$NON-NLS-1$
+                + "waiting forever; the clean may still be running in EDT afterwards. Does not cover the " //$NON-NLS-1$
+                + "subsequent revalidation wait.") //$NON-NLS-1$
             .build();
     }
 
@@ -102,23 +126,67 @@ public class CleanProjectTool implements IMcpTool
             }
         }
         
-        return cleanProject(projectName);
+        return cleanProject(projectName, resolveCleanTimeoutMs(params));
     }
-    
+
     /**
-     * Cleans project and triggers revalidation.
-     * 
-     * <p>To avoid race conditions, lifecycle listeners are registered BEFORE
-     * triggering the clean build operation.
-     * 
+     * Resolves the clean-build bound for this call: the explicit {@code timeout} argument
+     * when given, else the configured per-tool default, clamped to the accepted range.
+     *
+     * @param params the raw tool arguments
+     * @return the bound in milliseconds
+     */
+    static long resolveCleanTimeoutMs(Map<String, String> params)
+    {
+        int configuredDefault = ToolParameterSettings.getInstance()
+            .getParameterValue(NAME, KEY_TIMEOUT, DEFAULT_CLEAN_TIMEOUT_SECONDS);
+        int seconds = JsonUtils.extractIntArgument(params, KEY_TIMEOUT, configuredDefault);
+        return clampTimeoutSeconds(seconds) * 1000L;
+    }
+
+    /**
+     * Clamps a clean-build bound to the accepted range.
+     *
+     * @param seconds the requested bound in seconds
+     * @return the accepted bound in seconds
+     */
+    static int clampTimeoutSeconds(int seconds)
+    {
+        if (seconds < MIN_CLEAN_TIMEOUT_SECONDS)
+        {
+            return MIN_CLEAN_TIMEOUT_SECONDS;
+        }
+        return Math.min(seconds, MAX_CLEAN_TIMEOUT_SECONDS);
+    }
+
+    /**
+     * Cleans project and triggers revalidation, bounding the clean build with the
+     * configured per-tool default.
+     *
      * @param projectName name of the project to clean (null for all projects)
      * @return JSON string with result
      */
     public static String cleanProject(String projectName)
     {
+        int configured = ToolParameterSettings.getInstance()
+            .getParameterValue(NAME, KEY_TIMEOUT, DEFAULT_CLEAN_TIMEOUT_SECONDS);
+        return cleanProject(projectName, clampTimeoutSeconds(configured) * 1000L);
+    }
+
+    /**
+     * Cleans project and triggers revalidation.
+     *
+     * <p>To avoid race conditions, lifecycle listeners are registered BEFORE
+     * triggering the clean build operation.
+     *
+     * @param projectName name of the project to clean (null for all projects)
+     * @param cleanTimeoutMs bound on the clean-build phase, in milliseconds
+     * @return JSON string with result
+     */
+    public static String cleanProject(String projectName, long cleanTimeoutMs)
+    {
         try
         {
-            IProgressMonitor monitor = new NullProgressMonitor();
             IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
 
             // Resolve the set of projects to clean (read-only: validates state and
@@ -135,29 +203,46 @@ public class CleanProjectTool implements IMcpTool
             // This avoids race condition where STOPPED event could be missed
             List<ProjectRestartWaiter> waiters = registerRestartWaiters(projectsToClean);
 
-            // Phase 2: Trigger clean build for all projects
-            for (ProjectCleanInfo info : projectsToClean)
+            try
             {
-                cleanSingleProject(info.project, monitor);
+                // Phase 2: Trigger clean build for all projects, under a hard deadline. Without it
+                // a single wedged platform call holds the MCP request open forever (#349): the
+                // caller eventually dies on its own transport timeout with no answer, no cleanup.
+                String cleanError = runCleanPhase(projectsToClean, cleanTimeoutMs,
+                    (info, monitor) -> cleanSingleProject(info.project, monitor));
+                if (cleanError != null)
+                {
+                    return cleanError;
+                }
+
+                // Phase 3: Wait for lifecycle restarts (STOPPED -> STARTED)
+                for (ProjectRestartWaiter waiter : waiters)
+                {
+                    waiter.await(DEFAULT_LIFECYCLE_TIMEOUT_MS);
+                }
+
+                // Phase 4: Wait for derived data computations
+                for (ProjectCleanInfo info : projectsToClean)
+                {
+                    BuildUtils.waitForDerivedData(info.project);
+                }
+
+                return ToolResult.success()
+                    .put("projectsCleaned", projectNamesList.size()) //$NON-NLS-1$
+                    .put("projects", projectNamesList) //$NON-NLS-1$
+                    .put("message", "Clean and revalidation completed.") //$NON-NLS-1$ //$NON-NLS-2$
+                    .toJson();
             }
-            
-            // Phase 3: Wait for lifecycle restarts (STOPPED -> STARTED)
-            for (ProjectRestartWaiter waiter : waiters)
+            finally
             {
-                waiter.await(DEFAULT_LIFECYCLE_TIMEOUT_MS);
+                // A path that never reaches await() (clean timeout, clean failure, an early return
+                // added later) would otherwise leave the lifecycle listener registered for the rest
+                // of the session. cleanup() is idempotent, so the normal await() path is unaffected.
+                for (ProjectRestartWaiter waiter : waiters)
+                {
+                    waiter.cleanup();
+                }
             }
-            
-            // Phase 4: Wait for derived data computations
-            for (ProjectCleanInfo info : projectsToClean)
-            {
-                BuildUtils.waitForDerivedData(info.project);
-            }
-            
-            return ToolResult.success()
-                .put("projectsCleaned", projectNamesList.size()) //$NON-NLS-1$
-                .put("projects", projectNamesList) //$NON-NLS-1$
-                .put("message", "Clean and revalidation completed.") //$NON-NLS-1$ //$NON-NLS-2$
-                .toJson();
         }
         catch (Exception e)
         {
@@ -225,7 +310,7 @@ public class CleanProjectTool implements IMcpTool
         IDtProject dtProject = dtProjectManager != null ?
             dtProjectManager.getDtProject(project) : null;
 
-        collection.projectsToClean.add(new ProjectCleanInfo(project, dtProject));
+        collection.projectsToClean.add(new ProjectCleanInfo(project, dtProject, projectName));
         collection.projectNamesList.add(projectName);
     }
 
@@ -248,7 +333,7 @@ public class CleanProjectTool implements IMcpTool
             IProject project = dtProject.getWorkspaceProject();
             if (project != null && project.isOpen())
             {
-                collection.projectsToClean.add(new ProjectCleanInfo(project, dtProject));
+                collection.projectsToClean.add(new ProjectCleanInfo(project, dtProject, project.getName()));
                 collection.projectNamesList.add(project.getName());
             }
         }
@@ -278,6 +363,119 @@ public class CleanProjectTool implements IMcpTool
             }
         }
         return waiters;
+    }
+
+    /**
+     * Phase 2: runs the clean build for every project under a single hard deadline shared by
+     * the whole phase, and translates a missed deadline into an actionable error.
+     *
+     * <p>The work runs in a {@link BoundedJob}, so the platform calls receive a monitor that is
+     * cancelled on expiry AND the caller stops waiting regardless — cancellation alone cannot
+     * preempt a platform call that never polls its monitor.
+     *
+     * @param projectsToClean the projects to clean
+     * @param timeoutMs       the bound for the whole phase, in milliseconds
+     * @param action          the per-project clean action (test seam; production cleans for real)
+     * @return {@code null} when the phase completed, otherwise the error JSON to return as-is
+     */
+    static String runCleanPhase(List<ProjectCleanInfo> projectsToClean, long timeoutMs, ICleanAction action)
+    {
+        // Written by the job thread before each project, read by this thread only after the
+        // deadline elapsed — names the project the clean was sitting on when time ran out.
+        AtomicReference<String> current = new AtomicReference<>(null);
+
+        BoundedJob.Result result = BoundedJob.run(NAME + ": clean build", timeoutMs, monitor -> { //$NON-NLS-1$
+            for (ProjectCleanInfo info : projectsToClean)
+            {
+                // The deadline may have passed while the previous project was cleaning. Stop here
+                // rather than starting another project's clean after the caller already gave up.
+                if (monitor.isCanceled())
+                {
+                    return;
+                }
+                current.set(info.name);
+                action.clean(info, monitor);
+            }
+        });
+
+        switch (result.getOutcome())
+        {
+        case TIMED_OUT:
+            return timeoutError(current.get(), timeoutMs);
+        case INTERRUPTED:
+            return ToolResult.error("Project clean was interrupted while waiting for the clean build" //$NON-NLS-1$
+                + onProject(current.get()) + ". The clean may still be running in EDT — check the " //$NON-NLS-1$
+                + "project state with list_projects before retrying.").toJson(); //$NON-NLS-1$
+        case NOT_RUN:
+            return ToolResult.error("The clean build was cancelled before it started, so nothing was " //$NON-NLS-1$
+                + "cleaned. Retry; if it keeps happening, EDT is shutting down or another operation " //$NON-NLS-1$
+                + "is cancelling background jobs.").toJson(); //$NON-NLS-1$
+        default:
+            break;
+        }
+
+        Throwable failure = result.getFailure();
+        if (failure != null)
+        {
+            // Same shape as the surrounding catch: the clean build failed for a real reason.
+            Activator.logError("Error during project clean", failure); //$NON-NLS-1$
+            return ToolResult.error(failure.getMessage()).toJson();
+        }
+        return null;
+    }
+
+    /**
+     * Builds the timeout error: what did not finish, how long we waited, and the levers.
+     *
+     * @param projectName the project the clean was on when time ran out (may be {@code null})
+     * @param timeoutMs   the bound that elapsed, in milliseconds
+     * @return the error JSON
+     */
+    private static String timeoutError(String projectName, long timeoutMs)
+    {
+        long seconds = Math.max(1, Math.round(timeoutMs / 1000.0));
+        // At the ceiling there is no larger value to suggest — advising one would be an
+        // instruction the tool itself would reject.
+        String lever = seconds >= MAX_CLEAN_TIMEOUT_SECONDS
+            ? "This is already the largest accepted '" + KEY_TIMEOUT + "', so the clean is not merely " //$NON-NLS-1$ //$NON-NLS-2$
+                + "slow — look for a stuck build or an EDT operation holding the workspace." //$NON-NLS-1$
+            : "If this configuration legitimately needs longer, pass a larger '" + KEY_TIMEOUT //$NON-NLS-1$
+                + "' (seconds, up to " + MAX_CLEAN_TIMEOUT_SECONDS + ") or raise the default in " //$NON-NLS-1$ //$NON-NLS-2$
+                + "Preferences > MCP Server > Tools > " + NAME + "."; //$NON-NLS-1$ //$NON-NLS-2$
+
+        return ToolResult.error("Clean build did not finish within " + seconds //$NON-NLS-1$
+            + (seconds == 1 ? " second" : " seconds") + onProject(projectName) //$NON-NLS-1$ //$NON-NLS-2$
+            + ". Cancellation was requested, but EDT may still be working on it, so the model can be " //$NON-NLS-1$
+            + "mid-rebuild: check list_projects until the project reports 'ready' before relying on " //$NON-NLS-1$
+            + "the model. " + lever).toJson(); //$NON-NLS-1$
+    }
+
+    /**
+     * Renders the optional " on project 'X'" clause used by the phase-2 error messages.
+     *
+     * @param projectName the project name (may be {@code null} when the phase never started one)
+     * @return the clause, or an empty string when there is no project to name
+     */
+    private static String onProject(String projectName)
+    {
+        return projectName == null || projectName.isEmpty() ? "" : " on project '" + projectName + "'"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    /**
+     * The per-project clean action. Production passes {@link #cleanSingleProject}; tests
+     * substitute a controllable action to exercise the deadline without a live workspace.
+     */
+    @FunctionalInterface
+    interface ICleanAction
+    {
+        /**
+         * Cleans one project.
+         *
+         * @param info    the project to clean
+         * @param monitor the bounded job's monitor, cancelled when the deadline elapses
+         * @throws CoreException when the platform refuses the refresh or the build
+         */
+        void clean(ProjectCleanInfo info, IProgressMonitor monitor) throws CoreException;
     }
 
     /**
@@ -319,15 +517,21 @@ public class CleanProjectTool implements IMcpTool
     /**
      * Helper class to store project info for cleaning.
      */
-    private static class ProjectCleanInfo
+    static class ProjectCleanInfo
     {
         final IProject project;
         final IDtProject dtProject;
-        
-        ProjectCleanInfo(IProject project, IDtProject dtProject)
+        /**
+         * Project name captured up front, so a timeout message can name the project without
+         * touching a project the wedged clean may have left mid-lifecycle.
+         */
+        final String name;
+
+        ProjectCleanInfo(IProject project, IDtProject dtProject, String name)
         {
             this.project = project;
             this.dtProject = dtProject;
+            this.name = name;
         }
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CleanProjectTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CleanProjectTool.java
@@ -9,7 +9,6 @@ package com.ditrix.edt.mcp.server.tools.impl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -85,7 +84,8 @@ public class CleanProjectTool implements IMcpTool
     {
         return JsonSchemaBuilder.object()
             .stringProperty("projectName", "Name of the project to clean (optional, cleans all EDT projects if not specified)") //$NON-NLS-1$ //$NON-NLS-2$
-            .integerProperty(KEY_TIMEOUT, "How long to wait for the clean build itself, in seconds (default " //$NON-NLS-1$
+            .integerProperty(KEY_TIMEOUT, "How long to wait for the clean build itself, per project, " //$NON-NLS-1$
+                + "in seconds (default " //$NON-NLS-1$
                 + DEFAULT_CLEAN_TIMEOUT_SECONDS + ", clamped to " + MIN_CLEAN_TIMEOUT_SECONDS + ".." //$NON-NLS-1$ //$NON-NLS-2$
                 + MAX_CLEAN_TIMEOUT_SECONDS + "). On expiry the call fails with a timeout error instead of " //$NON-NLS-1$
                 + "waiting forever; the clean may still be running in EDT afterwards. Does not cover the " //$NON-NLS-1$
@@ -380,36 +380,47 @@ public class CleanProjectTool implements IMcpTool
      */
     static String runCleanPhase(List<ProjectCleanInfo> projectsToClean, long timeoutMs, ICleanAction action)
     {
-        // Written by the job thread before each project, read by this thread only after the
-        // deadline elapsed — names the project the clean was sitting on when time ran out.
-        AtomicReference<String> current = new AtomicReference<>(null);
-
-        BoundedJob.Result result = BoundedJob.run(NAME + ": clean build", timeoutMs, monitor -> { //$NON-NLS-1$
-            for (ProjectCleanInfo info : projectsToClean)
+        // The bound is PER PROJECT, not for the whole phase: 'clean all' over several healthy
+        // projects would otherwise be refused once their COMBINED time crossed the limit, with
+        // nothing actually wedged. A single wedged project still fails on its own deadline, and the
+        // error returns immediately - so the projects behind it are never started.
+        for (ProjectCleanInfo info : projectsToClean)
+        {
+            String error = cleanOneBounded(info, timeoutMs, action);
+            if (error != null)
             {
-                // The deadline may have passed while the previous project was cleaning. Stop here
-                // rather than starting another project's clean after the caller already gave up.
-                if (monitor.isCanceled())
-                {
-                    return;
-                }
-                current.set(info.name);
-                action.clean(info, monitor);
+                return error;
             }
-        });
+        }
+        return null;
+    }
+
+    /**
+     * Cleans one project under its own deadline and turns anything but a clean completion into the
+     * error JSON to return.
+     *
+     * @param info      the project to clean
+     * @param timeoutMs the bound for THIS project, in milliseconds
+     * @param action    the per-project clean action
+     * @return {@code null} when the project was cleaned, otherwise the error JSON
+     */
+    private static String cleanOneBounded(ProjectCleanInfo info, long timeoutMs, ICleanAction action)
+    {
+        BoundedJob.Result result = BoundedJob.run(NAME + ": clean build " + info.name, timeoutMs, //$NON-NLS-1$
+            monitor -> action.clean(info, monitor));
 
         switch (result.getOutcome())
         {
         case TIMED_OUT:
-            return timeoutError(current.get(), timeoutMs);
+            return timeoutError(info.name, timeoutMs);
         case INTERRUPTED:
             return ToolResult.error("Project clean was interrupted while waiting for the clean build" //$NON-NLS-1$
-                + onProject(current.get()) + ". The clean may still be running in EDT — check the " //$NON-NLS-1$
+                + onProject(info.name) + ". The clean may still be running in EDT — check the " //$NON-NLS-1$
                 + "project state with list_projects before retrying.").toJson(); //$NON-NLS-1$
         case NOT_RUN:
-            return ToolResult.error("The clean build was cancelled before it started, so nothing was " //$NON-NLS-1$
-                + "cleaned. Retry; if it keeps happening, EDT is shutting down or another operation " //$NON-NLS-1$
-                + "is cancelling background jobs.").toJson(); //$NON-NLS-1$
+            return ToolResult.error("The clean build" + onProject(info.name) + " was cancelled before " //$NON-NLS-1$ //$NON-NLS-2$
+                + "it started, so nothing was cleaned. Retry; if it keeps happening, EDT is shutting " //$NON-NLS-1$
+                + "down or another operation is cancelling background jobs.").toJson(); //$NON-NLS-1$
         default:
             break;
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskTool.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
@@ -41,6 +42,9 @@ import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.base.AbstractMetadataWriteTool;
 import com.ditrix.edt.mcp.server.utils.BmTransactions;
 import com.ditrix.edt.mcp.server.utils.MetadataPathResolver;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 /**
  * Bulk re-synchronizes the in-memory BM model to the on-disk {@code src/}
@@ -377,11 +381,30 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
      */
     private String runOptionalRevalidation(String projectName, boolean revalidate, boolean exported)
     {
+        return runOptionalRevalidation(projectName, revalidate, exported, CleanProjectTool::cleanProject);
+    }
+
+    /**
+     * Same as {@link #runOptionalRevalidation(String, boolean, boolean)} with the revalidation
+     * delegate injected, so the reporting contract can be tested without a live workspace.
+     *
+     * @param projectName the project to revalidate
+     * @param revalidate whether revalidation was requested
+     * @param exported whether the export succeeded
+     * @param revalidator the delegate that revalidates and returns a tool result envelope
+     * @return the warning message when revalidation failed or was reported as failed, else {@code null}
+     */
+    static String runOptionalRevalidation(String projectName, boolean revalidate, boolean exported,
+        UnaryOperator<String> revalidator)
+    {
         if (revalidate && exported)
         {
             try
             {
-                CleanProjectTool.cleanProject(projectName);
+                // clean_project REPORTS most failures instead of throwing (a missed clean-build
+                // deadline, a project that went missing/closed). Ignoring the returned envelope
+                // would let resync_to_disk claim success while EDT is still mid-rebuild.
+                return revalidateWarningFrom(revalidator.apply(projectName));
             }
             catch (Exception e)
             {
@@ -390,6 +413,52 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
             }
         }
         return null;
+    }
+
+    /**
+     * Extracts the warning to surface from a {@code clean_project} result envelope.
+     *
+     * <p>Uses the same error rule as the protocol layer: ONLY an explicit {@code success == false}
+     * boolean marks an error payload, so a successful result that happens to carry an
+     * {@code error}-named field is not mistaken for a failure.
+     *
+     * @param cleanResultJson the JSON returned by {@link CleanProjectTool#cleanProject(String)}
+     * @return the message to report as {@code revalidateWarning}, or {@code null} when the
+     *     revalidation succeeded (or the payload is not a readable envelope)
+     */
+    static String revalidateWarningFrom(String cleanResultJson)
+    {
+        if (cleanResultJson == null || cleanResultJson.isEmpty())
+        {
+            return null;
+        }
+        try
+        {
+            JsonElement element = JsonParser.parseString(cleanResultJson);
+            if (!element.isJsonObject())
+            {
+                return null;
+            }
+            JsonObject obj = element.getAsJsonObject();
+            JsonElement success = obj.get("success"); //$NON-NLS-1$
+            boolean isError = success != null && success.isJsonPrimitive()
+                && success.getAsJsonPrimitive().isBoolean() && !success.getAsBoolean();
+            if (!isError)
+            {
+                return null;
+            }
+            JsonElement error = obj.get("error"); //$NON-NLS-1$
+            if (error != null && error.isJsonPrimitive())
+            {
+                return "Revalidation after resync did not complete: " + error.getAsString(); //$NON-NLS-1$
+            }
+            return "Revalidation after resync did not complete."; //$NON-NLS-1$
+        }
+        catch (Exception e) // NOSONAR an unreadable envelope must not fail the resync itself
+        {
+            Activator.logError("Could not read the revalidation result envelope", e); //$NON-NLS-1$
+            return null;
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BoundedJob.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BoundedJob.java
@@ -1,0 +1,203 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+
+/**
+ * Runs a unit of platform work in a background {@link Job} and waits for it with a hard
+ * deadline, so an unattended MCP call can never be held open indefinitely by a wedged
+ * platform operation.
+ *
+ * <p>Two layers of protection, deliberately combined:
+ * <ul>
+ * <li>the work receives the {@link Job}'s own {@link IProgressMonitor}, which is cancelled
+ * when the deadline elapses — a platform call that polls its monitor (notably one waiting
+ * for a conflicting scheduling rule) unwinds with {@code OperationCanceledException};</li>
+ * <li>the caller stops waiting at the deadline regardless — cancellation is cooperative and
+ * cannot preempt code that never polls, so the bound on the CALLER is what actually
+ * guarantees an answer.</li>
+ * </ul>
+ *
+ * <p><b>A timed-out job keeps running.</b> Cancelling only asks it to stop; the caller must
+ * report the timeout honestly rather than pretend the work was undone.
+ *
+ * <p>The job is joined synchronously by the calling thread, so an unattended-safety
+ * suppressor armed around the call (auth dialogs, launch auto-confirm) still sees the
+ * request in flight and keeps covering modals raised from the job thread.
+ */
+public final class BoundedJob
+{
+    /** How a bounded run ended. */
+    public enum Outcome
+    {
+        /** The work returned before the deadline (it may still have failed — see the failure). */
+        COMPLETED,
+        /** The deadline elapsed first; the job was cancelled but may still be running. */
+        TIMED_OUT,
+        /** The waiting thread was interrupted; the job was cancelled but may still be running. */
+        INTERRUPTED,
+        /**
+         * The job left the queue without ever entering the work — it was cancelled before it
+         * started. Distinguished from {@link #COMPLETED} because a job that never ran did NOT do
+         * the work, and reporting that as success is a false green.
+         */
+        NOT_RUN
+    }
+
+    /**
+     * The work to run under a deadline.
+     */
+    @FunctionalInterface
+    public interface IBoundedWork
+    {
+        /**
+         * Performs the work.
+         *
+         * @param monitor the job's monitor; cancelled when the deadline elapses
+         * @throws Exception any failure — captured into {@link Result#getFailure()}, never
+         *     propagated out of the job thread
+         */
+        void run(IProgressMonitor monitor) throws Exception; // NOSONAR the work is arbitrary platform code
+    }
+
+    /**
+     * The outcome of a bounded run.
+     */
+    public static final class Result
+    {
+        private final Outcome outcome;
+        private final long elapsedMs;
+        private final Throwable failure;
+
+        Result(Outcome outcome, long elapsedMs, Throwable failure)
+        {
+            this.outcome = outcome;
+            this.elapsedMs = elapsedMs;
+            this.failure = failure;
+        }
+
+        /**
+         * @return how the run ended
+         */
+        public Outcome getOutcome()
+        {
+            return outcome;
+        }
+
+        /**
+         * @return wall-clock milliseconds the caller waited
+         */
+        public long getElapsedMs()
+        {
+            return elapsedMs;
+        }
+
+        /**
+         * @return the throwable the work raised, or {@code null} when it did not raise one
+         *     (always {@code null} for {@link Outcome#TIMED_OUT}, where the work never returned)
+         */
+        public Throwable getFailure()
+        {
+            return failure;
+        }
+
+        /**
+         * @return {@code true} when the work returned before the deadline WITHOUT raising
+         */
+        public boolean isSuccess()
+        {
+            return outcome == Outcome.COMPLETED && failure == null;
+        }
+    }
+
+    private BoundedJob()
+    {
+        // Utility
+    }
+
+    /**
+     * Runs {@code work} in a background job and waits at most {@code timeoutMs} for it.
+     *
+     * <p>An {@link Error} raised by the work is NOT captured as a result: it is rethrown on the
+     * calling thread, exactly as it would have propagated before the work moved off that thread.
+     * Only {@link Exception}s are reportable outcomes.
+     *
+     * @param jobName   the job name shown in EDT's progress UI
+     * @param timeoutMs the deadline in milliseconds (values below 1 are treated as 1)
+     * @param work      the work to run
+     * @return the outcome — never {@code null}, never throws for a work that raised an Exception
+     */
+    public static Result run(String jobName, long timeoutMs, IBoundedWork work)
+    {
+        long startMs = System.currentTimeMillis();
+        // Written by the job thread, read by the calling thread only after join() reports the job
+        // finished — that report is the happens-before edge. On the TIMED_OUT path they are not
+        // read at all, precisely because the job may still be writing them.
+        final Throwable[] failureHolder = new Throwable[1];
+        final boolean[] enteredWork = new boolean[1];
+
+        Job job = new Job(jobName)
+        {
+            @Override
+            protected IStatus run(IProgressMonitor monitor)
+            {
+                enteredWork[0] = true;
+                try
+                {
+                    work.run(monitor);
+                }
+                catch (Throwable t) // NOSONAR captured here, but an Error is rethrown by the caller
+                {
+                    failureHolder[0] = t;
+                }
+                return Status.OK_STATUS;
+            }
+        };
+        job.setUser(false);
+        job.schedule();
+
+        boolean finished;
+        try
+        {
+            finished = job.join(Math.max(1L, timeoutMs), new NullProgressMonitor());
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            job.cancel();
+            return new Result(Outcome.INTERRUPTED, System.currentTimeMillis() - startMs, e);
+        }
+
+        if (!finished)
+        {
+            // Ask the platform call to unwind at its next monitor poll. It may never poll —
+            // hence the caller already stopped waiting, and the job may outlive this call.
+            job.cancel();
+            return new Result(Outcome.TIMED_OUT, System.currentTimeMillis() - startMs, null);
+        }
+
+        long elapsedMs = System.currentTimeMillis() - startMs;
+        if (!enteredWork[0])
+        {
+            // The job left the queue without running (cancelled before it started). It did NOT do
+            // the work, so it must not be reported as a completed one.
+            return new Result(Outcome.NOT_RUN, elapsedMs, null);
+        }
+        if (failureHolder[0] instanceof Error)
+        {
+            // Preserve pre-#349 semantics: an Error was never a reportable tool outcome, it
+            // propagated. Moving the work to a job thread must not turn that into a JSON error.
+            throw (Error)failureHolder[0];
+        }
+        return new Result(Outcome.COMPLETED, elapsedMs, failureHolder[0]);
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LifecycleWaiter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LifecycleWaiter.java
@@ -8,6 +8,7 @@ package com.ditrix.edt.mcp.server.utils;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com._1c.g5.v8.dt.core.lifecycle.ProjectContext;
 import com._1c.g5.v8.dt.core.platform.IDtProject;
@@ -162,6 +163,8 @@ public final class LifecycleWaiter
         private final CountDownLatch startedLatch = new CountDownLatch(1);
         private final IServiceContextLifecycleListener listener;
         private final long registrationTime;
+        /** Guards {@link #cleanup()} so abandoning a wait cannot double-remove the listener. */
+        private final AtomicBoolean cleaned = new AtomicBoolean(false);
         
         ProjectRestartWaiter(IServicesOrchestrator orchestrator, String projectName)
         {
@@ -260,6 +263,12 @@ public final class LifecycleWaiter
          */
         public void cleanup()
         {
+            // Idempotent: a caller that abandons the wait (clean timeout, early error) cleans up in
+            // a finally, which may run after await() already cleaned up on the normal path.
+            if (!cleaned.compareAndSet(false, true))
+            {
+                return;
+            }
             try
             {
                 orchestrator.removeListener(listener);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LifecycleWaiter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LifecycleWaiter.java
@@ -276,6 +276,10 @@ public final class LifecycleWaiter
             }
             catch (Exception e)
             {
+                // Removal did NOT happen, so the listener is still registered: release the guard so
+                // the caller's fallback cleanup can try again. Keeping it set would retire a still
+                // -live listener for the rest of the session.
+                cleaned.set(false);
                 Activator.logError("Error removing lifecycle listener", e); //$NON-NLS-1$
             }
         }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CleanProjectToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CleanProjectToolTest.java
@@ -8,11 +8,27 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.junit.Test;
 
+import com.ditrix.edt.mcp.server.preferences.ToolParameterSettings;
+import com.ditrix.edt.mcp.server.preferences.ToolParameterSettings.ParameterDef;
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+import com.ditrix.edt.mcp.server.tools.impl.CleanProjectTool.ProjectCleanInfo;
 
 /**
  * Tests for {@link CleanProjectTool}.
@@ -22,6 +38,11 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
  * lifecycle, so there is no argument-validation branch reachable before live
  * access. This is a destructive tool — the tests assert the static contract only
  * and never invoke {@code execute()}; cleaning is covered by the E2E suite.
+ * <p>
+ * The clean-build phase is the exception: it is reachable through the
+ * {@link CleanProjectTool.ICleanAction} seam, so the deadline that keeps a wedged platform
+ * call from holding the MCP request open forever (issue #349) is tested here with a
+ * controllable action and no live workspace.
  */
 public class CleanProjectToolTest
 {
@@ -57,5 +78,219 @@ public class CleanProjectToolTest
         String schema = new CleanProjectTool().getInputSchema();
         assertNotNull(schema);
         assertTrue(schema.contains("\"projectName\"")); //$NON-NLS-1$
+        assertTrue("the clean-build bound must be reachable from the wire", //$NON-NLS-1$
+            schema.contains("\"timeout\"")); //$NON-NLS-1$
+    }
+
+    /**
+     * Deadline for the wedged-clean test. The deadline starts when the job is scheduled, so it
+     * must stay well above the job-start latency — a job cancelled before it ran would never set
+     * the current project, and the "names the project" assertion would have nothing to see.
+     */
+    private static final long SHORT_TIMEOUT_MS = 2000;
+
+    /** Ceiling on the wedged action — finite, so a lost deadline fails instead of hanging the suite. */
+    private static final long WEDGE_CEILING_MS = 60_000;
+
+    /** Bound that a bounded call must beat comfortably. */
+    private static final long SANE_RETURN_MS = 30_000;
+
+    @Test
+    public void testWedgedCleanFailsOnItsDeadlineWithAnActionableError() throws Exception
+    {
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch started = new CountDownLatch(1);
+        List<ProjectCleanInfo> projects =
+            Collections.singletonList(new ProjectCleanInfo(null, null, "Demo")); //$NON-NLS-1$
+        try
+        {
+            long startMs = System.currentTimeMillis();
+            String error = CleanProjectTool.runCleanPhase(projects, SHORT_TIMEOUT_MS,
+                (info, monitor) -> {
+                    started.countDown();
+                    awaitQuietly(release);
+                });
+            long elapsedMs = System.currentTimeMillis() - startMs;
+
+            // Asserted first: a stalled scheduler must report as "the clean never started", not as
+            // "the error text is wrong".
+            assertTrue("the clean action must have started for this test to judge its message", //$NON-NLS-1$
+                started.await(SANE_RETURN_MS, TimeUnit.MILLISECONDS));
+
+            // Without the deadline this returns only when the action's own ceiling expires.
+            assertTrue("a wedged clean must fail on its deadline, not on the action's ceiling (waited " //$NON-NLS-1$
+                + elapsedMs + "ms)", elapsedMs < SANE_RETURN_MS); //$NON-NLS-1$
+            assertNotNull("a missed deadline must produce an error payload", error); //$NON-NLS-1$
+            assertTrue("the error must say what did not finish: " + error, //$NON-NLS-1$
+                error.contains("Clean build did not finish within")); //$NON-NLS-1$
+            assertTrue("the error must name the project it was cleaning: " + error, //$NON-NLS-1$
+                error.contains("Demo")); //$NON-NLS-1$
+            assertTrue("the error must say the model may still be rebuilding: " + error, //$NON-NLS-1$
+                error.contains("list_projects")); //$NON-NLS-1$
+            assertTrue("the error must name the lever that raises the bound: " + error, //$NON-NLS-1$
+                error.contains("'timeout'")); //$NON-NLS-1$
+        }
+        finally
+        {
+            release.countDown();
+        }
+    }
+
+    /**
+     * Cleaning ALL projects must stop at the deadline, not walk on to the next project after the
+     * caller already got its timeout answer. Without the cancellation check the loop would clean
+     * the second project long after the MCP call returned.
+     */
+    @Test
+    public void testDeadlineStopsTheLoopInsteadOfCleaningTheNextProject() throws Exception
+    {
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        AtomicBoolean secondWasCleaned = new AtomicBoolean(false);
+        List<ProjectCleanInfo> projects = Arrays.asList(
+            new ProjectCleanInfo(null, null, "First"), //$NON-NLS-1$
+            new ProjectCleanInfo(null, null, "Second")); //$NON-NLS-1$
+        try
+        {
+            String error = CleanProjectTool.runCleanPhase(projects, SHORT_TIMEOUT_MS, (info, monitor) -> {
+                if ("Second".equals(info.name)) //$NON-NLS-1$
+                {
+                    secondWasCleaned.set(true);
+                    return;
+                }
+                firstStarted.countDown();
+                awaitQuietly(release);
+            });
+
+            assertTrue("the first clean must have started", //$NON-NLS-1$
+                firstStarted.await(SANE_RETURN_MS, TimeUnit.MILLISECONDS));
+            assertNotNull("a wedged first project must still produce the timeout error", error); //$NON-NLS-1$
+        }
+        finally
+        {
+            release.countDown();
+        }
+
+        // Give the abandoned job a chance to misbehave: once released, an unguarded loop would
+        // proceed to the second project. The guard must stop it even though the job is still alive.
+        Thread.sleep(500);
+        assertTrue("the deadline must stop the loop, not let it clean the next project after the " //$NON-NLS-1$
+            + "call already returned", !secondWasCleaned.get()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testCleanThatFinishesReportsNoError()
+    {
+        AtomicBoolean cleaned = new AtomicBoolean(false);
+        List<ProjectCleanInfo> projects =
+            Collections.singletonList(new ProjectCleanInfo(null, null, "Demo")); //$NON-NLS-1$
+
+        String error = CleanProjectTool.runCleanPhase(projects, WEDGE_CEILING_MS,
+            (info, monitor) -> cleaned.set(true));
+
+        assertTrue("the action must have run", cleaned.get()); //$NON-NLS-1$
+        assertNull("a completed clean phase reports no error", error); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testCleanFailureIsReportedWithItsOwnMessage()
+    {
+        List<ProjectCleanInfo> projects =
+            Collections.singletonList(new ProjectCleanInfo(null, null, "Demo")); //$NON-NLS-1$
+
+        String error = CleanProjectTool.runCleanPhase(projects, WEDGE_CEILING_MS, (info, monitor) -> {
+            throw new CoreException(new Status(IStatus.ERROR, "test", "refresh refused")); //$NON-NLS-1$ //$NON-NLS-2$
+        });
+
+        assertNotNull("a failing clean must produce an error payload", error); //$NON-NLS-1$
+        assertTrue("the platform's own message must survive: " + error, //$NON-NLS-1$
+            error.contains("refresh refused")); //$NON-NLS-1$
+        assertTrue("a real failure must not be dressed up as a timeout: " + error, //$NON-NLS-1$
+            !error.contains("did not finish within")); //$NON-NLS-1$
+    }
+
+    /**
+     * The configurable default and the tool's accepted range are two statements of one rule.
+     * Pinned in both directions so moving either one alone reddens.
+     */
+    @Test
+    public void testConfigurableTimeoutMatchesTheToolsOwnBounds()
+    {
+        List<ParameterDef> params =
+            ToolParameterSettings.getInstance().getParametersForTool(CleanProjectTool.NAME);
+        assertEquals("clean_project publishes exactly one configurable parameter", 1, params.size()); //$NON-NLS-1$
+        ParameterDef timeout = params.get(0);
+        assertEquals(CleanProjectTool.KEY_TIMEOUT, timeout.getName());
+        assertEquals("the configured default must be the tool's own default", //$NON-NLS-1$
+            CleanProjectTool.DEFAULT_CLEAN_TIMEOUT_SECONDS, timeout.getDefaultValue());
+
+        assertEquals("the settings minimum must be the smallest value the tool accepts", //$NON-NLS-1$
+            timeout.getMinValue(), CleanProjectTool.clampTimeoutSeconds(timeout.getMinValue()));
+        assertEquals("anything below it is raised to the minimum", //$NON-NLS-1$
+            timeout.getMinValue(), CleanProjectTool.clampTimeoutSeconds(timeout.getMinValue() - 1));
+        assertEquals("the settings maximum must be the largest value the tool accepts", //$NON-NLS-1$
+            timeout.getMaxValue(), CleanProjectTool.clampTimeoutSeconds(timeout.getMaxValue()));
+        assertEquals("anything above it is lowered to the maximum", //$NON-NLS-1$
+            timeout.getMaxValue(), CleanProjectTool.clampTimeoutSeconds(timeout.getMaxValue() + 1));
+    }
+
+    /**
+     * The wire parameter must actually reach the deadline. A tool that declared {@code timeout}
+     * in its schema but never read it would pass every other test here — this one fails.
+     */
+    @Test
+    public void testWireTimeoutIsTheOneThatBoundsTheClean()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put(CleanProjectTool.KEY_TIMEOUT, "600"); //$NON-NLS-1$
+        assertEquals("an explicit timeout must be the bound that is used", //$NON-NLS-1$
+            600_000L, CleanProjectTool.resolveCleanTimeoutMs(params));
+
+        assertEquals("no argument falls back to the configured default", //$NON-NLS-1$
+            CleanProjectTool.DEFAULT_CLEAN_TIMEOUT_SECONDS * 1000L,
+            CleanProjectTool.resolveCleanTimeoutMs(new HashMap<>()));
+    }
+
+    /**
+     * Out-of-range values are clamped, not rejected (the same contract as terminate_launch), and
+     * the schema says so. Pinned here so a silent change of that contract is visible.
+     */
+    @Test
+    public void testOutOfRangeWireTimeoutIsClampedIntoTheAcceptedRange()
+    {
+        List<ParameterDef> params =
+            ToolParameterSettings.getInstance().getParametersForTool(CleanProjectTool.NAME);
+        ParameterDef def = params.get(0);
+
+        Map<String, String> tooSmall = new HashMap<>();
+        tooSmall.put(CleanProjectTool.KEY_TIMEOUT, String.valueOf(def.getMinValue() - 1));
+        assertEquals("a value below the range is raised to the minimum, not rejected", //$NON-NLS-1$
+            def.getMinValue() * 1000L, CleanProjectTool.resolveCleanTimeoutMs(tooSmall));
+
+        Map<String, String> tooLarge = new HashMap<>();
+        tooLarge.put(CleanProjectTool.KEY_TIMEOUT, String.valueOf(def.getMaxValue() + 1));
+        assertEquals("a value above the range is lowered to the maximum, not rejected", //$NON-NLS-1$
+            def.getMaxValue() * 1000L, CleanProjectTool.resolveCleanTimeoutMs(tooLarge));
+
+        assertTrue("the schema must not promise rejection when the tool clamps", //$NON-NLS-1$
+            new CleanProjectTool().getInputSchema().contains("clamped")); //$NON-NLS-1$
+    }
+
+    /**
+     * Blocks until released or the wedge ceiling expires — the stand-in for a platform call
+     * that stopped making progress.
+     *
+     * @param release the latch the test releases in its finally block
+     */
+    private static void awaitQuietly(CountDownLatch release)
+    {
+        try
+        {
+            release.await(WEDGE_CEILING_MS, TimeUnit.MILLISECONDS);
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskToolTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.UnaryOperator;
 
 import org.junit.Test;
 
@@ -598,6 +599,81 @@ public class ResyncToDiskToolTest
         {
             deleteRecursively(projectRoot);
         }
+    }
+
+    /**
+     * The optional post-export revalidation delegates to {@code clean_project}, which REPORTS
+     * most failures instead of throwing — a missed clean-build deadline among them (#349).
+     * Discarding that envelope would let resync_to_disk claim success while EDT is still
+     * mid-rebuild, so the failure must come back as the declared {@code revalidateWarning}.
+     */
+    @Test
+    public void testReportedRevalidationFailureBecomesAWarningInsteadOfBeingDiscarded()
+    {
+        String timeout = ResyncToDiskTool.revalidateWarningFrom(
+            "{\"success\":false,\"error\":\"Clean build did not finish within 120 seconds\"}"); //$NON-NLS-1$
+        assertNotNull("a reported clean failure must not be swallowed", timeout); //$NON-NLS-1$
+        assertTrue("the warning must carry the reason: " + timeout, //$NON-NLS-1$
+            timeout.contains("Clean build did not finish within 120 seconds")); //$NON-NLS-1$
+    }
+
+    /**
+     * The wiring, not just the helper: the revalidation step must FEED the delegate's envelope
+     * through the reporting rule. A call site that discarded the returned JSON would pass every
+     * helper test above and fail this one.
+     */
+    @Test
+    public void testRevalidationStepReportsWhatTheDelegateReturned()
+    {
+        String warning = ResyncToDiskTool.runOptionalRevalidation("Demo", true, true, //$NON-NLS-1$
+            project -> "{\"success\":false,\"error\":\"Clean build did not finish within 120 seconds\"}"); //$NON-NLS-1$
+
+        assertNotNull("a reported clean failure must reach the caller", warning); //$NON-NLS-1$
+        assertTrue("the reason must survive: " + warning, //$NON-NLS-1$
+            warning.contains("Clean build did not finish within 120 seconds")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRevalidationStepIsSkippedWhenNotRequestedOrExportFailed()
+    {
+        AtomicBoolean called = new AtomicBoolean(false);
+        UnaryOperator<String> spy = project -> {
+            called.set(true);
+            return "{\"success\":false,\"error\":\"must not run\"}"; //$NON-NLS-1$
+        };
+
+        assertNull(ResyncToDiskTool.runOptionalRevalidation("Demo", false, true, spy)); //$NON-NLS-1$
+        assertNull(ResyncToDiskTool.runOptionalRevalidation("Demo", true, false, spy)); //$NON-NLS-1$
+        assertFalse("a failed or unrequested export must not trigger a clean build", called.get()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSuccessfulRevalidationProducesNoWarning()
+    {
+        assertNull("a successful clean must not raise a warning", //$NON-NLS-1$
+            ResyncToDiskTool.revalidateWarningFrom(
+                "{\"success\":true,\"projectsCleaned\":1,\"projects\":[\"Demo\"]}")); //$NON-NLS-1$
+    }
+
+    /**
+     * The error rule is an explicit {@code success == false}, the same one the protocol layer
+     * uses. A successful payload that merely carries a field named "error" is NOT a failure —
+     * otherwise every future field name would be coupled to error detection.
+     */
+    @Test
+    public void testSuccessCarryingAnErrorFieldIsNotTreatedAsFailure()
+    {
+        assertNull("only success==false marks an error envelope", //$NON-NLS-1$
+            ResyncToDiskTool.revalidateWarningFrom(
+                "{\"success\":true,\"error\":\"a diagnostics field, not a failure\"}")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testUnreadableRevalidationEnvelopeDoesNotInventAWarning()
+    {
+        assertNull(ResyncToDiskTool.revalidateWarningFrom(null));
+        assertNull(ResyncToDiskTool.revalidateWarningFrom("")); //$NON-NLS-1$
+        assertNull(ResyncToDiskTool.revalidateWarningFrom("not json at all")); //$NON-NLS-1$
     }
 
     /** Recursively deletes a temp directory tree (best-effort test cleanup). */

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/BoundedJobTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/BoundedJobTest.java
@@ -1,0 +1,152 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.utils.BoundedJob.Outcome;
+
+/**
+ * Tests for {@link BoundedJob}: the deadline that keeps a wedged platform call from holding an
+ * unattended MCP request open forever (issue #349).
+ * <p>
+ * The "wedged" work in these tests waits on a latch with its OWN finite ceiling, so an
+ * implementation that lost the bound fails the elapsed-time assertion instead of hanging the
+ * whole suite — a test for a timeout must itself terminate when the timeout is gone.
+ */
+public class BoundedJobTest
+{
+    /**
+     * Deadline for the timeout tests. The deadline starts at schedule time, so it must stay well
+     * above the job-start latency: a job that had not started yet when the deadline elapsed is
+     * cancelled before it ever runs, and the start-dependent assertions below would have nothing
+     * to observe. Jobs start in single-digit milliseconds here, so 2s is a large margin.
+     */
+    private static final long SHORT_TIMEOUT_MS = 2000;
+
+    /** Ceiling on the wedged work, well above {@link #SHORT_TIMEOUT_MS} but still finite. */
+    private static final long WEDGE_CEILING_MS = 60_000;
+
+    /** Bound that comfortably exceeds any real scheduling delay yet stays far below the wedge ceiling. */
+    private static final long SANE_RETURN_MS = 30_000;
+
+    /** Deadline for work that is expected to finish on its own. */
+    private static final long GENEROUS_TIMEOUT_MS = 60_000;
+
+    @Test
+    public void testWorkThatReturnsIsReportedAsSuccess()
+    {
+        AtomicBoolean ran = new AtomicBoolean(false);
+
+        BoundedJob.Result result = BoundedJob.run("test: quick work", GENEROUS_TIMEOUT_MS, //$NON-NLS-1$
+            monitor -> ran.set(true));
+
+        assertTrue("the work must have run", ran.get()); //$NON-NLS-1$
+        assertEquals(Outcome.COMPLETED, result.getOutcome());
+        assertTrue("work that returned without raising is a success", result.isSuccess()); //$NON-NLS-1$
+        assertNull("nothing was raised", result.getFailure()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testWorkFailureIsCapturedNotPropagated()
+    {
+        BoundedJob.Result result = BoundedJob.run("test: failing work", GENEROUS_TIMEOUT_MS, //$NON-NLS-1$
+            monitor -> {
+                throw new IllegalStateException("boom"); //$NON-NLS-1$
+            });
+
+        assertEquals("a raising work still returned before the deadline", //$NON-NLS-1$
+            Outcome.COMPLETED, result.getOutcome());
+        assertFalse("a raising work is not a success", result.isSuccess()); //$NON-NLS-1$
+        assertEquals("boom", result.getFailure().getMessage()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testWorkThatDoesNotReturnTimesOutInsteadOfWaitingForIt() throws Exception
+    {
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch started = new CountDownLatch(1);
+        try
+        {
+            BoundedJob.Result result = BoundedJob.run("test: wedged work", SHORT_TIMEOUT_MS, //$NON-NLS-1$
+                monitor -> {
+                    started.countDown();
+                    release.await(WEDGE_CEILING_MS, TimeUnit.MILLISECONDS);
+                });
+
+            assertTrue("the work must have started", started.await(SANE_RETURN_MS, TimeUnit.MILLISECONDS)); //$NON-NLS-1$
+            assertEquals(Outcome.TIMED_OUT, result.getOutcome());
+            assertFalse("a timed-out run is not a success", result.isSuccess()); //$NON-NLS-1$
+            assertNull("the work never returned, so it never reported a failure", result.getFailure()); //$NON-NLS-1$
+            // The real assertion: the caller stopped waiting. Without the bound this would be
+            // the work's own ceiling (WEDGE_CEILING_MS), not a fraction of it.
+            assertTrue("the call must return on its deadline, not on the work's ceiling (waited " //$NON-NLS-1$
+                + result.getElapsedMs() + "ms)", result.getElapsedMs() < SANE_RETURN_MS); //$NON-NLS-1$
+        }
+        finally
+        {
+            release.countDown();
+        }
+    }
+
+    @Test
+    public void testTimeoutCancelsTheMonitorHandedToTheWork() throws Exception
+    {
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch observedCancel = new CountDownLatch(1);
+
+        BoundedJob.Result result = BoundedJob.run("test: cancellable work", SHORT_TIMEOUT_MS, //$NON-NLS-1$
+            monitor -> {
+                started.countDown();
+                long ceiling = System.currentTimeMillis() + WEDGE_CEILING_MS;
+                while (System.currentTimeMillis() < ceiling)
+                {
+                    if (monitor.isCanceled())
+                    {
+                        observedCancel.countDown();
+                        return;
+                    }
+                    Thread.sleep(20);
+                }
+            });
+
+        assertEquals(Outcome.TIMED_OUT, result.getOutcome());
+        // Asserted separately so a stalled scheduler reports as "the work never started" rather
+        // than masquerading as "cancellation was not propagated".
+        assertTrue("the work must have started for this test to say anything about cancellation", //$NON-NLS-1$
+            started.await(SANE_RETURN_MS, TimeUnit.MILLISECONDS));
+        assertTrue("work polling its monitor must see the cancellation the deadline raises", //$NON-NLS-1$
+            observedCancel.await(SANE_RETURN_MS, TimeUnit.MILLISECONDS));
+    }
+
+    /**
+     * The NOT_RUN guard distinguishes "the job left the queue" from "the work ran". Its own branch
+     * needs a job cancelled by a third party before it starts, which cannot be produced
+     * deterministically from here; what IS pinned is that adding the guard did not make the normal
+     * COMPLETED path unreachable — the failure mode a "did it really run?" flag invites.
+     */
+    @Test
+    public void testTheDidItRunGuardLeavesTheNormalCompletedPathReachable()
+    {
+        BoundedJob.Result result = BoundedJob.run("test: ordinary work", SHORT_TIMEOUT_MS, //$NON-NLS-1$
+            monitor -> {
+                // Reached only if the job actually runs.
+            });
+
+        assertEquals(Outcome.COMPLETED, result.getOutcome());
+        assertTrue("work that ran and returned is a success", result.isSuccess()); //$NON-NLS-1$
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LifecycleWaiterCleanupTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LifecycleWaiterCleanupTest.java
@@ -1,0 +1,84 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.junit.Test;
+
+import com._1c.g5.v8.dt.lifecycle.ILifecycleContext;
+import com._1c.g5.v8.dt.lifecycle.IServiceContextLifecycleListener;
+import com._1c.g5.v8.dt.lifecycle.IServicesOrchestrator;
+import com.ditrix.edt.mcp.server.utils.LifecycleWaiter.ProjectRestartWaiter;
+
+/**
+ * Tests {@link ProjectRestartWaiter#cleanup()} idempotency.
+ * <p>
+ * A caller that abandons the wait (a clean that timed out, an early error) must unregister the
+ * lifecycle listener in a {@code finally}, and that finally can run after {@code await()} already
+ * unregistered it on the normal path. Both calls must be safe — hence the guard, and hence this
+ * pin: it counts REAL {@code removeListener} calls, so removing the guard reddens it.
+ */
+public class LifecycleWaiterCleanupTest
+{
+    /** Counts what actually reached the orchestrator; the other methods are never exercised here. */
+    private static final class CountingOrchestrator implements IServicesOrchestrator
+    {
+        final AtomicInteger added = new AtomicInteger();
+        final AtomicInteger removed = new AtomicInteger();
+
+        @Override
+        public void addListener(IServiceContextLifecycleListener listener)
+        {
+            added.incrementAndGet();
+        }
+
+        @Override
+        public void removeListener(IServiceContextLifecycleListener listener)
+        {
+            removed.incrementAndGet();
+        }
+
+        @Override
+        public void startServices(ILifecycleContext context, IProgressMonitor monitor)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void stopServices(ILifecycleContext context, IProgressMonitor monitor)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isInfrastructureReady()
+        {
+            return true;
+        }
+    }
+
+    @Test
+    public void testCleanupUnregistersTheListenerExactlyOnceHoweverOftenItIsCalled()
+    {
+        CountingOrchestrator orchestrator = new CountingOrchestrator();
+        ProjectRestartWaiter waiter = new ProjectRestartWaiter(orchestrator, "Demo"); //$NON-NLS-1$
+        assertEquals("the waiter registers its listener up front", 1, orchestrator.added.get()); //$NON-NLS-1$
+
+        waiter.cleanup();
+        assertEquals("the first cleanup unregisters", 1, orchestrator.removed.get()); //$NON-NLS-1$
+
+        // The abandoning caller's finally, arriving after await() already cleaned up.
+        waiter.cleanup();
+        waiter.cleanup();
+        assertEquals("further cleanups must be no-ops, not repeated deregistrations", //$NON-NLS-1$
+            1, orchestrator.removed.get());
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LifecycleWaiterCleanupTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LifecycleWaiterCleanupTest.java
@@ -33,6 +33,8 @@ public class LifecycleWaiterCleanupTest
     {
         final AtomicInteger added = new AtomicInteger();
         final AtomicInteger removed = new AtomicInteger();
+        /** When set, the NEXT removal attempt throws - the recoverable failure under test. */
+        boolean failNextRemoval;
 
         @Override
         public void addListener(IServiceContextLifecycleListener listener)
@@ -44,6 +46,11 @@ public class LifecycleWaiterCleanupTest
         public void removeListener(IServiceContextLifecycleListener listener)
         {
             removed.incrementAndGet();
+            if (failNextRemoval)
+            {
+                failNextRemoval = false;
+                throw new IllegalStateException("orchestrator refused the removal"); //$NON-NLS-1$
+            }
         }
 
         @Override
@@ -63,6 +70,31 @@ public class LifecycleWaiterCleanupTest
         {
             return true;
         }
+    }
+
+    /**
+     * A removal that THREW did not happen - the listener is still registered - so the guard must
+     * not retire the waiter. Otherwise the caller's fallback cleanup becomes a no-op and a live
+     * listener keeps receiving lifecycle events for the rest of the session.
+     */
+    @Test
+    public void testAFailedRemovalCanStillBeRetried()
+    {
+        CountingOrchestrator orchestrator = new CountingOrchestrator();
+        orchestrator.failNextRemoval = true;
+        ProjectRestartWaiter waiter = new ProjectRestartWaiter(orchestrator, "Demo"); //$NON-NLS-1$
+
+        waiter.cleanup();
+        assertEquals("the failing removal was attempted", 1, orchestrator.removed.get()); //$NON-NLS-1$
+
+        waiter.cleanup();
+        assertEquals("a removal that threw must leave the waiter retryable", //$NON-NLS-1$
+            2, orchestrator.removed.get());
+
+        // ...and once it succeeds, the guard closes again.
+        waiter.cleanup();
+        assertEquals("after a successful removal further cleanups are no-ops", //$NON-NLS-1$
+            2, orchestrator.removed.get());
     }
 
     @Test

--- a/tests/e2e/tools/test_clean_project.py
+++ b/tests/e2e/tools/test_clean_project.py
@@ -28,12 +28,19 @@ layer marks the result isError; assert_error returns that error string.
 
 Parameter shape (from CleanProjectTool.getInputSchema / execute)
 ----------------------------------------------------------------
-There is exactly ONE parameter: projectName (string, OPTIONAL). Omitting it cleans
-ALL open EDT projects (not an error — a real happy branch). There is NO enum, NO XOR
-pair, and NO conditional-required parameter, so the "invalid enum" /
-"mutually-exclusive" / "conditional-required" negatives from the matrix do not apply
-here (documented, not skipped). The reachable negatives are driven entirely by the
-project-state pre-check:
+Both parameters are OPTIONAL: projectName (string) and timeout (integer, seconds).
+Omitting projectName cleans ALL open EDT projects (not an error — a real happy
+branch). timeout bounds the CLEAN BUILD itself (default 120s, clamped to 10..3600):
+on expiry the call returns a timeout error instead of holding the MCP request open
+forever (issue #349); it does NOT bound the revalidation wait that follows. A live
+timeout is not forced here — the fixture cleans in seconds, so a test that tried to
+provoke it would be asserting on EDT's scheduling, not on our contract; the deadline
+itself is proven by CleanProjectToolTest against a controllable clean action. What
+e2e proves is that the parameter is accepted on the wire and does not change the
+success envelope. There is NO enum, NO XOR pair, and NO conditional-required
+parameter, so the "invalid enum" / "mutually-exclusive" / "conditional-required"
+negatives from the matrix do not apply here (documented, not skipped). The reachable
+negatives are driven entirely by the project-state pre-check:
 
   - non-existent project -> the readiness pre-check is now
     ProjectStateChecker.buildingErrorOrNull(projectName), which refuses ONLY the
@@ -189,6 +196,30 @@ def test_empty_projectname_falls_through_to_clean_all():
             'empty projectName must behave like clean-all and include %r: %r' % (PROJECT, projects))
 
     assert_no_diff("empty-name clean-all must not rewrite tracked project files")
+
+
+@e2e_test(tool="clean_project", kind="action")
+def test_explicit_timeout_is_accepted_and_keeps_the_success_envelope():
+    """An explicit `timeout` is accepted on the wire and does not alter the contract.
+
+    The bound exists so a wedged CLEAN_BUILD fails honestly instead of holding the MCP
+    request open forever (#349). A generous value cannot expire on the fixture (a clean
+    here takes seconds), so the observable contract is unchanged: the same success
+    envelope, the fixture among the cleaned projects, the tree untouched. A server that
+    rejected the new parameter as unknown, or that let it leak into the response, fails
+    here."""
+    r = call("clean_project", {"projectName": PROJECT, "timeout": 600})
+    assert_ok(r, "clean_project with an explicit timeout")
+
+    projects, cleaned = _success_envelope(r, "explicit timeout")
+    if PROJECT not in projects:
+        raise AssertionError(
+            "cleaned set must include the requested project %r: %r" % (PROJECT, projects))
+    if cleaned != 1:
+        raise AssertionError(
+            "cleaning a single named project must report projectsCleaned==1: %r" % cleaned)
+
+    assert_no_diff("a bounded clean must still not rewrite tracked project files")
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/e2e/tools/test_clean_project.py
+++ b/tests/e2e/tools/test_clean_project.py
@@ -204,11 +204,18 @@ def test_explicit_timeout_is_accepted_and_keeps_the_success_envelope():
 
     The bound exists so a wedged CLEAN_BUILD fails honestly instead of holding the MCP
     request open forever (#349). A generous value cannot expire on the fixture (a clean
-    here takes seconds), so the observable contract is unchanged: the same success
+    here takes 3-5s), so the observable contract is unchanged: the same success
     envelope, the fixture among the cleaned projects, the tree untouched. A server that
     rejected the new parameter as unknown, or that let it leak into the response, fails
-    here."""
-    r = call("clean_project", {"projectName": PROJECT, "timeout": 600})
+    here.
+
+    The value stays well BELOW the harness call budget (CALL_TIMEOUT, 180s by default and
+    600s on CI) on purpose. Passing a bound at or above that budget would mean that if this
+    very call hit the CLEAN_BUILD wedge #349 exists to contain, the HTTP client would give
+    up BEFORE the server-side fuse could answer - E2ECallTimeout, the remaining suite
+    aborted, EDT still working. The test proving the fuse must not be the one that defeats
+    it."""
+    r = call("clean_project", {"projectName": PROJECT, "timeout": 60})
     assert_ok(r, "clean_project with an explicit timeout")
 
     projects, cleaned = _success_envelope(r, "explicit timeout")

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -150,6 +150,10 @@
         "projectName": {
           "description": "Name of the project to clean (optional, cleans all EDT projects if not specified)",
           "type": "string"
+        },
+        "timeout": {
+          "description": "How long to wait for the clean build itself, in seconds (default 120, clamped to 10..3600). On expiry the call fails with a timeout error instead of waiting forever; the clean may still be running in EDT afterwards. Does not cover the subsequent revalidation wait.",
+          "type": "integer"
         }
       },
       "required": [],

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -152,7 +152,7 @@
           "type": "string"
         },
         "timeout": {
-          "description": "How long to wait for the clean build itself, in seconds (default 120, clamped to 10..3600). On expiry the call fails with a timeout error instead of waiting forever; the clean may still be running in EDT afterwards. Does not cover the subsequent revalidation wait.",
+          "description": "How long to wait for the clean build itself, per project, in seconds (default 120, clamped to 10..3600). On expiry the call fails with a timeout error instead of waiting forever; the clean may still be running in EDT afterwards. Does not cover the subsequent revalidation wait.",
           "type": "integer"
         }
       },


### PR DESCRIPTION
Closes #349.

## Что было

`CleanProjectTool.cleanSingleProject` передавал `new NullProgressMonitor()` в оба тяжёлых вызова:

```java
project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
project.build(IncrementalProjectBuilder.CLEAN_BUILD, monitor);
```

Такой монитор никогда не отменяется и не несёт срока. Если платформа задержалась внутри — вернуться нечем: прогон e2e стоял все 600 с своего `MCP_CALL_TIMEOUT`, фикстура оставалась несброшенной, **188 тестов пропускались вместо одного честного падения**. Наблюдалось 04.08 трижды, в том числе на чистом `master`, — то есть причина самой задержки ни к чьей ветке не привязана. Эта правка **не про неё**: она про отсутствующий предохранитель.

## Что сделано

Фаза clean уехала в новый `BoundedJob`: работа выполняется в Eclipse `Job`, монитор которого отменяется по истечении срока, а вызывающий поток перестаёт ждать в любом случае.

Важны обе половины, и по разным причинам:

* **отмена** даёт платформенному вызову шанс размотаться самому — в частности тому, что стоит на захвате правила воркспейса: ожидание правила прерывается отменой монитора;
* **предел на стороне вызывающего** — то, что реально гарантирует ответ, потому что отмена кооперативна и не может прервать код, который монитор не опрашивает.

Тот же приём уже был написан по месту в `BuildExternalObjectsTool` — здесь он не скопирован, а вынесен в общий помощник.

Срок стал проволочным параметром `timeout` (секунды, зажимается в 10..3600), дефолт лежит там же, где прочие пер-инструментные — в `ToolParameterSettings`, поэтому он же появился в настройках EDT.

Текст отказа называет проект, срок и рычаги — и **не врёт**: он говорит, что EDT может всё ещё работать над clean. Job попросили остановиться, а не доказали, что он остановился.

## Что нашлось попутно (и почему это в том же PR)

Всё перечисленное — на пути, который открывает сам отказ по сроку; чинить отдельно смысла нет.

1. **Утечка слушателя.** Ранний `return` по таймауту проходил мимо `waiter.await(...)`, а `cleanup()` вызывается только из него. Каждый таймаут оставлял слушателя в `IServicesOrchestrator` до конца сессии. Теперь очистка в `finally`, а `cleanup()` сделан идемпотентным (у `ProjectRestartWaiter` единственный потребитель — этот инструмент).
2. **Цикл шёл дальше.** При `clean_project` без имени проекта цикл после истечения срока брался за следующий проект — уже после того, как вызов ответил. Добавлена проверка отмены перед каждым проектом.
3. **`Error` больше не превращается в JSON-ошибку.** Раньше внешний `catch (Exception)` его не ловил и он улетал наверх; перенос работы в поток Job не должен этого менять — `Error` перебрасывается в вызывающем потоке.
4. **Гайд врал.** Он обещал «up to ~3 min per project» и полностью устоявшийся проект. На деле это три последовательных ожидания на КАЖДЫЙ проект (clean build → рестарт контекста 3 мин → derived data 5 мин), причём два последних при истечении **только логируются, а вызов всё равно рапортует success**. Формулировка исправлена по коду.

## Доказательства

Каждый предохранитель закреплён тестом, который краснеет, если убрать **именно его** (проверено мутацией источника, а не «зеленью»):

| мутация | что происходит |
|---|---|
| убрать предел (`join()` без таймаута — до-#349 поведение) | 3 теста краснеют, ожидание становится 60 с вместо 0,5 с, то есть ждали потолка работы, а не дедлайна |
| убрать проверку отмены в цикле | второй проект чистится после ответа → тест краснеет |
| убрать guard идемпотентности | слушатель снимается дважды → тест краснеет |

Заведомо зависшая работа в тестах имеет **свой конечный потолок**, поэтому потерянный предел даёт падение, а не висящий навсегда прогон.

Отдельно закреплено, что проволочный `timeout` действительно доходит до срока: инструмент, объявивший параметр в схеме и не читающий его, проходит все остальные тесты и падает на этом.

Сборка: `4273` теста зелёные. Стенд EDT **2026.2 / Java 25**, срез e2e `clean_project` 6/6, `resync_to_disk` 10/10 (второй потребитель `cleanProject`), `revalidate_objects` 8/8, фикстура чистая. `tools/list` изменился — golden и `docs/tools` перегенерированы; отпечаток предварительно проверен на чувствительность (он покраснел до обновления).

## Вопросы к тебе

1. **Дефолт 120 с** выбран так: здоровый вызов на фикстуре укладывается в ~3,6 с целиком, включая все четыре фазы. Но `refreshLocal(DEPTH_INFINITE)` + `CLEAN_BUILD` на конфигурации уровня ERP я не мерил — если знаешь, что там бывает дольше, скажи число, поправлю (или оставим на настройку).
2. **Брошенный Job живёт дальше.** Повторные вызовы при реально вечном `refreshLocal` будут накапливать занятые worker'ы. Ограничитель «один clean на проект в полёте» не делал: он может давать ложные отказы. Нужен?
3. **Фазы 3 и 4 остались как были** — их таймауты по-прежнему только логируются, и `success` возвращается даже когда derived data не досчитались. Я это описал в гайде, но не менял: похоже на отдельную задачу. Заводить ишью?
