### PR TITLE
findItemIn: обход только персистентных containment'ов формы (#350)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
@@ -63,6 +63,7 @@ import com.ditrix.edt.mcp.server.utils.FormValidationException;
 import com.ditrix.edt.mcp.server.utils.MetadataNodeResolver;
 import com.ditrix.edt.mcp.server.utils.MetadataPathResolver;
 import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils;
+import com.ditrix.edt.mcp.server.utils.PersistedContents;
 import com.ditrix.edt.mcp.server.utils.PredefinedWriter;
 import com.ditrix.edt.mcp.server.utils.XdtoWriteException;
 import com.ditrix.edt.mcp.server.utils.XdtoWriter;
@@ -2414,37 +2415,16 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
 
     /**
      * Pushes {@code parent}'s PERSISTED contained objects so they pop in metamodel order (so the walk
-     * above stays depth-first, left to right).
+     * above stays depth-first, left to right). Which children count as persisted - and why the
+     * derived / transient question is asked before the value is read - is
+     * {@link PersistedContents}.
      *
      * @param parent the object whose containments to follow
      * @param pending the traversal stack
      */
     private static void pushPersistedChildren(EObject parent, Deque<EObject> pending)
     {
-        List<EObject> children = new ArrayList<>();
-        for (EReference reference : parent.eClass().getEAllReferences())
-        {
-            // Derived / transient BEFORE eGet: a derived feature can compute a whole model on read.
-            if (!reference.isContainment() || reference.isDerived() || reference.isTransient())
-            {
-                continue;
-            }
-            Object value = parent.eGet(reference);
-            if (value instanceof List<?>)
-            {
-                for (Object child : (List<?>)value)
-                {
-                    if (child instanceof EObject)
-                    {
-                        children.add((EObject)child);
-                    }
-                }
-            }
-            else if (value instanceof EObject)
-            {
-                children.add((EObject)value);
-            }
-        }
+        List<EObject> children = PersistedContents.of(parent);
         for (int i = children.size() - 1; i >= 0; i--)
         {
             pending.push(children.get(i));

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -7,9 +7,11 @@
 package com.ditrix.edt.mcp.server.utils;
 
 import java.lang.reflect.Method;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -3317,7 +3319,7 @@ public final class FormElementWriter
     }
 
     /**
-     * Finds a form item by name anywhere in the form-item tree (the same all-containment walk
+     * Finds a form item by name anywhere in the form-item tree (the same persisted-containment walk
      * {@code findItem} uses: items, command bars, context menus, tooltips), REJECTING an ambiguous
      * name (more than one match) with a clear error rather than silently picking the first match.
      * Returns the unique match, or {@code null} when none exists.
@@ -3339,21 +3341,24 @@ public final class FormElementWriter
         return matches.isEmpty() ? null : matches.get(0);
     }
 
-    /** Collects every {@code FormItem} in the tree whose name matches (case-insensitive). */
+    /**
+     * Collects every {@code FormItem} in the AUTHORED tree whose name matches (case-insensitive),
+     * over the same persisted-containment walk (and for the same reasons) as {@link #findItemIn} -
+     * so the ambiguity verdict is passed on exactly the items the by-name search can return.
+     */
     private static void collectItemsByName(EObject container, String name, EClass formItem,
         List<EObject> out)
     {
-        for (EObject child : container.eContents())
+        Deque<EObject> pending = new ArrayDeque<>();
+        pushFormItems(container, formItem, pending);
+        while (!pending.isEmpty())
         {
-            if (!formItem.isInstance(child))
+            EObject item = pending.pop();
+            if (name.equalsIgnoreCase(stringFeature(item, FEATURE_NAME)))
             {
-                continue;
+                out.add(item);
             }
-            if (name.equalsIgnoreCase(stringFeature(child, FEATURE_NAME)))
-            {
-                out.add(child);
-            }
-            collectItemsByName(child, name, formItem, out);
+            pushFormItems(item, formItem, pending);
         }
     }
 
@@ -5994,11 +5999,28 @@ public final class FormElementWriter
     }
 
     /**
-     * Depth-first search of ALL contained {@code FormItem}s for an item by its (form-wide unique)
-     * programmatic name. Walks every containment that holds form items - the {@code items} tree, the
-     * auto command bars (form- and table-level), context menus, extended tooltips - not just
-     * {@code items}, by filtering {@code eContents()} to {@code FormItem} instances (the same filter
-     * {@code nextItemId} uses).
+     * Depth-first search of the AUTHORED {@code FormItem} tree for an item by its (form-wide unique)
+     * programmatic name. Walks every PERSISTED containment that holds form items - the {@code items}
+     * tree, the {@code autoCommandBar} (form- and table-level), context menus, extended tooltips, the
+     * table additions - by filtering {@link PersistedContents} to {@code FormItem} instances.
+     *
+     * <p>Deliberately NOT {@code eContents()}: that list evaluates the derived and transient
+     * containments too, and in this metamodel they are computations, not empty slots. Measured on an
+     * EDT 2026.2 catalog item form, the computed containments across the whole item tree handed back
+     * 24 objects - the BSL {@code ContextDef}, the 22 inferred standard commands, the global
+     * command-source marker - and not one of them was a {@code FormItem}.</p>
+     *
+     * <p>That is one form, not a proof. What makes the narrowing safe in general is PERSISTENCE: a
+     * form write lands in {@code Form.form}, so an element the model does not persist - the
+     * layouter-only {@code topCommandBar} / {@code bottomCommandBar} / {@code fABCommandBar} and the
+     * {@code SelectedItemsActionsPanel} / {@code RowActionsPanel} pair, should EDT ever fill them -
+     * is one no caller could have created and no edit could keep. Resolving such an element would
+     * only make a vanishing write look successful (issue #350).</p>
+     *
+     * <p>Traversal is an explicit stack, not recursion - a {@code StackOverflowError} is an
+     * {@link Error} no {@code catch (Exception)} above would stop. It carries NO node budget on
+     * purpose: a truncated search would answer "not found" for an item that exists, and the callers
+     * turn that into a duplicate name or a wrong-target edit.</p>
      */
     private static EObject findItem(EObject root, String name)
     {
@@ -6012,23 +6034,40 @@ public final class FormElementWriter
 
     private static EObject findItemIn(EObject container, String name, EClass formItem)
     {
-        for (EObject child : container.eContents())
+        Deque<EObject> pending = new ArrayDeque<>();
+        pushFormItems(container, formItem, pending);
+        while (!pending.isEmpty())
         {
-            if (!formItem.isInstance(child))
+            EObject item = pending.pop();
+            if (name.equalsIgnoreCase(stringFeature(item, FEATURE_NAME)))
             {
-                continue;
+                return item;
             }
-            if (name.equalsIgnoreCase(stringFeature(child, FEATURE_NAME)))
-            {
-                return child;
-            }
-            EObject nested = findItemIn(child, name, formItem);
-            if (nested != null)
-            {
-                return nested;
-            }
+            pushFormItems(item, formItem, pending);
         }
         return null;
+    }
+
+    /**
+     * Pushes the {@code FormItem}s among {@code parent}'s PERSISTED children so they pop in metamodel
+     * order, keeping the walks above depth-first, left to right. The single place both form-item
+     * searches learn what a child is, so they cannot drift apart.
+     *
+     * @param parent the object whose containments to follow
+     * @param formItem the {@code FormItem} EClass of the form instance's own EPackage
+     * @param pending the traversal stack
+     */
+    private static void pushFormItems(EObject parent, EClass formItem, Deque<EObject> pending)
+    {
+        List<EObject> children = PersistedContents.of(parent);
+        for (int i = children.size() - 1; i >= 0; i--)
+        {
+            EObject child = children.get(i);
+            if (formItem.isInstance(child))
+            {
+                pending.push(child);
+            }
+        }
     }
 
     private static EObject findByName(EList<EObject> list, String name)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -667,6 +667,15 @@ public final class FormElementWriter
      * for a name that is not a column; an item that predates the retype must not be left in the exact
      * shape the creator forbids (issue #295 review).</p>
      *
+     * <p>Scans the PERSISTED descendants only. What this guard exists to prevent is a dangling
+     * binding in the SAVED form, and a path that only a computed containment leads to cannot become
+     * one: in this metamodel those containments are {@code transient}, so the element is never
+     * written to {@code Form.form} and is recomputed after any edit. Refusing on such a match would
+     * be worse than useless - the caller is told to delete or re-point an element that
+     * {@code findFormItem} no longer addresses at all, an error they cannot act on. (The exact rule,
+     * and why {@code derived} alone would not have justified this, is on
+     * {@link PersistedContents#of}.) Issue #350.</p>
+     *
      * @param attribute the form attribute about to be retyped
      * @return the offending item names, empty when nothing binds below it
      */
@@ -690,12 +699,14 @@ public final class FormElementWriter
             return broken;
         }
         List<String> columns = attributeColumnNames(attribute);
-        // eAllContents, not a hand-rolled recursion: it visits the WHOLE form without a depth budget
-        // that could silently stop before the item that would have blocked the retype, and without a
-        // StackOverflowError on a pathological tree.
-        for (TreeIterator<EObject> it = formModel.eAllContents(); it.hasNext();)
+        // PersistedContents.descendants, not eAllContents and not a hand-rolled recursion: it keeps
+        // everything the old walk gave here - EVERY descendant regardless of EClass (a dataPath can
+        // sit on an unnamed property holder, so a form-item filter would lose real matches),
+        // depth-first in metamodel order, no depth budget that could silently stop before the item
+        // that would have blocked the retype, and no StackOverflowError on a pathological tree - and
+        // drops only the computed branches, which cannot hold an authored binding.
+        for (EObject item : PersistedContents.descendants(formModel))
         {
-            EObject item = it.next();
             String[] segments = dataPathSegments(item);
             if (segments.length > prefix.size() && startsWithIgnoreCase(segments, prefix)
                 && !containsIgnoreCase(columns, segments[prefix.size()]))
@@ -713,6 +724,10 @@ public final class FormElementWriter
      * {@link #createTable} refuses to build: without this the tool was stricter about CREATING a form
      * than about editing one into the same state (issue #295 review).
      *
+     * <p>Scans the PERSISTED descendants only, for the reason spelled out on
+     * {@link #itemsBoundBelowAttribute}: a computed table is not an authored binding, so skipping it
+     * cannot leave a stranded one in the saved form (issue #350).</p>
+     *
      * @param attribute the form attribute about to be retyped
      * @return the offending item names, empty when nothing needs its rows
      */
@@ -729,9 +744,10 @@ public final class FormElementWriter
         {
             return consumers;
         }
-        for (TreeIterator<EObject> it = formModel.eAllContents(); it.hasNext();)
+        // The EClass test below picks the MATCHES; the walk itself must still descend through
+        // everything (a table lives inside groups), so it filters by persistence, never by type.
+        for (EObject item : PersistedContents.descendants(formModel))
         {
-            EObject item = it.next();
             String[] segments = dataPathSegments(item);
             // EQUAL to the address, not merely starting with it: a table bound BELOW the member does
             // not consume the member's own rows.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PersistedContents.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PersistedContents.java
@@ -1,0 +1,83 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+
+/**
+ * The PERSISTED contained children of an EMF object - the containments the model would write to
+ * disk - in metamodel order.
+ *
+ * <p>{@link EObject#eContents()} is deliberately NOT that list. EMF builds it over
+ * <em>every</em> containment reference of the object's {@code EClass} and evaluates each one
+ * ({@code eIsSet}, then {@code eGet}); its own inclusion filter accepts derived and transient
+ * features unconditionally. In the EDT models such a containment is not an empty slot but a
+ * computation. Measured on an EDT 2026.2 form, the form root alone answers three of them:
+ * {@code Form.formContext} hands back the whole BSL {@code ContextDef} (its types, properties,
+ * methods, parameters and events), {@code FormStandardCommandSource.commands} infers the 22
+ * standard commands, and {@code commandPanelGlobalCommandSource} materializes its marker - none
+ * of which is authored and none of which reaches {@code Form.form}.</p>
+ *
+ * <p>Hence the ordering rule this class exists to enforce: the feature is asked whether it is
+ * derived or transient <b>before</b> its value is read. Asking afterwards is no protection at
+ * all - the model has already been computed by the time the answer arrives.</p>
+ */
+public final class PersistedContents
+{
+    private PersistedContents()
+    {
+    }
+
+    /**
+     * The persisted contained children of {@code parent}, in metamodel order (declaration order of
+     * the containment references, then list order within each).
+     *
+     * <p>Non-containment references are skipped, as are derived and transient containments - the
+     * check runs BEFORE {@code eGet}, so a computed containment is never triggered. Only ordinary
+     * containment {@code EReference}s are followed: a containment held through a {@code FeatureMap}
+     * (which {@code eContents()} would also yield) is not, and no EDT model this serves uses one.</p>
+     *
+     * @param parent the object whose containments to follow; {@code null} yields an empty list
+     * @return a fresh, caller-owned list of the persisted children (never {@code null})
+     */
+    public static List<EObject> of(EObject parent)
+    {
+        List<EObject> children = new ArrayList<>();
+        if (parent == null)
+        {
+            return children;
+        }
+        for (EReference reference : parent.eClass().getEAllReferences())
+        {
+            // Derived / transient BEFORE eGet: a derived feature can compute a whole model on read.
+            if (!reference.isContainment() || reference.isDerived() || reference.isTransient())
+            {
+                continue;
+            }
+            Object value = parent.eGet(reference);
+            if (value instanceof List<?>)
+            {
+                for (Object child : (List<?>)value)
+                {
+                    if (child instanceof EObject)
+                    {
+                        children.add((EObject)child);
+                    }
+                }
+            }
+            else if (value instanceof EObject)
+            {
+                children.add((EObject)value);
+            }
+        }
+        return children;
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PersistedContents.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PersistedContents.java
@@ -6,8 +6,12 @@
 
 package com.ditrix.edt.mcp.server.utils;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
@@ -16,11 +20,15 @@ import org.eclipse.emf.ecore.EReference;
  * The PERSISTED contained children of an EMF object - the containments the model would write to
  * disk - in metamodel order.
  *
- * <p>{@link EObject#eContents()} is deliberately NOT that list. EMF builds it over
- * <em>every</em> containment reference of the object's {@code EClass} and evaluates each one
- * ({@code eIsSet}, then {@code eGet}); its own inclusion filter accepts derived and transient
- * features unconditionally. In the EDT models such a containment is not an empty slot but a
- * computation. Measured on an EDT 2026.2 form, the form root alone answers three of them:
+ * <p>{@link EObject#eContents()} is deliberately NOT that list. EMF builds it over every ordinary
+ * containment reference of the object's {@code EClass} and evaluates each one ({@code eIsSet}, then
+ * {@code eGet}); its own inclusion filter accepts derived and transient features without asking
+ * about either flag. (The exception is a reference assigned to a {@code FeatureMap} group: EMF
+ * yields those children through the map instead, and the grouped reference itself is not evaluated.
+ * The models this serves use no such grouping - see {@link #of}.)</p>
+ *
+ * <p>In the EDT models such a containment is not an empty slot but a computation. Measured on an
+ * EDT 2026.2 form, the form root alone answers three of them:
  * {@code Form.formContext} hands back the whole BSL {@code ContextDef} (its types, properties,
  * methods, parameters and events), {@code FormStandardCommandSource.commands} infers the 22
  * standard commands, and {@code commandPanelGlobalCommandSource} materializes its marker - none
@@ -44,6 +52,17 @@ public final class PersistedContents
      * check runs BEFORE {@code eGet}, so a computed containment is never triggered. Only ordinary
      * containment {@code EReference}s are followed: a containment held through a {@code FeatureMap}
      * (which {@code eContents()} would also yield) is not, and no EDT model this serves uses one.</p>
+     *
+     * <p>Precision about the two flags, because they do different jobs and are NOT interchangeable.
+     * What keeps a feature out of the saved file is {@code transient}; {@code derived} on its own
+     * only says the value is computed, and a derived-but-not-transient feature would still be
+     * serialized. Both are skipped here, for different reasons: {@code transient} because such a
+     * child is not part of the persisted model, {@code derived} because reading it is the very cost
+     * this class exists to avoid. They are also not redundant - dropping the {@code transient} test
+     * would skip nothing at all in the form metamodel, where every computed containment is declared
+     * {@code transient} with {@code isDerived() == false}. What the metamodel happens not to contain
+     * is the third combination, a derived containment that IS serialized; one appearing would need
+     * this rule revisited.</p>
      *
      * @param parent the object whose containments to follow; {@code null} yields an empty list
      * @return a fresh, caller-owned list of the persisted children (never {@code null})
@@ -79,5 +98,72 @@ public final class PersistedContents
             }
         }
         return children;
+    }
+
+    /**
+     * Every PERSISTED descendant of {@code root}, depth-first in metamodel order - what
+     * {@link EObject#eAllContents()} yields, minus the objects only a computed containment leads to
+     * (and, as {@link #of} notes, minus anything held through a {@code FeatureMap}), and without
+     * evaluating those containments at all.
+     *
+     * <p>Filters NOTHING by EClass, deliberately. A caller that scans for a feature rather than for
+     * a kind - a bound {@code dataPath}, an allocated {@code id} - has to see the unnamed property
+     * holders too, so narrowing this to any one type would lose legitimate matches.</p>
+     *
+     * <p>LAZY, like the tree iterator it stands in for: a node is expanded when the walk reaches it,
+     * not up front. What is held at any moment is the child list of each node on the current path -
+     * bounded by fan-out times depth - and not one entry per descendant, which a materialized result
+     * would be. It is NOT free, though: each visited node's persisted children are copied into a
+     * fresh list once, where {@code eAllContents()} iterates the live {@code EList} in place.</p>
+     *
+     * <p>An explicit iterator stack, not recursion - a {@code StackOverflowError} is an
+     * {@link Error} that no {@code catch (Exception)} above would stop. No node budget either: the
+     * callers use this to decide whether something blocks an edit, and a walk that stopped early
+     * would answer "nothing blocks it" about a form it never finished reading.</p>
+     *
+     * @param root the object to descend from; it is NOT itself included, and {@code null} yields an
+     *     empty sequence
+     * @return the descendants, iterable once per call (never {@code null})
+     */
+    public static Iterable<EObject> descendants(EObject root)
+    {
+        return () -> new DescendantIterator(root);
+    }
+
+    /** Depth-first pre-order over the persisted containments, expanding a node only when reached. */
+    private static final class DescendantIterator implements Iterator<EObject>
+    {
+        private final Deque<Iterator<EObject>> levels = new ArrayDeque<>();
+
+        DescendantIterator(EObject root)
+        {
+            if (root != null)
+            {
+                levels.push(of(root).iterator());
+            }
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            while (!levels.isEmpty() && !levels.peek().hasNext())
+            {
+                levels.pop();
+            }
+            return !levels.isEmpty();
+        }
+
+        @Override
+        public EObject next()
+        {
+            if (!hasNext())
+            {
+                throw new NoSuchElementException();
+            }
+            EObject node = levels.peek().next();
+            // Descend BEFORE the siblings are resumed - that is what makes the order depth-first.
+            levels.push(of(node).iterator());
+            return node;
+        }
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -4495,4 +4495,214 @@ public class FormElementWriterTest
             return reference;
         }
     }
+
+    // ============ the retype guards scan PERSISTED descendants only (issue #350) ============
+
+    @Test
+    public void testRetypeGuardStillSeesEveryAuthoredBinding()
+    {
+        // The side that must not move. This guard scans for a FEATURE (a bound dataPath), not for a
+        // kind, so it may not be narrowed to the form-item tree: a data path also sits on unnamed
+        // property holders, and a FormItem-filtered walk would drop them silently. The column
+        // exemption (a path whose next segment IS a column is legitimate) must survive too.
+        RetypeGuardModel model = new RetypeGuardModel();
+
+        assertEquals("both authored bindings, in metamodel order, and nothing else", //$NON-NLS-1$
+            Arrays.asList("QtyField", "PropertyHolder"), //$NON-NLS-1$ //$NON-NLS-2$
+            FormElementWriter.itemsBoundBelowAttribute(model.rows));
+    }
+
+    @Test
+    public void testRetypeGuardIgnoresBindingsUnderAComputedContainment()
+    {
+        // A path only a computed containment leads to is not authored: it never reaches Form.form
+        // and is recomputed after any edit, so passing it over cannot leave a dangling binding in
+        // the saved file - which is the only thing this guard exists to prevent. Refusing on it
+        // would hand the caller an error they cannot act on, since the by-name resolver no longer
+        // addresses that element at all.
+        RetypeGuardModel model = new RetypeGuardModel();
+
+        assertFalse("a binding under a computed containment must not block the retype", //$NON-NLS-1$
+            FormElementWriter.itemsBoundBelowAttribute(model.rows).contains("GhostField")); //$NON-NLS-1$
+        assertEquals("and the computed containment must not even be read", //$NON-NLS-1$
+            0, model.form.reads);
+    }
+
+    @Test
+    public void testRowConsumerGuardStillSeesTheAuthoredTable()
+    {
+        RetypeGuardModel model = new RetypeGuardModel();
+
+        assertEquals(Collections.singletonList("RowsTable"), //$NON-NLS-1$
+            FormElementWriter.rowConsumersBoundToAttribute(model.rows));
+    }
+
+    @Test
+    public void testRowConsumerGuardIgnoresAComputedTable()
+    {
+        RetypeGuardModel model = new RetypeGuardModel();
+
+        assertFalse("a computed table does not consume the attribute's authored rows", //$NON-NLS-1$
+            FormElementWriter.rowConsumersBoundToAttribute(model.rows).contains("GhostTable")); //$NON-NLS-1$
+        assertEquals(0, model.form.reads);
+    }
+
+    /**
+     * A form-shaped dynamic model for the two retype guards: a {@code Rows} attribute with one
+     * {@code Price} column, and bindings of every shape the scan has to judge - one below the
+     * attribute at a NON-column segment (blocks), one at the column itself (legitimate), one on a
+     * plain object that is not a {@code FormItem} at all (blocks, and pins that the walk is not
+     * type-filtered), a {@code Table} bound to the attribute itself (a row consumer), and the same
+     * two offenders hanging off a TRANSIENT containment, reachable no other way.
+     */
+    private static final class RetypeGuardModel
+    {
+        final ComputingEObject form;
+        final EObject rows;
+
+        RetypeGuardModel()
+        {
+            EcoreFactory f = EcoreFactory.eINSTANCE;
+            EPackage pkg = f.createEPackage();
+            pkg.setName("formretype"); //$NON-NLS-1$
+            pkg.setNsPrefix("formretype"); //$NON-NLS-1$
+            pkg.setNsURI("http://ditrix.com/test/formlike-retype"); //$NON-NLS-1$
+
+            EClass dataPath = f.createEClass();
+            dataPath.setName("DataPath"); //$NON-NLS-1$
+            EAttribute segments = f.createEAttribute();
+            segments.setName("segments"); //$NON-NLS-1$
+            segments.setEType(EcorePackage.Literals.ESTRING);
+            segments.setUpperBound(-1);
+            dataPath.getEStructuralFeatures().add(segments);
+
+            EClass formItem = f.createEClass();
+            formItem.setName("FormItem"); //$NON-NLS-1$
+            formItem.setAbstract(true);
+            addName(f, formItem);
+            formItem.getEStructuralFeatures().add(containment(f, "dataPath", dataPath, false)); //$NON-NLS-1$
+
+            EClass formField = f.createEClass();
+            formField.setName("FormField"); //$NON-NLS-1$
+            formField.getESuperTypes().add(formItem);
+
+            EClass table = f.createEClass();
+            table.setName("Table"); //$NON-NLS-1$
+            table.getESuperTypes().add(formItem);
+
+            EClass formGroup = f.createEClass();
+            formGroup.setName("FormGroup"); //$NON-NLS-1$
+            formGroup.getESuperTypes().add(formItem);
+            formGroup.getEStructuralFeatures().add(containment(f, "items", formItem, true)); //$NON-NLS-1$
+
+            // NOT a FormItem, yet it carries a bound data path - the shape a form-item-filtered walk
+            // would lose.
+            EClass propertyHolder = f.createEClass();
+            propertyHolder.setName("PropertyHolder"); //$NON-NLS-1$
+            addName(f, propertyHolder);
+            propertyHolder.getEStructuralFeatures().add(containment(f, "dataPath", dataPath, false)); //$NON-NLS-1$
+
+            EClass column = f.createEClass();
+            column.setName("FormAttributeColumn"); //$NON-NLS-1$
+            addName(f, column);
+
+            EClass attribute = f.createEClass();
+            attribute.setName("FormAttribute"); //$NON-NLS-1$
+            addName(f, attribute);
+            attribute.getEStructuralFeatures().add(containment(f, "columns", column, true)); //$NON-NLS-1$
+
+            // Declaration order IS traversal order, so the expected result lists are deterministic.
+            EClass formClass = f.createEClass();
+            formClass.setName("Form"); //$NON-NLS-1$
+            formClass.getEStructuralFeatures().add(containment(f, "items", formItem, true)); //$NON-NLS-1$
+            formClass.getEStructuralFeatures().add(containment(f, "attributes", attribute, true)); //$NON-NLS-1$
+            formClass.getEStructuralFeatures().add(
+                containment(f, "holders", propertyHolder, true)); //$NON-NLS-1$
+            EReference ghost = computedContainment(f, "ghostItems", formItem, false, true); //$NON-NLS-1$
+            formClass.getEStructuralFeatures().add(ghost);
+
+            pkg.getEClassifiers().add(dataPath);
+            pkg.getEClassifiers().add(formItem);
+            pkg.getEClassifiers().add(formField);
+            pkg.getEClassifiers().add(table);
+            pkg.getEClassifiers().add(formGroup);
+            pkg.getEClassifiers().add(propertyHolder);
+            pkg.getEClassifiers().add(column);
+            pkg.getEClassifiers().add(attribute);
+            pkg.getEClassifiers().add(formClass);
+
+            form = new ComputingEObject(formClass, ghost);
+
+            EObject group = new DynamicEObjectImpl(formGroup);
+            setNameOf(group, "Grp"); //$NON-NLS-1$
+            addTo(form, "items", group); //$NON-NLS-1$
+            addTo(group, "items", bound(formField, "QtyField", dataPath, "Rows", "Qty")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            // Bound AT the column - a legitimate path that must stay unreported.
+            addTo(group, "items", bound(formField, "PriceField", dataPath, "Rows", "Price")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            addTo(form, "items", bound(table, "RowsTable", dataPath, "Rows")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+            rows = new DynamicEObjectImpl(attribute);
+            setNameOf(rows, "Rows"); //$NON-NLS-1$
+            EObject price = new DynamicEObjectImpl(column);
+            setNameOf(price, "Price"); //$NON-NLS-1$
+            addTo(rows, "columns", price); //$NON-NLS-1$
+            addTo(form, "attributes", rows); //$NON-NLS-1$
+
+            addTo(form, "holders", //$NON-NLS-1$
+                bound(propertyHolder, "PropertyHolder", dataPath, "Rows", "HolderPath")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+            // Reachable ONLY through the transient containment.
+            form.materialized.add(bound(formField, "GhostField", dataPath, "Rows", "GhostQty")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            form.materialized.add(bound(table, "GhostTable", dataPath, "Rows")); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+
+        /** An object of {@code eClass} named {@code name} and bound to the given path segments. */
+        private static EObject bound(EClass eClass, String name, EClass dataPathClass,
+            String... pathSegments)
+        {
+            EObject object = new DynamicEObjectImpl(eClass);
+            setNameOf(object, name);
+            EObject path = new DynamicEObjectImpl(dataPathClass);
+            @SuppressWarnings("unchecked")
+            List<String> values =
+                (List<String>)path.eGet(dataPathClass.getEStructuralFeature("segments")); //$NON-NLS-1$
+            values.addAll(Arrays.asList(pathSegments));
+            object.eSet(object.eClass().getEStructuralFeature("dataPath"), path); //$NON-NLS-1$
+            return object;
+        }
+
+        private static void setNameOf(EObject object, String name)
+        {
+            object.eSet(object.eClass().getEStructuralFeature("name"), name); //$NON-NLS-1$
+        }
+
+        private static void addName(EcoreFactory f, EClass owner)
+        {
+            EAttribute name = f.createEAttribute();
+            name.setName("name"); //$NON-NLS-1$
+            name.setEType(EcorePackage.Literals.ESTRING);
+            owner.getEStructuralFeatures().add(name);
+        }
+
+        private static EReference containment(EcoreFactory f, String featureName, EClass type,
+            boolean many)
+        {
+            EReference reference = f.createEReference();
+            reference.setName(featureName);
+            reference.setEType(type);
+            reference.setContainment(true);
+            reference.setUpperBound(many ? -1 : 1);
+            return reference;
+        }
+
+        private static EReference computedContainment(EcoreFactory f, String featureName, EClass type,
+            boolean derived, boolean isTransient)
+        {
+            EReference reference = containment(f, featureName, type, true);
+            reference.setDerived(derived);
+            reference.setTransient(isTransient);
+            reference.setVolatile(true);
+            return reference;
+        }
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -35,6 +36,7 @@ import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.impl.DynamicEObjectImpl;
+import org.eclipse.emf.ecore.util.EcoreEList;
 import org.junit.Test;
 
 import com._1c.g5.v8.dt.metadata.mdclass.CommonForm;
@@ -4238,5 +4240,259 @@ public class FormElementWriterTest
         assertTrue(itemLevel.isItemLevel());
         assertEquals("Code", itemLevel.itemName); //$NON-NLS-1$
         assertEquals(Kind.FIELD, FormElementWriter.kindForToken(itemLevel.itemKindToken));
+    }
+
+    // ============ the by-name item search walks PERSISTED containments only (issue #350) ============
+
+    @Test
+    public void testFindFormItemStillFindsEveryAuthoredItem()
+    {
+        // The "other side" of the narrowing: what the search found before it must still find. The
+        // authored items sit at three depths - form root, a nested group, and the group's field -
+        // and each is reached over a PERSISTED containment, so none of them may be lost.
+        GhostModel model = new GhostModel();
+
+        assertSame("a root-level item must still resolve", model.panel, //$NON-NLS-1$
+            FormElementWriter.findFormItem(model.form, "Panel")); //$NON-NLS-1$
+        assertSame("a nested item must still resolve", model.price, //$NON-NLS-1$
+            FormElementWriter.findFormItem(model.form, "Price")); //$NON-NLS-1$
+        assertSame("the search stays case-insensitive", model.price, //$NON-NLS-1$
+            FormElementWriter.findFormItem(model.form, "pRiCe")); //$NON-NLS-1$
+        assertSame("an item under the persisted auto command bar must still resolve", model.barButton, //$NON-NLS-1$
+            FormElementWriter.findFormItem(model.form, "BarButton")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindFormItemNeverReadsAComputedContainment()
+    {
+        // The defect: the walk used eContents(), which EMF builds over EVERY containment of the
+        // EClass - derived and transient included - and evaluates each one (eIsSet, then eGet). In
+        // the form metamodel those are not empty slots but computations: on an EDT 2026.2 catalog
+        // item form the root alone answered three of them with the whole BSL ContextDef, the 22
+        // inferred standard commands and the global command-source marker - none of it authored,
+        // none of it written to Form.form, and all of it rebuilt on every findItem call.
+        GhostModel model = new GhostModel();
+
+        // A MISS forces the whole tree to be walked - the worst case for the traversal.
+        assertNull(FormElementWriter.findFormItem(model.form, "NoSuchItem")); //$NON-NLS-1$
+
+        // 1. The computed branch is not entered: its items are not addressable...
+        assertNull("an item under a transient containment must not be found", //$NON-NLS-1$
+            FormElementWriter.findFormItem(model.form, "RootGhost")); //$NON-NLS-1$
+        assertNull("...nor under a derived one, at any depth", //$NON-NLS-1$
+            FormElementWriter.findFormItem(model.form, "NestedGhost")); //$NON-NLS-1$
+
+        // 2. ...and, the part a "was it found?" assertion cannot show, it is never READ. Asking the
+        // feature AFTER eGet would leave 1. green while the model had already been computed, which
+        // is the whole cost being removed here. Counted on both objects, so a check that only covers
+        // the root cannot pass.
+        assertEquals("the form's computed containment must never be evaluated", //$NON-NLS-1$
+            0, model.form.reads);
+        assertEquals("nor a descendant's", 0, model.panel.reads); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFindUniqueFormItemIgnoresAComputedNamesake()
+    {
+        // findUniqueFormItem walks the same tree to REJECT an ambiguous name. Over eContents() a
+        // computed namesake made the count 2, so a legitimate, uniquely-named authored item was
+        // refused with "ambiguous" - the strict resolver's failure mode is worse than the loose
+        // one's. Over persisted containments only the authored item is a candidate.
+        GhostModel model = new GhostModel();
+
+        assertSame("a computed namesake must not make an authored item ambiguous", model.price, //$NON-NLS-1$
+            FormElementWriter.findUniqueFormItem(model.form, "Price")); //$NON-NLS-1$
+        assertEquals(0, model.form.reads);
+    }
+
+    @Test
+    public void testFindUniqueFormItemStillRejectsTwoAuthoredNamesakes()
+    {
+        // ...while a genuine collision between two PERSISTED items must still be refused: the
+        // narrowing removes computed candidates, not the ambiguity check itself.
+        GhostModel model = new GhostModel();
+        EObject duplicate = new DynamicEObjectImpl(model.field);
+        duplicate.eSet(model.field.getEStructuralFeature("name"), "Price"); //$NON-NLS-1$ //$NON-NLS-2$
+        addTo(model.form, "items", duplicate); //$NON-NLS-1$
+
+        try
+        {
+            FormElementWriter.findUniqueFormItem(model.form, "Price"); //$NON-NLS-1$
+            fail("two authored items with the same name must still be reported as ambiguous"); //$NON-NLS-1$
+        }
+        catch (RuntimeException expected)
+        {
+            assertTrue(expected.getMessage().contains("ambiguous")); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * A dynamic EMF object whose {@code ghostItems} containment behaves like a real derived /
+     * transient form feature: it is not stored, it MATERIALIZES its value on read, and it answers
+     * {@code eIsSet} without consulting any storage. Every read is counted, so a test can assert the
+     * traversal never asked - which a "was the ghost found?" assertion alone cannot show, since a
+     * walk that reads the feature and then discards the result looks identical from outside.
+     */
+    private static final class ComputingEObject extends DynamicEObjectImpl
+    {
+        private final EReference computed;
+        private final List<EObject> materialized = new ArrayList<>();
+        int reads;
+
+        ComputingEObject(EClass eClass, EReference computed)
+        {
+            super(eClass);
+            this.computed = computed;
+        }
+
+        @Override
+        public Object eGet(EStructuralFeature feature, boolean resolve, boolean coreType)
+        {
+            if (feature == computed)
+            {
+                reads++;
+                return new EcoreEList.UnmodifiableEList<EObject>(this, computed, materialized.size(),
+                    materialized.toArray());
+            }
+            return super.eGet(feature, resolve, coreType);
+        }
+
+        @Override
+        public boolean eIsSet(EStructuralFeature feature)
+        {
+            if (feature == computed)
+            {
+                // A derived feature computes to answer this too - hence it counts as a read.
+                reads++;
+                return !materialized.isEmpty();
+            }
+            return super.eIsSet(feature);
+        }
+    }
+
+    /**
+     * A form-shaped dynamic model in which the authored tree and a COMPUTED branch hang off the same
+     * objects, mirroring the real metamodel: {@code items} / {@code autoCommandBar} are persisted,
+     * while {@code ghostItems} stands for {@code FormStandardCommandSource.commands} and the
+     * layouter-only command bars. The form's ghost is TRANSIENT (the shape EDT really uses, with
+     * {@code derived=false}) and the nested group's is DERIVED, so neither flag can be dropped from
+     * the check without a test noticing. One ghost deliberately shares the name of an authored item,
+     * so the ambiguity verdict is exercised as well.
+     */
+    private static final class GhostModel
+    {
+        final EClass field;
+        final ComputingEObject form;
+        final ComputingEObject panel;
+        final EObject price;
+        final EObject barButton;
+
+        GhostModel()
+        {
+            EcoreFactory f = EcoreFactory.eINSTANCE;
+            EPackage pkg = f.createEPackage();
+            pkg.setName("formghost"); //$NON-NLS-1$
+            pkg.setNsPrefix("formghost"); //$NON-NLS-1$
+            pkg.setNsURI("http://ditrix.com/test/formlike-ghost"); //$NON-NLS-1$
+
+            EClass formItem = f.createEClass();
+            formItem.setName("FormItem"); //$NON-NLS-1$
+            formItem.setAbstract(true);
+            EAttribute name = f.createEAttribute();
+            name.setName("name"); //$NON-NLS-1$
+            name.setEType(EcorePackage.Literals.ESTRING);
+            formItem.getEStructuralFeatures().add(name);
+
+            field = f.createEClass();
+            field.setName("FormField"); //$NON-NLS-1$
+            field.getESuperTypes().add(formItem);
+
+            EClass autoCommandBar = f.createEClass();
+            autoCommandBar.setName("AutoCommandBar"); //$NON-NLS-1$
+            autoCommandBar.getESuperTypes().add(formItem);
+            autoCommandBar.getEStructuralFeatures().add(containment(f, "items", formItem, true)); //$NON-NLS-1$
+
+            EClass formGroup = f.createEClass();
+            formGroup.setName("FormGroup"); //$NON-NLS-1$
+            formGroup.getESuperTypes().add(formItem);
+            formGroup.getEStructuralFeatures().add(containment(f, "items", formItem, true)); //$NON-NLS-1$
+            // DERIVED here, TRANSIENT on the form below: the two flags are separate, and a check
+            // that asked about only one would still let the other branch through.
+            EReference groupGhost = computedContainment(f, "ghostItems", formItem, true, false); //$NON-NLS-1$
+            formGroup.getEStructuralFeatures().add(groupGhost);
+
+            EClass formClass = f.createEClass();
+            formClass.setName("Form"); //$NON-NLS-1$
+            formClass.getEStructuralFeatures().add(containment(f, "items", formItem, true)); //$NON-NLS-1$
+            formClass.getEStructuralFeatures().add(
+                containment(f, "autoCommandBar", autoCommandBar, false)); //$NON-NLS-1$
+            // TRANSIENT with derived=false - the shape every computed containment the live EDT form
+            // root answers with actually has (formContext, commands, commandPanelGlobalCommandSource).
+            EReference formGhost = computedContainment(f, "ghostItems", formItem, false, true); //$NON-NLS-1$
+            formClass.getEStructuralFeatures().add(formGhost);
+
+            pkg.getEClassifiers().add(formItem);
+            pkg.getEClassifiers().add(field);
+            pkg.getEClassifiers().add(autoCommandBar);
+            pkg.getEClassifiers().add(formGroup);
+            pkg.getEClassifiers().add(formClass);
+
+            form = new ComputingEObject(formClass, formGhost);
+            panel = new ComputingEObject(formGroup, groupGhost);
+            setName(panel, "Panel"); //$NON-NLS-1$
+            addTo(form, "items", panel); //$NON-NLS-1$
+            price = new DynamicEObjectImpl(field);
+            setName(price, "Price"); //$NON-NLS-1$
+            addTo(panel, "items", price); //$NON-NLS-1$
+
+            // The persisted auto command bar: the writer creates items under it, so it is the proof
+            // that the narrowing is about COMPUTED features, not about "anything outside items".
+            EObject bar = new DynamicEObjectImpl(autoCommandBar);
+            setName(bar, "FormCommandBar"); //$NON-NLS-1$
+            form.eSet(formClass.getEStructuralFeature("autoCommandBar"), bar); //$NON-NLS-1$
+            barButton = new DynamicEObjectImpl(field);
+            setName(barButton, "BarButton"); //$NON-NLS-1$
+            addTo(bar, "items", barButton); //$NON-NLS-1$
+
+            // The computed branch: reachable ONLY through the transient / derived containments.
+            form.materialized.add(namedItem(field, "RootGhost")); //$NON-NLS-1$
+            // ...including one that shadows an authored name, so an over-wide walk reports ambiguity.
+            form.materialized.add(namedItem(field, "Price")); //$NON-NLS-1$
+            panel.materialized.add(namedItem(field, "NestedGhost")); //$NON-NLS-1$
+        }
+
+        private static EObject namedItem(EClass eClass, String itemName)
+        {
+            EObject item = new DynamicEObjectImpl(eClass);
+            setName(item, itemName);
+            return item;
+        }
+
+        private static void setName(EObject item, String itemName)
+        {
+            item.eSet(item.eClass().getEStructuralFeature("name"), itemName); //$NON-NLS-1$
+        }
+
+        private static EReference containment(EcoreFactory f, String featureName, EClass type,
+            boolean many)
+        {
+            EReference reference = f.createEReference();
+            reference.setName(featureName);
+            reference.setEType(type);
+            reference.setContainment(true);
+            reference.setUpperBound(many ? -1 : 1);
+            return reference;
+        }
+
+        /** A containment EMF computes instead of storing, flagged the way the caller asks. */
+        private static EReference computedContainment(EcoreFactory f, String featureName, EClass type,
+            boolean derived, boolean isTransient)
+        {
+            EReference reference = containment(f, featureName, type, true);
+            reference.setDerived(derived);
+            reference.setTransient(isTransient);
+            reference.setVolatile(true);
+            return reference;
+        }
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PersistedContentsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PersistedContentsTest.java
@@ -1,0 +1,249 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.EcoreFactory;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.emf.ecore.impl.DynamicEObjectImpl;
+import org.eclipse.emf.ecore.util.EcoreEList;
+import org.junit.Test;
+
+/**
+ * Pins the contract of {@link PersistedContents}: which contained children it yields, in which
+ * order, and - the point of the class - that a derived or transient containment is recognized as
+ * such BEFORE its value is read.
+ *
+ * <p>The fixture's computed features are real computations, not empty slots: each materializes its
+ * value on read and counts every read, exactly like the EDT models where such a containment hands
+ * back the whole BSL context or infers a standard-command set. A check placed after {@code eGet}
+ * would drop the same children from the result and still pay for them - so the read counter, not
+ * the returned list, is what distinguishes the two.</p>
+ *
+ * <p>Derived and transient are carried by SEPARATE features here. They are not the same flag and
+ * they do not travel together: every computed containment the live EDT form root answers with
+ * ({@code formContext}, {@code commands}, {@code commandPanelGlobalCommandSource}) is
+ * {@code transient} with {@code derived=false}, so a check that only asked about {@code derived}
+ * would skip nothing at all.</p>
+ */
+public class PersistedContentsTest
+{
+    @Test
+    public void testYieldsPersistedChildrenInMetamodelOrder()
+    {
+        Model model = new Model();
+        List<EObject> children = PersistedContents.of(model.parent);
+
+        // 'single' is declared before 'many', and the list keeps its own order inside it.
+        assertEquals(3, children.size());
+        assertSame(model.single, children.get(0));
+        assertSame(model.first, children.get(1));
+        assertSame(model.second, children.get(2));
+    }
+
+    @Test
+    public void testSkipsATransientContainmentWithoutReadingIt()
+    {
+        // The shape the EDT form model actually uses: transient, derived=false.
+        Model model = new Model();
+        List<EObject> children = PersistedContents.of(model.parent);
+
+        assertFalse("a transient containment's children must not be yielded", //$NON-NLS-1$
+            children.contains(model.transientChild));
+        assertEquals("nor may the feature be evaluated at all", //$NON-NLS-1$
+            0, model.parent.readsOf(model.transientRef));
+    }
+
+    @Test
+    public void testSkipsADerivedContainmentWithoutReadingIt()
+    {
+        // ...and the other flag on its own, so neither check can be dropped unnoticed.
+        Model model = new Model();
+        List<EObject> children = PersistedContents.of(model.parent);
+
+        assertFalse("a derived containment's children must not be yielded", //$NON-NLS-1$
+            children.contains(model.derivedChild));
+        assertEquals("nor may the feature be evaluated at all", //$NON-NLS-1$
+            0, model.parent.readsOf(model.derivedRef));
+    }
+
+    @Test
+    public void testSkipsNonContainmentReferencesWithoutReadingThem()
+    {
+        // The cross-reference points at a real object, but a reference is not a child - and, like
+        // the computed containments, it is refused before it is read rather than read and dropped.
+        Model model = new Model();
+
+        assertFalse(PersistedContents.of(model.parent).contains(model.referenced));
+        assertEquals(0, model.parent.readsOf(model.crossReference));
+    }
+
+    @Test
+    public void testNullParentYieldsAFreshEmptyList()
+    {
+        List<EObject> children = PersistedContents.of(null);
+        assertTrue(children.isEmpty());
+        // The documented contract is a caller-OWNED list, so the null branch may not hand back a
+        // shared immutable one: a caller that collects into the result would fail only there.
+        children.add(new DynamicEObjectImpl(EcorePackage.Literals.ECLASS));
+        assertEquals(1, children.size());
+    }
+
+    /**
+     * A dynamic object whose computed containments are materialized on read, counting every read
+     * (through {@code eGet} and through {@code eIsSet} alike - a derived feature computes to answer
+     * either one).
+     */
+    private static final class ComputingEObject extends DynamicEObjectImpl
+    {
+        private final Map<EStructuralFeature, List<EObject>> computed = new HashMap<>();
+        private final Map<EStructuralFeature, Integer> reads = new HashMap<>();
+
+        ComputingEObject(EClass eClass)
+        {
+            super(eClass);
+        }
+
+        void compute(EReference feature, EObject value)
+        {
+            computed.computeIfAbsent(feature, key -> new ArrayList<>()).add(value);
+        }
+
+        int readsOf(EStructuralFeature feature)
+        {
+            Integer count = reads.get(feature);
+            return count == null ? 0 : count.intValue();
+        }
+
+        private void count(EStructuralFeature feature)
+        {
+            reads.merge(feature, Integer.valueOf(1), (a, b) -> Integer.valueOf(a.intValue() + 1));
+        }
+
+        @Override
+        public Object eGet(EStructuralFeature feature, boolean resolve, boolean coreType)
+        {
+            count(feature);
+            List<EObject> value = computed.get(feature);
+            if (value != null)
+            {
+                return new EcoreEList.UnmodifiableEList<EObject>(this, feature, value.size(),
+                    value.toArray());
+            }
+            return super.eGet(feature, resolve, coreType);
+        }
+
+        @Override
+        public boolean eIsSet(EStructuralFeature feature)
+        {
+            List<EObject> value = computed.get(feature);
+            if (value != null)
+            {
+                count(feature);
+                return !value.isEmpty();
+            }
+            return super.eIsSet(feature);
+        }
+    }
+
+    /**
+     * A parent carrying one single-valued and one many-valued persisted containment, a
+     * derived-ONLY and a transient-ONLY computed containment, and one plain (non-containment)
+     * reference.
+     */
+    private static final class Model
+    {
+        final ComputingEObject parent;
+        final EObject single;
+        final EObject first;
+        final EObject second;
+        final EReference derivedRef;
+        final EObject derivedChild;
+        final EReference transientRef;
+        final EObject transientChild;
+        final EReference crossReference;
+        final EObject referenced;
+
+        @SuppressWarnings("unchecked")
+        Model()
+        {
+            EcoreFactory f = EcoreFactory.eINSTANCE;
+            EPackage pkg = f.createEPackage();
+            pkg.setName("persisted"); //$NON-NLS-1$
+            pkg.setNsPrefix("persisted"); //$NON-NLS-1$
+            pkg.setNsURI("http://ditrix.com/test/persisted-contents"); //$NON-NLS-1$
+
+            EClass child = f.createEClass();
+            child.setName("Child"); //$NON-NLS-1$
+            EAttribute name = f.createEAttribute();
+            name.setName("name"); //$NON-NLS-1$
+            name.setEType(EcorePackage.Literals.ESTRING);
+            child.getEStructuralFeatures().add(name);
+
+            EClass parentClass = f.createEClass();
+            parentClass.setName("Parent"); //$NON-NLS-1$
+            parentClass.getEStructuralFeatures().add(containment(f, "single", child, false)); //$NON-NLS-1$
+            parentClass.getEStructuralFeatures().add(containment(f, "many", child, true)); //$NON-NLS-1$
+            derivedRef = containment(f, "derivedChildren", child, true); //$NON-NLS-1$
+            derivedRef.setDerived(true);
+            derivedRef.setVolatile(true);
+            parentClass.getEStructuralFeatures().add(derivedRef);
+            transientRef = containment(f, "transientChildren", child, true); //$NON-NLS-1$
+            transientRef.setTransient(true);
+            parentClass.getEStructuralFeatures().add(transientRef);
+            crossReference = f.createEReference();
+            crossReference.setName("peer"); //$NON-NLS-1$
+            crossReference.setEType(child);
+            parentClass.getEStructuralFeatures().add(crossReference);
+
+            pkg.getEClassifiers().add(child);
+            pkg.getEClassifiers().add(parentClass);
+
+            parent = new ComputingEObject(parentClass);
+            single = new DynamicEObjectImpl(child);
+            parent.eSet(parentClass.getEStructuralFeature("single"), single); //$NON-NLS-1$
+            first = new DynamicEObjectImpl(child);
+            second = new DynamicEObjectImpl(child);
+            List<EObject> many =
+                (List<EObject>)parent.eGet(parentClass.getEStructuralFeature("many")); //$NON-NLS-1$
+            many.add(first);
+            many.add(second);
+            derivedChild = new DynamicEObjectImpl(child);
+            parent.compute(derivedRef, derivedChild);
+            transientChild = new DynamicEObjectImpl(child);
+            parent.compute(transientRef, transientChild);
+            referenced = new DynamicEObjectImpl(child);
+            parent.eSet(crossReference, referenced);
+        }
+
+        private static EReference containment(EcoreFactory f, String featureName, EClass type,
+            boolean many)
+        {
+            EReference reference = f.createEReference();
+            reference.setName(featureName);
+            reference.setEType(type);
+            reference.setContainment(true);
+            reference.setUpperBound(many ? -1 : 1);
+            return reference;
+        }
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PersistedContentsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PersistedContentsTest.java
@@ -12,7 +12,9 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -108,6 +110,84 @@ public class PersistedContentsTest
         assertEquals(1, children.size());
     }
 
+    @Test
+    public void testDescendantsWalkDepthFirstInMetamodelOrder()
+    {
+        // The sequence the callers depend on: the same depth-first pre-order eAllContents() gives,
+        // over the persisted containments only. 'grand' sits under 'first', so it must come between
+        // 'first' and 'second' - a breadth-first or reversed walk would put it last.
+        Model model = new Model();
+
+        assertEquals(Arrays.asList(model.single, model.first, model.grand, model.second),
+            collect(PersistedContents.descendants(model.parent)));
+    }
+
+    @Test
+    public void testDescendantsSkipComputedBranchesWithoutReadingThem()
+    {
+        Model model = new Model();
+        List<EObject> all = collect(PersistedContents.descendants(model.parent));
+
+        assertFalse(all.contains(model.derivedChild));
+        assertFalse(all.contains(model.transientChild));
+        assertEquals(0, model.parent.readsOf(model.derivedRef));
+        assertEquals(0, model.parent.readsOf(model.transientRef));
+    }
+
+    @Test
+    public void testDescendantsExpandANodeOnlyWhenTheWalkReachesIt()
+    {
+        // Laziness has to be observed, not asserted: an eager implementation that collected all four
+        // descendants into a list would satisfy every "is it in the result" check just as well. So
+        // the probe is a READ counter on a node the walk has not got to yet - 'second' is the last
+        // sibling, and its own children may not be looked up while the caller is still on the first.
+        Model model = new Model();
+
+        Iterator<EObject> iterator = PersistedContents.descendants(model.parent).iterator();
+        assertTrue(iterator.hasNext());
+        assertSame(model.single, iterator.next());
+        assertEquals("a later sibling must not be expanded before the walk reaches it", //$NON-NLS-1$
+            0, model.second.readsOf(model.subReference));
+
+        // ...and once the walk does reach it, it is expanded - otherwise the counter above would
+        // read 0 for a walk that never descends at all, and prove nothing.
+        while (iterator.hasNext())
+        {
+            iterator.next();
+        }
+        assertTrue("the walk must expand the node once it reaches it", //$NON-NLS-1$
+            model.second.readsOf(model.subReference) > 0);
+    }
+
+    @Test
+    public void testDescendantsAreRestartable()
+    {
+        // The Iterable is asked for a FRESH iterator each time, so a second traversal is not empty:
+        // the two retype guards walk the same form one after the other, and a one-shot Iterable
+        // would make the second of them silently answer "nothing blocks it".
+        Model model = new Model();
+        Iterable<EObject> descendants = PersistedContents.descendants(model.parent);
+
+        assertEquals(4, collect(descendants).size());
+        assertEquals(4, collect(descendants).size());
+    }
+
+    @Test
+    public void testDescendantsOfNullIsAnEmptySequence()
+    {
+        assertTrue(collect(PersistedContents.descendants(null)).isEmpty());
+    }
+
+    private static List<EObject> collect(Iterable<EObject> objects)
+    {
+        List<EObject> all = new ArrayList<>();
+        for (EObject object : objects)
+        {
+            all.add(object);
+        }
+        return all;
+    }
+
     /**
      * A dynamic object whose computed containments are materialized on read, counting every read
      * (through {@code eGet} and through {@code eIsSet} alike - a derived feature computes to answer
@@ -168,14 +248,18 @@ public class PersistedContentsTest
     /**
      * A parent carrying one single-valued and one many-valued persisted containment, a
      * derived-ONLY and a transient-ONLY computed containment, and one plain (non-containment)
-     * reference.
+     * reference. {@code first} owns a child of its own, so the descendant walk has a depth to get
+     * wrong.
      */
     private static final class Model
     {
         final ComputingEObject parent;
         final EObject single;
         final EObject first;
-        final EObject second;
+        final EObject grand;
+        /** Counting, so a test can watch WHEN the walk expands it. */
+        final ComputingEObject second;
+        final EReference subReference;
         final EReference derivedRef;
         final EObject derivedChild;
         final EReference transientRef;
@@ -198,6 +282,8 @@ public class PersistedContentsTest
             name.setName("name"); //$NON-NLS-1$
             name.setEType(EcorePackage.Literals.ESTRING);
             child.getEStructuralFeatures().add(name);
+            subReference = containment(f, "sub", child, true); //$NON-NLS-1$
+            child.getEStructuralFeatures().add(subReference);
 
             EClass parentClass = f.createEClass();
             parentClass.setName("Parent"); //$NON-NLS-1$
@@ -222,11 +308,16 @@ public class PersistedContentsTest
             single = new DynamicEObjectImpl(child);
             parent.eSet(parentClass.getEStructuralFeature("single"), single); //$NON-NLS-1$
             first = new DynamicEObjectImpl(child);
-            second = new DynamicEObjectImpl(child);
+            second = new ComputingEObject(child);
             List<EObject> many =
                 (List<EObject>)parent.eGet(parentClass.getEStructuralFeature("many")); //$NON-NLS-1$
             many.add(first);
             many.add(second);
+            grand = new DynamicEObjectImpl(child);
+            ((List<EObject>)first.eGet(subReference)).add(grand);
+            // 'second' is left childless on purpose: the laziness probe watches whether its 'sub'
+            // feature is READ, and an empty answer is still a read. The counter is deliberately NOT
+            // reset here - a read during construction should fail the probe, not be hidden from it.
             derivedChild = new DynamicEObjectImpl(child);
             parent.compute(derivedRef, derivedChild);
             transientChild = new DynamicEObjectImpl(child);


### PR DESCRIPTION
Closes #350

## Что было

`FormElementWriter.findItemIn` (и его близнец `collectItemsByName`, на котором стоит строгий
`findUniqueFormItem`) обходили форму через `EObject.eContents()`. Этот список EMF строит по **всем**
containment-фичам EClass'а и каждую **вычисляет** (`eIsSet`, затем `eGet`); собственный фильтр
`EContentsEList.isIncluded` пропускает производные и транзиентные фичи безусловно
(проверено по байткоду `org.eclipse.emf.ecore` 2.35: `isIncluded` возвращает `true` без условий,
`EClassImpl.getEAllContainments` тоже ничего не отсеивает).

В метамодели формы такая фича — не пустой слот, а вычисление. Живая проба на форме
`Catalog.Catalog.Form.ItemForm` (EDT 2026.2, инструментированная сборка, в PR не входит) показала,
что старый обход на **корне формы** трогал ровно три вычисляемых containment'а:

| фича | derived | transient | что возвращает |
|---|---|---|---|
| `Form.formContext` | false | **true** | весь BSL-`ContextDef` (типы, свойства, методы, параметры, события) |
| `FormStandardCommandSource.commands` | false | **true** | 22 выведенных `FormStandardCommand` |
| `Form.commandPanelGlobalCommandSource` | false | **true** | маркер глобального источника команд |

Обратите внимание: **`derived=false`, только `transient`**. Проверка одного лишь `isDerived()`
не отсекла бы здесь ничего.

## Замер до/после

Инструментированная сборка гоняла оба обхода подряд на одном и том же живом объекте формы и
писала счётчики. `nodes` — посещённые `FormItem`-узлы, `features` — вычисленные containment-фичи,
`enumerated` — выданные ими дочерние объекты.

| форма | | nodes | features | enumerated |
|---|---|---:|---:|---:|
| `Catalog.Catalog.Form.ItemForm`, 13 авторских элементов | было | 14 | 166 | **56** |
| | стало | 14 | 139 | **32** |
| та же форма, доращена до 43 элементов (10 декораций с их подсказками и контекстными меню) | было | 43 | 407 | **114** |
| | стало | 43 | 351 | **90** |

Разница в `enumerated` — те самые 24 объекта из таблицы выше, и она не растёт вместе с формой:
источник вычислений здесь — корень формы и элементы данных, а не количество элементов вообще.

Времена намеренно не привожу: в пробе новый обход шёл первым и грел кэши для старого, так что
сравнение по времени было бы в пользу старого и всё равно неинформативным.

### Про число «450» — сверка, чтобы не выдать закрытие за большее, чем сделано

В #350 на «450 записей» опираются и заголовок, и acceptance criteria, а мой замер по `findItemIn`
даёт другие числа. Это не расхождение в измерении — это **разные обходы**, и развожу их явно.

**Откуда 450.** Инвентарь из ишью — `34 DerivedProperty / 36 Type / 23 Property / 1 Method /
184 Parameter / 89 Event / 22 FormStandardCommand` (389 из 450 перечислены поимённо) — это то, что
перечисляет обход, **спускающийся во ВСЕХ детей**. Такой обход в `FormElementWriter` есть, и не
один, но это НЕ `findItemIn`: на момент заведения ишью их было восемь. Два из них — гарды
ре-типизации `itemsBoundBelowAttribute` и `rowConsumersBoundToAttribute` — починены в этом же PR
(см. ниже), оставшиеся шесть — распределение id, они в #373. `eAllContents()` — это `AbstractTreeIterator`, чей
`getChildren(Object)` есть `eContents().iterator()` (проверено по байткоду `BasicEObjectImpl$2`),
то есть он наследует то же безусловное включение И вдобавок заходит внутрь вычисленного поддерева.

**Что перечислял `findItemIn`.** Он спускается только в `FormItem`, поэтому до подтверева
`ContextDef` не доходил никогда. Его собственные числа — в таблице выше: 56 → 32 выданных объекта и
166 → 139 вычисленных фич на 13 элементах, 114 → 90 и 407 → 351 на 43.

**Где эти числа соприкасаются.** Из 24 объектов, которые старый `findItemIn` получал через
вычисляемые containment'ы, 22 — это ровно те `FormStandardCommand` из разбивки ишью, а ещё один —
сам `ContextDef`, то есть **корень** поддерева с остальными 367. Иначе говоря, `findItemIn` не
перечислял 450, но на каждом вызове **запрашивал** у EDT два объекта, под которыми эти 450 живут.
Во что обходится сам этот `eGet` внутри EDT, я не мерил — поэтому и не пишу, что «`findItemIn`
стоил 450».

**Что это значит для критериев #350.** Критерии 1 (проверка до `eGet`), 2 (парный тест) и 4
(зелёная регрессия без правки тестов) закрыты полностью. Критерий 3 («замер до/после») закрыт
**числами `findItemIn`**, а не числом 450: остаток живёт в глубоких `eAllContents()`-обходах и
вынесен в #373 (там механизм, перечень шести оставшихся мест и развилка по аллокации id, которую
механически повторять с этого PR нельзя). Если вы считаете глубокие обходы частью
#350 — скажите, я сниму `Closes #350` и оставлю ссылку, чтобы ишью закрылась вместе с #373.

## Что сделано

- новый общий помощник `utils/PersistedContents`: `of(EObject)` — персистентные containment-дети в
  порядке метамодели, `descendants(EObject)` — ленивый обход всех персистентных потомков. Фича
  спрашивается о `isDerived()`/`isTransient()` **до** `eGet`: спросить после — не защита, модель к
  этому моменту уже построена;
- `findItemIn` и `collectItemsByName` переведены на него и на **явный стек** вместо рекурсии
  (`StackOverflowError` — это `Error`, никакой `catch (Exception)` выше его не остановит).
  Порядок обхода прежний: тот же depth-first pre-order по той же последовательности детей
  (`getEAllReferences()` фильтруется из того же списка всех фич, что и `containments()` внутри
  `eContents()`, поэтому относительный порядок containment'ов совпадает);
- `DeleteMetadataTool.pushPersistedChildren` (#341) теперь **делегирует** тому же помощнику, а не
  держит вторую копию правила;
- **ещё два обхода из #373 взяты сюда** — гарды ре-типизации реквизита `itemsBoundBelowAttribute` и
  `rowConsumersBoundToAttribute` (были на `eAllContents()`). Они переведены на
  `PersistedContents.descendants`.

⚠️ У этих двух обходов **нет фильтра по EClass**: `itemsBoundBelowAttribute` читает `dataPath` у
ЛЮБОГО потомка, а не только у `FormItem` (путь может сидеть на безымянном property-holder'е), да и
`rowConsumers` обязан спускаться сквозь группы, чтобы дойти до таблиц. Поэтому обход из `findItemIn`
здесь переиспользовать было нельзя — `descendants` не фильтрует по типу вообще. Это закреплено
отдельной мутацией (см. таблицу ниже).

**Почему сужение этих двух безопасно** — довод не «в модели сейчас пусто», а по существу: оба места
ищут **авторские привязки**, чтобы не оставить висящую привязку в ЗАПИСАННОМ файле. Объект, до
которого доводит только вычисляемый containment, в `Form.form` не пишется (в этой метамодели такие
фичи `transient`) и пересчитывается после любой правки — значит пропустить его невозможно «оставив
висящую привязку». Вдобавок оба гарда превращают совпадение в **ошибку с требованием удалить или
перенаправить элемент**, а после этого же PR резолвер по имени такой элемент уже не адресует — то
есть пользователь получил бы ошибку, которую физически не может устранить.

**Бюджет узлов сознательно НЕ добавлен**, хотя явный стек это позволяет. В #341 усечение обхода
безопасно — там строится превью, и оно честно помечается обрезанным. Здесь усечённый поиск ответил
бы «не найдено» о существующем элементе, а вызывающие превращают такой ответ в дубль имени или в
правку не того элемента. Ограничение снимает только режим падения по стеку.

## Осознанное сужение поведения

Транзиентные containment'ы формы, которые **могут** держать `FormItem`:
`topCommandBar` / `bottomCommandBar` / `fABCommandBar` и пара
`SelectedItemsActionsPanel` / `RowActionsPanel` (в `Form.xcore` все помечены `// layouter only`).
Формально они попадают под токен `Group` в `addressableKindOf`, то есть до этого PR старый обход
мог бы их найти.

Проба на живой модели: из 24 объектов, доступных только через вычисляемые containment'ы, **ни один
не был `FormItem`** — эти панели и панели команд 8.5.1 в BM-модели не заполнены. Но одна форма —
не доказательство, поэтому правило формулирую по существу: запись формы уходит в `Form.form`,
значит элемент, который модель не персистит, никто из вызывающих не мог создать и никакая правка
его не удержит. Резолвить такой элемент — значит выдавать исчезающую запись за успешную.

Если вы считаете, что layouter-панели должны оставаться адресуемыми, скажите — верну их отдельной
веткой (обход по персистентным + явный список известных layouter-фич), но выглядит это как
починка симптома.

## Доказательства

**Юниты.** `bash source/compile.sh --java-home ... --maven-home ...` → `BUILD SUCCESS`,
`Tests run: 4452, Failures: 0, Errors: 0`.

Новые тесты — парные, на обе стороны:

- `testFindFormItemStillFindsEveryAuthoredItem` — корневой элемент, вложенный, регистронезависимый
  поиск и элемент под **персистентной** `autoCommandBar` по-прежнему находятся;
- `testFindFormItemNeverReadsAComputedContainment` — элементы вычисляемой ветки не адресуются
  **и сама фича не читается** (счётчик чтений на корне И на потомке);
- `testFindUniqueFormItemIgnoresAComputedNamesake` — вычисленный однофамилец больше не делает
  авторский элемент «ambiguous»;
- `testFindUniqueFormItemStillRejectsTwoAuthoredNamesakes` — а настоящее столкновение двух
  персистентных элементов по-прежнему отвергается;
- `PersistedContentsTest` — порядок метамодели, отдельно `derived`-только и отдельно
  `transient`-только containment, non-containment ссылка (не читается вовсе), null-вход.

**Мутации источника** (каждая — отдельная сборка, привожу упавшие тесты):

Пять мутаций, каждая — отдельная сборка; привожу упавшие тесты. Две последние специально нацелены
на ошибки, которых легко было наделать именно в этой правке.

| мутация | что покраснело |
|---|---|
| `of`: спрашивать только `isDerived()` (транзиентные проходят) | 6 тестов `FormElementWriterTest` + 5 `PersistedContentsTest` |
| `of`: спрашивать только `isTransient()` (производные проходят) | `testSkipsADerivedContainmentWithoutReadingIt`, `testDescendants*` (3), `testYieldsPersistedChildrenInMetamodelOrder`, `testFindFormItemNeverReadsAComputedContainment` |
| `of`: проверка **после** `eGet` (набор детей тот же, читается лишнее) | ровно счётчики чтений — 7 тестов. Утверждения «призрак не найден» при этом ЗЕЛЁНЫЕ, то есть счётчик проверяет именно порядок, а не исход |
| **обход гарда сужен до `FormItem`** (та самая ловушка) | **ровно один** тест: `testRetypeGuardStillSeesEveryAuthoredBinding` — property-holder перестаёт находиться |
| **`descendants` сделан жадным** (тот же порядок, та же перезапускаемость, но раскрывает всё сразу) | **ровно один** тест: `testDescendantsExpandANodeOnlyWhenTheWalkReachesIt` |

Вариант «убрать проверку целиком» отдельно не привожу: он пропускает и производные, и
транзиентные containment’ы, то есть строго перекрывает первые две строки таблицы.

`testFindFormItemStillFindsEveryAuthoredItem` и
`testFindUniqueFormItemStillRejectsTwoAuthoredNamesakes` остаются зелёными во всех пяти мутациях —
они и должны быть нечувствительны, это вторая сторона проверки.

Отдельно про `testRetypeGuardStillSeesEveryAuthoredBinding`: он сверяет **весь список целиком**, а не
«содержит хотя бы», поэтому чувствителен в обе стороны — краснеет и когда обход сузили (пропал
property-holder), и когда расширили (появился вычисленный `GhostField`). Так и задумано: список имён
из этого гарда уходит пользователю в текст ошибки, значит закреплять надо и состав, и порядок.

**e2e.** Локальный стенд EDT 2026.2, jar пересобран из этой ветки и перевыложен. Anti-stale с
контролями в обе стороны: в выложенном jar ЕСТЬ `PersistedContents.class` (положительный
контроль), НЕТ класса инструментовки (отрицательный контроль — он заведомо был в предыдущей
выкладке), и заведомо отсутствующее имя даёт 0. Первая попытка на этом и споткнулась: инкрементная
сборка оставила класс инструментовки в `target/classes`, и он уехал в jar — понадобился
`mvn clean`.

После e2e я ещё раз пересобрал ветку (правки были только в javadoc и в именах тестов) и сверил
байты: все 777 классов бандла в финальном артефакте побайтово совпадают с теми, на которых гонялся
e2e (сам `diff` проверен мутацией одного байта, манифесты при этом различаются — то есть сравнивались
разные файлы). Срезы форменных инструментов:
| срез | результат |
|---|---|
| `--filter create_metadata` | 116/116, fixture clean |
| `--filter modify_metadata` | 154/154, fixture clean |
| `--filter delete_metadata` | 36/36, fixture clean |
| `--filter get_metadata_details` | 25/25, fixture clean |
| `--filter get_project_errors` | 20/20, fixture clean (адресация элемента формы из #345) |
| `--filter tools_list` | 2/2 — golden совпал БЕЗ регенерации: проволочная поверхность не менялась |

Итого 353/353.

Тесты **не правились** — ни одного.

## Что НЕ покрыто

- **шесть оставшихся `eAllContents()`-проходов** в `FormElementWriter` — все про распределение
  идентификаторов (`nextItemId`, `maxAttributeId`, `maxCommandId` и три `normalizeForm*Ids`).
  Вынесены в **#373** и сюда сознательно НЕ взяты: довод про персистентность там не работает, потому
  что счётчики ищут максимум по «пространству идентификаторов», а `AutoCommandBar`,
  `SelectedItemsActionsPanel` и `RowActionsPanel` — подтипы `FormItem`, то есть объект, достижимый
  только через неперсистентную фичу, реально несёт `id`, который сканирует счётчик. Самого
  инварианта в репозитории нет (комментарии говорят «form-wide space», но не определяют, входят ли
  туда вычисленные элементы), поэтому в #373 вопрос сформулирован автору: пространство
  идентификаторов определено над персистентными авторскими объектами или над всей живой моделью
  формы;
- `FormLayoutSnapshotService.collectElementTree` тоже идёт по `eContents()`, но по модели
  layouter'а, где вычисленное содержимое и есть предмет — сознательно не трогал;
- `PersistedContents` не следует за containment'ами внутри `FeatureMap` (их `eContents()` тоже
  выдал бы). В обслуживаемых моделях таких нет; ограничение записано в javadoc;
- новый обход материализует всех детей узла до проверки первого, тогда как `eContents()`
  итерировался лениво. Разница видна только на битой ссылке-прокси среди детей одного узла;
  в форме-контенте (один top-объект BM) такой конфигурации нет.

## Самопроверка

Диф прогнан через локальный codex (read-only) четырьмя раундами до отправки — по два на каждую
порцию правки. Из найденного в раундах по гардам ре-типизации:
- «`descendants` материализует список всех потомков, тогда как `eAllContents()` держал O(глубины)» —
  верно, поведение по памяти менялось на ровном месте. Переписал на **ленивый** итератор (стек
  итераторов по уровням), добавил тест, который это проверяет **счётчиком чтений** на ещё не
  посещённом узле, и мутацию «сделать жадным» — она краснит ровно этот тест;
- «javadoc выводит безопасность из `derived`, а сериализацией управляет `transient`» — верно и
  важно: `derived` сам по себе НЕ выводит фичу из файла. Довод переписан через `transient`, а в
  `PersistedContents.of` записано, зачем всё-таки проверяются оба флага и какая комбинация
  потребовала бы пересмотра правила;
- «`descendants` обещает последовательность `eAllContents()`, но `of` тут же признаётся, что не
  ходит по `FeatureMap`» — верно, обещание сужено; заодно поправил утверждение «EMF включает
  **каждую** containment-фичу»: ссылка, назначенная в группу `FeatureMap`, из этого перечисления
  исключается;
- «тест назван про ленивость, а проверяет перезапускаемость» — верно, тест был вакуумным по своему
  названию; разделён на два, и ленивость теперь доказывается наблюдаемым чтением, а не названием.

Из более ранних раундов (по `findItemIn`):
- «сужение теряет `SelectedItemsActionsPanel`» — разобрано выше, ответ дан пробой и правилом
  персистентности, javadoc переписан, чтобы не утверждать больше, чем доказано;
- `Collections.emptyList()` в null-ветке противоречил обещанию «fresh, caller-owned list» —
  исправлено, тест на изменяемость добавлен;
- «оба тестовых фикстур ставят `derived` и `transient` вместе, проверку одного флага тесты не
  ловят» — верно, поэтому фичи в фикстурах разведены и добавлены две отдельные мутации;
- «`eContents()` итерируется резолвящим итератором, а не `eGet(feature,false)`» — верно,
  моё исходное описание разницы было неточным; направление резолва прокси не меняется.
