### PR TITLE
e2e: сделать падение subsystem-content диагностируемым и ждать тот файл, который тест читает

### DIFF
--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -907,6 +907,37 @@ def poll_disk_lacks(rel_path, substr, timeout=10, ctx=""):
     _fail("expected %s to no longer contain %r [%s]" % (rel_path, substr, ctx))
 
 
+def poll_disk_count(rel_path, substr, expected, timeout=10, ctx=""):
+    """Poll until ONE named fixture file contains substr EXACTLY `expected` times.
+
+    The COUNT sibling of poll_disk_contains, for the "written exactly once" class of assertion
+    (an idempotent re-add must not duplicate a row). Presence is not enough there: a write that
+    is a no-op IN THE MODEL still force-exports, so the file is rewritten, and a bare
+    `read_disk(f).count(x) == n` can land mid-rewrite and read 0 - failing with "must NOT
+    duplicate", which describes the exact opposite of what happened. Waiting for the count makes
+    the assertion say what it means, and a real duplicate still fails (the count settles at 2 and
+    never reaches `expected`).
+
+    A missing file keeps polling: the export may not have created it yet."""
+    full = os.path.join(PROJECT_DIR, rel_path)
+    deadline = time.time() + timeout
+    last = ""
+    actual = None
+    while time.time() < deadline:
+        try:
+            with open(full, encoding="utf-8", errors="replace") as f:
+                last = f.read()
+            actual = last.count(substr)
+            if actual == expected:
+                return
+        except FileNotFoundError:
+            last = "(file does not exist yet)"
+        time.sleep(0.5)
+    _fail("expected %s to contain %r exactly %d time(s), last saw %s [%s]; it holds:\n%s"
+          % (rel_path, substr, expected,
+             "no file" if actual is None else "%d" % actual, ctx, last[:700]))
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Live-infobase helpers (used only by the gated test_live_roundtrip.py suite)
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -907,34 +907,51 @@ def poll_disk_lacks(rel_path, substr, timeout=10, ctx=""):
     _fail("expected %s to no longer contain %r [%s]" % (rel_path, substr, ctx))
 
 
-def poll_disk_count(rel_path, substr, expected, timeout=10, ctx=""):
-    """Poll until ONE named fixture file contains substr EXACTLY `expected` times.
+def poll_disk_count(rel_path, substr, expected, timeout=10, stable_for=1.0, ctx=""):
+    """Poll until ONE named fixture file has held substr EXACTLY `expected` times for `stable_for`.
 
-    The COUNT sibling of poll_disk_contains, for the "written exactly once" class of assertion
-    (an idempotent re-add must not duplicate a row). Presence is not enough there: a write that
-    is a no-op IN THE MODEL still force-exports, so the file is rewritten, and a bare
-    `read_disk(f).count(x) == n` can land mid-rewrite and read 0 - failing with "must NOT
-    duplicate", which describes the exact opposite of what happened. Waiting for the count makes
-    the assertion say what it means, and a real duplicate still fails (the count settles at 2 and
-    never reaches `expected`).
+    The COUNT sibling of poll_disk_contains, for the "written exactly once" class of assertion (an
+    idempotent re-add must not duplicate a row), where presence is not enough: the count itself is
+    the claim, so the failure message has to carry the count - a bare
+    `read_disk(f).count(x) == n` reports neither the number it saw nor the file, and "must NOT
+    duplicate" then describes a count of 0 just as readily as a count of 2.
 
-    A missing file keeps polling: the export may not have created it yet."""
+    WHY THE DWELL, and not "return on the first matching read": in the case this exists for, the
+    expected count is ALREADY true before the call under test - the row was written by the previous
+    step. A first-sample poll is therefore satisfied by the PRE-call contents and never observes
+    what the call did, so a regression that eventually writes a second row would pass. Requiring the
+    count to HOLD for `stable_for` closes that: a late duplicate resets the dwell, the count settles
+    at 2, `expected` is never reached again and the call fails with the count it actually saw.
+
+    This is a dwell, not a proof that an export happened - the write under test may legitimately be
+    a no-op that rewrites nothing, so demanding evidence of a rewrite would fail those cases
+    spuriously. Pick `stable_for` longer than the export lag you care about.
+
+    A missing file keeps polling (and resets the dwell): the export may not have created it yet."""
     full = os.path.join(PROJECT_DIR, rel_path)
     deadline = time.time() + timeout
     last = ""
     actual = None
+    stable_since = None
     while time.time() < deadline:
         try:
             with open(full, encoding="utf-8", errors="replace") as f:
                 last = f.read()
             actual = last.count(substr)
-            if actual == expected:
-                return
         except FileNotFoundError:
             last = "(file does not exist yet)"
-        time.sleep(0.5)
-    _fail("expected %s to contain %r exactly %d time(s), last saw %s [%s]; it holds:\n%s"
-          % (rel_path, substr, expected,
+            actual = None
+        if actual == expected:
+            if stable_since is None:
+                stable_since = time.time()
+            if time.time() - stable_since >= stable_for:
+                return
+        else:
+            stable_since = None
+        time.sleep(0.1)
+    _fail("expected %s to contain %r exactly %d time(s) held for %.1fs, last saw %s [%s]; "
+          "it holds:\n%s"
+          % (rel_path, substr, expected, stable_for,
              "no file" if actual is None else "%d" % actual, ctx, last[:700]))
 
 

--- a/tests/e2e/tools/test_modify_metadata_subsystem.py
+++ b/tests/e2e/tools/test_modify_metadata_subsystem.py
@@ -40,9 +40,9 @@ from harness import (
     assert_error_quality,
     assert_tree_unchanged,
     tree_snapshot,
-    poll_diff_contains,
+    poll_disk_contains,
+    poll_disk_count,
     poll_disk_lacks,
-    read_disk,
     wait_for_project_ready,
     e2e_test,
     E2ESkip,
@@ -115,8 +115,10 @@ def test_subsystem_content_add_idempotent_remove():
     # (persisted=false would mean the change is silently discarded on a refresh / clean_project).
     assert add.structured.get("persisted") is True, \
         "the content change must persist to disk, not commit in-memory only: %r" % (add.structured,)
-    # ON-DISK: the object FQN lands in the subsystem's OWN .mdo <content> block.
-    poll_diff_contains(token,
+    # ON-DISK: the object FQN lands in the subsystem's OWN .mdo <content> block. Waited on THAT
+    # file, not on the diff: a diff-wide poll is satisfied by any changed file, so it can release
+    # while the .mdo this test reads is still being written.
+    poll_disk_contains(_subsystem_mdo(sub), token,
                        ctx="the added object must land in the subsystem's <content> block on disk")
 
     # (2) IDEMPOTENT re-add (a plain ref carries no flag) -> nothing added, no duplicate row.
@@ -130,8 +132,14 @@ def test_subsystem_content_add_idempotent_remove():
         "a flagless re-add of a listed object must be a pure no-op: %r" % (again.structured,)
     # Exactly ONE content entry references the object on disk (the added==0 above already proves the
     # re-add created no new item; this pins it on disk).
-    assert read_disk(_subsystem_mdo(sub)).count(token) == 1, \
-        "the idempotent re-add must NOT duplicate the object in the subsystem .mdo"
+    #
+    # WAITED, not read outright: the re-add is a no-op in the MODEL but still force-exports, so the
+    # .mdo is rewritten by the call above. A bare read here lands mid-rewrite and sees 0 occurrences
+    # - which failed as "must NOT duplicate", the exact opposite of what happened, and is why this
+    # was filed as a flake for weeks (issue #370). A real duplicate still fails: the count settles
+    # at 2 and never reaches 1.
+    poll_disk_count(_subsystem_mdo(sub), token, 1,
+                    ctx="the idempotent re-add must NOT duplicate the object in the subsystem .mdo")
 
     # (3) REMOVE -> the object is detached from the content.
     rem = call("modify_metadata", {
@@ -170,7 +178,7 @@ def test_subsystem_content_russian_token():
     assert_ok(r, "add a member addressed by the Russian type tokens")
     assert _content_counts(r, "subsystem content RU add").get("added") == 1, \
         "the bilingual tokens must resolve the same subsystem/member and add it: %r" % (r.structured,)
-    poll_diff_contains(_content_token(const_fqn),
+    poll_disk_contains(_subsystem_mdo(sub), _content_token(const_fqn),
                        ctx="the Russian-token object must serialize to the canonical Constant FQN")
 
 
@@ -279,11 +287,14 @@ def test_subsystem_content_nested():
         "exactly one object must be added to the nested child: %r" % (add_en.structured,)
     assert add_en.structured.get("persisted") is True, \
         "the nested content change must persist to disk, not commit in-memory only: %r" % (add_en.structured,)
+    # Waited on the CHILD's own file: this assertion is about THAT file specifically (it is the whole
+    # point of the test), so a diff-wide poll - satisfied by any of the several files this write
+    # touches - can release before the child .mdo exists.
     token_en = _content_token(const_en_fqn)
-    poll_diff_contains(token_en, ctx="the nested child's content must flush to disk")
-    assert token_en in read_disk(child_mdo), \
-        "the added object must land in the CHILD subsystem's OWN .mdo (%s), proving the nested " \
-        "force-export FQN resolved and persisted: %r" % (child_mdo, add_en.structured)
+    poll_disk_contains(child_mdo, token_en,
+                       ctx="the added object must land in the CHILD subsystem's OWN .mdo (%s), "
+                           "proving the nested force-export FQN resolved and persisted: %r"
+                           % (child_mdo, add_en.structured))
 
     # (2) ADD via a RUSSIAN non-leading type token (Subsystem.Subsystem.Подсистема.Child) -> the
     #     same child .mdo. This is exactly the mixed-language FQN whose export key must come from BM
@@ -299,8 +310,7 @@ def test_subsystem_content_nested():
         "the mixed-language nested change must persist (the export key must be canonicalized): %r" \
         % (add_ru.structured,)
     token_ru = _content_token(const_ru_fqn)
-    poll_diff_contains(token_ru, ctx="the Russian-nested-token content must flush to disk")
-    assert token_ru in read_disk(child_mdo), \
-        "the object added via a Russian non-leading type token must land in the CHILD's OWN .mdo " \
-        "(%s), proving the mixed-language nested FQN was canonicalized for force-export: %r" \
-        % (child_mdo, add_ru.structured)
+    poll_disk_contains(child_mdo, token_ru,
+                       ctx="the object added via a Russian non-leading type token must land in the "
+                           "CHILD's OWN .mdo (%s), proving the mixed-language nested FQN was "
+                           "canonicalized for force-export: %r" % (child_mdo, add_ru.structured))


### PR DESCRIPTION
Closes #370.

## Что было

`modify_metadata::test_subsystem_content_add_idempotent_remove` неделями краснел в CI одной и той же строкой:

```
[ERROR] the idempotent re-add must NOT duplicate the object in the subsystem .mdo
```

Сообщение не печатает **ни фактическое число вхождений, ни файл**. А два противоположных диагноза дают ровно эту строку:

- `count == 2` — настоящий дубликат, **дефект продукта**;
- `count == 0` — файл не в ожидаемом состоянии, **дефект теста**.

Поэтому его и записывали во «флейки»: ни один прогон не давал возможности их различить, а в случае `count == 0` текст утверждает буквально обратное произошедшему. Утверждение о количестве, которое не печатает количество, — это предикат, чей режим сбоя неотличим от другого режима сбоя.

## Что сделано

1. Новый `poll_disk_count(rel_path, substr, expected, …)` в `harness.py`, рядом с `poll_disk_contains` / `poll_disk_lacks`: ждёт **заданное число** вхождений, при неудаче печатает фактическое число и содержимое файла. Настоящий дубликат по-прежнему падает (счётчик встаёт на 2 и до 1 не доходит) — но теперь с диагнозом.
2. Все четыре утверждения о содержимом **конкретного** `.mdo` переведены с `poll_diff_contains` на ожидание того самого файла. `poll_diff_contains` удовлетворяется **любым** изменившимся файлом; `poll_disk_contains` появился в #318 ровно для этого класса, и в этом файле не использовался **ни разу** — при том что соседний `poll_disk_lacks` в нём уже применялся, то есть «пропало» ждали по файлу, а «появилось» — по всему диффу.

После правки в файле не осталось ни одного `poll_diff_contains` и ни одного `read_disk`.

## Чего этот PR НЕ утверждает

**Он не заявляется как лекарство от перемежаемости — механизм не доказан.** Моя гипотеза («повторное добавление — no-op в модели, но всё равно вызывает `forceExportToDisk`, и чтение попадает в момент перезаписи») **не воспроизвелась**: проба, повторяющая шаги теста и непрерывно опрашивающая файл ~3 с сразу после повторного добавления, за 6 раундов **ни разу** не увидела счётчик, отличный от 1. Значит экспорт либо атомарен, либо его нет.

8 прогонов среза `subsystem_content` с правкой — 80/80 зелёных. Но это **не** доказательство отсутствия гонки: базовая версия локально тоже давала 8/8, и на грязном воркспейсе падало вообще другое утверждение. Выдавать «прошло 8 раз» за доказательство я не буду.

Проверяемая ценность правки в другом: **следующее падение назовёт число** — `0` или `2` — и тем самым назовёт причину. Под это в ишью заведён отдельный пункт acceptance criteria.

## Второй режим падения: рассмотрен и сознательно отложен

У этого теста есть **второй**, отдельный режим — «Subsystem not found» сразу после сидов. Это **не** дисковая гонка: `_create_ok` уже вызывает `wait_for_project_ready()`, но на утяжелённой модели ожидание сдаётся раньше, чем объект становится видимым.

Напрашивающееся продолжение — опрашивать **модель** до появления объекта («у каждого чтения своё ожидание», но на уровне модели). **Сюда оно сознательно НЕ включено**, по трём причинам:

1. Режим **не воспроизводится на чистой фикстуре** — 0 раз за 16 прогонов. Правка общего помощника делалась бы по гипотезе, а не по наблюдаемому дефекту — ровно та ошибка, которую я в этом же PR поймал у себя с гипотезой об экспорте.
2. Правка `_create_ok` задевает **все** тесты файла: цена ошибки высокая, а доказательства нет — воспроизвести исходный режим стабильно не вышло, значит и проверить правку нечем. Пин без способа покраснеть вакуумен.
3. Этот PR как раз **даёт инструмент**: если режим вернётся, падение придёт с числом и содержимым файла.

**Критерий возврата:** повторение сбоя на чистой фикстуре с новым диагностическим сообщением. Тогда чиним по факту, а не по догадке.

## Что #364 ни при чём

- `git log f3a8e3b6..932a99f3` — **один** коммит, `git diff` — **9 файлов**, среди них нет ни `ModifyMetadataTool.java`, ни `ReferenceMembershipWriter.java`: код идемпотентности между зелёным и красным побайтово одинаков.
- На стенде в одинаковых условиях: **8/8 с #364** и **8/8 без #364** (обе сборки подтверждены anti-stale — маркер `malformedSegmentError` есть только в master-jar).
- ⚠️ Первые 5 прогонов дали 0/5, но на **грязном воркспейсе** и с **другим** текстом падения («Subsystem not found» после сидов). Сверять надо текст падения, а не факт.
- Косвенная связь есть: до #364 `test_subsystem_content_nested` пропускался (`E2ESkip`), теперь исполняется — прогон удлинился, два ранее спавших утверждения включились. Оба переведены на пофайловое ожидание в этом же PR.
