### PR TITLE
delete_metadata: одна точка согласия для всех веток удаления (#331)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
@@ -116,31 +116,50 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
     }
 
     /**
-     * The authorization point of the FORM delete branches: asks, and invokes {@code write} ONLY on
-     * ALLOW, so "did we ask before mutating?" is one question for both of them instead of one per
-     * call site.
+     * The mutation one delete branch performs once the gate has answered ALLOW. A dedicated type
+     * rather than a bare {@code Supplier<String>} because it is load-bearing for the enforcement:
+     * it is the ONE thing {@link #deleteWithConsent} invokes, and {@code
+     * DeleteMetadataConsentSinglePointRatchetTest} reads the compiled class to prove that no other
+     * method of this tool invokes it - which turns "nothing is written without ALLOW" into something
+     * checkable instead of something a reviewer has to re-read every time a branch is added.
+     */
+    @FunctionalInterface
+    interface DeleteWrite
+    {
+        /**
+         * Performs the branch's mutation.
+         *
+         * @return the branch's JSON result
+         */
+        String perform();
+    }
+
+    /**
+     * The tool's SINGLE authorization point: EVERY branch that can mutate - the generic mdclass
+     * object / member, an owned form object, a form member, a predefined item and an XDTO package
+     * member - asks here, and its write runs ONLY on ALLOW. "Did we ask before mutating?" is one
+     * question for the whole tool instead of one per branch, which is what issue #331 asked for after
+     * two branches were found writing with no gate at all; the branches that had their own
+     * {@link DestructiveConsentGate#getInstance()} call were routed through here for the same reason
+     * - a per-branch copy is a per-branch chance to forget.
      *
-     * <p>It is NOT the tool's only gate, and this javadoc used to claim it was: the mdclass
-     * top-object / member deletes and the XDTO delete still call
-     * {@link DestructiveConsentGate#getInstance()} directly (see the {@code requireConsent} call
-     * sites below). Those paths are older than the form branches and are not routed through here
-     * yet; at least the XDTO one asks BEFORE it looks its target up, so a typo raises a destructive
-     * prompt and only then answers "not found" - the ordering defect this branch fixed for the form
-     * paths. Recorded rather than quietly widened: rerouting them is a change to code this branch
-     * does not otherwise touch.</p>
+     * <p>Every branch resolves and validates its target BEFORE calling this, so a typo answers "not
+     * found" without ever raising a destructive prompt, and the prompt names what is really removed.
+     * The gate is the LAST check before the write and runs outside any transaction, because it may
+     * block on a UI dialog.</p>
      *
      * @param preview what the user is being asked to authorize
      * @param write the mutation, invoked only when consent is granted
      * @return the mutation's result, or the refusal error
      */
-    String deleteWithConsent(ConsentPreview preview, java.util.function.Supplier<String> write)
+    String deleteWithConsent(ConsentPreview preview, DeleteWrite write)
     {
         DestructiveConsentGate.ConsentDecision decision = consentRequester.request(NAME, preview);
         if (decision != DestructiveConsentGate.ConsentDecision.ALLOW)
         {
             return ToolResult.error(DestructiveConsentGate.consentDeniedMessage(decision, NAME)).toJson();
         }
-        return write.get();
+        return write.perform();
     }
 
     public static final String NAME = "delete_metadata"; //$NON-NLS-1$
@@ -433,13 +452,26 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         ConsentPreview preview = new ConsentPreview(
             "Delete metadata node", //$NON-NLS-1$
             subtitle, 1, Collections.singletonList(fqn));
-        DestructiveConsentGate.ConsentDecision consentDecision =
-            DestructiveConsentGate.getInstance().requireConsent(NAME, preview);
-        if (consentDecision != DestructiveConsentGate.ConsentDecision.ALLOW)
-        {
-            return ToolResult.error(DestructiveConsentGate.consentDeniedMessage(consentDecision, NAME)).toJson();
-        }
+        return deleteWithConsent(preview, () -> performDeleteRefactoring(fqn, refactoring, force, blocking));
+    }
 
+    /**
+     * Runs the delete refactoring and builds the result. Split out of {@link #performDelete} so the
+     * WHOLE mutation is the callback {@link #deleteWithConsent} invokes: this branch used to consult
+     * the gate itself and then fall through to the work below it, which left "nothing is written
+     * without ALLOW" true only by the order of statements (issue #331).
+     *
+     * <p>Call only after consent was granted.</p>
+     *
+     * @param fqn the normalized FQN being deleted
+     * @param refactoring the prepared delete refactoring
+     * @param force whether blocking references were overridden
+     * @param blocking the blocking references the caller already collected
+     * @return the tool's JSON result
+     */
+    private static String performDeleteRefactoring(String fqn, IRefactoring refactoring, boolean force,
+        List<Map<String, Object>> blocking)
+    {
         try
         {
             refactoring.perform();
@@ -750,8 +782,9 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
     /**
      * The FORM-MEMBER branch's authorization step: builds the prompt from what the preview actually
      * found and hands the branch's write to {@link #deleteWithConsent}. Package-private and taking the
-     * write as a parameter so a unit test can drive THIS branch's dispatch without an EDT context -
-     * proving the branch is wired to the gate, not merely that the gate works (issue #331 review).
+     * write as a parameter so a unit test can drive THIS branch's prompt and refusal without an EDT
+     * context; that the branch REACHES this step - and that no branch reaches a write without it - is
+     * pinned separately by {@code DeleteMetadataConsentSinglePointRatchetTest} (issue #331).
      *
      * @param normFqn the normalized FQN being deleted
      * @param ref the parsed form-member ref
@@ -761,7 +794,7 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
      * @return the mutation's result, or the refusal error
      */
     String gateFormMemberDelete(String normFqn, FormElementWriter.FormMemberRef ref, boolean handler,
-        FormDeletePreview data, java.util.function.Supplier<String> write)
+        FormDeletePreview data, DeleteWrite write)
     {
         // The breakdown is DERIVED from what the walk actually found, not a fixed phrase naming the
         // kinds the walk used to follow: the prompt named "nested items, attribute columns" while an
@@ -789,8 +822,7 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
      * @param write this branch's mutation
      * @return the mutation's result, or the refusal error
      */
-    String gateFormObjectDelete(String normFqn, FormContentSummary content,
-        java.util.function.Supplier<String> write)
+    String gateFormObjectDelete(String normFqn, FormContentSummary content, DeleteWrite write)
     {
         return deleteWithConsent(new ConsentPreview("Delete form", //$NON-NLS-1$
             "Removes the form and its content" //$NON-NLS-1$
@@ -1237,12 +1269,12 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
             return putBlockingReferences(blocked, refScan.refs).toJson();
         }
 
-        // Destructive-operation consent gate: the LAST check before the mutation, mirroring the
-        // generic-node path above. delete_metadata is a gated tool, and a FOLDER delete cascades its
-        // whole content tree - so an interactive session that requires confirmation must get the
-        // dialog here too. On ALLOW the behaviour is unchanged; headless / env-bypass never block.
-        // Reached only when the reference check completed with nothing blocking, OR force=true bypasses
-        // either an incomplete check or a non-empty blocking set.
+        // Destructive-operation consent gate, through the tool's single authorization point: the LAST
+        // check before the mutation, mirroring every other branch. delete_metadata is a gated tool, and
+        // a FOLDER delete cascades its whole content tree - so an interactive session that requires
+        // confirmation must get the dialog here too. On ALLOW the behaviour is unchanged; headless /
+        // env-bypass never block. Reached only when the reference check completed with nothing
+        // blocking, OR force=true bypasses either an incomplete check or a non-empty blocking set.
         int cascadeTotal = 1 + preview.descendantCount;
         // Cascade wording follows the real containment-descendant count, not isFolder: a
         // ChartOfAccounts parent account (isFolder=false) still cascades its childItems, so the
@@ -1266,14 +1298,8 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         ConsentPreview consentPreview = new ConsentPreview(
             "Delete predefined item", //$NON-NLS-1$
             consentSubtitle.toString(), cascadeTotal, Collections.singletonList(normFqn));
-        DestructiveConsentGate.ConsentDecision consentDecision =
-            DestructiveConsentGate.getInstance().requireConsent(NAME, consentPreview);
-        if (consentDecision != DestructiveConsentGate.ConsentDecision.ALLOW)
-        {
-            return ToolResult.error(DestructiveConsentGate.consentDeniedMessage(consentDecision, NAME)).toJson();
-        }
-
-        return performPredefinedItemDelete(ctx.project, owner, normFqn, ref, refScan, force);
+        return deleteWithConsent(consentPreview,
+            () -> performPredefinedItemDelete(ctx.project, owner, normFqn, ref, refScan, force));
     }
 
     /**
@@ -1924,16 +1950,61 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
             : buildXdtoMemberDeletePreview(normFqn, ref, bmModel, pkgBmId);
     }
 
+    /**
+     * What a pre-write lookup of an XDTO member found. Two OUTCOMES, not one, because the two callers
+     * owe the caller different errors: the confirm path must be able to report the package-level
+     * failure with the SAME message the write transaction would have produced, instead of collapsing
+     * it into "member not found" (issue #331 review).
+     */
+    private static final class XdtoLookup
+    {
+        /** Whether the owning package resolved inside the transaction at all. */
+        final boolean packageResolved;
+
+        /** {eClassName} of the member, or {@code null} when it is not there. */
+        final String[] member;
+
+        XdtoLookup(boolean packageResolved, String[] member)
+        {
+            this.packageResolved = packageResolved;
+            this.member = member;
+        }
+    }
+
+    /**
+     * Locates the target member inside a rolled-back (read-with-materialize) transaction - the
+     * package's content is a lazy {@code @ExternalProperty}, so even a pure read has to materialize it.
+     * Shared by the preview and the confirm path so both ask the model the same question, and so the
+     * confirm path can answer "not found" BEFORE the consent gate (issue #331). It is a separate
+     * transaction from the write, so it is a pre-check and not a guarantee: the write re-locates the
+     * member and reports its own error if it went in between.
+     *
+     * @param bmModel the project's BM model
+     * @param pkgBmId the owning XDTO package's BM id
+     * @param ref the parsed member ref
+     * @return what the lookup found; never {@code null}
+     */
+    private static XdtoLookup locateXdtoMemberInModel(IBmModel bmModel, long pkgBmId,
+        XdtoWriter.MemberRef ref)
+    {
+        return BmTransactions.executeAndRollback(bmModel, "DeleteXdtoMemberLookup", (tx, pm) -> //$NON-NLS-1$
+        {
+            Object inTx = tx.getObjectById(pkgBmId);
+            if (!(inTx instanceof XDTOPackage))
+            {
+                return new XdtoLookup(false, null);
+            }
+            return new XdtoLookup(true, locateXdtoMember(((XDTOPackage)inTx).getPackage(), ref));
+        });
+    }
+
     /** Preview inside a rolled-back (read-with-materialize) transaction: locates the target, no mutation. */
     private String buildXdtoMemberDeletePreview(String normFqn, XdtoWriter.MemberRef ref, IBmModel bmModel,
         long pkgBmId)
     {
-        String[] found = BmTransactions.executeAndRollback(bmModel, "DeleteXdtoMemberPreview", (tx, pm) -> //$NON-NLS-1$
-        {
-            Object inTx = tx.getObjectById(pkgBmId);
-            Package content = inTx instanceof XDTOPackage ? ((XDTOPackage)inTx).getPackage() : null;
-            return locateXdtoMember(content, ref);
-        });
+        // The preview reports both misses as "not found" exactly as it did before the lookup gained a
+        // second outcome: a preview cannot mutate, so the package-level distinction buys it nothing.
+        String[] found = locateXdtoMemberInModel(bmModel, pkgBmId, ref).member;
         if (found == null)
         {
             return xdtoMemberNotFoundError(ref);
@@ -1959,22 +2030,77 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
             .toJson();
     }
 
-    /** Delete behind the destructive-consent gate, then a write transaction; force-exports the package. */
+    /**
+     * Resolves the target, then asks the gate, then writes: the ORDER is the fix, not an accident of
+     * layout. This branch used to ask FIRST and look the member up only inside the write transaction,
+     * so a typo in the member name raised a destructive prompt at a human and answered "not found"
+     * only after it had been dealt with - the ordering defect the form branches had already fixed
+     * (issue #331). The lookup is the SAME rolled-back read the preview runs.
+     *
+     * @param ctx the resolved project/configuration
+     * @param normFqn the normalized FQN being deleted
+     * @param ref the parsed XDTO member ref
+     * @param bmModel the project's BM model
+     * @param pkgBmId the owning package's BM id
+     * @param fqnGenerator generator for the content's own export FQN
+     * @param pkgExportFqn the resolved package's canonical export FQN
+     * @return the tool's JSON result
+     */
     private String performXdtoMemberDelete(ProjectContext ctx, String normFqn, XdtoWriter.MemberRef ref,
         IBmModel bmModel, long pkgBmId, ITopObjectFqnGenerator fqnGenerator,
         String pkgExportFqn)
     {
+        XdtoLookup found;
+        try
+        {
+            found = locateXdtoMemberInModel(bmModel, pkgBmId, ref);
+        }
+        catch (Exception e)
+        {
+            // The lookup materializes the package's lazy content, so it can fail exactly the way the
+            // write can; mapping it through the SAME helper keeps the error contract identical to
+            // the one this branch had when the lookup lived inside the write transaction.
+            return xdtoDeleteFailure(e);
+        }
+        // Both misses answer with the error the WRITE transaction would have produced for them, so
+        // moving the lookup in front of the gate changes when the caller is told, never what.
+        if (!found.packageResolved)
+        {
+            return xdtoPackageUnresolvedError();
+        }
+        if (found.member == null)
+        {
+            return xdtoMemberNotFoundError(ref);
+        }
         ConsentPreview preview = new ConsentPreview("Delete metadata node", //$NON-NLS-1$
             "This deletes '" + normFqn + "'" //$NON-NLS-1$ //$NON-NLS-2$
                 + (ref.kind == XdtoWriter.Kind.OBJECT_TYPE ? " and all its own properties." : "."), //$NON-NLS-1$ //$NON-NLS-2$
             1, Collections.singletonList(normFqn));
-        DestructiveConsentGate.ConsentDecision consentDecision =
-            DestructiveConsentGate.getInstance().requireConsent(NAME, preview);
-        if (consentDecision != DestructiveConsentGate.ConsentDecision.ALLOW)
-        {
-            return ToolResult.error(DestructiveConsentGate.consentDeniedMessage(consentDecision, NAME)).toJson();
-        }
+        return deleteWithConsent(preview,
+            () -> writeXdtoMemberDelete(ctx, normFqn, ref, bmModel, pkgBmId, fqnGenerator, pkgExportFqn));
+    }
 
+    /**
+     * The XDTO member delete itself: the write transaction and the dual force-export. Split out of
+     * {@link #performXdtoMemberDelete} so the WHOLE mutation is the callback
+     * {@link #deleteWithConsent} invokes. The member is re-located inside the transaction (it may have
+     * gone while the prompt was open), so the pre-gate lookup above never becomes the only check.
+     *
+     * <p>Call only after consent was granted.</p>
+     *
+     * @param ctx the resolved project/configuration
+     * @param normFqn the normalized FQN being deleted
+     * @param ref the parsed XDTO member ref
+     * @param bmModel the project's BM model
+     * @param pkgBmId the owning package's BM id
+     * @param fqnGenerator generator for the content's own export FQN
+     * @param pkgExportFqn the resolved package's canonical export FQN
+     * @return the tool's JSON result
+     */
+    private String writeXdtoMemberDelete(ProjectContext ctx, String normFqn, XdtoWriter.MemberRef ref,
+        IBmModel bmModel, long pkgBmId, ITopObjectFqnGenerator fqnGenerator,
+        String pkgExportFqn)
+    {
         XdtoDeleteResult result;
         try
         {
@@ -1983,13 +2109,7 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         }
         catch (Exception e)
         {
-            String ready = XdtoWriteException.jsonOf(e);
-            if (ready != null)
-            {
-                return ready;
-            }
-            Activator.logError("Error deleting XDTO member", e); //$NON-NLS-1$
-            return ToolResult.error("Delete failed: " + unwrapCauseMessage(e)).toJson(); //$NON-NLS-1$
+            return xdtoDeleteFailure(e);
         }
 
         // DUAL force-export, mirroring create_metadata / modify_metadata exactly: the owning
@@ -2015,7 +2135,39 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
             .toJson();
     }
 
-    /** The write-transaction result for {@link #performXdtoMemberDelete}: the removed kind + the content's own export FQN. */
+    /**
+     * The "package is not there" error of the XDTO delete, in ONE place: the pre-gate lookup and the
+     * write transaction both hit this condition and must report it identically, so that moving the
+     * lookup in front of the gate (issue #331) changed when the caller hears it, not what.
+     *
+     * @return the tool's JSON error
+     */
+    private static String xdtoPackageUnresolvedError()
+    {
+        return ToolResult.error("The XDTO package could not be resolved inside the transaction.").toJson(); //$NON-NLS-1$
+    }
+
+    /**
+     * Maps an EXCEPTION from the XDTO member delete to the tool's JSON error: a ready one carried by an
+     * {@link XdtoWriteException}, otherwise a logged generic. One helper for both the pre-gate lookup
+     * and the write, so a failure that used to surface from inside the write transaction still reaches
+     * the caller in the same shape now that the lookup runs before it (issue #331).
+     *
+     * @param e the failure
+     * @return the tool's JSON error
+     */
+    private static String xdtoDeleteFailure(Exception e)
+    {
+        String ready = XdtoWriteException.jsonOf(e);
+        if (ready != null)
+        {
+            return ready;
+        }
+        Activator.logError("Error deleting XDTO member", e); //$NON-NLS-1$
+        return ToolResult.error("Delete failed: " + unwrapCauseMessage(e)).toJson(); //$NON-NLS-1$
+    }
+
+    /** The write-transaction result for {@link #writeXdtoMemberDelete}: the removed kind + the content's own export FQN. */
     private static final class XdtoDeleteResult
     {
         final String kind;
@@ -2029,7 +2181,7 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
     }
 
     /**
-     * The write-transaction body for {@link #performXdtoMemberDelete}: re-fetches the XDTOPackage,
+     * The write-transaction body for {@link #writeXdtoMemberDelete}: re-fetches the XDTOPackage,
      * reads its (possibly {@code null} / never-materialized) content directly - no ATTACH needed for a
      * delete of an EXISTING member, since a package that already has a member was necessarily
      * materialized + attached by an earlier create/modify - derives the content's OWN export FQN (for
@@ -2047,8 +2199,7 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         Object inTx = tx.getObjectById(pkgBmId);
         if (!(inTx instanceof XDTOPackage))
         {
-            throw new XdtoWriteException(ToolResult.error("The XDTO package could not be resolved " //$NON-NLS-1$
-                + "inside the transaction.").toJson()); //$NON-NLS-1$
+            throw new XdtoWriteException(xdtoPackageUnresolvedError());
         }
         XDTOPackage txPkg = (XDTOPackage)inTx;
         Package content = txPkg.getPackage();

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
@@ -119,9 +119,11 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
      * The mutation one delete branch performs once the gate has answered ALLOW. A dedicated type
      * rather than a bare {@code Supplier<String>} because it is load-bearing for the enforcement:
      * it is the ONE thing {@link #deleteWithConsent} invokes, and {@code
-     * DeleteMetadataConsentSinglePointRatchetTest} reads the compiled class to prove that no other
-     * method of this tool invokes it - which turns "nothing is written without ALLOW" into something
-     * checkable instead of something a reviewer has to re-read every time a branch is added.
+     * DeleteMetadataConsentSinglePointRatchetTest} reads the compiled classes - this one and every
+     * class compiled inside it - to prove that nothing else reaches it, by call OR by method handle,
+     * and that a callback nobody hands to the gate is not exempt from its walk. That turns "nothing is
+     * written without ALLOW" into something checkable instead of something a reviewer has to re-read
+     * every time a branch is added.
      */
     @FunctionalInterface
     interface DeleteWrite
@@ -1955,8 +1957,12 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
      * owe the caller different errors: the confirm path must be able to report the package-level
      * failure with the SAME message the write transaction would have produced, instead of collapsing
      * it into "member not found" (issue #331 review).
+     *
+     * <p>Package-visible so a unit test can hand each of the three states to
+     * {@link #gateXdtoMemberDelete} and check what the caller is told - and, above all, that the two
+     * miss states are told it without a consent prompt ever being raised.</p>
      */
-    private static final class XdtoLookup
+    static final class XdtoLookup
     {
         /** Whether the owning package resolved inside the transaction at all. */
         final boolean packageResolved;
@@ -2060,10 +2066,36 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
             // The lookup materializes the package's lazy content, so it can fail exactly the way the
             // write can; mapping it through the SAME helper keeps the error contract identical to
             // the one this branch had when the lookup lived inside the write transaction.
-            return xdtoDeleteFailure(e);
+            return xdtoDeleteFailure(normFqn, e);
         }
+        return gateXdtoMemberDelete(normFqn, ref, found,
+            () -> writeXdtoMemberDelete(ctx, normFqn, ref, bmModel, pkgBmId, fqnGenerator, pkgExportFqn));
+    }
+
+    /**
+     * The XDTO branch's authorization step, the twin of {@link #gateFormMemberDelete}: turns what the
+     * pre-write lookup found into either an error or a consent prompt, and hands the branch's write to
+     * {@link #deleteWithConsent}.
+     *
+     * <p>Package-private and taking BOTH the lookup outcome and the write as parameters so a unit test
+     * can drive all three states without an EDT context. That matters more here than anywhere else in
+     * this tool: the ORDER (resolve, then ask) is what issue #331 asked for, and an order pinned only
+     * by bytecode offsets would stay green if the lookup's RESULT stopped being used - the prompt would
+     * come back for a target that is not there. The behavioural pin is
+     * {@code DeleteMetadataToolTest#testXdtoBranch...}; the offsets are pinned separately by
+     * {@code DeleteMetadataConsentSinglePointRatchetTest}.</p>
+     *
+     * @param normFqn the normalized FQN being deleted
+     * @param ref the parsed XDTO member ref
+     * @param found what the pre-write lookup found
+     * @param write this branch's mutation
+     * @return the mutation's result, the refusal error, or the miss the lookup found
+     */
+    String gateXdtoMemberDelete(String normFqn, XdtoWriter.MemberRef ref, XdtoLookup found, DeleteWrite write)
+    {
         // Both misses answer with the error the WRITE transaction would have produced for them, so
-        // moving the lookup in front of the gate changes when the caller is told, never what.
+        // moving the lookup in front of the gate changes when the caller is told, never what - and
+        // neither of them reaches the gate, so a typo never raises a destructive prompt.
         if (!found.packageResolved)
         {
             return xdtoPackageUnresolvedError();
@@ -2076,8 +2108,7 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
             "This deletes '" + normFqn + "'" //$NON-NLS-1$ //$NON-NLS-2$
                 + (ref.kind == XdtoWriter.Kind.OBJECT_TYPE ? " and all its own properties." : "."), //$NON-NLS-1$ //$NON-NLS-2$
             1, Collections.singletonList(normFqn));
-        return deleteWithConsent(preview,
-            () -> writeXdtoMemberDelete(ctx, normFqn, ref, bmModel, pkgBmId, fqnGenerator, pkgExportFqn));
+        return deleteWithConsent(preview, write);
     }
 
     /**
@@ -2109,7 +2140,7 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         }
         catch (Exception e)
         {
-            return xdtoDeleteFailure(e);
+            return xdtoDeleteFailure(normFqn, e);
         }
 
         // DUAL force-export, mirroring create_metadata / modify_metadata exactly: the owning
@@ -2153,18 +2184,31 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
      * and the write, so a failure that used to surface from inside the write transaction still reaches
      * the caller in the same shape now that the lookup runs before it (issue #331).
      *
+     * <p>The generic branch names the TARGET and what to do next, because the platform message alone
+     * ("Resource ... could not be loaded") does not tell the caller which delete it belongs to nor how
+     * to proceed - CLAUDE.md rule #8. The message itself is kept: it is the only thing that
+     * distinguishes a corrupt {@code .xdto} from a stale BM id, the same text the write path has always
+     * returned, and the preview (no consent at all) reaches the identical failure - so withholding it
+     * here would buy no confidentiality and cost the caller its only diagnosis. The stack trace goes to
+     * the workspace error log only.</p>
+     *
+     * <p>Package-visible so a unit test can pin that shape.</p>
+     *
+     * @param fqn the normalized FQN the delete was addressed to
      * @param e the failure
      * @return the tool's JSON error
      */
-    private static String xdtoDeleteFailure(Exception e)
+    static String xdtoDeleteFailure(String fqn, Exception e)
     {
         String ready = XdtoWriteException.jsonOf(e);
         if (ready != null)
         {
             return ready;
         }
-        Activator.logError("Error deleting XDTO member", e); //$NON-NLS-1$
-        return ToolResult.error("Delete failed: " + unwrapCauseMessage(e)).toJson(); //$NON-NLS-1$
+        Activator.logError("Error deleting XDTO member " + fqn, e); //$NON-NLS-1$
+        return ToolResult.error("Delete failed for '" + fqn + "': " + unwrapCauseMessage(e) //$NON-NLS-1$ //$NON-NLS-2$
+            + ". Nothing was deleted. Re-read the owning XDTO package with get_metadata_details and " //$NON-NLS-1$
+            + "retry; if the package itself does not load, fix it on disk first.").toJson(); //$NON-NLS-1$
     }
 
     /** The write-transaction result for {@link #writeXdtoMemberDelete}: the removed kind + the content's own export FQN. */

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/ConsentRatchetFixtures.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/ConsentRatchetFixtures.java
@@ -6,6 +6,9 @@
 
 package com.ditrix.edt.mcp.server.tools;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -75,6 +78,17 @@ public final class ConsentRatchetFixtures
         {
             return write.perform();
         }
+
+        /**
+         * The same, for the fixture that builds two callbacks and gates only one.
+         *
+         * @param write the callback
+         * @return its result
+         */
+        public static String runAny(TwoCallbackBypass.DeleteWrite write)
+        {
+            return write.perform();
+        }
     }
 
     /**
@@ -119,6 +133,153 @@ public final class ConsentRatchetFixtures
             DeleteWrite write = () -> sink.mutate();
             Runner.run(write);
             return deleteWithConsent("preview", write); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Builds TWO callbacks back to back and hands the harmless one to the gate. Every rule phrased
+     * about the method as a whole is satisfied - a gate call is there, and it is even the first
+     * invocation after both creations - and the second callback rides in on the first one's
+     * authorization while being run somewhere else entirely.
+     */
+    public static final class TwoCallbackBypass
+    {
+        /** This fixture's own callback type. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /**
+         * The single authorization point.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param sink the fixture's write API
+         * @return the branch's result
+         */
+        String executeOnUiThread(Sink sink)
+        {
+            DeleteWrite harmless = () -> "{}"; //$NON-NLS-1$
+            DeleteWrite leaked = () -> sink.mutate();
+            String gated = deleteWithConsent("preview", harmless); //$NON-NLS-1$
+            return gated + Runner.runAny(leaked);
+        }
+    }
+
+    /**
+     * Reaches its write through a STATIC FIELD of a nested holder. Nothing in the entry point is a
+     * call into the holder - the only instruction naming it is a {@code getstatic} - so a walk that
+     * records invocations alone never opens the class, and both the field's function and the
+     * {@code <clinit>} that built it stay invisible.
+     */
+    public static final class StaticFieldBypass
+    {
+        /** This fixture's own callback type. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /** The holder: touched only by reading its field. */
+        static final class Holder
+        {
+            static final Function<Sink, String> WRITE = sink -> sink.mutate();
+
+            private Holder()
+            {
+                // Constants.
+            }
+        }
+
+        /**
+         * The single authorization point.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param sink the fixture's write API
+         * @return the branch's result
+         */
+        String executeOnUiThread(Sink sink)
+        {
+            return Holder.WRITE.apply(sink);
+        }
+    }
+
+    /**
+     * Deletes on disk with plain Java. {@code java.nio.file.Files} is not an Eclipse resource, not a
+     * {@code *Writer} and on no list - and this is the tool whose whole job is deleting things.
+     */
+    public static final class FileDeleteBypass
+    {
+        /** This fixture's own callback type. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /**
+         * The single authorization point.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param victim the file this branch removes behind everyone's back
+         * @param sink the fixture's write API
+         * @return the branch's result
+         * @throws IOException never - the shape only has to compile
+         */
+        String executeOnUiThread(Path victim, Sink sink) throws IOException
+        {
+            Files.delete(victim);
+            return deleteWithConsent("preview", () -> sink.mutate()); //$NON-NLS-1$
         }
     }
 
@@ -202,8 +363,8 @@ public final class ConsentRatchetFixtures
         String executeOnUiThread(Sink sink)
         {
             DeleteWrite write = () -> sink.mutate();
-            Supplier<String> escape = write::perform;
             String gated = deleteWithConsent("preview", write); //$NON-NLS-1$
+            Supplier<String> escape = write::perform;
             return gated + escape.get();
         }
     }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/ConsentRatchetFixtures.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/ConsentRatchetFixtures.java
@@ -1,0 +1,505 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2026 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import com._1c.g5.v8.dt.xdto.model.Package;
+import com.ditrix.edt.mcp.server.utils.XdtoWriter;
+
+/**
+ * Miniature delete tools, compiled but never run: the NEGATIVE controls of
+ * {@link DeleteMetadataConsentSinglePointRatchetTest}.
+ * <p>
+ * A ratchet that reads bytecode has the same problem as any other check - its failure mode can look
+ * exactly like its pass. Asserting that the real {@code DeleteMetadataTool} has no escape proves
+ * nothing on its own, because a walk that reached nothing, or a mutation test that recognised
+ * nothing, would say the same. Each class here is shaped like the real tool (an
+ * {@code executeOnUiThread} entry, a {@code deleteWithConsent} gate, its own {@code DeleteWrite}
+ * callback type) and then hides a write in ONE specific way. The ratchet runs its analysis against
+ * them and must REPORT that way; {@link Gated} is the counterpart that must come back clean, so a
+ * check that simply flagged everything would fail too.
+ * <p>
+ * Nothing here is ever instantiated or executed. The parameters exist only so the shapes compile.
+ */
+public final class ConsentRatchetFixtures
+{
+    private ConsentRatchetFixtures()
+    {
+        // Fixture holder.
+    }
+
+    /**
+     * The fixtures' stand-in for a real write API, so their mutation set is their own and a fixture
+     * cannot pass or fail because of what {@code DeleteMetadataTool} happens to call.
+     */
+    public interface Sink
+    {
+        /**
+         * Changes something.
+         *
+         * @return the fixture's result
+         */
+        String mutate();
+    }
+
+    /**
+     * A helper outside any fixture's own classes - the shape of a package-visible utility that takes
+     * the callback and runs it. What matters is that it is not one of the analysed classes and not an
+     * authorization step, so the write leaves through it; in the real world such a helper would sit in
+     * another class file and not be read at all.
+     */
+    public static final class Runner
+    {
+        private Runner()
+        {
+            // Utility.
+        }
+
+        /**
+         * Runs a callback the caller never got consent for.
+         *
+         * @param write the callback
+         * @return its result
+         */
+        public static String run(LeakedCallbackBypass.DeleteWrite write)
+        {
+            return write.perform();
+        }
+    }
+
+    /**
+     * Hands the callback to a helper this analysis never reads, and only THEN to the gate. Both
+     * structural rules are satisfied - one callback created, one gate call, {@code perform} invoked
+     * nowhere in the nest - and the write has already happened.
+     */
+    public static final class LeakedCallbackBypass
+    {
+        /** This fixture's own callback type. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /**
+         * The single authorization point.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param sink the fixture's write API
+         * @return the branch's result
+         */
+        String executeOnUiThread(Sink sink)
+        {
+            DeleteWrite write = () -> sink.mutate();
+            Runner.run(write);
+            return deleteWithConsent("preview", write); //$NON-NLS-1$
+        }
+    }
+
+    /** The compliant shape: the ONLY write is a {@code DeleteWrite} handed to the gate. */
+    public static final class Gated
+    {
+        /** This fixture's own callback type, named exactly as the tool names its own. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /**
+         * The single authorization point.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param sink the fixture's write API
+         * @return the branch's result
+         */
+        String executeOnUiThread(Sink sink)
+        {
+            return deleteWithConsent("preview", () -> sink.mutate()); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Hands a proper {@code DeleteWrite} to the gate - and keeps a method reference to the SAME
+     * callback, which it then runs itself. Every structural rule about who may create a callback is
+     * satisfied; the write still happens whatever the gate answered. Only counting a method HANDLE on
+     * the callback as an invocation catches this.
+     */
+    public static final class MethodHandleBypass
+    {
+        /** This fixture's own callback type. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /**
+         * The single authorization point.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param sink the fixture's write API
+         * @return the branch's result
+         */
+        String executeOnUiThread(Sink sink)
+        {
+            DeleteWrite write = () -> sink.mutate();
+            Supplier<String> escape = write::perform;
+            String gated = deleteWithConsent("preview", write); //$NON-NLS-1$
+            return gated + escape.get();
+        }
+    }
+
+    /**
+     * The shape the review reported verbatim: wrap the write in a {@code DeleteWrite}, convert it to a
+     * {@code Supplier} and run it - never going near the gate at all. Its body is exempt from the walk
+     * on the strength of its TYPE, so an unconditional exemption makes the branch vanish.
+     */
+    public static final class UnconsumedCallbackBypass
+    {
+        /** This fixture's own callback type. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /**
+         * The single authorization point, present and unused.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param sink the fixture's write API
+         * @return the branch's result
+         */
+        String executeOnUiThread(Sink sink)
+        {
+            DeleteWrite write = () -> sink.mutate();
+            Supplier<String> escape = write::perform;
+            return escape.get();
+        }
+    }
+
+    /**
+     * Hides the write in an ANONYMOUS class the branch runs itself. Its body is compiled into a
+     * separate class file, so a parser that reads only the tool's own {@code .class} sees an entry
+     * point that calls {@code Supplier.get()} on something it knows nothing about.
+     */
+    public static final class AnonymousClassBypass
+    {
+        /** This fixture's own callback type. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /**
+         * The single authorization point.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param sink the fixture's write API
+         * @return the branch's result
+         */
+        String executeOnUiThread(final Sink sink)
+        {
+            Supplier<String> escape = new Supplier<String>()
+            {
+                @Override
+                public String get()
+                {
+                    return sink.mutate();
+                }
+            };
+            return escape.get();
+        }
+    }
+
+    /**
+     * Writes through a setter on a CONCRETE model class. Nothing here is {@code EObject}, an
+     * {@code EList} or a {@code *Writer} - the constant pool spells the static type - so no family
+     * rule applies and only the verb does. Every generated EMF setter has exactly this shape.
+     */
+    public static final class ConcreteSetterBypass
+    {
+        /** This fixture's own callback type. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /**
+         * The single authorization point.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param target the classifier this branch quietly renames
+         * @param sink the fixture's write API
+         * @return the branch's result
+         */
+        String executeOnUiThread(EClass target, Sink sink)
+        {
+            target.setName("renamed"); //$NON-NLS-1$
+            return deleteWithConsent("preview", () -> sink.mutate()); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Hides the write behind a CONSTRUCTOR reference. Following the callback body reaches only
+     * {@code <init>}; the object is run through a {@code Runnable}, whose owner is outside anything
+     * this analysis parses, so the write is one edge further on than a body-only walk ever goes.
+     */
+    public static final class ConstructorReferenceBypass
+    {
+        /** This fixture's own callback type. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /** A deferred write: constructed here, run by somebody else. */
+        static final class Deferred implements Runnable
+        {
+            private final Sink sink;
+
+            Deferred(Sink sink)
+            {
+                this.sink = sink;
+            }
+
+            @Override
+            public void run()
+            {
+                sink.mutate();
+            }
+        }
+
+        /**
+         * The single authorization point.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param sink the fixture's write API
+         * @return the branch's result
+         */
+        String executeOnUiThread(Sink sink)
+        {
+            Function<Sink, Runnable> make = Deferred::new;
+            make.apply(sink).run();
+            return "done"; //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Writes through a {@code *Writer} helper whose VERB nobody anticipated. Not on the mutation
+     * list, and not a set/remove/clear either - only treating the writer family as denied-by-default
+     * catches it. {@code XdtoWriter.rewriteNamespaceReferences} is a real method of this repo that
+     * really does mutate its argument in place.
+     */
+    public static final class UnlistedWriterVerbBypass
+    {
+        /** This fixture's own callback type. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /**
+         * The single authorization point.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param content the XDTO package content this branch quietly rewrites
+         * @param sink the fixture's write API
+         * @return the branch's result
+         */
+        String executeOnUiThread(Package content, Sink sink)
+        {
+            XdtoWriter.rewriteNamespaceReferences(content, "old", "new"); //$NON-NLS-1$ //$NON-NLS-2$
+            return deleteWithConsent("preview", () -> sink.mutate()); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Writes through an API nobody put on the known-mutations list - raw EMF, outside any transaction.
+     * Only a rule that treats the write-capable API FAMILIES as denied by default catches this; a
+     * fixed list of call names cannot, and its own positive control stays green because the listed
+     * names still occur in the branches that use them.
+     */
+    public static final class UnlistedMutationApiBypass
+    {
+        /** This fixture's own callback type. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /**
+         * The single authorization point.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param target the object this branch removes behind everyone's back
+         * @param sink the fixture's write API
+         * @return the branch's result
+         */
+        String executeOnUiThread(EObject target, Sink sink)
+        {
+            EcoreUtil.remove(target);
+            return deleteWithConsent("preview", () -> sink.mutate()); //$NON-NLS-1$
+        }
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/ConsentRatchetFixtures.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/ConsentRatchetFixtures.java
@@ -6,6 +6,7 @@
 
 package com.ditrix.edt.mcp.server.tools;
 
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -283,6 +284,207 @@ public final class ConsentRatchetFixtures
         }
     }
 
+    /**
+     * The second callback is made with a CONSTRUCTOR, not a lambda. A uniqueness check that counts
+     * only {@code invokedynamic} sees one creation where there are two, and the named one keeps the
+     * exemption while being run somewhere else.
+     */
+    public static final class NamedCallbackBypass
+    {
+        /** This fixture's own callback type. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /** A named implementation of the callback - no lambda involved. */
+        static final class Named implements DeleteWrite
+        {
+            private final Sink sink;
+
+            Named(Sink sink)
+            {
+                this.sink = sink;
+            }
+
+            @Override
+            public String perform()
+            {
+                return sink.mutate();
+            }
+        }
+
+        /**
+         * The single authorization point.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param sink the fixture's write API
+         * @return the branch's result
+         */
+        String executeOnUiThread(Sink sink)
+        {
+            DeleteWrite harmless = () -> "{}"; //$NON-NLS-1$
+            DeleteWrite leaked = new Named(sink);
+            String gated = deleteWithConsent("preview", harmless); //$NON-NLS-1$
+            return gated + leaked.perform();
+        }
+    }
+
+    /**
+     * Parks the callback in a STATIC FIELD on its way to the gate. The gate really is the next
+     * invocation, so a rule that only looks for the next call is satisfied - and the field keeps the
+     * value for whatever wants to run it later, consent or no consent.
+     */
+    public static final class FieldStoredCallbackBypass
+    {
+        /** This fixture's own callback type. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /** Where the callback is parked. */
+        static DeleteWrite parked;
+
+        /**
+         * The single authorization point.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param sink the fixture's write API
+         * @return the branch's result
+         */
+        String executeOnUiThread(Sink sink)
+        {
+            parked = () -> sink.mutate();
+            return deleteWithConsent("preview", parked); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Copies over a file. {@code Files.copy} writes its destination, and {@code copy} used to read
+     * like a query because {@code EcoreUtil.copy} really is one - the same word, two acts.
+     */
+    public static final class FileCopyBypass
+    {
+        /** This fixture's own callback type. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /**
+         * The single authorization point.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param from the file overwritten
+         * @param to where it goes
+         * @param sink the fixture's write API
+         * @return the branch's result
+         * @throws IOException never - the shape only has to compile
+         */
+        String executeOnUiThread(Path from, Path to, Sink sink) throws IOException
+        {
+            Files.copy(from, to);
+            return deleteWithConsent("preview", () -> sink.mutate()); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Truncates a file by merely OPENING it. No write verb is spoken at all: the mutation is a
+     * constructor, whose name is {@code <init>}.
+     */
+    public static final class OutputStreamBypass
+    {
+        /** This fixture's own callback type. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /**
+         * The single authorization point.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param victim the file emptied by opening it
+         * @param sink the fixture's write API
+         * @return the branch's result
+         * @throws IOException never - the shape only has to compile
+         */
+        String executeOnUiThread(String victim, Sink sink) throws IOException
+        {
+            new FileOutputStream(victim).close();
+            return deleteWithConsent("preview", () -> sink.mutate()); //$NON-NLS-1$
+        }
+    }
+
     /** The compliant shape: the ONLY write is a {@code DeleteWrite} handed to the gate. */
     public static final class Gated
     {
@@ -355,16 +557,18 @@ public final class ConsentRatchetFixtures
         }
 
         /**
-         * The dispatch entry point.
+         * The dispatch entry point. The leaked callback arrives from OUTSIDE, so this branch never
+         * creates or stores one - every structural rule about creation is silent here, and the only
+         * thing left to notice is the method handle.
          *
          * @param sink the fixture's write API
+         * @param fromCaller a callback this branch did not build
          * @return the branch's result
          */
-        String executeOnUiThread(Sink sink)
+        String executeOnUiThread(Sink sink, DeleteWrite fromCaller)
         {
-            DeleteWrite write = () -> sink.mutate();
-            String gated = deleteWithConsent("preview", write); //$NON-NLS-1$
-            Supplier<String> escape = write::perform;
+            Supplier<String> escape = fromCaller::perform;
+            String gated = deleteWithConsent("preview", () -> sink.mutate()); //$NON-NLS-1$
             return gated + escape.get();
         }
     }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/ConsentRatchetFixtures.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/ConsentRatchetFixtures.java
@@ -54,6 +54,18 @@ public final class ConsentRatchetFixtures
          * @return the fixture's result
          */
         String mutate();
+
+        /**
+         * The same, reachable without an instance - a static initializer has none. Deliberately the
+         * same NAME, so the fixtures' mutation set stays one entry.
+         *
+         * @param what what is being changed
+         * @return the fixture's result
+         */
+        static String mutate(String what)
+        {
+            return what;
+        }
     }
 
     /**
@@ -482,6 +494,67 @@ public final class ConsentRatchetFixtures
         {
             new FileOutputStream(victim).close();
             return deleteWithConsent("preview", () -> sink.mutate()); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Writes in the STATIC INITIALIZER of a callback built directly in the gate's argument. The
+     * handover is impeccable - the object goes straight from {@code new} into
+     * {@code deleteWithConsent}, never stored, never shared - and the write has already happened by
+     * the time the gate is asked anything, because {@code <clinit>} runs when the class is first
+     * touched. Nothing ever CALLS a static initializer, so it is reachable only by expanding the
+     * class; exempting the whole class because its {@code perform} is authorized loses it entirely.
+     * <p>
+     * A constructor would not have shown this: {@code <init>} is an ordinary call and the walk
+     * follows it whatever the exemption says.
+     */
+    public static final class ConstructedInArgumentBypass
+    {
+        /** This fixture's own callback type. */
+        @FunctionalInterface
+        interface DeleteWrite
+        {
+            /**
+             * Performs the branch's mutation.
+             *
+             * @return the branch's result
+             */
+            String perform();
+        }
+
+        /** A callback whose real work happens when the CLASS is touched, before anyone is asked. */
+        static final class WritingClinit implements DeleteWrite
+        {
+            static final String DONE = Sink.mutate("victim"); //$NON-NLS-1$
+
+            @Override
+            public String perform()
+            {
+                return DONE;
+            }
+        }
+
+        /**
+         * The single authorization point.
+         *
+         * @param preview what is being authorized
+         * @param write the mutation, run only when consent is granted
+         * @return the mutation's result, or the refusal
+         */
+        String deleteWithConsent(String preview, DeleteWrite write)
+        {
+            return preview.isEmpty() ? "denied" : write.perform(); //$NON-NLS-1$
+        }
+
+        /**
+         * The dispatch entry point.
+         *
+         * @param sink the fixture's write API
+         * @return the branch's result
+         */
+        String executeOnUiThread()
+        {
+            return deleteWithConsent("preview", new WritingClinit()); //$NON-NLS-1$
         }
     }
 

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/DeleteMetadataConsentSinglePointRatchetTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/DeleteMetadataConsentSinglePointRatchetTest.java
@@ -60,13 +60,15 @@ import com.ditrix.edt.mcp.server.tools.impl.DeleteMetadataTool;
  * would report every branch as ungated. It is skipped - but the skip has to be EARNED, or it becomes
  * the hole it is meant to close. Four rules together:
  * <ul>
- * <li>the first thing that runs after a callback is BUILT must be a gate entry point
- * ({@link #GATE_ENTRIES}, each proven to reach the gate), and that invocation must belong to that
- * one value: two callbacks built before the same gate call authorize NEITHER, because nothing here
- * can say which of them was the argument. Every weaker phrasing was tried and every one is a
- * per-method aggregate in disguise - "calls a gate somewhere" and even "the next call is the gate"
- * are both satisfied by a harmless callback while a second one is leaked past it. The exemption is
- * decided per CREATION, never per method;</li>
+ * <li>a callback must travel from where it is BUILT into a gate entry point
+ * ({@link #GATE_ENTRIES}, each proven to reach the gate) without ever leaving the operand stack.
+ * The next invocation has to be the handover, and in between there may be no STORE - no
+ * {@code astore}, no {@code putfield}, no {@code putstatic} - and no second creation of the same
+ * type, by lambda or by constructor. Everything weaker was tried and every one of them turned out
+ * to be a per-method aggregate in disguise: "calls a gate somewhere", "the next call is the gate",
+ * even "no other lambda in between" are all satisfied by a harmless callback while a second one is
+ * parked in a field or built with {@code new} and leaked past it. Adjacency was never the point -
+ * it was a proxy for "this value never got away", and the stores are what that actually means;</li>
  * <li>the only thing that may INVOKE {@code DeleteWrite.perform} is the gate, and a method HANDLE on
  * it counts as an invocation. Converting the callback to some other functional interface
  * ({@code write::perform}) is the one way to run it without an invoke instruction;</li>
@@ -106,10 +108,16 @@ import com.ditrix.edt.mcp.server.tools.impl.DeleteMetadataTool;
  * <li>a write through a seam in NEITHER the list nor the families, under a verb that reads like a
  * query - a brand-new helper class that is not named {@code *Writer} and does not touch BM, EMF,
  * refactoring, the workspace or {@code java.nio} - is invisible here, and is covered only by the
- * transaction-boundary rules in CLAUDE.md;</li>
- * <li>the value analysis is instruction ADJACENCY, not dataflow. It answers "was this callback the
- * argument of the very next call, alone?" - which is enough to refuse every shape that stores or
- * shares it, and is why the rule is strict rather than clever;</li>
+ * transaction-boundary rules in CLAUDE.md. The families are named types, so these are known to be
+ * outside them and are left outside DELIBERATELY rather than by oversight: {@code Runtime.exec} and
+ * {@code ProcessBuilder}, JDBC, sockets, {@code java.util.prefs}, anything reached by reflection or
+ * a {@code MethodHandle} that is not a lambda, and any third-party IO library. Adding one is a line
+ * in {@link #FILES} or a verb in {@link #writeCapableCall} - the list is the contract, and a write
+ * that wants to be caught has to be put on it;</li>
+ * <li>the value analysis is a linear scan, not dataflow. It answers "did this callback reach the
+ * next call without being stored, and was it the only one?" - which is enough to refuse every shape
+ * that parks or shares the value, and is why the rule is strict rather than clever. It does not
+ * follow branches, so it reasons about instruction ORDER and not about execution paths;</li>
  * <li>owners are compared by SIMPLE name and by the STATIC type at the call site - that is all the
  * constant pool spells - so two same-named classes from different packages are one owner here, and a
  * family rule keyed on {@code EList} does not follow into {@code BasicEList};</li>
@@ -481,6 +489,53 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             + "nothing authorized it: " + bypass.escapes, !bypass.escapes.isEmpty()); //$NON-NLS-1$
     }
 
+    /** The second callback built with a CONSTRUCTOR: invisible to a check that counts only lambdas. */
+    @Test
+    public void theAnalysisCatchesASecondCallbackMadeWithAConstructor()
+    {
+        Analysis bypass = analyseFixture(ConsentRatchetFixtures.NamedCallbackBypass.class);
+
+        assertTrue("the leaked callback here is a named class, not a lambda, so a uniqueness check " //$NON-NLS-1$
+            + "that scans invokedynamic alone counts one creation where there are two - and the " //$NON-NLS-1$
+            + "named one keeps the exemption it never earned.", !bypass.unconsumed.isEmpty()); //$NON-NLS-1$
+        assertTrue("... and once nothing authorized it, its body is walked: " + bypass.escapes, //$NON-NLS-1$
+            !bypass.escapes.isEmpty());
+    }
+
+    /** The callback parked in a field on the way to the gate: the gate IS the next invocation. */
+    @Test
+    public void theAnalysisCatchesACallbackStoredBeforeItReachesTheGate()
+    {
+        Analysis bypass = analyseFixture(ConsentRatchetFixtures.FieldStoredCallbackBypass.class);
+
+        assertTrue("the fixture puts its callback in a static field and only then calls the gate. " //$NON-NLS-1$
+            + "The gate really is the next invocation, so looking for the next CALL says yes - but " //$NON-NLS-1$
+            + "the value is in a slot now, and the field outlives the consent that was asked for " //$NON-NLS-1$
+            + "it.", !bypass.unconsumed.isEmpty()); //$NON-NLS-1$
+    }
+
+    /** {@code Files.copy} writes its destination, whatever {@code EcoreUtil.copy} does. */
+    @Test
+    public void theAnalysisCatchesAFileOverwrittenByACopy()
+    {
+        Analysis bypass = analyseFixture(ConsentRatchetFixtures.FileCopyBypass.class);
+
+        assertTrue("Files.copy overwrites its destination. 'copy' read like a query because " //$NON-NLS-1$
+            + "EcoreUtil.copy is one - and a name-based rule cannot tell the two apart, so the " //$NON-NLS-1$
+            + "fail-closed direction is to call it a write.", !bypass.escapes.isEmpty()); //$NON-NLS-1$
+    }
+
+    /** Opening a stream truncates the file: the mutation is a constructor, named {@code <init>}. */
+    @Test
+    public void theAnalysisCatchesAFileTruncatedByOpeningAStream()
+    {
+        Analysis bypass = analyseFixture(ConsentRatchetFixtures.OutputStreamBypass.class);
+
+        assertTrue("new FileOutputStream(path) empties the file before any write verb is spoken, " //$NON-NLS-1$
+            + "and a constructor is called <init>, which reads like nothing at all. Only having " //$NON-NLS-1$
+            + "the stream types in a write-capable family sees it.", !bypass.escapes.isEmpty()); //$NON-NLS-1$
+    }
+
     /** A nested holder reached only by reading its static field: no call names it. */
     @Test
     public void theAnalysisCatchesAWriteReachedThroughAStaticField()
@@ -688,7 +743,7 @@ public class DeleteMetadataConsentSinglePointRatchetTest
         // implementation classes' own spelling (InternalEList.basicRemove, doDelete).
         if (startsWithAny(name, "set", "unset", "remove", "delete", "insert", "move", "rename", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$
             "replace", "write", "append", "truncate", "destroy", "discard", "purge", "drop", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$
-            "eSet", "eUnset", "eInvoke", "save", "persist", "commit") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+            "copy", "eSet", "eUnset", "eInvoke", "save", "persist", "commit") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
             || containsAny(name, "Remove", "Delete", "Unset", "Clear", "Write") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
             || "clear".equals(name)) //$NON-NLS-1$
         {
@@ -730,10 +785,14 @@ public class DeleteMetadataConsentSinglePointRatchetTest
     /**
      * The plain-Java way to the same disk. {@code delete_metadata} is about removing things, and
      * nothing stops a branch from removing them without the workspace: {@code Files.delete} is not
-     * an Eclipse resource, not a {@code *Writer} and not on any list.
+     * an Eclipse resource, not a {@code *Writer} and not on any list. The output streams are here
+     * because OPENING one is the mutation - {@code new FileOutputStream(path)} truncates the file
+     * before a single write verb is spoken, and a constructor's name is {@code <init>}, which reads
+     * like nothing at all.
      */
-    private static final Set<String> FILES =
-        Set.of("Files", "File", "Path", "FileChannel", "RandomAccessFile"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+    private static final Set<String> FILES = Set.of("Files", "File", "Path", "FileChannel", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        "RandomAccessFile", "FileOutputStream", "PrintStream", "FileWriter", "BufferedWriter", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+        "PrintWriter", "OutputStreamWriter", "FileSystemProvider"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
     /**
      * Whether a method NAME reads like a query. Deliberately about the name and nothing else: on a
@@ -751,7 +810,10 @@ public class DeleteMetadataConsentSinglePointRatchetTest
         {
             return false;
         }
-        return startsWithAny(name, "get", "is", "has", "find", "read", "resolve", "parse", "copy", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$
+        // 'copy' is deliberately NOT here: EcoreUtil.copy returns one, Files.copy writes one, and a
+        // name-based rule cannot tell them apart - so it counts as a write and a read-only copy has
+        // to be admitted on purpose.
+        return startsWithAny(name, "get", "is", "has", "find", "read", "resolve", "parse", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$
             "desc", "format", "kind", "preview", "exists", "members", "accept", "toString", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$
             "toArray", "size", "iterator", "contains", "indexOf", "stream", "forEach", "equals", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$
             "hashCode") //$NON-NLS-1$
@@ -912,6 +974,9 @@ public class DeleteMetadataConsentSinglePointRatchetTest
         private final List<Callback> callbacks = new ArrayList<>();
 
         private final List<Reference> references = new ArrayList<>();
+
+        /** Offsets at which a REFERENCE is put somewhere it can outlive the current expression. */
+        private final List<Integer> stores = new ArrayList<>();
     }
 
     /**
@@ -997,6 +1062,12 @@ public class DeleteMetadataConsentSinglePointRatchetTest
         {
             MethodBody body = methods.get(node);
             return body == null ? List.of() : body.references;
+        }
+
+        List<Integer> storesIn(String node)
+        {
+            MethodBody body = methods.get(node);
+            return body == null ? List.of() : body.stores;
         }
 
         /** Whether any method creates a callback of {@code type} - the walk's own positive control. */
@@ -1134,33 +1205,34 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             {
                 return false;
             }
-            // ... and that invocation must belong to THIS value alone. One gate call authorizes one
-            // callback; when two creations both point at it, one of them is riding on the other's
-            // authorization and nothing here can say which - so neither is exempt. Without this the
-            // rule is still a per-method aggregate wearing a per-value disguise.
-            for (Callback callback : callbacksIn(node))
+            // ... and the value must still be the same one when it gets there. Adjacency was never
+            // the point; it was a proxy for "this value never left the operand stack", and the
+            // honest way to ask that is to look for the instructions that would take it off:
+            //
+            //   * a STORE - astore into a local, putfield / putstatic into an object. Once the
+            //     callback is in a slot, the gate call proves nothing about it: something else can
+            //     read that slot afterwards, which is the whole two-callback bypass;
+            //   * another CREATION of the same type, of ANY kind. Counting only lambdas here left
+            //     `new SomeDeleteWrite(...)` uninvolved, so a second callback made with a
+            //     constructor was invisible to the very check meant to find a second callback.
+            //
+            // Anything else between the two - loads, constants, arithmetic - pushes OTHER values and
+            // cannot divert this one.
+            for (int store : storesIn(node))
             {
-                if (callback.offset != offset && callback.offset < next.offset
-                    && callback.offset > lastCallBefore(node, next.offset))
+                if (store > offset && store < next.offset)
+                {
+                    return false;
+                }
+            }
+            for (int other : creationsOf(node, unit + WRITE_CALLBACK_SUFFIX))
+            {
+                if (other != offset && other > offset && other < next.offset)
                 {
                     return false;
                 }
             }
             return true;
-        }
-
-        /** The offset of the last invocation strictly before {@code offset}, or -1. */
-        private int lastCallBefore(String node, int offset)
-        {
-            int best = -1;
-            for (Call call : callsIn(node))
-            {
-                if (call.offset < offset && call.offset > best)
-                {
-                    best = call.offset;
-                }
-            }
-            return best;
         }
 
         /** The first invocation instruction after {@code offset} in {@code node}, or {@code null}. */
@@ -1654,6 +1726,15 @@ public class DeleteMetadataConsentSinglePointRatchetTest
                 {
                     int ref = readUnsignedShort(code, pc + 1);
                     into.references.add(new Reference(simpleName(nameOf(classNames, refOwners[ref]))));
+                    if (opcode == 0xB3 || opcode == 0xB5) // putstatic / putfield
+                    {
+                        into.stores.add(pc);
+                    }
+                }
+                else if (opcode == 0x3A || (opcode >= 0x4B && opcode <= 0x4E) || opcode == 0x53
+                    || (opcode == 0xC4 && (code[pc + 1] & 0xFF) == 0x3A)) // astore* / aastore / wide
+                {
+                    into.stores.add(pc);
                 }
                 else if (opcode == 0xBA) // invokedynamic: creates a callback, does not run it
                 {

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/DeleteMetadataConsentSinglePointRatchetTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/DeleteMetadataConsentSinglePointRatchetTest.java
@@ -47,11 +47,12 @@ import com.ditrix.edt.mcp.server.tools.impl.DeleteMetadataTool;
  * <li>an ordinary call ({@code invokevirtual/special/static/interface}) into the nest;</li>
  * <li>a lambda / method reference, resolved through {@code BootstrapMethods} to the method that
  * actually holds the body;</li>
- * <li>ANY reference to a nest member - construction, a constructor reference, a static call that
- * triggers its {@code <clinit>}: everything that class declares becomes reachable, because whoever
- * holds the instance decides when to run it. Modelling those JVM edges one at a time is how a blind
- * spot gets built, so the coarse rule is the safe one. That is what makes an anonymous
- * {@code Supplier} a followed edge rather than a hiding place.</li>
+ * <li>ANY reference to a nest member - construction, a constructor reference, a static call, or
+ * merely READING one of its fields: everything that class declares becomes reachable, because
+ * whoever holds the instance decides when to run it. Modelling those JVM edges one at a time is how
+ * a blind spot gets built (a holder touched only by {@code getstatic} was exactly that), so the
+ * coarse rule is the safe one. That is what makes an anonymous {@code Supplier} a followed edge
+ * rather than a hiding place.</li>
  * </ul>
  *
  * <h2>Why the gate's own callback may be skipped, and only then</h2>
@@ -59,18 +60,18 @@ import com.ditrix.edt.mcp.server.tools.impl.DeleteMetadataTool;
  * would report every branch as ungated. It is skipped - but the skip has to be EARNED, or it becomes
  * the hole it is meant to close. Four rules together:
  * <ul>
- * <li>the body is left unfollowed only when the method that created the callback also calls a gate
- * entry point ({@link #GATE_ENTRIES}, each proven to reach the gate). A method that builds a
- * {@code DeleteWrite} and never goes near the gate is walked like any other code;</li>
+ * <li>the first thing that runs after a callback is BUILT must be a gate entry point
+ * ({@link #GATE_ENTRIES}, each proven to reach the gate), and that invocation must belong to that
+ * one value: two callbacks built before the same gate call authorize NEITHER, because nothing here
+ * can say which of them was the argument. Every weaker phrasing was tried and every one is a
+ * per-method aggregate in disguise - "calls a gate somewhere" and even "the next call is the gate"
+ * are both satisfied by a harmless callback while a second one is leaked past it. The exemption is
+ * decided per CREATION, never per method;</li>
  * <li>the only thing that may INVOKE {@code DeleteWrite.perform} is the gate, and a method HANDLE on
  * it counts as an invocation. Converting the callback to some other functional interface
  * ({@code write::perform}) is the one way to run it without an invoke instruction;</li>
- * <li>the first thing that runs after a callback is BUILT must be a gate entry point. Anything that
- * can hold on to the value - a local, a helper taking {@code Object}, a second callback standing in
- * for it at the gate call - would put the write where nothing here reads it, and no rule about the
- * method as a whole can tell those apart without tracking which value went where;</li>
  * <li>the same applies to a nest member that IMPLEMENTS the callback type: referencing it is a
- * followed edge unless its creator hands it to the gate.</li>
+ * followed edge unless that construction itself was handed straight to the gate.</li>
  * </ul>
  * The direction is deliberate: where the rules cannot tell, they treat the write as ungated. Handing
  * the gate a callback that wraps another one ({@code deleteWithConsent(preview, w::get)}), or a
@@ -97,11 +98,18 @@ import com.ditrix.edt.mcp.server.tools.impl.DeleteMetadataTool;
  * </ul>
  *
  * <h2>What it still does NOT prove, stated plainly</h2>
+ * The rules above are a NAME-based predicate over external calls plus a reachability walk over one
+ * nest. Two consequences follow from that alone, and everything in this list is one of them: a verb
+ * it has not been taught, on an owner outside the families, reads as a read; and it sees only the
+ * static type at the call site.
  * <ul>
  * <li>a write through a seam in NEITHER the list nor the families, under a verb that reads like a
  * query - a brand-new helper class that is not named {@code *Writer} and does not touch BM, EMF,
- * refactoring or resources - is invisible here, and is covered only by the transaction-boundary
- * rules in CLAUDE.md;</li>
+ * refactoring, the workspace or {@code java.nio} - is invisible here, and is covered only by the
+ * transaction-boundary rules in CLAUDE.md;</li>
+ * <li>the value analysis is instruction ADJACENCY, not dataflow. It answers "was this callback the
+ * argument of the very next call, alone?" - which is enough to refuse every shape that stores or
+ * shares it, and is why the rule is strict rather than clever;</li>
  * <li>owners are compared by SIMPLE name and by the STATIC type at the call site - that is all the
  * constant pool spells - so two same-named classes from different packages are one owner here, and a
  * family rule keyed on {@code EList} does not follow into {@code BasicEList};</li>
@@ -319,11 +327,44 @@ public class DeleteMetadataConsentSinglePointRatchetTest
 
         // Running the lookup first proves nothing if its ANSWER can be thrown away: passing a
         // hand-built XdtoLookup would satisfy every assertion above and the unit tests too, and the
-        // prompt would be back for a target that is not there. The branch may not build one.
-        assertTrue(XDTO_BRANCH + "() constructs an " + XDTO_LOOKUP_TYPE + " of its own, so what it " //$NON-NLS-1$ //$NON-NLS-2$
-            + "hands to " + XDTO_GATE + " need not be what the lookup found. The only " //$NON-NLS-1$ //$NON-NLS-2$
-            + "lookup outcome it may pass on is the one it got back (issue #331 review).", //$NON-NLS-1$
-            nest.firstOffsetOf(branch, XDTO_LOOKUP_TYPE + "#<init>") < 0); //$NON-NLS-1$
+        // prompt would be back for a target that is not there.
+        //
+        // Forbidding it in THIS method is not enough - a helper that runs the real lookup and then
+        // returns a fresh successful one reads exactly the same from here. So the whole class is
+        // pinned instead: the only code that may build a lookup outcome is the lookup's own
+        // transaction body, which is the only place that has actually asked the model. Anything
+        // else - a factory, a copy, an XdtoLookup::new handed on - grows this set and fails.
+        Set<String> constructors = nest.methodsReaching(XDTO_LOOKUP_TYPE + "#<init>"); //$NON-NLS-1$
+        assertEquals("only the transaction body of " + XDTO_LOOKUP + "() may build an " //$NON-NLS-1$ //$NON-NLS-2$
+            + XDTO_LOOKUP_TYPE + ": it is the one place that asked the model. Any other producer " //$NON-NLS-1$
+            + "can hand " + XDTO_GATE + " an outcome the lookup never found, and the prompt is back " //$NON-NLS-1$ //$NON-NLS-2$
+            + "for a target that is not there (issue #331 review).", //$NON-NLS-1$
+            lookupTransactionBodies(nest), constructors);
+    }
+
+    /**
+     * The bodies {@code locateXdtoMemberInModel} hands to the BM transaction - the only code entitled
+     * to say what the lookup found. Derived from the class, never named: the compiler chooses what a
+     * lambda body is called ({@code lambda$0} here, {@code lambda$new$0} elsewhere), and a pin that
+     * spelled the name would be pinning the compiler.
+     *
+     * @param nest the parsed classes
+     * @return the node keys of those bodies
+     */
+    private static Set<String> lookupTransactionBodies(Nest nest)
+    {
+        Set<String> bodies = new TreeSet<>();
+        String lookup = nest.requireSingleDeclaration(SELF, XDTO_LOOKUP.substring(SELF.length() + 1));
+        for (Callback callback : nest.callbacksIn(lookup))
+        {
+            if (SELF.equals(callback.implOwner))
+            {
+                bodies.add(callback.node());
+            }
+        }
+        assertTrue(XDTO_LOOKUP + "() no longer runs its lookup in a transaction body, so there is " //$NON-NLS-1$
+            + "nothing to attribute the outcome to", !bodies.isEmpty()); //$NON-NLS-1$
+        return bodies;
     }
 
     // ---- the ratchet's own controls ------------------------------------------------------------
@@ -359,8 +400,9 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             + "That helper is not parsed here and never will be, so the only thing that can catch " //$NON-NLS-1$
             + "this is requiring the gate to be the very next thing that runs.", //$NON-NLS-1$
             !bypass.unconsumed.isEmpty());
-        assertTrue("... and it is the only thing that catches it: the walk is satisfied here.", //$NON-NLS-1$
-            bypass.escapes.isEmpty());
+        assertTrue("... and once the handover is refused, nothing authorized that callback, so its " //$NON-NLS-1$
+            + "body is walked like any other code and the write inside it surfaces too: " //$NON-NLS-1$
+            + bypass.escapes, !bypass.escapes.isEmpty());
     }
 
     /**
@@ -420,6 +462,47 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             + "outside MUTATIONS. If only the named list decided what a write is, this branch would " //$NON-NLS-1$
             + "be invisible while the list's own positive control stayed green - which is exactly " //$NON-NLS-1$
             + "the failure mode the verb rule exists for.", !bypass.escapes.isEmpty()); //$NON-NLS-1$
+    }
+
+    /**
+     * Two callbacks, one gate call, and the gate really is the first invocation after both. Every
+     * rule phrased about the METHOD is satisfied; only asking the question per CREATION sees it.
+     */
+    @Test
+    public void theAnalysisCatchesASecondCallbackRidingOnTheFirstOnesAuthorization()
+    {
+        Analysis bypass = analyseFixture(ConsentRatchetFixtures.TwoCallbackBypass.class);
+
+        assertTrue("the fixture builds a harmless callback and a leaked one back to back, then " //$NON-NLS-1$
+            + "gates the harmless one. 'This method calls a gate' and 'the next CALL is the gate' " //$NON-NLS-1$
+            + "are both true of the leaked one as well - it shares the very same invocation.", //$NON-NLS-1$
+            !bypass.unconsumed.isEmpty());
+        assertTrue("... and the leaked body must then be walked like any other code, because " //$NON-NLS-1$
+            + "nothing authorized it: " + bypass.escapes, !bypass.escapes.isEmpty()); //$NON-NLS-1$
+    }
+
+    /** A nested holder reached only by reading its static field: no call names it. */
+    @Test
+    public void theAnalysisCatchesAWriteReachedThroughAStaticField()
+    {
+        Analysis bypass = analyseFixture(ConsentRatchetFixtures.StaticFieldBypass.class);
+
+        assertTrue("the write is a Function in a static field of a nested holder, run through " //$NON-NLS-1$
+            + "apply(). The only instruction naming the holder is a getstatic, so recording " //$NON-NLS-1$
+            + "invocations alone leaves the class - and its <clinit> - unopened.", //$NON-NLS-1$
+            !bypass.escapes.isEmpty());
+    }
+
+    /** A delete on disk with plain Java: the verb the fail-closed list had forgotten. */
+    @Test
+    public void theAnalysisCatchesAFileDeletedWithPlainJava()
+    {
+        Analysis bypass = analyseFixture(ConsentRatchetFixtures.FileDeleteBypass.class);
+
+        assertTrue("the fixture calls Files.delete. It is not an Eclipse resource, not a *Writer " //$NON-NLS-1$
+            + "and on no mutation list - and this is the tool whose entire job is deleting things, " //$NON-NLS-1$
+            + "so a predicate that calls itself fail-closed cannot let 'delete' through.", //$NON-NLS-1$
+            !bypass.escapes.isEmpty());
     }
 
     /** A generated setter on a concrete model class: no family owns it, only the verb sees it. */
@@ -590,14 +673,24 @@ public class DeleteMetadataConsentSinglePointRatchetTest
         {
             return false; // assembling a message or a JSON payload changes nothing outside the method
         }
-        // The verb first, the owner second. The constant pool spells the STATIC type, so keying the
-        // EMF mutators on the interface name would miss every generated one: EObject.eSet and
+        // The refactoring service goes first, because it is the one place where a name that reads
+        // like a mutation is not one: createMdObjectDeleteRefactoring BUILDS a delete, it does not
+        // run it, and only running it writes.
+        if (owner.startsWith("IRefactoring") || owner.endsWith("RefactoringService")) //$NON-NLS-1$ //$NON-NLS-2$
+        {
+            return !readShaped(name)
+                && !(name.startsWith("create") && !containsAny(name, "Perform", "Apply", "Execute")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        }
+        // Then the verb, and only then the owner. The constant pool spells the STATIC type, so keying
+        // the EMF mutators on the interface name would miss every generated one: EObject.eSet and
         // Import.setNamespace are the same act. Iterator.remove belongs here too - on the iterator of
         // a containment EList it writes straight through to the model. The infix forms catch the
-        // implementation classes' own spelling (InternalEList.basicRemove).
-        if (startsWithAny(name, "set", "unset", "remove", "insert", "move", "rename", "replace", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$
+        // implementation classes' own spelling (InternalEList.basicRemove, doDelete).
+        if (startsWithAny(name, "set", "unset", "remove", "delete", "insert", "move", "rename", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$
+            "replace", "write", "append", "truncate", "destroy", "discard", "purge", "drop", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$
             "eSet", "eUnset", "eInvoke", "save", "persist", "commit") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
-            || containsAny(name, "Remove", "Unset", "Clear") || "clear".equals(name)) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            || containsAny(name, "Remove", "Delete", "Unset", "Clear", "Write") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+            || "clear".equals(name)) //$NON-NLS-1$
         {
             return true;
         }
@@ -615,33 +708,32 @@ public class DeleteMetadataConsentSinglePointRatchetTest
         // nobody anticipated - rewriteNamespaceReferences, ensureExtInfo, configureDynamicListQuery,
         // rebindHandler all exist in this repo today - counts as a write until it reads like a read.
         if ("IBmTransaction".equals(owner) || "EcoreUtil".equals(owner) || "EList".equals(owner) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-            || RESOURCES.contains(owner) || (owner.endsWith("Writer") && !JDK_WRITERS.contains(owner))) //$NON-NLS-1$
+            || RESOURCES.contains(owner) || FILES.contains(owner) || owner.endsWith("Writer")) //$NON-NLS-1$
         {
             return !readShaped(name);
-        }
-        // The refactoring service: BUILDING a refactoring is inert, only running it writes - which is
-        // why 'create' is a read here and nowhere else, and only while it stays a pure factory.
-        if (owner.startsWith("IRefactoring") || owner.endsWith("RefactoringService")) //$NON-NLS-1$ //$NON-NLS-2$
-        {
-            return !readShaped(name)
-                && !(name.startsWith("create") && !containsAny(name, "Perform", "Apply", "Execute")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
         }
         return false;
     }
 
-    /** Owners whose mutators are local bookkeeping: a message being built, never the model. */
-    private static final Set<String> LOCAL_VALUES =
-        Set.of("String", "StringBuilder", "StringBuffer"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-
     /**
-     * ... and the {@code *Writer}s that write into MEMORY. The on-disk ones are deliberately absent:
-     * a metadata file rewritten through a {@code FileWriter} is exactly as destructive as one
-     * rewritten through the model.
+     * Owners whose mutators are local bookkeeping: a message being built, never the model. The
+     * in-memory {@code *Writer}s belong here and the on-disk ones deliberately do not - a metadata
+     * file rewritten through a {@code FileWriter} is exactly as destructive as one rewritten through
+     * the model.
      */
-    private static final Set<String> JDK_WRITERS = Set.of("StringWriter", "CharArrayWriter"); //$NON-NLS-1$ //$NON-NLS-2$
+    private static final Set<String> LOCAL_VALUES = Set.of("String", "StringBuilder", //$NON-NLS-1$ //$NON-NLS-2$
+        "StringBuffer", "StringWriter", "CharArrayWriter"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
     private static final Set<String> RESOURCES = Set.of("IResource", "IFolder", "IFile", "IContainer", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
         "IProject", "IWorkspaceRoot", "IWorkspace"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+    /**
+     * The plain-Java way to the same disk. {@code delete_metadata} is about removing things, and
+     * nothing stops a branch from removing them without the workspace: {@code Files.delete} is not
+     * an Eclipse resource, not a {@code *Writer} and not on any list.
+     */
+    private static final Set<String> FILES =
+        Set.of("Files", "File", "Path", "FileChannel", "RandomAccessFile"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 
     /**
      * Whether a method NAME reads like a query. Deliberately about the name and nothing else: on a
@@ -797,12 +889,29 @@ public class DeleteMetadataConsentSinglePointRatchetTest
         }
     }
 
-    /** One method of one class: its ordinary calls and the callbacks it creates. */
+    /**
+     * A class named by a FIELD instruction. Reading a static field of a nested class is a way of
+     * getting at its code - through whatever the field holds, and through its {@code <clinit>} - that
+     * leaves no call behind, so the walk has to see it as a reference in its own right.
+     */
+    private static final class Reference
+    {
+        private final String owner;
+
+        Reference(String owner)
+        {
+            this.owner = owner;
+        }
+    }
+
+    /** One method of one class: its calls, the callbacks it creates, the classes it names. */
     private static final class MethodBody
     {
         private final List<Call> calls = new ArrayList<>();
 
         private final List<Callback> callbacks = new ArrayList<>();
+
+        private final List<Reference> references = new ArrayList<>();
     }
 
     /**
@@ -884,6 +993,12 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             return body == null ? List.of() : body.callbacks;
         }
 
+        List<Reference> referencesIn(String node)
+        {
+            MethodBody body = methods.get(node);
+            return body == null ? List.of() : body.references;
+        }
+
         /** Whether any method creates a callback of {@code type} - the walk's own positive control. */
         boolean hasCallbackOfType(String type)
         {
@@ -933,19 +1048,6 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             return first;
         }
 
-        /** Whether {@code node} hands anything to one of the gate's entry points. */
-        private boolean callsAGate(String node, String unit, Set<String> gateEntries)
-        {
-            for (Call call : callsIn(node))
-            {
-                if (inUnit(call.owner, unit) && gateEntries.contains(call.name))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
         /**
          * Every place a write callback is built without going STRAIGHT into the gate.
          *
@@ -955,11 +1057,14 @@ public class DeleteMetadataConsentSinglePointRatchetTest
          * taking {@code Object} hides it. Both fail for the same reason: without tracking WHICH value
          * went where, any rule about the method as a whole can be satisfied by a second callback.</p>
          *
-         * <p>So the rule is about the value's only safe lifetime: the first invocation after the one
-         * that CREATES the callback must be an authorization step. Then it was never stored, never
-         * passed anywhere else, and no second callback can stand in for it - which is how every branch
-         * in this tool already writes it. A branch that wants a named local instead has to make the
-         * gate call the next thing it does.</p>
+         * <p>So the rule is about the value's only safe lifetime: the very next thing the method DOES
+         * after building the callback - the next invocation or the next callback creation, whichever
+         * comes first - must be an authorization step. Then the value was never stored, never handed
+         * anywhere else, and no second callback can stand in for it, because a second creation is
+         * itself the violation. Looking only at the next CALL was not enough: two callbacks built
+         * back to back share the gate invocation that follows them, and the leaked one rides in on
+         * the harmless one's authorization. This is how every branch in this tool already writes it;
+         * a branch that wants a named local has to make the gate call the next thing it does.</p>
          *
          * @param unit the analysed class
          * @param writeType the gate's callback type
@@ -976,26 +1081,11 @@ public class DeleteMetadataConsentSinglePointRatchetTest
                 {
                     continue;
                 }
-                List<Integer> created = new ArrayList<>();
-                for (Callback callback : method.getValue().callbacks)
+                for (int at : creationsOf(method.getKey(), writeType))
                 {
-                    if (writeType.equals(callback.type))
+                    if (!handedStraightToTheGate(method.getKey(), at, unit, gateEntries))
                     {
-                        created.add(callback.offset);
-                    }
-                }
-                for (Call call : method.getValue().calls)
-                {
-                    if ("<init>".equals(call.name) && implementsType(call.owner, writeType)) //$NON-NLS-1$
-                    {
-                        created.add(call.offset); // a named / anonymous implementation of it
-                    }
-                }
-                for (int at : created)
-                {
-                    Call next = firstCallAfter(method.getKey(), at);
-                    if (next == null || !(inUnit(next.owner, unit) && gateEntries.contains(next.name)))
-                    {
+                        Call next = nextCallAfter(method.getKey(), at);
                         offenders.add(method.getKey() + " -> " //$NON-NLS-1$
                             + (next == null ? "nothing" : next.target())); //$NON-NLS-1$
                     }
@@ -1004,8 +1094,77 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             return offenders;
         }
 
+        /** Every offset in {@code node} at which a value of {@code writeType} comes into existence. */
+        private List<Integer> creationsOf(String node, String writeType)
+        {
+            List<Integer> created = new ArrayList<>();
+            for (Callback callback : callbacksIn(node))
+            {
+                if (writeType.equals(callback.type))
+                {
+                    created.add(callback.offset);
+                }
+            }
+            for (Call call : callsIn(node))
+            {
+                if ("<init>".equals(call.name) && implementsType(call.owner, writeType)) //$NON-NLS-1$
+                {
+                    created.add(call.offset); // a named / anonymous implementation of it
+                }
+            }
+            return created;
+        }
+
+        /**
+         * Whether the callback created at {@code offset} goes straight into an authorization step.
+         * This is the per-VALUE question the whole exemption rests on, so nothing here may be
+         * answered about the method as a whole.
+         *
+         * @param node the method holding the creation
+         * @param offset where the callback is created
+         * @param unit the analysed class
+         * @param gateEntries the methods a callback may legitimately be handed to
+         * @return whether the next thing that happens is the handover
+         */
+        private boolean handedStraightToTheGate(String node, int offset, String unit,
+            Set<String> gateEntries)
+        {
+            Call next = nextCallAfter(node, offset);
+            if (next == null || !(inUnit(next.owner, unit) && gateEntries.contains(next.name)))
+            {
+                return false;
+            }
+            // ... and that invocation must belong to THIS value alone. One gate call authorizes one
+            // callback; when two creations both point at it, one of them is riding on the other's
+            // authorization and nothing here can say which - so neither is exempt. Without this the
+            // rule is still a per-method aggregate wearing a per-value disguise.
+            for (Callback callback : callbacksIn(node))
+            {
+                if (callback.offset != offset && callback.offset < next.offset
+                    && callback.offset > lastCallBefore(node, next.offset))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /** The offset of the last invocation strictly before {@code offset}, or -1. */
+        private int lastCallBefore(String node, int offset)
+        {
+            int best = -1;
+            for (Call call : callsIn(node))
+            {
+                if (call.offset < offset && call.offset > best)
+                {
+                    best = call.offset;
+                }
+            }
+            return best;
+        }
+
         /** The first invocation instruction after {@code offset} in {@code node}, or {@code null}. */
-        private Call firstCallAfter(String node, int offset)
+        private Call nextCallAfter(String node, int offset)
         {
             Call best = null;
             for (Call call : callsIn(node))
@@ -1041,7 +1200,6 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             while (!queue.isEmpty())
             {
                 String from = queue.poll();
-                boolean authorizes = callsAGate(from, unit, gateEntries);
                 for (Call call : callsIn(from))
                 {
                     if (!inUnit(call.owner, unit))
@@ -1052,11 +1210,22 @@ public class DeleteMetadataConsentSinglePointRatchetTest
                     {
                         queue.add(call.node());
                     }
-                    expand(call.owner, unit, gatedType, authorizes, seen, queue);
+                    expand(call.owner, unit, gatedType,
+                        handedStraightToTheGate(from, call.offset, unit, gateEntries), seen, queue);
+                }
+                // A class this method only READS a static field of never appears as a call owner, so
+                // without this a nested holder - a static Function built from a method reference, run
+                // through apply() - would be touched by the branch and still be invisible.
+                for (Reference reference : referencesIn(from))
+                {
+                    expand(reference.owner, unit, gatedType, false, seen, queue);
                 }
                 for (Callback callback : callbacksIn(from))
                 {
-                    if (authorizes && gatedType.equals(callback.type))
+                    // Per CREATION, never per method: "this method calls a gate somewhere" exempts
+                    // every callback built in it, and a branch that builds two only has to gate one.
+                    if (gatedType.equals(callback.type)
+                        && handedStraightToTheGate(from, callback.offset, unit, gateEntries))
                     {
                         continue;
                     }
@@ -1073,7 +1242,9 @@ public class DeleteMetadataConsentSinglePointRatchetTest
                     // gated ones included.
                     if ("<init>".equals(callback.implMethod)) //$NON-NLS-1$
                     {
-                        expand(callback.implOwner, unit, gatedType, authorizes, seen, queue);
+                        expand(callback.implOwner, unit, gatedType,
+                            handedStraightToTheGate(from, callback.offset, unit, gateEntries), seen,
+                            queue);
                     }
                 }
             }
@@ -1478,6 +1649,11 @@ public class DeleteMetadataConsentSinglePointRatchetTest
                     int nameAndType = refNameAndTypes[ref];
                     into.calls.add(new Call(pc, simpleName(nameOf(classNames, refOwners[ref])),
                         text(nameAndTypeNames[nameAndType]), text(nameAndTypeDescriptors[nameAndType])));
+                }
+                else if (opcode >= 0xB2 && opcode <= 0xB5) // getstatic / putstatic / getfield / putfield
+                {
+                    int ref = readUnsignedShort(code, pc + 1);
+                    into.references.add(new Reference(simpleName(nameOf(classNames, refOwners[ref]))));
                 }
                 else if (opcode == 0xBA) // invokedynamic: creates a callback, does not run it
                 {

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/DeleteMetadataConsentSinglePointRatchetTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/DeleteMetadataConsentSinglePointRatchetTest.java
@@ -1,0 +1,879 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2026 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.tools.impl.DeleteMetadataTool;
+
+/**
+ * Ratchet for issue #331: in {@code delete_metadata} the destructive-consent gate must be a SINGLE
+ * point that every mutating branch goes through, and no branch may reach a write without it.
+ * <p>
+ * Why a ratchet and not a unit test: driving the real dispatch needs a resolved EDT project plus BM
+ * services, which a headless run has none of, and the gate itself may ASK a human. Every behavioural
+ * case therefore drives the authorization step directly ({@code DeleteMetadataToolTest}), and that
+ * test says so in as many words - which leaves exactly the thing #331 is about, the WIRING,
+ * unpinned. The issue asked for a single point "so the next new branch cannot forget it again"; a
+ * single point nobody checks is forgotten the same way. This reads the compiled class instead.
+ * <p>
+ * The model is deliberately small. A mutation runs when the method holding it runs, so the question
+ * is which methods {@code executeOnUiThread} can reach. Two kinds of edge lead somewhere:
+ * <ul>
+ * <li>an ordinary call ({@code invokevirtual/special/static/interface}) into this class;</li>
+ * <li>a lambda / method reference, resolved through the {@code BootstrapMethods} attribute to the
+ * method that actually holds the body - followed exactly like a call, EXCEPT when the callback's
+ * type is {@code DeleteWrite}: that one runs only when something invokes it, and the third test
+ * below proves the only invoker is {@code deleteWithConsent}, after an ALLOW.</li>
+ * </ul>
+ * Following ordinary lambdas matters: hiding the write in a {@code Supplier} the branch calls itself
+ * would otherwise satisfy a walk that ignored {@code invokedynamic} altogether.
+ * <p>
+ * What it does NOT prove, stated plainly:
+ * <ul>
+ * <li>the mutation entry points are a LIST ({@link #MUTATIONS}). A branch that writes through some
+ * other API - a new writer helper, raw EMF outside a transaction - is invisible here, and is covered
+ * only by the transaction-boundary rules in CLAUDE.md. The list carries a positive control, so it
+ * fails loudly when a name drifts instead of silently checking nothing;</li>
+ * <li>the two ORDER assertions compare bytecode offsets. That catches the shape both defects
+ * actually had (the later step written above the earlier one); it is not a dominance proof, so a
+ * branch that jumps over the earlier call could still pass. For {@code deleteWithConsent} the
+ * semantics are pinned behaviourally as well ({@code testConsentRejectNeverRunsTheWrite}).</li>
+ * </ul>
+ * Where it errs, it errs CLOSED, which is the only safe direction for a gate: creating a non-gated
+ * callback counts as running it, so wrapping the write in one callback and handing THAT to the gate
+ * ({@code Supplier<String> w = () -> write(); deleteWithConsent(preview, w::get);}) is reported even
+ * though it would in fact be safe. Modelling callback consumption to allow it would buy nothing - a
+ * branch's write goes to the gate directly.
+ * The compiled class is read as a resource ({@link Class#getResourceAsStream}), the way
+ * {@code BareErrorStringRatchetTest} reads constant pools: a call that was commented out, or left
+ * behind in a javadoc, cannot satisfy it. JaCoCo instruments classes as they are LOADED and never
+ * rewrites the file, so what is parsed here is the compiler's own output. Nothing depends on how a
+ * lambda body is NAMED (Tycho's compiler emits {@code lambda$0}, javac {@code lambda$new$0}) - the
+ * link comes from {@code BootstrapMethods}, not from the name.
+ */
+public class DeleteMetadataConsentSinglePointRatchetTest
+{
+    /** The tool's dispatch entry point: every branch is reached from here. */
+    private static final String ENTRY = "executeOnUiThread"; //$NON-NLS-1$
+
+    /** The single authorization point. */
+    private static final String GATE = "deleteWithConsent"; //$NON-NLS-1$
+
+    /** The tool's own class, as the constant pool spells its owner. */
+    private static final String SELF = "DeleteMetadataTool"; //$NON-NLS-1$
+
+    /** The callback type a branch hands to the gate. */
+    private static final String WRITE_CALLBACK_TYPE = "DeleteMetadataTool$DeleteWrite"; //$NON-NLS-1$
+
+    /** Its only invocation must sit inside the gate. */
+    private static final String WRITE_CALLBACK = WRITE_CALLBACK_TYPE + "#perform"; //$NON-NLS-1$
+
+    /** The consent seam the gate asks through. */
+    private static final String ASK = "DeleteMetadataTool$ConsentRequester#request"; //$NON-NLS-1$
+
+    /** The gate singleton: only the production constructor's lambda may touch it. */
+    private static final String SINGLETON = "DestructiveConsentGate#getInstance"; //$NON-NLS-1$
+
+    /** ... and only there may consent actually be requested from it. */
+    private static final String REQUIRE_CONSENT = "DestructiveConsentGate#requireConsent"; //$NON-NLS-1$
+
+    /**
+     * Every call through which this tool changes something: the md-refactoring, the two form writers,
+     * the BM write transaction, the on-disk export and the physical removal of a form's folder. None
+     * of them may be reachable without the gate.
+     */
+    private static final List<String> MUTATIONS = List.of(
+        "IRefactoring#perform", //$NON-NLS-1$
+        "FormElementWriter#writeEditableForm", //$NON-NLS-1$
+        "FormElementWriter#writeMdForm", //$NON-NLS-1$
+        "BmTransactions#write", //$NON-NLS-1$
+        "BmTransactions#forceExportToDisk", //$NON-NLS-1$
+        "IFolder#delete"); //$NON-NLS-1$
+
+    /** The XDTO branch's target lookup: it has to run BEFORE the gate, not after it. */
+    private static final String XDTO_BRANCH = "performXdtoMemberDelete"; //$NON-NLS-1$
+
+    private static final String XDTO_LOOKUP = "DeleteMetadataTool#locateXdtoMemberInModel"; //$NON-NLS-1$
+
+    @Test
+    public void theGateSingletonIsConsultedInExactlyOnePlace()
+    {
+        ClassFile tool = read();
+        Set<String> asks = tool.methodsCalling(SINGLETON);
+        Set<String> requires = tool.methodsCalling(REQUIRE_CONSENT);
+
+        assertEquals("the destructive-consent singleton must be reached from exactly one method of " //$NON-NLS-1$
+            + SELF + " - the production constructor's requester lambda. Found: " + asks //$NON-NLS-1$
+            + ". A branch with its own gate call is a branch that can drift: its own preview, its own " //$NON-NLS-1$
+            + "denial message, its own ordering relative to validation - and one that cannot be driven " //$NON-NLS-1$
+            + "by the ConsentRequester test seam. Route it through " + GATE + " instead (issue #331).", //$NON-NLS-1$ //$NON-NLS-2$
+            1, asks.size());
+        assertEquals("consent must be REQUESTED only where the singleton is obtained", asks, requires); //$NON-NLS-1$
+
+        String gate = tool.requireSingleDeclaration(GATE);
+        assertTrue(GATE + " must ask through the ConsentRequester seam, never the singleton - " //$NON-NLS-1$
+            + "otherwise no unit test can drive a refusal", //$NON-NLS-1$
+            !asks.contains(gate) && tool.firstOffsetOf(gate, ASK) >= 0);
+    }
+
+    @Test
+    public void noBranchCanReachAWriteWithoutPassingThroughTheGate()
+    {
+        ClassFile tool = read();
+
+        // Positive control: a mutation name that no longer occurs would make this test's failure mode
+        // identical to its pass - it would guard nothing and stay green forever.
+        for (String mutation : MUTATIONS)
+        {
+            assertTrue("the mutation entry point '" + mutation + "' no longer occurs in " + SELF //$NON-NLS-1$ //$NON-NLS-2$
+                + ": this ratchet would be checking a name that is not there. Update " //$NON-NLS-1$
+                + "MUTATIONS to the call the branch really writes through.", //$NON-NLS-1$
+                !tool.methodsCalling(mutation).isEmpty());
+        }
+        // ... and the same for the mechanism itself: if no callback of the gate's type were found, the
+        // walk below would be a plain call graph and would pass for the wrong reason.
+        assertTrue("no lambda of type " + WRITE_CALLBACK_TYPE + " was found in " + SELF //$NON-NLS-1$ //$NON-NLS-2$
+            + ": either BootstrapMethods parsing is broken or no branch hands its write to the gate", //$NON-NLS-1$
+            tool.hasCallbackOfType(WRITE_CALLBACK_TYPE));
+
+        Set<String> ungated = tool.reachableWithout(tool.requireSingleDeclaration(ENTRY), WRITE_CALLBACK_TYPE);
+        assertTrue("nothing was reached from " + ENTRY + "(): the call-graph walk is broken, and a " //$NON-NLS-1$ //$NON-NLS-2$
+            + "reachability ratchet that reaches nothing proves nothing", ungated.size() > 1); //$NON-NLS-1$
+        assertTrue(ENTRY + "() must still reach the authorization point", //$NON-NLS-1$
+            ungated.contains(tool.requireSingleDeclaration(GATE)));
+
+        Map<String, Set<String>> escapes = new LinkedHashMap<>();
+        for (String method : ungated)
+        {
+            for (Call call : tool.callsIn(method))
+            {
+                if (MUTATIONS.contains(call.target()))
+                {
+                    escapes.computeIfAbsent(method, unused -> new TreeSet<>()).add(call.target());
+                }
+            }
+            // A method REFERENCE to a mutation ({@code refactoring::perform} handed to a Runnable the
+            // branch then runs) never appears as a call, and its target is not one of our methods, so
+            // the walk cannot step into it. It still names a mutation - count it as one.
+            for (Callback callback : tool.callbacksIn(method))
+            {
+                if (!WRITE_CALLBACK_TYPE.equals(callback.type) && MUTATIONS.contains(callback.target()))
+                {
+                    escapes.computeIfAbsent(method, unused -> new TreeSet<>()).add(callback.target());
+                }
+            }
+        }
+        assertTrue("these methods are reachable from " + ENTRY + "() without passing through the " //$NON-NLS-1$ //$NON-NLS-2$
+            + "gate's callback AND perform a mutation, so the write happens whether or not consent " //$NON-NLS-1$
+            + "was granted: " + escapes + ". Every delete branch must hand its write to " + GATE //$NON-NLS-1$ //$NON-NLS-2$
+            + " as a DeleteWrite callback (issue #331) - see how deleteFormObject does it.", //$NON-NLS-1$
+            escapes.isEmpty());
+    }
+
+    @Test
+    public void theWriteCallbackIsInvokedOnlyByTheGateAndOnlyAfterAsking()
+    {
+        ClassFile tool = read();
+        String gate = tool.requireSingleDeclaration(GATE);
+        Set<String> invokers = tool.methodsCalling(WRITE_CALLBACK);
+
+        assertEquals("a DeleteWrite callback must be invoked ONLY by " + GATE + ": that single " //$NON-NLS-1$ //$NON-NLS-2$
+            + "invocation is what makes 'reachable only through the callback' mean 'reachable only " //$NON-NLS-1$
+            + "after ALLOW'. Found: " + invokers, Set.of(gate), invokers); //$NON-NLS-1$
+
+        int asked = tool.firstOffsetOf(gate, ASK);
+        int wrote = tool.firstOffsetOf(gate, WRITE_CALLBACK);
+        assertTrue(GATE + " no longer asks for consent", asked >= 0); //$NON-NLS-1$
+        assertTrue(GATE + " invokes the write at bytecode offset " + wrote + ", BEFORE it asks at " //$NON-NLS-1$ //$NON-NLS-2$
+            + asked + ". The mutation must run only after an ALLOW.", asked < wrote); //$NON-NLS-1$
+    }
+
+    @Test
+    public void theXdtoBranchResolvesItsTargetBeforeItAsks()
+    {
+        // The ordering defect #331 recorded: this branch asked first and looked the member up only
+        // inside the write transaction, so a typo in the member name raised a destructive prompt at a
+        // human and answered "not found" only after it had been dealt with.
+        ClassFile tool = read();
+        String branch = tool.requireSingleDeclaration(XDTO_BRANCH);
+        int lookup = tool.firstOffsetOf(branch, XDTO_LOOKUP);
+        int gate = tool.firstOffsetOf(branch, SELF + '#' + GATE);
+
+        assertTrue(XDTO_BRANCH + "() no longer looks its target up before writing: a typo would " //$NON-NLS-1$
+            + "reach the gate", lookup >= 0); //$NON-NLS-1$
+        assertTrue(XDTO_BRANCH + "() no longer goes through " + GATE, gate >= 0); //$NON-NLS-1$
+        assertTrue(XDTO_BRANCH + "() asks for consent at bytecode offset " + gate + " BEFORE it " //$NON-NLS-1$ //$NON-NLS-2$
+            + "resolves the target at " + lookup + ". Resolve first: a delete that can only answer " //$NON-NLS-1$
+            + "'not found' must never raise a destructive prompt (issue #331).", lookup < gate); //$NON-NLS-1$
+    }
+
+    private static ClassFile read()
+    {
+        try
+        {
+            return ClassFile.read(DeleteMetadataTool.class);
+        }
+        catch (IOException e)
+        {
+            fail("could not read the compiled " + SELF + ": " + e //$NON-NLS-1$ //$NON-NLS-2$
+                + " - a wiring ratchet must never pass because it read nothing"); //$NON-NLS-1$
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /** One invocation instruction: where it sits and what it calls, as {@code Owner#method}. */
+    private static final class Call
+    {
+        private final int offset;
+
+        private final String owner;
+
+        private final String name;
+
+        private final String descriptor;
+
+        Call(int offset, String owner, String name, String descriptor)
+        {
+            this.offset = offset;
+            this.owner = owner;
+            this.name = name;
+            this.descriptor = descriptor;
+        }
+
+        String target()
+        {
+            return owner + '#' + name;
+        }
+
+        /** The callee's node key in this class's graph: overloads are DIFFERENT methods. */
+        String node()
+        {
+            return name + descriptor;
+        }
+    }
+
+    /**
+     * One lambda / method reference created by an {@code invokedynamic}: the functional interface it
+     * produces, and the method that actually holds the body (from {@code BootstrapMethods}).
+     */
+    private static final class Callback
+    {
+        private final String type;
+
+        private final String implOwner;
+
+        private final String implMethod;
+
+        private final String implDescriptor;
+
+        Callback(String type, String implOwner, String implMethod, String implDescriptor)
+        {
+            this.type = type;
+            this.implOwner = implOwner;
+            this.implMethod = implMethod;
+            this.implDescriptor = implDescriptor;
+        }
+
+        /** The body's owner and name, as {@code Owner#method} - comparable with {@link Call#target()}. */
+        String target()
+        {
+            return implOwner + '#' + implMethod;
+        }
+
+        /** The body's node key in this class's graph. */
+        String node()
+        {
+            return implMethod + implDescriptor;
+        }
+    }
+
+    /**
+     * The pieces of a compiled class this ratchet needs: the constant pool, the
+     * {@code BootstrapMethods} table, and for every method its ordinary calls plus the callbacks it
+     * creates.
+     */
+    private static final class ClassFile
+    {
+        private final String[] utf8;
+
+        private final int[] classNames;
+
+        private final int[] refOwners;
+
+        private final int[] refNameAndTypes;
+
+        private final int[] nameAndTypeNames;
+
+        private final int[] nameAndTypeDescriptors;
+
+        /** For a CONSTANT_MethodHandle: the pool index of the ref it points at. */
+        private final int[] methodHandleRefs;
+
+        /** For a CONSTANT_InvokeDynamic: its BootstrapMethods index and its NameAndType. */
+        private final int[] indyBootstraps;
+
+        private final int[] indyNameAndTypes;
+
+        /** BootstrapMethods: the bootstrap MethodHandle and the static arguments, per entry. */
+        private int[] bootstrapHandles = new int[0];
+
+        private int[][] bootstrapArguments = new int[0][];
+
+        /** Raw bodies, kept until BootstrapMethods (a CLASS attribute) has been read. */
+        private final Map<String, List<byte[]>> bodies = new LinkedHashMap<>();
+
+        /** How many methods carry each name - an ordering check may not straddle two overloads. */
+        private final Map<String, Integer> declarations = new LinkedHashMap<>();
+
+        /** Node keys ({@code name+descriptor}) by bare name, so an assertion can name a method. */
+        private final Map<String, Set<String>> nodesByName = new LinkedHashMap<>();
+
+        private final Map<String, List<Call>> calls = new LinkedHashMap<>();
+
+        private final Map<String, List<Callback>> callbacks = new LinkedHashMap<>();
+
+        private ClassFile(int poolSize)
+        {
+            utf8 = new String[poolSize];
+            classNames = new int[poolSize];
+            refOwners = new int[poolSize];
+            refNameAndTypes = new int[poolSize];
+            nameAndTypeNames = new int[poolSize];
+            nameAndTypeDescriptors = new int[poolSize];
+            methodHandleRefs = new int[poolSize];
+            indyBootstraps = new int[poolSize];
+            indyNameAndTypes = new int[poolSize];
+        }
+
+        /** Every method that contains a call to {@code target} ({@code Owner#method}). */
+        Set<String> methodsCalling(String target)
+        {
+            Set<String> found = new TreeSet<>();
+            for (Map.Entry<String, List<Call>> method : calls.entrySet())
+            {
+                for (Call call : method.getValue())
+                {
+                    if (target.equals(call.target()))
+                    {
+                        found.add(method.getKey());
+                    }
+                }
+            }
+            return found;
+        }
+
+        List<Call> callsIn(String node)
+        {
+            return calls.getOrDefault(node, List.of());
+        }
+
+        List<Callback> callbacksIn(String node)
+        {
+            return callbacks.getOrDefault(node, List.of());
+        }
+
+        /** Whether any method creates a callback of {@code type} - the walk's own positive control. */
+        boolean hasCallbackOfType(String type)
+        {
+            for (List<Callback> created : callbacks.values())
+            {
+                for (Callback callback : created)
+                {
+                    if (type.equals(callback.type))
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        /**
+         * The node key of {@code method}, failing when it is overloaded: an ordering assertion names a
+         * method, and across two same-named methods an offset comparison would read unrelated
+         * instructions.
+         *
+         * @param method the bare method name an ordering assertion is about to read
+         * @return its single node key
+         */
+        String requireSingleDeclaration(String method)
+        {
+            int declared = declarations.getOrDefault(method, 0);
+            assertEquals("an ordering assertion names " + method + "(), so it must be declared " //$NON-NLS-1$ //$NON-NLS-2$
+                + "exactly once; split the assertion per descriptor before overloading it", //$NON-NLS-1$
+                1, declared);
+            return nodesByName.get(method).iterator().next();
+        }
+
+        /** The bytecode offset of the first call to {@code target} inside {@code node}, or -1. */
+        int firstOffsetOf(String node, String target)
+        {
+            int first = -1;
+            for (Call call : callsIn(node))
+            {
+                if (target.equals(call.target()) && (first < 0 || call.offset < first))
+                {
+                    first = call.offset;
+                }
+            }
+            return first;
+        }
+
+        /**
+         * The methods of this class reachable from {@code entry} by ordinary calls AND by every
+         * callback EXCEPT those of {@code gatedType}: a body handed over as {@code gatedType} runs
+         * only when that interface is invoked, and who may invoke it is a separate assertion.
+         *
+         * @param entry the method to start from
+         * @param gatedType the callback type whose bodies are NOT followed
+         * @return the reachable method names, {@code entry} included
+         */
+        Set<String> reachableWithout(String entry, String gatedType)
+        {
+            Set<String> seen = new LinkedHashSet<>();
+            Deque<String> queue = new ArrayDeque<>();
+            seen.add(entry);
+            queue.add(entry);
+            while (!queue.isEmpty())
+            {
+                String from = queue.poll();
+                for (Call call : callsIn(from))
+                {
+                    if (SELF.equals(call.owner) && bodies.containsKey(call.node()) && seen.add(call.node()))
+                    {
+                        queue.add(call.node());
+                    }
+                }
+                for (Callback callback : callbacksIn(from))
+                {
+                    if (!gatedType.equals(callback.type) && SELF.equals(callback.implOwner)
+                        && bodies.containsKey(callback.node()) && seen.add(callback.node()))
+                    {
+                        queue.add(callback.node());
+                    }
+                }
+            }
+            return seen;
+        }
+
+        private static ClassFile read(Class<?> clazz) throws IOException
+        {
+            String resource = clazz.getSimpleName() + ".class"; //$NON-NLS-1$
+            try (InputStream raw = clazz.getResourceAsStream(resource))
+            {
+                if (raw == null)
+                {
+                    throw new IOException("class resource not found: " + resource); //$NON-NLS-1$
+                }
+                try (DataInputStream in = new DataInputStream(raw))
+                {
+                    return parse(in);
+                }
+            }
+        }
+
+        private static ClassFile parse(DataInputStream in) throws IOException
+        {
+            if (in.readInt() != 0xCAFEBABE)
+            {
+                throw new IOException("not a class file (bad magic)"); //$NON-NLS-1$
+            }
+            in.readUnsignedShort(); // minor version
+            in.readUnsignedShort(); // major version
+
+            ClassFile parsed = new ClassFile(in.readUnsignedShort());
+            parsed.readConstantPool(in);
+            in.readUnsignedShort(); // access flags
+            in.readUnsignedShort(); // this class
+            in.readUnsignedShort(); // super class
+            skipFully(in, in.readUnsignedShort() * 2); // interfaces
+            parsed.skipMembers(in); // fields
+            parsed.readMethods(in);
+            parsed.readClassAttributes(in); // BootstrapMethods lives here, AFTER the methods
+            parsed.resolveBodies();
+            return parsed;
+        }
+
+        private void readConstantPool(DataInputStream in) throws IOException
+        {
+            for (int i = 1; i < utf8.length; i++)
+            {
+                int tag = in.readUnsignedByte();
+                switch (tag)
+                {
+                    case 1: // CONSTANT_Utf8
+                        utf8[i] = in.readUTF();
+                        break;
+                    case 7: // CONSTANT_Class
+                        classNames[i] = in.readUnsignedShort();
+                        break;
+                    case 8: // CONSTANT_String
+                    case 16: // CONSTANT_MethodType
+                    case 19: // CONSTANT_Module
+                    case 20: // CONSTANT_Package
+                        in.readUnsignedShort();
+                        break;
+                    case 15: // CONSTANT_MethodHandle
+                        in.readUnsignedByte(); // reference kind
+                        methodHandleRefs[i] = in.readUnsignedShort();
+                        break;
+                    case 9: // CONSTANT_Fieldref
+                    case 10: // CONSTANT_Methodref
+                    case 11: // CONSTANT_InterfaceMethodref
+                        refOwners[i] = in.readUnsignedShort();
+                        refNameAndTypes[i] = in.readUnsignedShort();
+                        break;
+                    case 12: // CONSTANT_NameAndType
+                        nameAndTypeNames[i] = in.readUnsignedShort();
+                        nameAndTypeDescriptors[i] = in.readUnsignedShort();
+                        break;
+                    case 17: // CONSTANT_Dynamic
+                    case 18: // CONSTANT_InvokeDynamic
+                        indyBootstraps[i] = in.readUnsignedShort();
+                        indyNameAndTypes[i] = in.readUnsignedShort();
+                        break;
+                    case 3: // CONSTANT_Integer
+                    case 4: // CONSTANT_Float
+                        in.readInt();
+                        break;
+                    case 5: // CONSTANT_Long
+                    case 6: // CONSTANT_Double
+                        in.readLong();
+                        i++; // 8-byte constants take two pool slots
+                        break;
+                    default:
+                        throw new IOException("unknown constant pool tag: " + tag); //$NON-NLS-1$
+                }
+            }
+        }
+
+        /** Skips a whole fields table. */
+        private void skipMembers(DataInputStream in) throws IOException
+        {
+            int count = in.readUnsignedShort();
+            for (int i = 0; i < count; i++)
+            {
+                in.readUnsignedShort(); // access flags
+                in.readUnsignedShort(); // name
+                in.readUnsignedShort(); // descriptor
+                int attributes = in.readUnsignedShort();
+                for (int a = 0; a < attributes; a++)
+                {
+                    in.readUnsignedShort(); // attribute name
+                    skipFully(in, in.readInt());
+                }
+            }
+        }
+
+        private void readMethods(DataInputStream in) throws IOException
+        {
+            int count = in.readUnsignedShort();
+            for (int i = 0; i < count; i++)
+            {
+                in.readUnsignedShort(); // access flags
+                String name = text(in.readUnsignedShort());
+                String descriptor = text(in.readUnsignedShort());
+                int attributes = in.readUnsignedShort();
+                // Keyed by name AND descriptor: two overloads are two methods, and merging them would
+                // import one's mutations into the other's reachability (issue #331 review).
+                String node = name + descriptor;
+                declarations.merge(name, 1, Integer::sum);
+                nodesByName.computeIfAbsent(name, unused -> new TreeSet<>()).add(node);
+                List<byte[]> body = bodies.computeIfAbsent(node, unused -> new ArrayList<>());
+                for (int a = 0; a < attributes; a++)
+                {
+                    String attribute = text(in.readUnsignedShort());
+                    int length = in.readInt();
+                    if (!"Code".equals(attribute)) //$NON-NLS-1$
+                    {
+                        skipFully(in, length);
+                        continue;
+                    }
+                    in.readUnsignedShort(); // max stack
+                    in.readUnsignedShort(); // max locals
+                    int codeLength = in.readInt();
+                    byte[] code = new byte[codeLength];
+                    in.readFully(code);
+                    body.add(code);
+                    // The exception table and the Code attribute's own attributes follow.
+                    skipFully(in, length - 8 - codeLength);
+                }
+            }
+        }
+
+        /** Reads the class-level attributes, keeping {@code BootstrapMethods}. */
+        private void readClassAttributes(DataInputStream in) throws IOException
+        {
+            int attributes = in.readUnsignedShort();
+            for (int a = 0; a < attributes; a++)
+            {
+                String attribute = text(in.readUnsignedShort());
+                int length = in.readInt();
+                if (!"BootstrapMethods".equals(attribute)) //$NON-NLS-1$
+                {
+                    skipFully(in, length);
+                    continue;
+                }
+                int count = in.readUnsignedShort();
+                bootstrapHandles = new int[count];
+                bootstrapArguments = new int[count][];
+                for (int b = 0; b < count; b++)
+                {
+                    bootstrapHandles[b] = in.readUnsignedShort();
+                    int arguments = in.readUnsignedShort();
+                    bootstrapArguments[b] = new int[arguments];
+                    for (int g = 0; g < arguments; g++)
+                    {
+                        bootstrapArguments[b][g] = in.readUnsignedShort();
+                    }
+                }
+            }
+        }
+
+        /** Walks every kept body once the constant pool AND BootstrapMethods are both available. */
+        private void resolveBodies()
+        {
+            for (Map.Entry<String, List<byte[]>> method : bodies.entrySet())
+            {
+                List<Call> found = calls.computeIfAbsent(method.getKey(), unused -> new ArrayList<>());
+                List<Callback> made = callbacks.computeIfAbsent(method.getKey(), unused -> new ArrayList<>());
+                for (byte[] code : method.getValue())
+                {
+                    walk(code, found, made);
+                }
+            }
+        }
+
+        /**
+         * Walks one method body instruction by instruction (including the variable-length {@code wide}
+         * / {@code tableswitch} / {@code lookupswitch} forms), so a constant-pool index that happens to
+         * look like an opcode inside another instruction's operands cannot be mistaken for a call.
+         *
+         * @param code the method's bytecode
+         * @param found collects its ordinary calls, in execution order
+         * @param made collects the callbacks it creates
+         */
+        private void walk(byte[] code, List<Call> found, List<Callback> made)
+        {
+            int pc = 0;
+            while (pc < code.length)
+            {
+                int opcode = code[pc] & 0xFF;
+                if (opcode >= 0xB6 && opcode <= 0xB9) // invokevirtual / special / static / interface
+                {
+                    int ref = readUnsignedShort(code, pc + 1);
+                    int nameAndType = refNameAndTypes[ref];
+                    found.add(new Call(pc, simpleName(nameOf(classNames, refOwners[ref])),
+                        text(nameAndTypeNames[nameAndType]), text(nameAndTypeDescriptors[nameAndType])));
+                }
+                else if (opcode == 0xBA) // invokedynamic: creates a callback, does not run it
+                {
+                    Callback callback = callbackAt(readUnsignedShort(code, pc + 1));
+                    if (callback != null)
+                    {
+                        made.add(callback);
+                    }
+                }
+                pc += instructionLength(code, pc);
+            }
+        }
+
+        /**
+         * The lambda / method reference an {@code invokedynamic} constant creates, or {@code null}
+         * when it is not one (string concatenation compiles to an {@code invokedynamic} too, through
+         * {@code StringConcatFactory}, and carries no implementation handle).
+         *
+         * @param poolIndex the CONSTANT_InvokeDynamic index
+         * @return the callback, or {@code null}
+         */
+        private Callback callbackAt(int poolIndex)
+        {
+            int bootstrap = indyBootstraps[poolIndex];
+            if (bootstrap >= bootstrapHandles.length)
+            {
+                return null;
+            }
+            String factory = simpleName(nameOf(classNames, refOwners[methodHandleRefs[bootstrapHandles[bootstrap]]]));
+            if (!"LambdaMetafactory".equals(factory)) //$NON-NLS-1$
+            {
+                return null;
+            }
+            int[] arguments = bootstrapArguments[bootstrap];
+            // metafactory(caller, name, type, samMethodType, IMPL, instantiatedMethodType) and
+            // altMetafactory(..., flags) agree on argument 1 being the implementation handle.
+            if (arguments.length < 2 || methodHandleRefs[arguments[1]] == 0)
+            {
+                return null;
+            }
+            int impl = methodHandleRefs[arguments[1]];
+            int implNameAndType = refNameAndTypes[impl];
+            String descriptor = text(nameAndTypeDescriptors[indyNameAndTypes[poolIndex]]);
+            return new Callback(returnTypeOf(descriptor), simpleName(nameOf(classNames, refOwners[impl])),
+                text(nameAndTypeNames[implNameAndType]), text(nameAndTypeDescriptors[implNameAndType]));
+        }
+
+        private String nameOf(int[] indirection, int poolIndex)
+        {
+            if (poolIndex <= 0 || poolIndex >= indirection.length)
+            {
+                return ""; //$NON-NLS-1$
+            }
+            return text(indirection[poolIndex]);
+        }
+
+        private String text(int poolIndex)
+        {
+            if (poolIndex <= 0 || poolIndex >= utf8.length || utf8[poolIndex] == null)
+            {
+                return ""; //$NON-NLS-1$
+            }
+            return utf8[poolIndex];
+        }
+    }
+
+    /** The simple name of a descriptor's return type, e.g. {@code (I)La/b/C;} -> {@code C}. */
+    private static String returnTypeOf(String descriptor)
+    {
+        int close = descriptor.lastIndexOf(')');
+        if (close < 0 || close + 1 >= descriptor.length() || descriptor.charAt(close + 1) != 'L')
+        {
+            return ""; //$NON-NLS-1$
+        }
+        String internal = descriptor.substring(close + 2, descriptor.length() - 1);
+        return simpleName(internal);
+    }
+
+    /** The class name without its package, from the internal {@code a/b/C} form. */
+    private static String simpleName(String internalName)
+    {
+        int lastSlash = internalName.lastIndexOf('/');
+        return lastSlash < 0 ? internalName : internalName.substring(lastSlash + 1);
+    }
+
+    private static int readUnsignedShort(byte[] code, int at)
+    {
+        return ((code[at] & 0xFF) << 8) | (code[at + 1] & 0xFF);
+    }
+
+    private static int readInt(byte[] code, int at)
+    {
+        return ((code[at] & 0xFF) << 24) | ((code[at + 1] & 0xFF) << 16) | ((code[at + 2] & 0xFF) << 8)
+            | (code[at + 3] & 0xFF);
+    }
+
+    /**
+     * The full length of the instruction at {@code pc}, including its operands.
+     *
+     * @param code the method's bytecode
+     * @param pc the instruction's offset
+     * @return the number of bytes it occupies
+     */
+    private static int instructionLength(byte[] code, int pc)
+    {
+        int opcode = code[pc] & 0xFF;
+        if (opcode == 0xC4) // wide
+        {
+            return (code[pc + 1] & 0xFF) == 0x84 ? 6 : 4; // wide iinc, else wide load/store/ret
+        }
+        if (opcode == 0xAA) // tableswitch: padding, default, low, high, then one offset per case
+        {
+            int operands = padded(pc);
+            int low = readInt(code, operands + 4);
+            int high = readInt(code, operands + 8);
+            return operands + 12 + (high - low + 1) * 4 - pc;
+        }
+        if (opcode == 0xAB) // lookupswitch: padding, default, npairs, then match/offset pairs
+        {
+            int operands = padded(pc);
+            return operands + 8 + readInt(code, operands + 4) * 8 - pc;
+        }
+        int length = LENGTHS[opcode];
+        if (length <= 0)
+        {
+            throw new IllegalStateException("unknown opcode 0x" + Integer.toHexString(opcode) //$NON-NLS-1$
+                + " at " + pc); //$NON-NLS-1$
+        }
+        return length;
+    }
+
+    /** The offset of a switch instruction's operands: the next 4-byte boundary after the opcode. */
+    private static int padded(int pc)
+    {
+        return (pc + 4) / 4 * 4;
+    }
+
+    /** Instruction lengths by opcode; the three variable-length forms are handled separately. */
+    private static final int[] LENGTHS = buildLengths();
+
+    private static int[] buildLengths()
+    {
+        int[] lengths = new int[256];
+        Arrays.fill(lengths, 1); // most instructions are a bare opcode
+        // One operand byte: the small pushes, the single-index loads/stores, ret, newarray.
+        for (int opcode : new int[] { 0x10, 0x12, 0x15, 0x16, 0x17, 0x18, 0x19, 0x36, 0x37, 0x38,
+            0x39, 0x3A, 0xA9, 0xBC })
+        {
+            lengths[opcode] = 2;
+        }
+        // Two operand bytes: sipush, the wide ldc forms, iinc, the field/method refs, the type ops.
+        for (int opcode : new int[] { 0x11, 0x13, 0x14, 0x84, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7,
+            0xB8, 0xBB, 0xBD, 0xC0, 0xC1, 0xC6, 0xC7 })
+        {
+            lengths[opcode] = 3;
+        }
+        for (int opcode = 0x99; opcode <= 0xA8; opcode++) // ifeq..jsr: 16-bit branch offsets
+        {
+            lengths[opcode] = 3;
+        }
+        lengths[0xC5] = 4; // multianewarray
+        lengths[0xB9] = 5; // invokeinterface
+        lengths[0xBA] = 5; // invokedynamic
+        lengths[0xC8] = 5; // goto_w
+        lengths[0xC9] = 5; // jsr_w
+        lengths[0xAA] = -1; // tableswitch
+        lengths[0xAB] = -1; // lookupswitch
+        lengths[0xC4] = -1; // wide
+        for (int opcode = 0xCB; opcode < 0x100; opcode++) // reserved / not emitted by javac
+        {
+            lengths[opcode] = -1;
+        }
+        return lengths;
+    }
+
+    private static void skipFully(DataInputStream in, int bytes) throws IOException
+    {
+        int remaining = bytes;
+        while (remaining > 0)
+        {
+            int skipped = in.skipBytes(remaining);
+            if (skipped <= 0)
+            {
+                throw new IOException("truncated class file: " + remaining + " bytes missing"); //$NON-NLS-1$ //$NON-NLS-2$
+            }
+            remaining -= skipped;
+        }
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/DeleteMetadataConsentSinglePointRatchetTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/DeleteMetadataConsentSinglePointRatchetTest.java
@@ -37,37 +37,92 @@ import com.ditrix.edt.mcp.server.tools.impl.DeleteMetadataTool;
  * case therefore drives the authorization step directly ({@code DeleteMetadataToolTest}), and that
  * test says so in as many words - which leaves exactly the thing #331 is about, the WIRING,
  * unpinned. The issue asked for a single point "so the next new branch cannot forget it again"; a
- * single point nobody checks is forgotten the same way. This reads the compiled class instead.
- * <p>
- * The model is deliberately small. A mutation runs when the method holding it runs, so the question
- * is which methods {@code executeOnUiThread} can reach. Two kinds of edge lead somewhere:
+ * single point nobody checks is forgotten the same way. This reads the compiled classes instead.
+ *
+ * <h2>The model</h2>
+ * A mutation runs when the method holding it runs, so the question is which methods
+ * {@code executeOnUiThread} can reach. The walk covers the whole NEST - the tool's class and every
+ * class compiled inside it, anonymous ones included - and follows three kinds of edge:
  * <ul>
- * <li>an ordinary call ({@code invokevirtual/special/static/interface}) into this class;</li>
- * <li>a lambda / method reference, resolved through the {@code BootstrapMethods} attribute to the
- * method that actually holds the body - followed exactly like a call, EXCEPT when the callback's
- * type is {@code DeleteWrite}: that one runs only when something invokes it, and the third test
- * below proves the only invoker is {@code deleteWithConsent}, after an ALLOW.</li>
+ * <li>an ordinary call ({@code invokevirtual/special/static/interface}) into the nest;</li>
+ * <li>a lambda / method reference, resolved through {@code BootstrapMethods} to the method that
+ * actually holds the body;</li>
+ * <li>ANY reference to a nest member - construction, a constructor reference, a static call that
+ * triggers its {@code <clinit>}: everything that class declares becomes reachable, because whoever
+ * holds the instance decides when to run it. Modelling those JVM edges one at a time is how a blind
+ * spot gets built, so the coarse rule is the safe one. That is what makes an anonymous
+ * {@code Supplier} a followed edge rather than a hiding place.</li>
  * </ul>
- * Following ordinary lambdas matters: hiding the write in a {@code Supplier} the branch calls itself
- * would otherwise satisfy a walk that ignored {@code invokedynamic} altogether.
- * <p>
- * What it does NOT prove, stated plainly:
+ *
+ * <h2>Why the gate's own callback may be skipped, and only then</h2>
+ * A {@code DeleteWrite} body runs only when something invokes it, so following it from its creator
+ * would report every branch as ungated. It is skipped - but the skip has to be EARNED, or it becomes
+ * the hole it is meant to close. Four rules together:
  * <ul>
- * <li>the mutation entry points are a LIST ({@link #MUTATIONS}). A branch that writes through some
- * other API - a new writer helper, raw EMF outside a transaction - is invisible here, and is covered
- * only by the transaction-boundary rules in CLAUDE.md. The list carries a positive control, so it
- * fails loudly when a name drifts instead of silently checking nothing;</li>
- * <li>the two ORDER assertions compare bytecode offsets. That catches the shape both defects
+ * <li>the body is left unfollowed only when the method that created the callback also calls a gate
+ * entry point ({@link #GATE_ENTRIES}, each proven to reach the gate). A method that builds a
+ * {@code DeleteWrite} and never goes near the gate is walked like any other code;</li>
+ * <li>the only thing that may INVOKE {@code DeleteWrite.perform} is the gate, and a method HANDLE on
+ * it counts as an invocation. Converting the callback to some other functional interface
+ * ({@code write::perform}) is the one way to run it without an invoke instruction;</li>
+ * <li>the first thing that runs after a callback is BUILT must be a gate entry point. Anything that
+ * can hold on to the value - a local, a helper taking {@code Object}, a second callback standing in
+ * for it at the gate call - would put the write where nothing here reads it, and no rule about the
+ * method as a whole can tell those apart without tracking which value went where;</li>
+ * <li>the same applies to a nest member that IMPLEMENTS the callback type: referencing it is a
+ * followed edge unless its creator hands it to the gate.</li>
+ * </ul>
+ * The direction is deliberate: where the rules cannot tell, they treat the write as ungated. Handing
+ * the gate a callback that wraps another one ({@code deleteWithConsent(preview, w::get)}), or a
+ * method reference into a helper object the branch also constructs
+ * ({@code deleteWithConsent(preview, plan::apply)}), is therefore reported although it would in fact
+ * be safe - modelling that away would buy nothing, since a branch hands its write to the gate
+ * directly.
+ *
+ * <h2>What counts as a write</h2>
+ * Two answers, and the second is the one that has to hold for code nobody has written yet:
+ * <ul>
+ * <li>{@link #MUTATIONS} names the calls the current branches write through. It carries a positive
+ * control, so it fails loudly when a name drifts instead of silently checking nothing - but it is a
+ * list, and a list only knows what is already on it;</li>
+ * <li>{@link #writeCapableCall} is the fail-closed half. It does not enumerate writes; it asks the
+ * opposite question - is this recognisably a READ? - first of the VERB (a setter is a setter
+ * whatever the concrete EMF class is called, which a rule keyed on {@code EObject} would miss on
+ * every generated one), and then of the SEAMS this codebase changes anything through at all: the BM
+ * transaction helper and the BM API under it, {@code EcoreUtil} / {@code EList}, the {@code *Writer}
+ * helpers, the refactoring service, the resource API. On those, anything it does not recognise as a
+ * read counts as a write - which is what catches a verb nobody anticipated
+ * ({@code rewriteNamespaceReferences}, {@code ensureExtInfo}, {@code configureDynamicListQuery} and
+ * {@code rebindHandler} all exist in this repo today).</li>
+ * </ul>
+ *
+ * <h2>What it still does NOT prove, stated plainly</h2>
+ * <ul>
+ * <li>a write through a seam in NEITHER the list nor the families, under a verb that reads like a
+ * query - a brand-new helper class that is not named {@code *Writer} and does not touch BM, EMF,
+ * refactoring or resources - is invisible here, and is covered only by the transaction-boundary
+ * rules in CLAUDE.md;</li>
+ * <li>owners are compared by SIMPLE name and by the STATIC type at the call site - that is all the
+ * constant pool spells - so two same-named classes from different packages are one owner here, and a
+ * family rule keyed on {@code EList} does not follow into {@code BasicEList};</li>
+ * <li>{@code add}, {@code put} and {@code append} are not mutating verbs anywhere, because that is
+ * what building a JSON payload looks like on every line of this tool. Adding to a containment
+ * {@code EList} through a {@code List}-typed variable is therefore a read to these rules;</li>
+ * <li>a callback built in a branch that then picks between two of them, rather than handing its own
+ * straight over, is reported even when it is correct - the same erring-closed as above;</li>
+ * <li>the ORDER assertions compare bytecode offsets. That catches the shape both #331 defects
  * actually had (the later step written above the earlier one); it is not a dominance proof, so a
- * branch that jumps over the earlier call could still pass. For {@code deleteWithConsent} the
- * semantics are pinned behaviourally as well ({@code testConsentRejectNeverRunsTheWrite}).</li>
+ * branch that jumps over the earlier call could still pass. Both things the order is FOR are pinned
+ * behaviourally as well: that a refusal runs no write, and that the XDTO branch answers a missing
+ * target without asking ({@code DeleteMetadataToolTest});</li>
+ * <li>reachability is not reflection-aware.</li>
  * </ul>
- * Where it errs, it errs CLOSED, which is the only safe direction for a gate: creating a non-gated
- * callback counts as running it, so wrapping the write in one callback and handing THAT to the gate
- * ({@code Supplier<String> w = () -> write(); deleteWithConsent(preview, w::get);}) is reported even
- * though it would in fact be safe. Modelling callback consumption to allow it would buy nothing - a
- * branch's write goes to the gate directly.
- * The compiled class is read as a resource ({@link Class#getResourceAsStream}), the way
+ * {@link ConsentRatchetFixtures} is this test's own control: four miniature tools, one clean and
+ * three hiding a write in one specific way each. The analysis is run against them too and must
+ * report exactly the one that is there - otherwise a walk that reached nothing, or a mutation rule
+ * that recognised nothing, would pass here for the wrong reason.
+ * <p>
+ * The classes are read as resources ({@link Class#getResourceAsStream}), the way
  * {@code BareErrorStringRatchetTest} reads constant pools: a call that was commented out, or left
  * behind in a javadoc, cannot satisfy it. JaCoCo instruments classes as they are LOADED and never
  * rewrites the file, so what is parsed here is the compiler's own output. Nothing depends on how a
@@ -85,11 +140,16 @@ public class DeleteMetadataConsentSinglePointRatchetTest
     /** The tool's own class, as the constant pool spells its owner. */
     private static final String SELF = "DeleteMetadataTool"; //$NON-NLS-1$
 
-    /** The callback type a branch hands to the gate. */
-    private static final String WRITE_CALLBACK_TYPE = "DeleteMetadataTool$DeleteWrite"; //$NON-NLS-1$
+    /**
+     * The methods a branch may hand its write to: the gate itself and the per-branch steps that only
+     * build a prompt and forward. Every one of them is checked to really reach {@link #GATE}, so the
+     * set cannot be widened into a bypass by adding a name to it.
+     */
+    private static final Set<String> GATE_ENTRIES =
+        Set.of(GATE, "gateFormMemberDelete", "gateFormObjectDelete", "gateXdtoMemberDelete"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
-    /** Its only invocation must sit inside the gate. */
-    private static final String WRITE_CALLBACK = WRITE_CALLBACK_TYPE + "#perform"; //$NON-NLS-1$
+    /** The callback type a branch hands to the gate, relative to its declaring class. */
+    private static final String WRITE_CALLBACK_SUFFIX = "$DeleteWrite"; //$NON-NLS-1$
 
     /** The consent seam the gate asks through. */
     private static final String ASK = "DeleteMetadataTool$ConsentRequester#request"; //$NON-NLS-1$
@@ -101,9 +161,10 @@ public class DeleteMetadataConsentSinglePointRatchetTest
     private static final String REQUIRE_CONSENT = "DestructiveConsentGate#requireConsent"; //$NON-NLS-1$
 
     /**
-     * Every call through which this tool changes something: the md-refactoring, the two form writers,
-     * the BM write transaction, the on-disk export and the physical removal of a form's folder. None
-     * of them may be reachable without the gate.
+     * Every call through which this tool changes something TODAY: the md-refactoring, the two form
+     * writers, the BM write transaction, the on-disk export and the physical removal of a form's
+     * folder. None of them may be reachable without the gate. This list is the named half of the
+     * check; {@link #writeCapableCall} is the half that also covers what is not on it.
      */
     private static final List<String> MUTATIONS = List.of(
         "IRefactoring#perform", //$NON-NLS-1$
@@ -118,12 +179,21 @@ public class DeleteMetadataConsentSinglePointRatchetTest
 
     private static final String XDTO_LOOKUP = "DeleteMetadataTool#locateXdtoMemberInModel"; //$NON-NLS-1$
 
+    private static final String XDTO_GATE = "DeleteMetadataTool#gateXdtoMemberDelete"; //$NON-NLS-1$
+
+    /** What the lookup returns: the branch must PASS ONE ON, never make one up. */
+    private static final String XDTO_LOOKUP_TYPE = "DeleteMetadataTool$XdtoLookup"; //$NON-NLS-1$
+
+    // ---- the tool ------------------------------------------------------------------------------
+
     @Test
     public void theGateSingletonIsConsultedInExactlyOnePlace()
     {
-        ClassFile tool = read();
-        Set<String> asks = tool.methodsCalling(SINGLETON);
-        Set<String> requires = tool.methodsCalling(REQUIRE_CONSENT);
+        // methodsReaching, not methodsCalling: DestructiveConsentGate::getInstance handed on as a
+        // Supplier is a second gate access with no invoke instruction to find.
+        Nest nest = readTool();
+        Set<String> asks = nest.methodsReaching(SINGLETON);
+        Set<String> requires = nest.methodsReaching(REQUIRE_CONSENT);
 
         assertEquals("the destructive-consent singleton must be reached from exactly one method of " //$NON-NLS-1$
             + SELF + " - the production constructor's requester lambda. Found: " + asks //$NON-NLS-1$
@@ -133,16 +203,41 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             1, asks.size());
         assertEquals("consent must be REQUESTED only where the singleton is obtained", asks, requires); //$NON-NLS-1$
 
-        String gate = tool.requireSingleDeclaration(GATE);
+        String gate = nest.requireSingleDeclaration(SELF, GATE);
         assertTrue(GATE + " must ask through the ConsentRequester seam, never the singleton - " //$NON-NLS-1$
             + "otherwise no unit test can drive a refusal", //$NON-NLS-1$
-            !asks.contains(gate) && tool.firstOffsetOf(gate, ASK) >= 0);
+            !asks.contains(gate) && nest.firstOffsetOf(gate, ASK) >= 0);
+    }
+
+    /**
+     * Every name the walk trusts as "handed to the gate" has to earn it. Without this, widening
+     * {@link #GATE_ENTRIES} - or renaming a branch step to look like one - would silently make a
+     * whole branch's write invisible.
+     */
+    @Test
+    public void everyGateEntryPointReallyReachesTheGate()
+    {
+        Nest nest = readTool();
+        for (String entry : GATE_ENTRIES)
+        {
+            String node = nest.requireSingleDeclaration(SELF, entry);
+            if (GATE.equals(entry))
+            {
+                continue;
+            }
+            assertTrue(entry + "() is trusted as a way to reach the consent gate, but it does not " //$NON-NLS-1$
+                + "call " + GATE + "(). Either route it through the gate or take it out of " //$NON-NLS-1$ //$NON-NLS-2$
+                + "GATE_ENTRIES - as long as it is listed there, a write handed to it counts as " //$NON-NLS-1$
+                + "authorized (issue #331).", //$NON-NLS-1$
+                nest.firstOffsetOf(node, SELF + '#' + GATE) >= 0);
+        }
     }
 
     @Test
     public void noBranchCanReachAWriteWithoutPassingThroughTheGate()
     {
-        ClassFile tool = read();
+        Nest nest = readTool();
+        Analysis analysis = analyse(nest, SELF);
 
         // Positive control: a mutation name that no longer occurs would make this test's failure mode
         // identical to its pass - it would guard nothing and stay green forever.
@@ -151,61 +246,52 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             assertTrue("the mutation entry point '" + mutation + "' no longer occurs in " + SELF //$NON-NLS-1$ //$NON-NLS-2$
                 + ": this ratchet would be checking a name that is not there. Update " //$NON-NLS-1$
                 + "MUTATIONS to the call the branch really writes through.", //$NON-NLS-1$
-                !tool.methodsCalling(mutation).isEmpty());
+                !nest.methodsCalling(mutation).isEmpty());
         }
         // ... and the same for the mechanism itself: if no callback of the gate's type were found, the
         // walk below would be a plain call graph and would pass for the wrong reason.
-        assertTrue("no lambda of type " + WRITE_CALLBACK_TYPE + " was found in " + SELF //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("no lambda of type " + SELF + WRITE_CALLBACK_SUFFIX + " was found in " + SELF //$NON-NLS-1$ //$NON-NLS-2$
             + ": either BootstrapMethods parsing is broken or no branch hands its write to the gate", //$NON-NLS-1$
-            tool.hasCallbackOfType(WRITE_CALLBACK_TYPE));
+            nest.hasCallbackOfType(SELF + WRITE_CALLBACK_SUFFIX));
+        // ... and for the nest: reading only the tool's own class file would hide every anonymous body.
+        assertTrue("only " + nest.classes + " was parsed: the nest members were not found, so a write " //$NON-NLS-1$ //$NON-NLS-2$
+            + "compiled into an anonymous class would be invisible", nest.classes.size() > 1); //$NON-NLS-1$
 
-        Set<String> ungated = tool.reachableWithout(tool.requireSingleDeclaration(ENTRY), WRITE_CALLBACK_TYPE);
         assertTrue("nothing was reached from " + ENTRY + "(): the call-graph walk is broken, and a " //$NON-NLS-1$ //$NON-NLS-2$
-            + "reachability ratchet that reaches nothing proves nothing", ungated.size() > 1); //$NON-NLS-1$
+            + "reachability ratchet that reaches nothing proves nothing", analysis.ungated.size() > 1); //$NON-NLS-1$
         assertTrue(ENTRY + "() must still reach the authorization point", //$NON-NLS-1$
-            ungated.contains(tool.requireSingleDeclaration(GATE)));
+            analysis.ungated.contains(nest.requireSingleDeclaration(SELF, GATE)));
 
-        Map<String, Set<String>> escapes = new LinkedHashMap<>();
-        for (String method : ungated)
-        {
-            for (Call call : tool.callsIn(method))
-            {
-                if (MUTATIONS.contains(call.target()))
-                {
-                    escapes.computeIfAbsent(method, unused -> new TreeSet<>()).add(call.target());
-                }
-            }
-            // A method REFERENCE to a mutation ({@code refactoring::perform} handed to a Runnable the
-            // branch then runs) never appears as a call, and its target is not one of our methods, so
-            // the walk cannot step into it. It still names a mutation - count it as one.
-            for (Callback callback : tool.callbacksIn(method))
-            {
-                if (!WRITE_CALLBACK_TYPE.equals(callback.type) && MUTATIONS.contains(callback.target()))
-                {
-                    escapes.computeIfAbsent(method, unused -> new TreeSet<>()).add(callback.target());
-                }
-            }
-        }
         assertTrue("these methods are reachable from " + ENTRY + "() without passing through the " //$NON-NLS-1$ //$NON-NLS-2$
             + "gate's callback AND perform a mutation, so the write happens whether or not consent " //$NON-NLS-1$
-            + "was granted: " + escapes + ". Every delete branch must hand its write to " + GATE //$NON-NLS-1$ //$NON-NLS-2$
-            + " as a DeleteWrite callback (issue #331) - see how deleteFormObject does it.", //$NON-NLS-1$
-            escapes.isEmpty());
+            + "was granted: " + analysis.escapes + ". Every delete branch must hand its write to " //$NON-NLS-1$ //$NON-NLS-2$
+            + GATE + " as a DeleteWrite callback (issue #331) - see how deleteFormObject does it.", //$NON-NLS-1$
+            analysis.escapes.isEmpty());
+
+        assertTrue("a " + SELF + WRITE_CALLBACK_SUFFIX + " is built here and the next thing that " //$NON-NLS-1$ //$NON-NLS-2$
+            + "runs is not an authorization step: " + analysis.unconsumed + ". Its body is exempted " //$NON-NLS-1$ //$NON-NLS-2$
+            + "from the walk on the strength of its TYPE, so anything that can hold on to it - a " //$NON-NLS-1$
+            + "local, a helper taking Object, a second callback standing in for it - puts the whole " //$NON-NLS-1$
+            + "mutation somewhere nothing here reads. Hand it to one of " + GATE_ENTRIES //$NON-NLS-1$
+            + " as the very next call (issue #331).", analysis.unconsumed.isEmpty());
     }
 
     @Test
     public void theWriteCallbackIsInvokedOnlyByTheGateAndOnlyAfterAsking()
     {
-        ClassFile tool = read();
-        String gate = tool.requireSingleDeclaration(GATE);
-        Set<String> invokers = tool.methodsCalling(WRITE_CALLBACK);
+        Nest nest = readTool();
+        String gate = nest.requireSingleDeclaration(SELF, GATE);
+        String callback = SELF + WRITE_CALLBACK_SUFFIX + "#perform"; //$NON-NLS-1$
+        Set<String> invokers = nest.methodsReaching(callback);
 
         assertEquals("a DeleteWrite callback must be invoked ONLY by " + GATE + ": that single " //$NON-NLS-1$ //$NON-NLS-2$
             + "invocation is what makes 'reachable only through the callback' mean 'reachable only " //$NON-NLS-1$
-            + "after ALLOW'. Found: " + invokers, Set.of(gate), invokers); //$NON-NLS-1$
+            + "after ALLOW'. A method REFERENCE to it counts - passing write::perform on as some " //$NON-NLS-1$
+            + "other functional interface runs the write with no invoke instruction in sight. " //$NON-NLS-1$
+            + "Found: " + invokers, Set.of(gate), invokers); //$NON-NLS-1$
 
-        int asked = tool.firstOffsetOf(gate, ASK);
-        int wrote = tool.firstOffsetOf(gate, WRITE_CALLBACK);
+        int asked = nest.firstOffsetOf(gate, ASK);
+        int wrote = nest.firstOffsetOf(gate, callback);
         assertTrue(GATE + " no longer asks for consent", asked >= 0); //$NON-NLS-1$
         assertTrue(GATE + " invokes the write at bytecode offset " + wrote + ", BEFORE it asks at " //$NON-NLS-1$ //$NON-NLS-2$
             + asked + ". The mutation must run only after an ALLOW.", asked < wrote); //$NON-NLS-1$
@@ -216,29 +302,427 @@ public class DeleteMetadataConsentSinglePointRatchetTest
     {
         // The ordering defect #331 recorded: this branch asked first and looked the member up only
         // inside the write transaction, so a typo in the member name raised a destructive prompt at a
-        // human and answered "not found" only after it had been dealt with.
-        ClassFile tool = read();
-        String branch = tool.requireSingleDeclaration(XDTO_BRANCH);
-        int lookup = tool.firstOffsetOf(branch, XDTO_LOOKUP);
-        int gate = tool.firstOffsetOf(branch, SELF + '#' + GATE);
+        // human and answered "not found" only after it had been dealt with. That the lookup's RESULT
+        // then decides whether to ask at all is a separate, behavioural pin (DeleteMetadataToolTest):
+        // an offset comparison alone would stay green if the answer were simply ignored.
+        Nest nest = readTool();
+        String branch = nest.requireSingleDeclaration(SELF, XDTO_BRANCH);
+        int lookup = nest.firstOffsetOf(branch, XDTO_LOOKUP);
+        int gate = nest.firstOffsetOf(branch, XDTO_GATE);
 
         assertTrue(XDTO_BRANCH + "() no longer looks its target up before writing: a typo would " //$NON-NLS-1$
             + "reach the gate", lookup >= 0); //$NON-NLS-1$
-        assertTrue(XDTO_BRANCH + "() no longer goes through " + GATE, gate >= 0); //$NON-NLS-1$
+        assertTrue(XDTO_BRANCH + "() no longer goes through " + XDTO_GATE, gate >= 0); //$NON-NLS-1$
         assertTrue(XDTO_BRANCH + "() asks for consent at bytecode offset " + gate + " BEFORE it " //$NON-NLS-1$ //$NON-NLS-2$
             + "resolves the target at " + lookup + ". Resolve first: a delete that can only answer " //$NON-NLS-1$
             + "'not found' must never raise a destructive prompt (issue #331).", lookup < gate); //$NON-NLS-1$
+
+        // Running the lookup first proves nothing if its ANSWER can be thrown away: passing a
+        // hand-built XdtoLookup would satisfy every assertion above and the unit tests too, and the
+        // prompt would be back for a target that is not there. The branch may not build one.
+        assertTrue(XDTO_BRANCH + "() constructs an " + XDTO_LOOKUP_TYPE + " of its own, so what it " //$NON-NLS-1$ //$NON-NLS-2$
+            + "hands to " + XDTO_GATE + " need not be what the lookup found. The only " //$NON-NLS-1$ //$NON-NLS-2$
+            + "lookup outcome it may pass on is the one it got back (issue #331 review).", //$NON-NLS-1$
+            nest.firstOffsetOf(branch, XDTO_LOOKUP_TYPE + "#<init>") < 0); //$NON-NLS-1$
     }
 
-    private static ClassFile read()
+    // ---- the ratchet's own controls ------------------------------------------------------------
+
+    /**
+     * The clean shape must come back clean. Without this, a check that flagged everything would pass
+     * the three bypass tests below and still be worthless.
+     */
+    @Test
+    public void theAnalysisReportsNothingAgainstAGatedFixture()
+    {
+        Analysis clean = analyseFixture(ConsentRatchetFixtures.Gated.class);
+
+        assertTrue("the compliant fixture hands its only write to the gate, yet the analysis " //$NON-NLS-1$
+            + "reported: " + clean.escapes + ". A check that flags a correct shape cannot be used to " //$NON-NLS-1$ //$NON-NLS-2$
+            + "judge the real tool.", clean.escapes.isEmpty()); //$NON-NLS-1$
+        assertTrue("the compliant fixture hands its callback straight to the gate: " //$NON-NLS-1$
+            + clean.unconsumed, clean.unconsumed.isEmpty());
+        assertEquals("only the gate may invoke the compliant fixture's callback", //$NON-NLS-1$
+            1, clean.callbackInvokers.size());
+    }
+
+    /**
+     * The callback handed to a helper the walk never reads, and to the gate afterwards. Nothing
+     * inside the analysed classes invokes {@code perform}, and the counts all balance.
+     */
+    @Test
+    public void theAnalysisCatchesAWriteCallbackHandedToSomethingOtherThanTheGate()
+    {
+        Analysis bypass = analyseFixture(ConsentRatchetFixtures.LeakedCallbackBypass.class);
+
+        assertTrue("the fixture passes its callback to a helper class before asking for consent. " //$NON-NLS-1$
+            + "That helper is not parsed here and never will be, so the only thing that can catch " //$NON-NLS-1$
+            + "this is requiring the gate to be the very next thing that runs.", //$NON-NLS-1$
+            !bypass.unconsumed.isEmpty());
+        assertTrue("... and it is the only thing that catches it: the walk is satisfied here.", //$NON-NLS-1$
+            bypass.escapes.isEmpty());
+    }
+
+    /**
+     * The escape hatch's own escape hatch: a callback that IS handed to the gate, and is also turned
+     * into another functional interface by method reference and run directly.
+     */
+    @Test
+    public void theAnalysisCatchesAWriteRunThroughAMethodReferenceToTheCallback()
+    {
+        Analysis bypass = analyseFixture(ConsentRatchetFixtures.MethodHandleBypass.class);
+
+        assertTrue("this fixture satisfies every structural rule - it creates one callback and hands " //$NON-NLS-1$
+            + "it to the gate - and still runs the write itself through write::perform. Counting a " //$NON-NLS-1$
+            + "method HANDLE on the callback as an invocation is the only thing that sees it, and " //$NON-NLS-1$
+            + "the analysis reported invokers " + bypass.callbackInvokers, //$NON-NLS-1$
+            bypass.callbackInvokers.size() > 1);
+        assertTrue("... and it is the ONLY thing that sees it: the walk exempts this callback " //$NON-NLS-1$
+            + "legitimately, so the escape set is empty here. " + bypass.escapes, //$NON-NLS-1$
+            bypass.escapes.isEmpty());
+    }
+
+    /**
+     * The reported shape, verbatim: build a {@code DeleteWrite}, hand it to nobody, and run it as a
+     * {@code Supplier}. Exempting a callback's body because of its TYPE alone loses this whole branch.
+     */
+    @Test
+    public void theAnalysisCatchesAWriteCallbackThatIsNeverHandedToTheGate()
+    {
+        Analysis bypass = analyseFixture(ConsentRatchetFixtures.UnconsumedCallbackBypass.class);
+
+        assertTrue("the fixture never calls its gate, so the callback it builds may not be exempted " //$NON-NLS-1$
+            + "from the walk - the write inside it has to be reported: " + bypass.escapes, //$NON-NLS-1$
+            !bypass.escapes.isEmpty());
+        assertTrue("... and the callback itself has to be reported as unconsumed: " //$NON-NLS-1$
+            + bypass.unconsumed, !bypass.unconsumed.isEmpty()); //$NON-NLS-1$
+    }
+
+    /** A write compiled into an anonymous class: a different class file, invisible without the nest. */
+    @Test
+    public void theAnalysisCatchesAWriteHiddenInAnAnonymousClass()
+    {
+        Analysis bypass = analyseFixture(ConsentRatchetFixtures.AnonymousClassBypass.class);
+
+        assertTrue("the write sits in the get() of an anonymous Supplier the branch runs itself. " //$NON-NLS-1$
+            + "Reading only the fixture's own class file, or refusing to follow construction of a " //$NON-NLS-1$
+            + "nest member, makes it disappear - the analysis found no escape at all.", //$NON-NLS-1$
+            !bypass.escapes.isEmpty());
+    }
+
+    /** A write through an API nobody listed: only the verb rule can see this one. */
+    @Test
+    public void theAnalysisCatchesAWriteThroughAnUnlistedMutationApi()
+    {
+        Analysis bypass = analyseFixture(ConsentRatchetFixtures.UnlistedMutationApiBypass.class);
+
+        assertTrue("the fixture removes an EObject with raw EMF, outside any transaction and " //$NON-NLS-1$
+            + "outside MUTATIONS. If only the named list decided what a write is, this branch would " //$NON-NLS-1$
+            + "be invisible while the list's own positive control stayed green - which is exactly " //$NON-NLS-1$
+            + "the failure mode the verb rule exists for.", !bypass.escapes.isEmpty()); //$NON-NLS-1$
+    }
+
+    /** A generated setter on a concrete model class: no family owns it, only the verb sees it. */
+    @Test
+    public void theAnalysisCatchesAWriteThroughASetterOnAConcreteType()
+    {
+        Analysis bypass = analyseFixture(ConsentRatchetFixtures.ConcreteSetterBypass.class);
+
+        assertTrue("the fixture renames a classifier through EClass.setName. The constant pool " //$NON-NLS-1$
+            + "spells the STATIC type, so a rule keyed on EObject/EList sees nothing here - and " //$NON-NLS-1$
+            + "every generated EMF setter in the metamodel has this exact shape.", //$NON-NLS-1$
+            !bypass.escapes.isEmpty());
+    }
+
+    /**
+     * The primitive both the singleton assertion and the invoker assertion stand on: a method HANDLE
+     * has to count as reaching its target. If {@code methodsReaching} were only
+     * {@code methodsCalling}, every "reached from exactly one place" claim would be about invoke
+     * instructions alone, and a handle would slip past all of them.
+     */
+    @Test
+    public void aMethodHandleCountsAsReachingItsTarget()
+    {
+        Nest fixtures = read(ConsentRatchetFixtures.class);
+        String perform = binaryName(ConsentRatchetFixtures.MethodHandleBypass.class)
+            + WRITE_CALLBACK_SUFFIX + "#perform"; //$NON-NLS-1$
+
+        Set<String> calling = fixtures.methodsCalling(perform);
+        Set<String> reaching = fixtures.methodsReaching(perform);
+
+        assertTrue("the fixture takes a method handle on " + perform + ", so 'reaching' must be a " //$NON-NLS-1$ //$NON-NLS-2$
+            + "STRICT superset of 'calling'. calling=" + calling + " reaching=" + reaching, //$NON-NLS-1$ //$NON-NLS-2$
+            reaching.containsAll(calling) && reaching.size() > calling.size());
+    }
+
+    /** A write whose VERB nobody anticipated, on a helper that can write: the family rule's case. */
+    @Test
+    public void theAnalysisCatchesAWriteThroughAnUnlistedVerbOnAWriterHelper()
+    {
+        Analysis bypass = analyseFixture(ConsentRatchetFixtures.UnlistedWriterVerbBypass.class);
+
+        assertTrue("the fixture calls XdtoWriter.rewriteNamespaceReferences, which really does " //$NON-NLS-1$
+            + "mutate its argument. It is on no list, and 'rewrite' is no set/remove/clear - the " //$NON-NLS-1$
+            + "only thing that reports it is treating a helper that CAN write as denied until the " //$NON-NLS-1$
+            + "call reads like a read.", !bypass.escapes.isEmpty()); //$NON-NLS-1$
+    }
+
+    /** The write one edge past the callback body: a constructor reference, run by a Runnable. */
+    @Test
+    public void theAnalysisCatchesAWriteReachedThroughAConstructorReference()
+    {
+        Analysis bypass = analyseFixture(ConsentRatchetFixtures.ConstructorReferenceBypass.class);
+
+        assertTrue("Deferred::new links only to <init>; run() is invoked through Runnable, whose " //$NON-NLS-1$
+            + "owner this analysis never reads. Following the callback BODY and stopping there " //$NON-NLS-1$
+            + "leaves the write invisible - referencing a nested class has to expand it.", //$NON-NLS-1$
+            !bypass.escapes.isEmpty());
+    }
+
+    // ---- the analysis ---------------------------------------------------------------------------
+
+    /** What one run of the walk found. */
+    private static final class Analysis
+    {
+        /** Methods reachable from the entry point without going through the gate's callback. */
+        final Set<String> ungated;
+
+        /** Of those, the ones that write, and what they write through. */
+        final Map<String, Set<String>> escapes;
+
+        /** Places where a write callback is built and not handed straight to the gate. */
+        final Set<String> unconsumed;
+
+        /** Methods that invoke the write callback, by call OR by method handle. */
+        final Set<String> callbackInvokers;
+
+        Analysis(Set<String> ungated, Map<String, Set<String>> escapes, Set<String> unconsumed,
+            Set<String> callbackInvokers)
+        {
+            this.ungated = ungated;
+            this.escapes = escapes;
+            this.unconsumed = unconsumed;
+            this.callbackInvokers = callbackInvokers;
+        }
+    }
+
+    private static Analysis analyse(Nest nest, String unit)
+    {
+        return analyse(nest, unit, MUTATIONS, GATE_ENTRIES);
+    }
+
+    /**
+     * Runs the whole model over one unit (a class and everything compiled inside it).
+     *
+     * @param nest the parsed classes
+     * @param unit the analysed class, as the constant pool spells it
+     * @param mutations the calls that count as a write by name
+     * @param gateEntries the methods a write callback may legitimately be handed to
+     * @return what the walk found
+     */
+    private static Analysis analyse(Nest nest, String unit, List<String> mutations, Set<String> gateEntries)
+    {
+        String writeType = unit + WRITE_CALLBACK_SUFFIX;
+        Set<String> ungated = nest.reachableWithout(nest.requireSingleDeclaration(unit, ENTRY), unit,
+            writeType, gateEntries);
+
+        Map<String, Set<String>> escapes = new LinkedHashMap<>();
+        for (String method : ungated)
+        {
+            for (Call call : nest.callsIn(method))
+            {
+                // Only EXTERNAL calls are judged. A call into the analysed classes is FOLLOWED, so
+                // asking whether its name looks like a mutation would double-count it - and would
+                // read a name this ratchet has no business reading (collectRemovedMembers is a walk).
+                if (!Nest.inUnit(call.owner, unit))
+                {
+                    addWrite(escapes, method, call.target(), call.name, mutations);
+                }
+            }
+            // A method REFERENCE to a mutation ({@code refactoring::perform} handed to a Runnable the
+            // branch then runs) never appears as a call, and its target is not one of our methods, so
+            // the walk cannot step into it. It still names a mutation - count it as one.
+            for (Callback callback : nest.callbacksIn(method))
+            {
+                if (!writeType.equals(callback.type) && !Nest.inUnit(callback.implOwner, unit))
+                {
+                    addWrite(escapes, method, callback.target(), callback.implMethod, mutations);
+                }
+            }
+        }
+        return new Analysis(ungated, escapes,
+            nest.callbacksNotHandedStraightToTheGate(unit, writeType, gateEntries),
+            nest.methodsReaching(writeType + "#perform")); //$NON-NLS-1$
+    }
+
+    private static Analysis analyseFixture(Class<?> fixture)
+    {
+        // The fixtures write through their own sink, so what they prove does not depend on what the
+        // real tool happens to call - except for the family rule, which is the point of one of them.
+        return analyse(read(ConsentRatchetFixtures.class), binaryName(fixture),
+            List.of("ConsentRatchetFixtures$Sink#mutate"), Set.of(GATE)); //$NON-NLS-1$
+    }
+
+    private static void addWrite(Map<String, Set<String>> escapes, String method, String target, String name,
+        List<String> mutations)
+    {
+        if (mutations.contains(target) || writeCapableCall(target, name))
+        {
+            escapes.computeIfAbsent(method, unused -> new TreeSet<>()).add(target);
+        }
+    }
+
+    /**
+     * Whether {@code target} can change something. This is the fail-closed half of "what counts as a
+     * write": instead of listing the calls we know about it asks the OPPOSITE question - is this
+     * recognisably a read? - about the verb, and about the seams this codebase changes anything
+     * through at all. A new mutation reached from an ungated branch therefore fails this ratchet the
+     * day it is written, without anyone remembering to extend {@link #MUTATIONS}.
+     *
+     * @param target the callee, as {@code Owner#method}
+     * @param name the callee's bare method name
+     * @return whether the call may change something
+     */
+    private static boolean writeCapableCall(String target, String name)
+    {
+        String owner = target.substring(0, target.indexOf('#'));
+        if (LOCAL_VALUES.contains(owner))
+        {
+            return false; // assembling a message or a JSON payload changes nothing outside the method
+        }
+        // The verb first, the owner second. The constant pool spells the STATIC type, so keying the
+        // EMF mutators on the interface name would miss every generated one: EObject.eSet and
+        // Import.setNamespace are the same act. Iterator.remove belongs here too - on the iterator of
+        // a containment EList it writes straight through to the model. The infix forms catch the
+        // implementation classes' own spelling (InternalEList.basicRemove).
+        if (startsWithAny(name, "set", "unset", "remove", "insert", "move", "rename", "replace", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$
+            "eSet", "eUnset", "eInvoke", "save", "persist", "commit") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+            || containsAny(name, "Remove", "Unset", "Clear") || "clear".equals(name)) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        {
+            return true;
+        }
+        // The transaction helper: reads and rolled-back reads are the only non-writing entry points.
+        if ("BmTransactions".equals(owner)) //$NON-NLS-1$
+        {
+            return !"read".equals(name) && !"executeAndRollback".equals(name); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        // The BM API under it: this tool must not touch it directly at all (CLAUDE.md rule #1).
+        if ("IBmModel".equals(owner) || "IBmEngine".equals(owner)) //$NON-NLS-1$ //$NON-NLS-2$
+        {
+            return true;
+        }
+        // Everything below is DENY-by-default on a family that can write, so a helper whose verb
+        // nobody anticipated - rewriteNamespaceReferences, ensureExtInfo, configureDynamicListQuery,
+        // rebindHandler all exist in this repo today - counts as a write until it reads like a read.
+        if ("IBmTransaction".equals(owner) || "EcoreUtil".equals(owner) || "EList".equals(owner) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            || RESOURCES.contains(owner) || (owner.endsWith("Writer") && !JDK_WRITERS.contains(owner))) //$NON-NLS-1$
+        {
+            return !readShaped(name);
+        }
+        // The refactoring service: BUILDING a refactoring is inert, only running it writes - which is
+        // why 'create' is a read here and nowhere else, and only while it stays a pure factory.
+        if (owner.startsWith("IRefactoring") || owner.endsWith("RefactoringService")) //$NON-NLS-1$ //$NON-NLS-2$
+        {
+            return !readShaped(name)
+                && !(name.startsWith("create") && !containsAny(name, "Perform", "Apply", "Execute")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        }
+        return false;
+    }
+
+    /** Owners whose mutators are local bookkeeping: a message being built, never the model. */
+    private static final Set<String> LOCAL_VALUES =
+        Set.of("String", "StringBuilder", "StringBuffer"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+    /**
+     * ... and the {@code *Writer}s that write into MEMORY. The on-disk ones are deliberately absent:
+     * a metadata file rewritten through a {@code FileWriter} is exactly as destructive as one
+     * rewritten through the model.
+     */
+    private static final Set<String> JDK_WRITERS = Set.of("StringWriter", "CharArrayWriter"); //$NON-NLS-1$ //$NON-NLS-2$
+
+    private static final Set<String> RESOURCES = Set.of("IResource", "IFolder", "IFile", "IContainer", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        "IProject", "IWorkspaceRoot", "IWorkspace"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+    /**
+     * Whether a method NAME reads like a query. Deliberately about the name and nothing else: on a
+     * family that can write, anything this does not recognise is treated as a write, so the burden is
+     * on a new helper to be named like the read it is. Kept narrow on purpose - a bare {@code to}
+     * prefix would have made {@code IResource.touch} a read, and {@code getOrCreate...} is a real
+     * shape in this repo for a getter that writes.
+     *
+     * @param name the callee's bare method name
+     * @return whether it reads like a query
+     */
+    private static boolean readShaped(String name)
+    {
+        if (name.contains("OrCreate")) //$NON-NLS-1$
+        {
+            return false;
+        }
+        return startsWithAny(name, "get", "is", "has", "find", "read", "resolve", "parse", "copy", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$
+            "desc", "format", "kind", "preview", "exists", "members", "accept", "toString", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$
+            "toArray", "size", "iterator", "contains", "indexOf", "stream", "forEach", "equals", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$
+            "hashCode") //$NON-NLS-1$
+            || endsWithAny(name, "Error", "Advice", "Hint", "Message", "For", "Of"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+    }
+
+    private static boolean containsAny(String name, String... parts)
+    {
+        for (String part : parts)
+        {
+            if (name.contains(part))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean startsWithAny(String name, String... prefixes)
+    {
+        for (String prefix : prefixes)
+        {
+            if (name.startsWith(prefix))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean endsWithAny(String name, String... suffixes)
+    {
+        for (String suffix : suffixes)
+        {
+            if (name.endsWith(suffix))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** The class name as the constant pool spells it: {@code Outer$Inner}, no package. */
+    private static String binaryName(Class<?> clazz)
+    {
+        String name = clazz.getName();
+        return name.substring(name.lastIndexOf('.') + 1);
+    }
+
+    private static Nest readTool()
+    {
+        return read(DeleteMetadataTool.class);
+    }
+
+    private static Nest read(Class<?> root)
     {
         try
         {
-            return ClassFile.read(DeleteMetadataTool.class);
+            return Nest.read(root);
         }
         catch (IOException e)
         {
-            fail("could not read the compiled " + SELF + ": " + e //$NON-NLS-1$ //$NON-NLS-2$
+            fail("could not read the compiled " + root.getSimpleName() + ": " + e //$NON-NLS-1$ //$NON-NLS-2$
                 + " - a wiring ratchet must never pass because it read nothing"); //$NON-NLS-1$
             throw new IllegalStateException(e);
         }
@@ -268,10 +752,10 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             return owner + '#' + name;
         }
 
-        /** The callee's node key in this class's graph: overloads are DIFFERENT methods. */
+        /** The callee's node key: an owner AND a descriptor, because overloads are different methods. */
         String node()
         {
-            return name + descriptor;
+            return owner + '#' + name + descriptor;
         }
     }
 
@@ -281,6 +765,8 @@ public class DeleteMetadataConsentSinglePointRatchetTest
      */
     private static final class Callback
     {
+        private final int offset;
+
         private final String type;
 
         private final String implOwner;
@@ -289,8 +775,9 @@ public class DeleteMetadataConsentSinglePointRatchetTest
 
         private final String implDescriptor;
 
-        Callback(String type, String implOwner, String implMethod, String implDescriptor)
+        Callback(int offset, String type, String implOwner, String implMethod, String implDescriptor)
         {
+            this.offset = offset;
             this.type = type;
             this.implOwner = implOwner;
             this.implMethod = implMethod;
@@ -303,78 +790,53 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             return implOwner + '#' + implMethod;
         }
 
-        /** The body's node key in this class's graph. */
+        /** The body's node key. */
         String node()
         {
-            return implMethod + implDescriptor;
+            return implOwner + '#' + implMethod + implDescriptor;
         }
     }
 
-    /**
-     * The pieces of a compiled class this ratchet needs: the constant pool, the
-     * {@code BootstrapMethods} table, and for every method its ordinary calls plus the callbacks it
-     * creates.
-     */
-    private static final class ClassFile
+    /** One method of one class: its ordinary calls and the callbacks it creates. */
+    private static final class MethodBody
     {
-        private final String[] utf8;
+        private final List<Call> calls = new ArrayList<>();
 
-        private final int[] classNames;
+        private final List<Callback> callbacks = new ArrayList<>();
+    }
 
-        private final int[] refOwners;
+    /**
+     * A class and every class compiled inside it, parsed together into one graph. Reading the nest -
+     * not just the outer class - is what makes an anonymous inner body part of the model instead of a
+     * blind spot.
+     */
+    private static final class Nest
+    {
+        /** The parsed classes, as the constant pool spells them. */
+        final Set<String> classes = new LinkedHashSet<>();
 
-        private final int[] refNameAndTypes;
+        /** Method bodies by node key ({@code Owner#name+descriptor}). */
+        private final Map<String, MethodBody> methods = new LinkedHashMap<>();
 
-        private final int[] nameAndTypeNames;
+        /** The methods each class declares, in declaration order. */
+        private final Map<String, Set<String>> methodsOf = new LinkedHashMap<>();
 
-        private final int[] nameAndTypeDescriptors;
-
-        /** For a CONSTANT_MethodHandle: the pool index of the ref it points at. */
-        private final int[] methodHandleRefs;
-
-        /** For a CONSTANT_InvokeDynamic: its BootstrapMethods index and its NameAndType. */
-        private final int[] indyBootstraps;
-
-        private final int[] indyNameAndTypes;
-
-        /** BootstrapMethods: the bootstrap MethodHandle and the static arguments, per entry. */
-        private int[] bootstrapHandles = new int[0];
-
-        private int[][] bootstrapArguments = new int[0][];
-
-        /** Raw bodies, kept until BootstrapMethods (a CLASS attribute) has been read. */
-        private final Map<String, List<byte[]>> bodies = new LinkedHashMap<>();
-
-        /** How many methods carry each name - an ordering check may not straddle two overloads. */
+        /** How many methods each class declares under a bare name. */
         private final Map<String, Integer> declarations = new LinkedHashMap<>();
 
-        /** Node keys ({@code name+descriptor}) by bare name, so an assertion can name a method. */
+        /** Node keys by {@code Owner#name}, so an assertion can name a method. */
         private final Map<String, Set<String>> nodesByName = new LinkedHashMap<>();
 
-        private final Map<String, List<Call>> calls = new LinkedHashMap<>();
-
-        private final Map<String, List<Callback>> callbacks = new LinkedHashMap<>();
-
-        private ClassFile(int poolSize)
-        {
-            utf8 = new String[poolSize];
-            classNames = new int[poolSize];
-            refOwners = new int[poolSize];
-            refNameAndTypes = new int[poolSize];
-            nameAndTypeNames = new int[poolSize];
-            nameAndTypeDescriptors = new int[poolSize];
-            methodHandleRefs = new int[poolSize];
-            indyBootstraps = new int[poolSize];
-            indyNameAndTypes = new int[poolSize];
-        }
+        /** The interfaces each class implements, by simple name. */
+        private final Map<String, Set<String>> interfacesOf = new LinkedHashMap<>();
 
         /** Every method that contains a call to {@code target} ({@code Owner#method}). */
         Set<String> methodsCalling(String target)
         {
             Set<String> found = new TreeSet<>();
-            for (Map.Entry<String, List<Call>> method : calls.entrySet())
+            for (Map.Entry<String, MethodBody> method : methods.entrySet())
             {
-                for (Call call : method.getValue())
+                for (Call call : method.getValue().calls)
                 {
                     if (target.equals(call.target()))
                     {
@@ -385,22 +847,49 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             return found;
         }
 
+        /**
+         * Every method that can RUN {@code target}: one that calls it, and one that turns it into a
+         * functional interface by method reference. The second form runs the callback just as
+         * effectively and leaves no invoke instruction behind, so a check that ignored it would be
+         * satisfied by {@code Supplier<String> s = write::perform; s.get();}.
+         *
+         * @param target the callee, as {@code Owner#method}
+         * @return the methods that reach it
+         */
+        Set<String> methodsReaching(String target)
+        {
+            Set<String> found = new TreeSet<>(methodsCalling(target));
+            for (Map.Entry<String, MethodBody> method : methods.entrySet())
+            {
+                for (Callback callback : method.getValue().callbacks)
+                {
+                    if (target.equals(callback.target()))
+                    {
+                        found.add(method.getKey());
+                    }
+                }
+            }
+            return found;
+        }
+
         List<Call> callsIn(String node)
         {
-            return calls.getOrDefault(node, List.of());
+            MethodBody body = methods.get(node);
+            return body == null ? List.of() : body.calls;
         }
 
         List<Callback> callbacksIn(String node)
         {
-            return callbacks.getOrDefault(node, List.of());
+            MethodBody body = methods.get(node);
+            return body == null ? List.of() : body.callbacks;
         }
 
         /** Whether any method creates a callback of {@code type} - the walk's own positive control. */
         boolean hasCallbackOfType(String type)
         {
-            for (List<Callback> created : callbacks.values())
+            for (MethodBody body : methods.values())
             {
-                for (Callback callback : created)
+                for (Callback callback : body.callbacks)
                 {
                     if (type.equals(callback.type))
                     {
@@ -412,20 +901,22 @@ public class DeleteMetadataConsentSinglePointRatchetTest
         }
 
         /**
-         * The node key of {@code method}, failing when it is overloaded: an ordering assertion names a
-         * method, and across two same-named methods an offset comparison would read unrelated
-         * instructions.
+         * The node key of {@code owner}'s {@code method}, failing when it is overloaded: an ordering
+         * assertion names a method, and across two same-named methods an offset comparison would read
+         * unrelated instructions.
          *
-         * @param method the bare method name an ordering assertion is about to read
+         * @param owner the declaring class
+         * @param method the bare method name an assertion is about to read
          * @return its single node key
          */
-        String requireSingleDeclaration(String method)
+        String requireSingleDeclaration(String owner, String method)
         {
-            int declared = declarations.getOrDefault(method, 0);
-            assertEquals("an ordering assertion names " + method + "(), so it must be declared " //$NON-NLS-1$ //$NON-NLS-2$
+            String key = owner + '#' + method;
+            int declared = declarations.getOrDefault(key, 0);
+            assertEquals("an assertion names " + key + "(), so it must be declared " //$NON-NLS-1$ //$NON-NLS-2$
                 + "exactly once; split the assertion per descriptor before overloading it", //$NON-NLS-1$
                 1, declared);
-            return nodesByName.get(method).iterator().next();
+            return nodesByName.get(key).iterator().next();
         }
 
         /** The bytecode offset of the first call to {@code target} inside {@code node}, or -1. */
@@ -442,16 +933,106 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             return first;
         }
 
+        /** Whether {@code node} hands anything to one of the gate's entry points. */
+        private boolean callsAGate(String node, String unit, Set<String> gateEntries)
+        {
+            for (Call call : callsIn(node))
+            {
+                if (inUnit(call.owner, unit) && gateEntries.contains(call.name))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         /**
-         * The methods of this class reachable from {@code entry} by ordinary calls AND by every
-         * callback EXCEPT those of {@code gatedType}: a body handed over as {@code gatedType} runs
-         * only when that interface is invoked, and who may invoke it is a separate assertion.
+         * Every place a write callback is built without going STRAIGHT into the gate.
+         *
+         * <p>Weaker phrasings of this were tried and are all dodgeable. "Calls a gate somewhere in the
+         * same method" lets a branch build two callbacks, authorize one and run the other. "Is not
+         * passed to anything but a gate" reads the callee's descriptor, so handing it to a helper
+         * taking {@code Object} hides it. Both fail for the same reason: without tracking WHICH value
+         * went where, any rule about the method as a whole can be satisfied by a second callback.</p>
+         *
+         * <p>So the rule is about the value's only safe lifetime: the first invocation after the one
+         * that CREATES the callback must be an authorization step. Then it was never stored, never
+         * passed anywhere else, and no second callback can stand in for it - which is how every branch
+         * in this tool already writes it. A branch that wants a named local instead has to make the
+         * gate call the next thing it does.</p>
+         *
+         * @param unit the analysed class
+         * @param writeType the gate's callback type
+         * @param gateEntries the methods a callback may legitimately be handed to
+         * @return the offending {@code method -> what it did with it instead} pairs
+         */
+        Set<String> callbacksNotHandedStraightToTheGate(String unit, String writeType,
+            Set<String> gateEntries)
+        {
+            Set<String> offenders = new TreeSet<>();
+            for (Map.Entry<String, MethodBody> method : methods.entrySet())
+            {
+                if (!inUnit(ownerOf(method.getKey()), unit))
+                {
+                    continue;
+                }
+                List<Integer> created = new ArrayList<>();
+                for (Callback callback : method.getValue().callbacks)
+                {
+                    if (writeType.equals(callback.type))
+                    {
+                        created.add(callback.offset);
+                    }
+                }
+                for (Call call : method.getValue().calls)
+                {
+                    if ("<init>".equals(call.name) && implementsType(call.owner, writeType)) //$NON-NLS-1$
+                    {
+                        created.add(call.offset); // a named / anonymous implementation of it
+                    }
+                }
+                for (int at : created)
+                {
+                    Call next = firstCallAfter(method.getKey(), at);
+                    if (next == null || !(inUnit(next.owner, unit) && gateEntries.contains(next.name)))
+                    {
+                        offenders.add(method.getKey() + " -> " //$NON-NLS-1$
+                            + (next == null ? "nothing" : next.target())); //$NON-NLS-1$
+                    }
+                }
+            }
+            return offenders;
+        }
+
+        /** The first invocation instruction after {@code offset} in {@code node}, or {@code null}. */
+        private Call firstCallAfter(String node, int offset)
+        {
+            Call best = null;
+            for (Call call : callsIn(node))
+            {
+                if (call.offset > offset && (best == null || call.offset < best.offset))
+                {
+                    best = call;
+                }
+            }
+            return best;
+        }
+
+        /**
+         * The methods of this unit reachable from {@code entry} without going through the gate's
+         * callback. Three kinds of edge are followed - ordinary calls, callback bodies, and the
+         * declared methods of any nest member the code constructs - and only ONE is ever cut: a
+         * callback of {@code gatedType} created by a method that also calls a gate entry point. Every
+         * other shape is walked, so a write the model cannot account for shows up as ungated rather
+         * than disappearing.
          *
          * @param entry the method to start from
-         * @param gatedType the callback type whose bodies are NOT followed
-         * @return the reachable method names, {@code entry} included
+         * @param unit the analysed class
+         * @param gatedType the callback type whose bodies may be left unfollowed
+         * @param gateEntries the methods a callback may legitimately be handed to
+         * @return the reachable method nodes, {@code entry} included
          */
-        Set<String> reachableWithout(String entry, String gatedType)
+        Set<String> reachableWithout(String entry, String unit, String gatedType, Set<String> gateEntries)
         {
             Set<String> seen = new LinkedHashSet<>();
             Deque<String> queue = new ArrayDeque<>();
@@ -460,29 +1041,134 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             while (!queue.isEmpty())
             {
                 String from = queue.poll();
+                boolean authorizes = callsAGate(from, unit, gateEntries);
                 for (Call call : callsIn(from))
                 {
-                    if (SELF.equals(call.owner) && bodies.containsKey(call.node()) && seen.add(call.node()))
+                    if (!inUnit(call.owner, unit))
+                    {
+                        continue;
+                    }
+                    if (methods.containsKey(call.node()) && seen.add(call.node()))
                     {
                         queue.add(call.node());
                     }
+                    expand(call.owner, unit, gatedType, authorizes, seen, queue);
                 }
                 for (Callback callback : callbacksIn(from))
                 {
-                    if (!gatedType.equals(callback.type) && SELF.equals(callback.implOwner)
-                        && bodies.containsKey(callback.node()) && seen.add(callback.node()))
+                    if (authorizes && gatedType.equals(callback.type))
+                    {
+                        continue;
+                    }
+                    if (inUnit(callback.implOwner, unit) && methods.containsKey(callback.node())
+                        && seen.add(callback.node()))
                     {
                         queue.add(callback.node());
+                    }
+                    // A CONSTRUCTOR reference (Deferred::new handed to a Function) links only to
+                    // <init>, and whatever runs the object afterwards is owned by java.util.function
+                    // - so following the body alone would stop one edge short of the write. Only for
+                    // <init>: an ordinary lambda body is a SYNTHETIC method that happens to sit in
+                    // the creating class, and expanding that class would follow every callback in it,
+                    // gated ones included.
+                    if ("<init>".equals(callback.implMethod)) //$NON-NLS-1$
+                    {
+                        expand(callback.implOwner, unit, gatedType, authorizes, seen, queue);
                     }
                 }
             }
             return seen;
         }
 
-        private static ClassFile read(Class<?> clazz) throws IOException
+        /**
+         * Touching a class compiled INSIDE the analysed one hands its whole surface to whoever holds
+         * it: construction, a constructor reference, a static call that runs its {@code <clinit>} -
+         * the JVM has more than one way to get such a class's code running, and modelling them one at
+         * a time is how a blind spot gets built. So any reference expands it. Two things are never
+         * expanded: the analysed class itself (that would make the walk universal and prove nothing),
+         * and an implementation of the gate's own callback type whose creator hands it to the gate.
+         *
+         * @param owner the referenced class
+         * @param unit the analysed class
+         * @param gatedType the callback type whose implementations may be left unfollowed
+         * @param authorizes whether the referencing method calls a gate entry point
+         * @param seen the reachable set so far
+         * @param queue the walk's queue
+         */
+        private void expand(String owner, String unit, String gatedType, boolean authorizes,
+            Set<String> seen, Deque<String> queue)
         {
-            String resource = clazz.getSimpleName() + ".class"; //$NON-NLS-1$
-            try (InputStream raw = clazz.getResourceAsStream(resource))
+            if (owner.equals(unit) || !inUnit(owner, unit)
+                || (authorizes && implementsType(owner, gatedType)))
+            {
+                return;
+            }
+            for (String member : methodsOf.getOrDefault(owner, Set.of()))
+            {
+                if (seen.add(member))
+                {
+                    queue.add(member);
+                }
+            }
+        }
+
+        private boolean implementsType(String clazz, String type)
+        {
+            return interfacesOf.getOrDefault(clazz, Set.of()).contains(type);
+        }
+
+        private static boolean inUnit(String owner, String unit)
+        {
+            return owner.equals(unit) || owner.startsWith(unit + "$"); //$NON-NLS-1$
+        }
+
+        private static String ownerOf(String node)
+        {
+            return node.substring(0, node.indexOf('#'));
+        }
+
+        /**
+         * Parses {@code root} and, transitively, every class compiled inside it.
+         *
+         * @param root the outermost class
+         * @return the parsed nest
+         * @throws IOException when a class resource is missing or truncated
+         */
+        static Nest read(Class<?> root) throws IOException
+        {
+            Nest nest = new Nest();
+            Deque<String> pending = new ArrayDeque<>();
+            pending.add(binaryName(root));
+            while (!pending.isEmpty())
+            {
+                String name = pending.poll();
+                if (!nest.classes.add(name))
+                {
+                    continue;
+                }
+                for (String member : nest.parse(root, name))
+                {
+                    if (!nest.classes.contains(member))
+                    {
+                        pending.add(member);
+                    }
+                }
+            }
+            return nest;
+        }
+
+        /**
+         * Reads one class file into this nest.
+         *
+         * @param neighbour any class in the same package, used to resolve the resource
+         * @param name the class to read, as the constant pool spells it
+         * @return the nest members it declares
+         * @throws IOException when the resource is missing or truncated
+         */
+        private Set<String> parse(Class<?> neighbour, String name) throws IOException
+        {
+            String resource = name + ".class"; //$NON-NLS-1$
+            try (InputStream raw = neighbour.getResourceAsStream(resource))
             {
                 if (raw == null)
                 {
@@ -490,12 +1176,57 @@ public class DeleteMetadataConsentSinglePointRatchetTest
                 }
                 try (DataInputStream in = new DataInputStream(raw))
                 {
-                    return parse(in);
+                    return new ClassFile(this, name).parse(in);
                 }
             }
         }
+    }
 
-        private static ClassFile parse(DataInputStream in) throws IOException
+    /** Parses one class file into a {@link Nest}. */
+    private static final class ClassFile
+    {
+        private final Nest nest;
+
+        private final String self;
+
+        private String[] utf8;
+
+        private int[] classNames;
+
+        private int[] refOwners;
+
+        private int[] refNameAndTypes;
+
+        private int[] nameAndTypeNames;
+
+        private int[] nameAndTypeDescriptors;
+
+        /** For a CONSTANT_MethodHandle: the pool index of the ref it points at. */
+        private int[] methodHandleRefs;
+
+        /** For a CONSTANT_InvokeDynamic: its BootstrapMethods index and its NameAndType. */
+        private int[] indyBootstraps;
+
+        private int[] indyNameAndTypes;
+
+        /** BootstrapMethods: the bootstrap MethodHandle and the static arguments, per entry. */
+        private int[] bootstrapHandles = new int[0];
+
+        private int[][] bootstrapArguments = new int[0][];
+
+        /** Raw bodies, kept until BootstrapMethods (a CLASS attribute) has been read. */
+        private final Map<String, List<byte[]>> bodies = new LinkedHashMap<>();
+
+        /** The nest members named by this class's NestMembers / InnerClasses attributes. */
+        private final Set<String> members = new LinkedHashSet<>();
+
+        ClassFile(Nest nest, String self)
+        {
+            this.nest = nest;
+            this.self = self;
+        }
+
+        private Set<String> parse(DataInputStream in) throws IOException
         {
             if (in.readInt() != 0xCAFEBABE)
             {
@@ -504,17 +1235,30 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             in.readUnsignedShort(); // minor version
             in.readUnsignedShort(); // major version
 
-            ClassFile parsed = new ClassFile(in.readUnsignedShort());
-            parsed.readConstantPool(in);
+            allocate(in.readUnsignedShort());
+            readConstantPool(in);
             in.readUnsignedShort(); // access flags
             in.readUnsignedShort(); // this class
             in.readUnsignedShort(); // super class
-            skipFully(in, in.readUnsignedShort() * 2); // interfaces
-            parsed.skipMembers(in); // fields
-            parsed.readMethods(in);
-            parsed.readClassAttributes(in); // BootstrapMethods lives here, AFTER the methods
-            parsed.resolveBodies();
-            return parsed;
+            readInterfaces(in);
+            skipMembers(in); // fields
+            readMethods(in);
+            readClassAttributes(in); // BootstrapMethods lives here, AFTER the methods
+            resolveBodies();
+            return members;
+        }
+
+        private void allocate(int poolSize)
+        {
+            utf8 = new String[poolSize];
+            classNames = new int[poolSize];
+            refOwners = new int[poolSize];
+            refNameAndTypes = new int[poolSize];
+            nameAndTypeNames = new int[poolSize];
+            nameAndTypeDescriptors = new int[poolSize];
+            methodHandleRefs = new int[poolSize];
+            indyBootstraps = new int[poolSize];
+            indyNameAndTypes = new int[poolSize];
         }
 
         private void readConstantPool(DataInputStream in) throws IOException
@@ -570,6 +1314,17 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             }
         }
 
+        private void readInterfaces(DataInputStream in) throws IOException
+        {
+            int count = in.readUnsignedShort();
+            Set<String> implemented = new LinkedHashSet<>();
+            for (int i = 0; i < count; i++)
+            {
+                implemented.add(simpleName(nameOf(classNames, in.readUnsignedShort())));
+            }
+            nest.interfacesOf.put(self, implemented);
+        }
+
         /** Skips a whole fields table. */
         private void skipMembers(DataInputStream in) throws IOException
         {
@@ -597,11 +1352,12 @@ public class DeleteMetadataConsentSinglePointRatchetTest
                 String name = text(in.readUnsignedShort());
                 String descriptor = text(in.readUnsignedShort());
                 int attributes = in.readUnsignedShort();
-                // Keyed by name AND descriptor: two overloads are two methods, and merging them would
-                // import one's mutations into the other's reachability (issue #331 review).
-                String node = name + descriptor;
-                declarations.merge(name, 1, Integer::sum);
-                nodesByName.computeIfAbsent(name, unused -> new TreeSet<>()).add(node);
+                // Keyed by owner, name AND descriptor: two overloads are two methods, and merging them
+                // would import one's mutations into the other's reachability (issue #331 review).
+                String node = self + '#' + name + descriptor;
+                nest.declarations.merge(self + '#' + name, 1, Integer::sum);
+                nest.nodesByName.computeIfAbsent(self + '#' + name, unused -> new TreeSet<>()).add(node);
+                nest.methodsOf.computeIfAbsent(self, unused -> new LinkedHashSet<>()).add(node);
                 List<byte[]> body = bodies.computeIfAbsent(node, unused -> new ArrayList<>());
                 for (int a = 0; a < attributes; a++)
                 {
@@ -624,7 +1380,7 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             }
         }
 
-        /** Reads the class-level attributes, keeping {@code BootstrapMethods}. */
+        /** Reads the class-level attributes, keeping {@code BootstrapMethods} and the nest members. */
         private void readClassAttributes(DataInputStream in) throws IOException
         {
             int attributes = in.readUnsignedShort();
@@ -632,23 +1388,59 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             {
                 String attribute = text(in.readUnsignedShort());
                 int length = in.readInt();
-                if (!"BootstrapMethods".equals(attribute)) //$NON-NLS-1$
+                if ("BootstrapMethods".equals(attribute)) //$NON-NLS-1$
+                {
+                    readBootstrapMethods(in);
+                }
+                else if ("NestMembers".equals(attribute)) //$NON-NLS-1$
+                {
+                    int count = in.readUnsignedShort();
+                    for (int m = 0; m < count; m++)
+                    {
+                        collect(simpleName(nameOf(classNames, in.readUnsignedShort())));
+                    }
+                }
+                else if ("InnerClasses".equals(attribute)) //$NON-NLS-1$
+                {
+                    // The fallback, and the only place a LOCAL class of a nested class is named on
+                    // some compilers. It also lists classes this one merely REFERENCES (Map$Entry),
+                    // hence the prefix filter in collect().
+                    int count = in.readUnsignedShort();
+                    for (int m = 0; m < count; m++)
+                    {
+                        collect(simpleName(nameOf(classNames, in.readUnsignedShort())));
+                        skipFully(in, 6); // outer class, inner name, access flags
+                    }
+                }
+                else
                 {
                     skipFully(in, length);
-                    continue;
                 }
-                int count = in.readUnsignedShort();
-                bootstrapHandles = new int[count];
-                bootstrapArguments = new int[count][];
-                for (int b = 0; b < count; b++)
+            }
+        }
+
+        private void collect(String name)
+        {
+            String root = nest.classes.iterator().next();
+            if (name.startsWith(root + "$")) //$NON-NLS-1$
+            {
+                members.add(name);
+            }
+        }
+
+        private void readBootstrapMethods(DataInputStream in) throws IOException
+        {
+            int count = in.readUnsignedShort();
+            bootstrapHandles = new int[count];
+            bootstrapArguments = new int[count][];
+            for (int b = 0; b < count; b++)
+            {
+                bootstrapHandles[b] = in.readUnsignedShort();
+                int arguments = in.readUnsignedShort();
+                bootstrapArguments[b] = new int[arguments];
+                for (int g = 0; g < arguments; g++)
                 {
-                    bootstrapHandles[b] = in.readUnsignedShort();
-                    int arguments = in.readUnsignedShort();
-                    bootstrapArguments[b] = new int[arguments];
-                    for (int g = 0; g < arguments; g++)
-                    {
-                        bootstrapArguments[b][g] = in.readUnsignedShort();
-                    }
+                    bootstrapArguments[b][g] = in.readUnsignedShort();
                 }
             }
         }
@@ -658,11 +1450,10 @@ public class DeleteMetadataConsentSinglePointRatchetTest
         {
             for (Map.Entry<String, List<byte[]>> method : bodies.entrySet())
             {
-                List<Call> found = calls.computeIfAbsent(method.getKey(), unused -> new ArrayList<>());
-                List<Callback> made = callbacks.computeIfAbsent(method.getKey(), unused -> new ArrayList<>());
+                MethodBody parsed = nest.methods.computeIfAbsent(method.getKey(), unused -> new MethodBody());
                 for (byte[] code : method.getValue())
                 {
-                    walk(code, found, made);
+                    walk(code, parsed);
                 }
             }
         }
@@ -673,10 +1464,9 @@ public class DeleteMetadataConsentSinglePointRatchetTest
          * look like an opcode inside another instruction's operands cannot be mistaken for a call.
          *
          * @param code the method's bytecode
-         * @param found collects its ordinary calls, in execution order
-         * @param made collects the callbacks it creates
+         * @param into collects its ordinary calls, in execution order, and the callbacks it creates
          */
-        private void walk(byte[] code, List<Call> found, List<Callback> made)
+        private void walk(byte[] code, MethodBody into)
         {
             int pc = 0;
             while (pc < code.length)
@@ -686,15 +1476,15 @@ public class DeleteMetadataConsentSinglePointRatchetTest
                 {
                     int ref = readUnsignedShort(code, pc + 1);
                     int nameAndType = refNameAndTypes[ref];
-                    found.add(new Call(pc, simpleName(nameOf(classNames, refOwners[ref])),
+                    into.calls.add(new Call(pc, simpleName(nameOf(classNames, refOwners[ref])),
                         text(nameAndTypeNames[nameAndType]), text(nameAndTypeDescriptors[nameAndType])));
                 }
                 else if (opcode == 0xBA) // invokedynamic: creates a callback, does not run it
                 {
-                    Callback callback = callbackAt(readUnsignedShort(code, pc + 1));
+                    Callback callback = callbackAt(pc, readUnsignedShort(code, pc + 1));
                     if (callback != null)
                     {
-                        made.add(callback);
+                        into.callbacks.add(callback);
                     }
                 }
                 pc += instructionLength(code, pc);
@@ -709,7 +1499,7 @@ public class DeleteMetadataConsentSinglePointRatchetTest
          * @param poolIndex the CONSTANT_InvokeDynamic index
          * @return the callback, or {@code null}
          */
-        private Callback callbackAt(int poolIndex)
+        private Callback callbackAt(int offset, int poolIndex)
         {
             int bootstrap = indyBootstraps[poolIndex];
             if (bootstrap >= bootstrapHandles.length)
@@ -731,7 +1521,7 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             int impl = methodHandleRefs[arguments[1]];
             int implNameAndType = refNameAndTypes[impl];
             String descriptor = text(nameAndTypeDescriptors[indyNameAndTypes[poolIndex]]);
-            return new Callback(returnTypeOf(descriptor), simpleName(nameOf(classNames, refOwners[impl])),
+            return new Callback(offset, returnTypeOf(descriptor), simpleName(nameOf(classNames, refOwners[impl])),
                 text(nameAndTypeNames[implNameAndType]), text(nameAndTypeDescriptors[implNameAndType]));
         }
 

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/DeleteMetadataConsentSinglePointRatchetTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/DeleteMetadataConsentSinglePointRatchetTest.java
@@ -72,8 +72,13 @@ import com.ditrix.edt.mcp.server.tools.impl.DeleteMetadataTool;
  * <li>the only thing that may INVOKE {@code DeleteWrite.perform} is the gate, and a method HANDLE on
  * it counts as an invocation. Converting the callback to some other functional interface
  * ({@code write::perform}) is the one way to run it without an invoke instruction;</li>
- * <li>the same applies to a nest member that IMPLEMENTS the callback type: referencing it is a
- * followed edge unless that construction itself was handed straight to the gate.</li>
+ * <li>a nest member that IMPLEMENTS the callback type is exempt in exactly ONE method - the one the
+ * gate invokes after an ALLOW - and only when that construction was itself handed straight to the
+ * gate. Never the whole class: {@code <clinit>} runs when the class is first touched, which is
+ * before the gate has been asked anything, and nothing ever CALLS a static initializer, so
+ * exempting the class is all that stands between the walk and a write the consent precedes. (A
+ * constructor is safe for a duller reason - {@code <init>} is an ordinary call and the walk follows
+ * it whatever the exemption says.)</li>
  * </ul>
  * The direction is deliberate: where the rules cannot tell, they treat the write as ungated. Handing
  * the gate a callback that wraps another one ({@code deleteWithConsent(preview, w::get)}), or a
@@ -118,6 +123,12 @@ import com.ditrix.edt.mcp.server.tools.impl.DeleteMetadataTool;
  * next call without being stored, and was it the only one?" - which is enough to refuse every shape
  * that parks or shares the value, and is why the rule is strict rather than clever. It does not
  * follow branches, so it reasons about instruction ORDER and not about execution paths;</li>
+ * <li>for the same reason {@link #everyGateEntryPointReallyReachesTheGate} proves that each
+ * forwarding step CALLS the gate, not that it forwards the very callback it was handed. A parameter
+ * lives in a local slot, and telling one slot from another is the dataflow this check does not do -
+ * so a forwarding step that gated some OTHER callback and dropped its own would pass. What stands
+ * behind it instead is that these steps are three-line forwarders, reviewed as such, and that every
+ * callback they could substitute is subject to the creation rules above;</li>
  * <li>owners are compared by SIMPLE name and by the STATIC type at the call site - that is all the
  * constant pool spells - so two same-named classes from different packages are one owner here, and a
  * family rule keyed on {@code EList} does not follow into {@code BasicEList};</li>
@@ -166,6 +177,9 @@ public class DeleteMetadataConsentSinglePointRatchetTest
 
     /** The callback type a branch hands to the gate, relative to its declaring class. */
     private static final String WRITE_CALLBACK_SUFFIX = "$DeleteWrite"; //$NON-NLS-1$
+
+    /** Its single method - the ONE thing an authorized implementation is exempt in. */
+    private static final String WRITE_CALLBACK_METHOD = "perform"; //$NON-NLS-1$
 
     /** The consent seam the gate asks through. */
     private static final String ASK = "DeleteMetadataTool$ConsentRequester#request"; //$NON-NLS-1$
@@ -297,7 +311,7 @@ public class DeleteMetadataConsentSinglePointRatchetTest
     {
         Nest nest = readTool();
         String gate = nest.requireSingleDeclaration(SELF, GATE);
-        String callback = SELF + WRITE_CALLBACK_SUFFIX + "#perform"; //$NON-NLS-1$
+        String callback = SELF + WRITE_CALLBACK_SUFFIX + '#' + WRITE_CALLBACK_METHOD;
         Set<String> invokers = nest.methodsReaching(callback);
 
         assertEquals("a DeleteWrite callback must be invoked ONLY by " + GATE + ": that single " //$NON-NLS-1$ //$NON-NLS-2$
@@ -489,6 +503,27 @@ public class DeleteMetadataConsentSinglePointRatchetTest
             + "nothing authorized it: " + bypass.escapes, !bypass.escapes.isEmpty()); //$NON-NLS-1$
     }
 
+    /**
+     * The write in the STATIC INITIALIZER of a callback built in the gate's own argument. The
+     * handover is perfect; the write is simply earlier than the question. A constructor would not
+     * have shown this - {@code <init>} is an ordinary call, followed whatever the exemption says -
+     * which is why the fixture uses the one member nothing ever calls.
+     */
+    @Test
+    public void theAnalysisCatchesAWriteInTheCallbacksStaticInitializer()
+    {
+        Analysis bypass = analyseFixture(ConsentRatchetFixtures.ConstructedInArgumentBypass.class);
+
+        assertTrue("the callback goes straight from new into the gate - never stored, never shared " //$NON-NLS-1$
+            + "- so the handover is impeccable and the exemption is deserved. But it is deserved by " //$NON-NLS-1$
+            + "ONE method, the one the gate invokes after an ALLOW: <clinit> has already run by " //$NON-NLS-1$
+            + "then, nothing ever calls it, and exempting the whole CLASS is the only thing " //$NON-NLS-1$
+            + "standing between the walk and a write the consent precedes.", //$NON-NLS-1$
+            !bypass.escapes.isEmpty());
+        assertTrue("... and the handover itself must still be accepted, or this fixture would be " //$NON-NLS-1$
+            + "proving the wrong thing: " + bypass.unconsumed, bypass.unconsumed.isEmpty()); //$NON-NLS-1$
+    }
+
     /** The second callback built with a CONSTRUCTOR: invisible to a check that counts only lambdas. */
     @Test
     public void theAnalysisCatchesASecondCallbackMadeWithAConstructor()
@@ -583,7 +618,7 @@ public class DeleteMetadataConsentSinglePointRatchetTest
     {
         Nest fixtures = read(ConsentRatchetFixtures.class);
         String perform = binaryName(ConsentRatchetFixtures.MethodHandleBypass.class)
-            + WRITE_CALLBACK_SUFFIX + "#perform"; //$NON-NLS-1$
+            + WRITE_CALLBACK_SUFFIX + '#' + WRITE_CALLBACK_METHOD;
 
         Set<String> calling = fixtures.methodsCalling(perform);
         Set<String> reaching = fixtures.methodsReaching(perform);
@@ -690,7 +725,7 @@ public class DeleteMetadataConsentSinglePointRatchetTest
         }
         return new Analysis(ungated, escapes,
             nest.callbacksNotHandedStraightToTheGate(unit, writeType, gateEntries),
-            nest.methodsReaching(writeType + "#perform")); //$NON-NLS-1$
+            nest.methodsReaching(writeType + '#' + WRITE_CALLBACK_METHOD));
     }
 
     private static Analysis analyseFixture(Class<?> fixture)
@@ -1341,13 +1376,22 @@ public class DeleteMetadataConsentSinglePointRatchetTest
         private void expand(String owner, String unit, String gatedType, boolean authorizes,
             Set<String> seen, Deque<String> queue)
         {
-            if (owner.equals(unit) || !inUnit(owner, unit)
-                || (authorizes && implementsType(owner, gatedType)))
+            if (owner.equals(unit) || !inUnit(owner, unit))
             {
                 return;
             }
+            // An authorized implementation of the callback type is exempt in ONE method: the one the
+            // gate invokes after an ALLOW. Skipping the whole CLASS was the same class-instead-of-
+            // value mistake as before, and here it is worse than elsewhere: <init> and <clinit> run
+            // when the object is BUILT, which is before the gate has been asked anything at all. A
+            // write in a constructor would have been exempted by the consent it precedes.
+            boolean exemptTheCallback = authorizes && implementsType(owner, gatedType);
             for (String member : methodsOf.getOrDefault(owner, Set.of()))
             {
+                if (exemptTheCallback && member.startsWith(owner + '#' + WRITE_CALLBACK_METHOD))
+                {
+                    continue;
+                }
                 if (seen.add(member))
                 {
                     queue.add(member);

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataToolTest.java
@@ -45,6 +45,7 @@ import com.ditrix.edt.mcp.server.utils.FormElementWriter;
 import com.ditrix.edt.mcp.server.utils.FormElementWriter.FormObjectRef;
 import com.ditrix.edt.mcp.server.utils.MetadataLanguageUtils;
 import com.ditrix.edt.mcp.server.utils.PredefinedWriter;
+import com.ditrix.edt.mcp.server.utils.XdtoWriter;
 
 /**
  * Lightweight contract tests for {@link DeleteMetadataTool}: tool metadata and JSON schema, without
@@ -1012,6 +1013,129 @@ public class DeleteMetadataToolTest
             "Catalog.Products.Form.ItemForm", new DeleteMetadataTool.FormContentSummary(), allowed); //$NON-NLS-1$
         assertEquals("an allowed form-object delete runs its write exactly once", 1, allowed.calls); //$NON-NLS-1$
         assertEquals("{\"written\":true}", ok); //$NON-NLS-1$
+    }
+
+    /** A requester that records what it was asked, so a test can assert it was NOT asked at all. */
+    private static final class RecordingRequester implements DeleteMetadataTool.ConsentRequester
+    {
+        final List<ConsentPreview> asked = new ArrayList<>();
+
+        private final DestructiveConsentGate.ConsentDecision answer;
+
+        RecordingRequester(DestructiveConsentGate.ConsentDecision answer)
+        {
+            this.answer = answer;
+        }
+
+        @Override
+        public DestructiveConsentGate.ConsentDecision request(String toolName, ConsentPreview preview)
+        {
+            asked.add(preview);
+            return answer;
+        }
+    }
+
+    private static final String XDTO_FQN = "XDTOPackage.MyPackage.ObjectType.Order"; //$NON-NLS-1$
+
+    private static XdtoWriter.MemberRef xdtoRef()
+    {
+        return XdtoWriter.parseMemberRef(XDTO_FQN);
+    }
+
+    /**
+     * The XDTO branch's ORDER, pinned by BEHAVIOUR: a target that is not there must be answered
+     * without a destructive prompt ever being raised. Bytecode offsets alone cannot see this - the
+     * lookup could run first and its RESULT be ignored, which is exactly the defect issue #331 records
+     * (the prompt came first, "not found" after it had been dealt with).
+     */
+    @Test
+    public void testXdtoBranchAnswersAnUnresolvedPackageWithoutAskingForConsent()
+    {
+        RecordingRequester requester = new RecordingRequester(DestructiveConsentGate.ConsentDecision.ALLOW);
+        RecordingWrite write = new RecordingWrite();
+
+        String result = new DeleteMetadataTool(requester).gateXdtoMemberDelete(XDTO_FQN, xdtoRef(),
+            new DeleteMetadataTool.XdtoLookup(false, null), write);
+
+        assertTrue("a delete that cannot even resolve its package must not raise a destructive prompt", //$NON-NLS-1$
+            requester.asked.isEmpty());
+        assertEquals("nothing may be written when the package did not resolve", 0, write.calls); //$NON-NLS-1$
+        assertTrue("the package-level failure must keep ITS own message, not be collapsed into the " //$NON-NLS-1$
+            + "member-level one: " + result, //$NON-NLS-1$
+            result.contains("The XDTO package could not be resolved inside the transaction.")); //$NON-NLS-1$
+        assertFalse("... and it must not be reported as a missing member: " + result, //$NON-NLS-1$
+            result.contains("ObjectType not found")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testXdtoBranchAnswersAMissingMemberWithoutAskingForConsent()
+    {
+        RecordingRequester requester = new RecordingRequester(DestructiveConsentGate.ConsentDecision.ALLOW);
+        RecordingWrite write = new RecordingWrite();
+
+        String result = new DeleteMetadataTool(requester).gateXdtoMemberDelete(XDTO_FQN, xdtoRef(),
+            new DeleteMetadataTool.XdtoLookup(true, null), write);
+
+        assertTrue("a typo in the member name must not raise a destructive prompt (issue #331)", //$NON-NLS-1$
+            requester.asked.isEmpty());
+        assertEquals("nothing may be written when the member is not there", 0, write.calls); //$NON-NLS-1$
+        assertTrue("the caller must be told WHICH member and where to look: " + result, //$NON-NLS-1$
+            result.contains("ObjectType not found: 'Order' in package XDTOPackage.MyPackage")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testXdtoBranchAsksOnceForAResolvedTargetAndRunsTheWriteOnAllow()
+    {
+        RecordingRequester requester = new RecordingRequester(DestructiveConsentGate.ConsentDecision.ALLOW);
+        RecordingWrite write = new RecordingWrite();
+
+        String result = new DeleteMetadataTool(requester).gateXdtoMemberDelete(XDTO_FQN, xdtoRef(),
+            new DeleteMetadataTool.XdtoLookup(true, new String[] { "ObjectType" }), write); //$NON-NLS-1$
+
+        assertEquals("a resolved target is asked about exactly once", 1, requester.asked.size()); //$NON-NLS-1$
+        assertEquals("the prompt must name what is really removed", //$NON-NLS-1$
+            java.util.Collections.singletonList(XDTO_FQN), requester.asked.get(0).getTopNames());
+        assertEquals("an allowed XDTO delete runs its write exactly once", 1, write.calls); //$NON-NLS-1$
+        assertEquals("{\"written\":true}", result); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testXdtoBranchRunsItsWriteOnlyWhenConsentIsGranted()
+    {
+        for (DestructiveConsentGate.ConsentDecision refused : new DestructiveConsentGate.ConsentDecision[] {
+            DestructiveConsentGate.ConsentDecision.REJECT, DestructiveConsentGate.ConsentDecision.TIMEOUT })
+        {
+            RecordingRequester requester = new RecordingRequester(refused);
+            RecordingWrite write = new RecordingWrite();
+
+            String result = new DeleteMetadataTool(requester).gateXdtoMemberDelete(XDTO_FQN, xdtoRef(),
+                new DeleteMetadataTool.XdtoLookup(true, new String[] { "ObjectType" }), write); //$NON-NLS-1$
+
+            assertEquals("a refused XDTO delete must not run its write (" + refused + ")", //$NON-NLS-1$ //$NON-NLS-2$
+                0, write.calls);
+            assertEquals("a resolved target is still asked about", 1, requester.asked.size()); //$NON-NLS-1$
+            assertTrue(result.contains("error")); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * The XDTO delete's generic failure now runs BEFORE consent as well (the lookup moved in front of
+     * the gate), so "Delete failed: &lt;whatever the platform said&gt;" is the first and often only thing
+     * the caller sees. It has to say which delete failed, that nothing was removed, and what to do -
+     * CLAUDE.md rule #8 - while keeping the platform's own message, which is the only thing that tells
+     * a corrupt .xdto apart from a stale BM id.
+     */
+    @Test
+    public void testXdtoDeleteFailureNamesTheTargetAndTheWayOut()
+    {
+        String json = DeleteMetadataTool.xdtoDeleteFailure(XDTO_FQN,
+            new IllegalStateException("Resource could not be loaded")); //$NON-NLS-1$
+
+        assertTrue("the error must name the delete it belongs to: " + json, json.contains(XDTO_FQN)); //$NON-NLS-1$
+        assertTrue("... say that nothing was removed: " + json, json.contains("Nothing was deleted")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("... point at the way out: " + json, json.contains("get_metadata_details")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("... and keep the platform's own diagnosis: " + json, //$NON-NLS-1$
+            json.contains("Resource could not be loaded")); //$NON-NLS-1$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataToolTest.java
@@ -877,12 +877,12 @@ public class DeleteMetadataToolTest
     /**
      * A recording write: it must run ONLY when consent was granted, and exactly once.
      */
-    private static final class RecordingWrite implements java.util.function.Supplier<String>
+    private static final class RecordingWrite implements DeleteMetadataTool.DeleteWrite
     {
         int calls;
 
         @Override
-        public String get()
+        public String perform()
         {
             calls++;
             return "{\"written\":true}"; //$NON-NLS-1$
@@ -967,8 +967,10 @@ public class DeleteMetadataToolTest
         // What this does NOT prove, stated plainly because the comment here used to claim it did: it
         // calls gateFormMemberDelete directly, so re-routing deleteFormMember() straight to
         // performFormDelete() would leave this test green. Driving the real dispatch needs a resolved
-        // project + BM services, which a headless unit test has none of; the production call site is
-        // one line (see deleteFormMember) and is what a reviewer must read.
+        // project + BM services, which a headless unit test has none of. That WIRING is no longer
+        // left to a reviewer's eye either: DeleteMetadataConsentSinglePointRatchetTest reads the
+        // compiled class and fails when any branch can reach a write without passing through
+        // deleteWithConsent (issue #331).
         for (DestructiveConsentGate.ConsentDecision refused : new DestructiveConsentGate.ConsentDecision[] {
             DestructiveConsentGate.ConsentDecision.REJECT, DestructiveConsentGate.ConsentDecision.TIMEOUT })
         {
@@ -992,7 +994,8 @@ public class DeleteMetadataToolTest
     @Test
     public void testFormObjectBranchRunsItsWriteOnlyWhenConsentIsGranted()
     {
-        // Same scope as its twin above: the authorization STEP, not the branch's wiring to it.
+        // Same scope as its twin above: the authorization STEP; the branch's wiring to it is pinned by
+        // DeleteMetadataConsentSinglePointRatchetTest, which reads the compiled class.
         for (DestructiveConsentGate.ConsentDecision refused : new DestructiveConsentGate.ConsentDecision[] {
             DestructiveConsentGate.ConsentDecision.REJECT, DestructiveConsentGate.ConsentDecision.TIMEOUT })
         {


### PR DESCRIPTION
Closes #331

## Что уже было сделано до этого PR

Основную претензию ишьи закрыл **PR #341** — там просто не проставили `Closes`. На текущем master обе ветки, на которые жалуется #331, гейт проходят:

| ветка | путь до гейта |
|---|---|
| член формы | `deleteFormMember` → `gateFormMemberDelete` (`:664`) → `deleteWithConsent` (`:809`) |
| объект формы | `deleteFormObject` → `gateFormObjectDelete` (`:1042`) → `deleteWithConsent` (`:826`) |

Причём сделано больше, чем просила ишья: запись передаётся **колбэком целиком**, поэтому «без ALLOW ничего не пишется» — свойство структуры, а не порядка операторов; и `ConsentPreview` считает реальный радиус (форма + содержимое `Form.form`, элемент + вложенное поддерево), а не константу 1.

## Что оставалось

Последний абзац ишьи: *«не стоит ли вынести вызов гейта в одну точку перед диспетчеризацией, чтобы следующая новая ветка не забыла его снова»*. Единой точки не было — три ветки звали гейт каждая сама:

- обычный md-объект / член объекта — `performDelete`, `DeleteMetadataTool.java:436`
- предопределённый элемент — `deletePredefinedItem`, `:1269`
- член XDTO-пакета — `performXdtoMemberDelete`, `:1971`

Ровно это записано и в javadoc самого `deleteWithConsent` (`:118–135`), там же зафиксирован попутный дефект **порядка**: XDTO спрашивал согласие **до** проверки существования цели. Опечатка в имени члена поднимала деструктивный запрос человеку, и только после ответа выяснялось «не найдено» — тот самый дефект, который форменные ветки у себя уже починили.

## Что сделано в этом PR

**1. Одна точка авторизации.** Три ветки отдают свою запись в `deleteWithConsent` как колбэк `DeleteWrite`. `DestructiveConsentGate.getInstance()` остался ровно в одном месте — в лямбде продакшн-конструктора. Побочный эффект, который стоит отметить: теперь **все** ветки можно прогнать через тестовый шов `ConsentRequester`, раньше это умели только форменные.

Чтобы вся мутация была колбэком, а не «тем, что написано ниже проверки», из `performDelete` выделен `performDeleteRefactoring`, из `performXdtoMemberDelete` — `writeXdtoMemberDelete`. Поведение на ALLOW не меняется.

**2. Порядок в XDTO.** Сначала резолв (тем же откатываемым чтением, что и превью), гейт — последним перед записью. Ошибки при этом остались прежними: `xdtoPackageUnresolvedError()` и `xdtoDeleteFailure()` — общие для предпроверки и для записи, поэтому перенос резолва вперёд изменил, **когда** вызывающий узнаёт об ошибке, а не **что** он получает. Превью отвечает как раньше.

**3. Чтобы новая ветка не смогла забыть гейт** — `DeleteMetadataConsentSinglePointRatchetTest`: читает скомпилированный класс и падает, если ветка может дойти до записи мимо гейта.

## Почему ратчет, а не полная структурная перестройка

Вы спрашивали именно про «одну точку перед диспетчеризацией». Разбирая, я уперся в то, что **структура одна этого не гарантирует**: какой бы ни была диспетчеризация, ничто в Java не мешает новому методу открыть write-транзакцию прямо у себя в теле. Единая точка даёт «запись запускается только после ALLOW» — но не «всякая запись идёт через эту точку». Второе проверяемо только чтением кода, поэтому:

- **структурная часть** — единая точка + запись в виде колбэка (её нельзя выполнить, не вызвав `DeleteWrite.perform()`);
- **ратчет** — доказывает, что вызвать её может только гейт, и что до мутаций иначе не добраться.

Полную перестройку «ветка возвращает план, гейт зовётся один раз в диспетчере» я **не делал сознательно**: это меняет тип возврата всех пяти веток и ~40 точек `return` в деструктивном файле из зоны «think twice», ради выигрыша, который ратчет и так закрывает. Если хотите такой вид — скажите, сделаю отдельным PR (вопрос 1 ниже).

### Что ратчет проверяет

Мутация выполняется тогда, когда выполняется держащий её метод, — значит вопрос в том, какие методы достижимы из `executeOnUiThread`. Обходятся обычные вызовы **и** лямбды/ссылки на методы (цель берётся из атрибута `BootstrapMethods`, поэтому имя синтетического метода роли не играет — ECJ пишет `lambda$0`, javac `lambda$new$0`). Не обходятся только колбэки типа `DeleteWrite`: их тело выполняется, лишь когда кто-то вызовет интерфейс, а отдельная проверка показывает, что вызывает его **только** `deleteWithConsent` и **после** запроса согласия.

1. `theGateSingletonIsConsultedInExactlyOnePlace` — синглтон гейта достижим ровно из одного метода;
2. `noBranchCanReachAWriteWithoutPassingThroughTheGate` — ни один метод, достижимый мимо колбэка, не вызывает мутацию;
3. `theWriteCallbackIsInvokedOnlyByTheGateAndOnlyAfterAsking` — единственный вызов `DeleteWrite.perform()` внутри гейта, после `request`;
4. `theXdtoBranchResolvesItsTargetBeforeItAsks` — резолв раньше гейта.

### Чего он НЕ доказывает (написано и в javadoc класса)

- Точки мутации — **список** (`MUTATIONS`). Ветка, пишущая через какой-то новый хелпер, тестом не видна; на это работают правила транзакционных границ из `CLAUDE.md`. У списка есть положительный контроль: если имя перестанет встречаться в классе, тест падает, а не «молча проверяет ничто».
- Две проверки порядка сравнивают смещения в байткоде — это ловит форму обоих реальных дефектов (позже написанный шаг стоит выше раньше нужного), но не является доказательством доминирования. Для `deleteWithConsent` семантика дополнительно закреплена поведенческими тестами.
- Ошибается он **в закрытую**: создание не-`DeleteWrite` колбэка считается его выполнением, поэтому безопасная композиция `Supplier<String> w = () -> write(); deleteWithConsent(preview, w::get);` тоже будет отмечена. Для гейта это единственное безопасное направление ошибки.

## Чем доказано

**Сборка:** `bash source/compile.sh` — `BUILD SUCCESS`, `Tests run: 4284, Failures: 0, Errors: 0`.

**Мутационная проверка каждого пина.** Каждая мутация — это воспроизведение до-фиксовой формы соответствующей ветки; после каждой мутация снималась, и сборка снова зелёная.

| мутация | что сломано | результат |
|---|---|---|
| M1b | `deletePredefinedItem` возвращён к своему вызову гейта + запись ниже | 🔴 сразу **два** теста: singleton (`Found: [deletePredefinedItem, lambda$0]`) и reachability (`performPredefinedItemDelete=[BmTransactions#forceExportToDisk, BmTransactions#write]`) |
| M2 | `write.perform()` поднят выше запроса согласия | 🔴 `deleteWithConsent invokes the write at bytecode offset 1, BEFORE it asks at 14` (+ 4 поведенческих теста в `DeleteMetadataToolTest`) |
| M3 | из XDTO убран предгейтовый резолв (до-фиксовая форма) | 🔴 `performXdtoMemberDelete() no longer looks its target up before writing` |
| M4 | в `MUTATIONS` переименована одна точка (`writeMdForm` → `writeMdFormRENAMED`) | 🔴 положительный контроль: `the mutation entry point ... no longer occurs` |
| M5 | `deleteFormObject` зовёт `performFormObjectDelete` напрямую | 🔴 reachability |
| M6 | запись спрятана в `Supplier`, который ветка вызывает сама | 🔴 reachability (**эту форму первая версия ратчета пропускала**, см. ниже) |
| M7 | мутация достижима только через ссылку на метод (`refactoring::perform`) | 🔴 reachability |

**Самопроверка через codex (2 раунда, до push).** Первый раунд нашёл реальную дыру: ратчет игнорировал `invokedynamic`, поэтому запись, спрятанная в `Supplier`, проходила (мутация M6 это подтвердила на коде). Переписал обход на `BootstrapMethods`. Второй раунд нашёл ещё три вещи, все починены: мутация через **ссылку на метод** не считалась побегом (M7), граф склеивал перегрузки по имени (теперь ключ — имя + дескриптор, плюс гарды перед проверками порядка), и предгейтовый резолв XDTO схлопывал «пакет не резолвится» в «член не найден» — из-за этого и появился три-стейт `XdtoLookup` с общим `xdtoPackageUnresolvedError()`.

**Стенд и e2e.** EDT 2026.2.0+289 на `:8766`, anti-stale выложенного jar с тремя пробами: положительный контроль (`DeleteFormMemberPreview` — есть и в master, и здесь) — найден; дискриминаторы (`DeleteXdtoMemberLookup`, `writeXdtoMemberDelete`) — найдены; отрицательный контроль (`DeleteXdtoMemberPreview` — только в master) — отсутствует.

- `--filter delete_metadata` → **36/36 passed**, fixture clean
- `--filter tools_list` → golden совпал без изменений (проволочная поверхность не менялась, `docs/tools` перегенерировать не нужно)

## Вопросы к вам

1. **Нужна ли полная перестройка диспетчеризации** («ветка возвращает план `(preview, write)`, гейт зовётся один раз в `executeOnUiThread`»)? Я её не делал: диф по деструктивному файлу вырастет на все пять веток и ~40 точек `return`, а гарантию даёт ратчет. Скажете — сделаю отдельным PR.

2. **`DeleteWrite` вместо `Supplier<String>`** — нужен ратчету, чтобы отличить «колбэк гейта» от любого другого функционального интерфейса. Если предпочитаете `Supplier`, проверку можно переписать на «единственный вызов `Supplier.get()` в классе», но это заметно хрупче. Оставить как есть?

3. **Парсер class-файла продублирован.** `BareErrorStringRatchetTest` (в master) и PR #358 (`GitToolPreflightOrderRatchetTest`) читают constant pool своими копиями; я не стал выносить общий хелпер, чтобы не создавать конфликт с #358. Как только оба вольются — вынести в общий тестовый хелпер?

4. **e2e на отказ согласия** ишья тоже просила. На стенде `EDT_MCP_DESTRUCTIVE_CONSENT=allow` (иначе деструктивные тесты висят на диалоге), так что REJECT там не наблюдаем. Отказ покрыт юнит-тестами через шов `ConsentRequester` для `deleteWithConsent` и обеих форменных веток. Заводить отдельный e2e-профиль с `ask`?

## Заметка не по этому PR

Фикстура стенда живёт в **основном клоне**, а не в worktree: прогон `tests/e2e/run_all.py` из worktree сравнивает диски своего чистого дерева и даёт ложные падения («expected on-disk change ...; diff:» пусто). У меня так «упало» 6 тестов из 36, все — артефакт. Запускать e2e надо из того клона, чей `TestConfiguration` импортирован в воркспейс стенда. Если полезно — оформлю отдельной ишьёй (гейт харнесса, который проверяет, что стенд правит именно его фикстуру).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
