### PR TITLE
Паритет каталога видов: закреплено обратное направление для Subsystem/Predefined (#352)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtils.java
@@ -792,6 +792,38 @@ public final class MetadataTypeUtils
     }
 
     /**
+     * EVERY spelling this TOP-LEVEL type catalogue accepts for the same type as {@code typeName} -
+     * English singular/plural plus every registered Russian name, all lowercase.
+     *
+     * <p>Read from {@code LOOKUP} itself, i.e. from the very map {@link #resolve} and
+     * {@link #toEnglishSingular} answer from, so a consumer that publishes its accepted tokens
+     * through this method publishes what it really accepts. Deriving such a set from the NESTED
+     * kind catalogue instead would make it a mirror of the thing it is compared against, and a pin
+     * taken from a mirror cannot see the two catalogues drift apart.</p>
+     *
+     * @param typeName any accepted spelling of a top-level type (may be {@code null})
+     * @return its sibling spellings, lowercase (including itself), or an empty set when the token
+     *     is not a known top-level type
+     */
+    public static Set<String> typeAliases(String typeName)
+    {
+        MetadataTypeInfo info = resolve(typeName);
+        if (info == null)
+        {
+            return Collections.emptySet();
+        }
+        Set<String> aliases = new LinkedHashSet<>();
+        for (Map.Entry<String, MetadataTypeInfo> entry : LOOKUP.entrySet())
+        {
+            if (entry.getValue() == info)
+            {
+                aliases.add(entry.getKey());
+            }
+        }
+        return aliases;
+    }
+
+    /**
      * Resolves a NESTED structural FQN segment token (English or Russian, singular or plural,
      * any case) to its canonical English/Russian spellings - e.g. {@code "Forms"} and the Russian
      * plural both resolve to the {@code Form} pair.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PredefinedWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PredefinedWriter.java
@@ -9,9 +9,11 @@ package com.ditrix.edt.mcp.server.utils;
 import java.math.BigDecimal;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -217,6 +219,14 @@ public final class PredefinedWriter
     private static final String RU_PREDEFINED_YO = MetadataLanguageUtils.cp(0x043f, 0x0440, 0x0435, 0x0434,
         0x043e, 0x043f, 0x0440, 0x0435, 0x0434, 0x0435, 0x043b, 0x0451, 0x043d, 0x043d, 0x044b, 0x0435);
 
+    /**
+     * The FQN kind tokens this writer accepts in the {@code Predefined} position, lowercase.
+     * THE single source of both {@link #isPredefinedToken} and {@link #acceptedKindTokens}, so what
+     * is accepted and what is published cannot drift apart.
+     */
+    private static final Set<String> KIND_TOKENS = Collections.unmodifiableSet(
+        new LinkedHashSet<>(Arrays.asList("predefined", RU_PREDEFINED, RU_PREDEFINED_YO))); //$NON-NLS-1$
+
     private PredefinedWriter()
     {
         // utility class
@@ -283,11 +293,30 @@ public final class PredefinedWriter
         {
             return false;
         }
-        String t = token.trim().toLowerCase(Locale.ROOT);
         // Accept English "predefined" and EXACTLY the two valid Russian spellings (the 'е' and the
         // natural 'ё' form). A blanket yo-normalization of the token would be too loose - it would
         // also accept a 'ё' misplaced onto any of RU_PREDEFINED's five 'е' positions.
-        return "predefined".equals(t) || RU_PREDEFINED.equals(t) || RU_PREDEFINED_YO.equals(t); //$NON-NLS-1$
+        return KIND_TOKENS.contains(token.trim().toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * The FQN kind tokens this writer accepts in the {@code Predefined} position - every spelling
+     * {@link #parseRef} reads as the predefined segment, lowercase.
+     *
+     * <p>Published so a regression check can compare this set with the NESTED-kind catalogue that
+     * {@code get_project_errors} advertises a {@code ...Predefined.<Item>} address through, and do
+     * it in BOTH directions. The lists are independent: this one is written out here because the
+     * two Russian spellings are enumerated deliberately (see {@link #isPredefinedToken}), while the
+     * catalogue keeps its own pair - so a spelling can appear on either side alone. A token the
+     * catalogue publishes and this writer does not is an address we document and then refuse; a
+     * token this writer accepts and the catalogue does not is an address that resolves but whose
+     * Russian form the marker filter cannot translate. Only set EQUALITY sees both.</p>
+     *
+     * @return the accepted tokens, lowercase and unmodifiable (never {@code null})
+     */
+    public static Set<String> acceptedKindTokens()
+    {
+        return KIND_TOKENS;
     }
 
     // ============================================================================================

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/SubsystemUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/SubsystemUtils.java
@@ -9,6 +9,7 @@ package com.ditrix.edt.mcp.server.utils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.eclipse.emf.common.util.EMap;
 
 import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
@@ -413,6 +414,30 @@ public final class SubsystemUtils
             return false;
         }
         return SUBSYSTEM_TOKEN.equals(MetadataTypeUtils.toEnglishSingular(token.trim()));
+    }
+
+    /**
+     * EVERY spelling {@link #isSubsystemTypeToken} accepts, lowercase.
+     *
+     * <p>Published so a regression check can compare this set with the NESTED-kind catalogue the
+     * object filters advertise a {@code Subsystem} segment through, in BOTH directions. The two are
+     * genuinely independent lists - the predicate answers from the TOP-LEVEL type catalogue
+     * ({@code MetadataTypeUtils.toEnglishSingular}), while a nested {@code Subsystem} segment is
+     * translated through the nested-kind catalogue - so either one can gain a spelling the other
+     * does not have. An alias added to the nested catalogue alone is an address the filter
+     * documents and this predicate then refuses; an alias added to the type catalogue alone is an
+     * address this predicate accepts and the filter cannot translate. Asking whether the sets
+     * OVERLAP would see neither.</p>
+     *
+     * <p>Derived from the type catalogue, i.e. from the very map the predicate reads, never from
+     * the nested catalogue it is compared against: a set copied from the other side of a comparison
+     * makes the comparison vacuous.</p>
+     *
+     * @return the accepted tokens, lowercase (never {@code null})
+     */
+    public static Set<String> acceptedTypeTokens()
+    {
+        return MetadataTypeUtils.typeAliases(SUBSYSTEM_TOKEN);
     }
 
     private static Subsystem findChild(Iterable<Subsystem> children, String name)

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtilsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataTypeUtilsTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -741,14 +742,47 @@ public class MetadataTypeUtilsTest
         // listing these by hand is exactly the "enumerate the fixes" habit that let the same drift
         // through twice, so they are checked through their resolver like everything else.
         Map<String, String> notAddressed = new LinkedHashMap<>();
-        // The only genuine exceptions: CONTENT segments of a marker location. They are translated so
-        // the filter can match a location, but no address is ever parsed with them as a segment.
+        // The only genuine exceptions: CONTENT segments of a marker location. They are NOT consumers
+        // of the address grammar at all - they are translated so the filter can match a location,
+        // and no parser ever reads them as a kind segment. Recorded here as a DECISION and checked
+        // below (no consumer may accept them), because "nothing pins these" and "nothing needs to"
+        // look identical in silence, and this catalogue has already been drifted through twice.
         notAddressed.put("Module", "a CONTENT segment of a marker location (CommonModule.X.Module), "
             + "never an address segment - it is translated for matching only");
         notAddressed.put("Package", "the CONTENT of an XDTO package (XDTOPackage.P.Package) - a "
             + "marker location segment; XDTO members are answered as objectsUnsupported");
 
-        for (String canonical : MetadataTypeUtils.nestedKindCanonicalTokens())
+        // The consumers that keep their OWN token list, each publishing it so the reverse direction
+        // - a token the CONSUMER accepts and this catalogue does not publish - can be pinned by
+        // EQUALITY. Declared by hand, like MDCLASS_RESOLVED_KINDS and for the same reason: deriving
+        // the list of pinned consumers from the consumers themselves would let a consumer that
+        // stopped publishing switch off its own check.
+        Map<String, Set<String>> consumerTokens = new LinkedHashMap<>();
+        // Subsystem: the predicate answers from the TOP-LEVEL type catalogue, a list independent of
+        // the nested-kind catalogue tested here - so the two really can drift in either direction.
+        consumerTokens.put("Subsystem", lowercased(SubsystemUtils.acceptedTypeTokens()));
+        // Predefined: three literals written out in the writer (the 'e' and the 'yo' spelling are
+        // enumerated on purpose rather than yo-normalized), so likewise an independent list.
+        consumerTokens.put("Predefined", lowercased(PredefinedWriter.acceptedKindTokens()));
+
+        // A declared kind must still BE in the catalogue. Without this the checks below are keyed by
+        // a walk over the catalogue, so deleting a kind from it takes the kind's own equality check
+        // away with it: the consumer would keep accepting 'Subsystem' addresses the filter can no
+        // longer translate, and the pin would go quiet at exactly the moment it is needed. Same
+        // self-confirmation MDCLASS_RESOLVED_KINDS is written by hand to avoid, one catalogue over.
+        Set<String> publishedKinds = MetadataTypeUtils.nestedKindCanonicalTokens();
+        for (String declared : consumerTokens.keySet())
+        {
+            assertTrue("a consumer is pinned against kind '" + declared + "', which the catalogue no "
+                + "longer publishes - the kind was removed, not the pin", publishedKinds.contains(declared));
+        }
+        for (String declared : KIND_SPECIFIC_TOKEN_OWNERS)
+        {
+            assertTrue("a kind-specific predicate is pinned against kind '" + declared + "', which the "
+                + "catalogue no longer publishes", publishedKinds.contains(declared));
+        }
+
+        for (String canonical : publishedKinds)
         {
             List<Predicate<String>> applicable = owners.get(canonical);
             if (applicable == null)
@@ -798,7 +832,133 @@ public class MetadataTypeUtilsTest
                 assertEquals("form parser and catalogue must accept EXACTLY the same tokens for "
                     + canonical, published, formTokens);
             }
+            // 3. ...and the consumers that keep a list of their own (Subsystem, Predefined). Same
+            // shape, same direction, same reason: until this block existed those kinds were pinned
+            // only from catalogue to consumer, so a token the consumer knew and the catalogue did
+            // not publish went unseen - the exact half of the invariant three review findings were
+            // about.
+            //
+            // The positive control - that the published set is what the parser REALLY accepts, not
+            // a second literal that merely agrees with the catalogue - is the forward loop above:
+            // once the sets are equal, every token the consumer publishes has already been run
+            // through the consumer's own predicate there. A separate loop over consumerSet would
+            // add no mutation it could be the first to catch.
+            Set<String> consumerSet = consumerTokens.get(canonical);
+            if (consumerSet != null)
+            {
+                assertEquals("consumer and catalogue must accept EXACTLY the same tokens for "
+                    + canonical, published, consumerSet);
+            }
+            // Every published kind must have a verdict on the REVERSE direction, not just on the
+            // forward one. Two ways to earn it: the consumer publishes its own token set and the
+            // sets are compared for equality (the three blocks above - resolver, form parser, own
+            // list), or it keeps no set at all because it asks this very catalogue
+            // (CATALOG_DERIVED_KINDS). A kind with neither is the silent gap this issue was about,
+            // and it fails here until it is classified.
+            boolean reversePinned = resolverTokens.containsKey(canonical) || formKind != null
+                || consumerSet != null;
+            assertTrue("no reverse-direction check for '" + canonical + "': its consumer must "
+                + "publish the tokens it accepts, or be declared as reading the catalogue directly",
+                reversePinned || CATALOG_DERIVED_KINDS.containsKey(canonical));
         }
+
+        // The predicates that answer for ONE kind must select EXACTLY that kind's aliases out of
+        // everything this catalogue publishes - not merely accept all of them (the forward loop) and
+        // not merely be equal to a set (the equality above, which a predicate rewritten around its
+        // own set escapes). This is the only check available at all for Form and Handler, whose
+        // predicates keep no set to compare: they ask this catalogue directly.
+        //
+        // SCOPE, stated because it is narrower than "the derivation is pinned": the probe universe
+        // is the published tokens, so a predicate that additionally accepts a token belonging to NO
+        // kind (a hardcoded 'LegacyHandler') is NOT seen here. Enumerating a set the consumer does
+        // not have is impossible, and copying one out of this catalogue would compare the catalogue
+        // with itself. That residue is listed as uncovered rather than papered over.
+        Set<String> universe = new TreeSet<>();
+        for (String canonical : publishedKinds)
+        {
+            universe.addAll(lowercased(MetadataTypeUtils.nestedKindAliases(canonical)));
+        }
+        for (String canonical : KIND_SPECIFIC_TOKEN_OWNERS)
+        {
+            List<Predicate<String>> applicable = owners.get(canonical);
+            assertNotNull("a kind-specific predicate must still be declared as an owner: " + canonical,
+                applicable);
+            Set<String> own = lowercased(MetadataTypeUtils.nestedKindAliases(canonical));
+            assertFalse("a pinned kind must still have spellings, or this compares two empty sets: "
+                + canonical, own.isEmpty());
+            for (Predicate<String> owner : applicable)
+            {
+                Set<String> selected = new TreeSet<>();
+                for (String token : universe)
+                {
+                    if (owner.test(token))
+                    {
+                        selected.add(token);
+                    }
+                }
+                assertEquals("a kind-specific predicate must select EXACTLY its own kind's aliases "
+                    + "out of everything the catalogue publishes: " + canonical, own, selected);
+            }
+        }
+
+        // ...and the content-only segments, stated rather than implied: no consumer of the address
+        // grammar may read them as a kind. Leaving them out of `owners` said the same thing by
+        // saying nothing, which is indistinguishable from having forgotten them.
+        for (String canonical : notAddressed.keySet())
+        {
+            for (String token : lowercased(MetadataTypeUtils.nestedKindAliases(canonical)))
+            {
+                String why = "'" + token + "' is a content-only segment (" + canonical
+                    + "), so no address parser may accept it as a kind";
+                assertNull(why, FormElementWriter.kindForToken(token));
+                assertFalse(why, FormElementWriter.isFormToken(token));
+                assertFalse(why, FormElementWriter.isHandlerToken(token));
+                assertFalse(why, SubsystemUtils.isSubsystemTypeToken(token));
+                assertFalse(why, predefinedTokenAccepted(token));
+                assertNull(why, MetadataNodeResolver.featureNameForKind(token));
+            }
+        }
+    }
+
+    /**
+     * Kinds whose consumer keeps NO token list of its own - it asks the nested-kind catalogue
+     * directly - mapped to the seam that makes that true.
+     *
+     * <p>Set equality is not available for these, and pretending otherwise would be worse than not
+     * checking: the only set to compare the catalogue with would be a copy of the catalogue. They
+     * are pinned by the kind-specific partition check instead, and listed here so a kind can never
+     * reach that weaker treatment by omission - it has to be written down.</p>
+     */
+    private static final Map<String, String> CATALOG_DERIVED_KINDS;
+    static
+    {
+        Map<String, String> derived = new LinkedHashMap<>();
+        derived.put("Form", "FormElementWriter.isFormToken -> isNestedKind -> resolveNestedKind");
+        derived.put("Handler", "FormElementWriter.isHandlerToken -> isNestedKind -> resolveNestedKind");
+        CATALOG_DERIVED_KINDS = Collections.unmodifiableMap(derived);
+    }
+
+    /**
+     * Kinds whose owner predicate answers for THAT kind alone, so it can be pinned by partition:
+     * over everything the catalogue publishes it must select exactly this kind's aliases.
+     *
+     * <p>Declared, not derived: the resolver predicate ({@code featureNameForKind != null}) answers
+     * for all sixteen mdclass kinds at once and would fail a partition check by design, so the set
+     * cannot be inferred from {@code owners} - and inferring it from the catalogue would let a
+     * deleted kind take its own check away.</p>
+     */
+    private static final Set<String> KIND_SPECIFIC_TOKEN_OWNERS = Collections.unmodifiableSet(
+        new LinkedHashSet<>(Arrays.asList("Form", "Handler", "Subsystem", "Predefined")));
+
+    /** The same tokens, lowercased with {@link Locale#ROOT} so two sets can be compared. */
+    private static Set<String> lowercased(Collection<String> tokens)
+    {
+        Set<String> lower = new TreeSet<>();
+        for (String token : tokens)
+        {
+            lower.add(token.toLowerCase(Locale.ROOT));
+        }
+        return lower;
     }
 
     /**


### PR DESCRIPTION
Closes #352

Пин каталога видов держал только одну половину инварианта, на котором стоит серия #342/#346. Направление «каталог → потребитель» (каждое объявленное написание должно приниматься) проверялось для всех видов; обратное — «потребитель знает токен, которого каталог не публикует» — только для резолвера mdclass и форменного парсера. У `Subsystem` и `Predefined` обратной проверки не было вовсе, а это ровно те два вида, где множества **действительно независимы**: подсистемный предикат отвечает из **верхнеуровневого** каталога типов (`MetadataTypeUtils.toEnglishSingular` → `LOOKUP`), а не из каталога вложенных видов; писатель предопределённых перечисляет два русских написания вручную.

## Вид → потребитель → закреплено ли равенство

| Вид | Потребитель | Своё множество? | До | После |
|---|---|---|---|---|
| 16 видов mdclass | `MetadataNodeResolver.childFeatureByToken()` | да | равенство ✔ | равенство ✔ |
| 8 видов элементов формы | `FormElementWriter.KIND_TOKENS` | да | равенство ✔ | равенство ✔ |
| **Subsystem** | `SubsystemUtils.isSubsystemTypeToken` | да — **верхнеуровневый каталог типов** | только «каталог → потребитель» | **равенство ✔** через `acceptedTypeTokens()` |
| **Predefined** | `PredefinedWriter.parseRef` / `isPredefinedToken` | да — три литерала | только «каталог → потребитель» | **равенство ✔** через `acceptedKindTokens()` |
| **Form** | `FormElementWriter.isFormToken` | **нет** — спрашивает сам каталог | — | объявлен catalogue-derived + проверка разбиением |
| **Handler** | `FormElementWriter.isHandlerToken` | **нет** — то же | — | объявлен catalogue-derived + проверка разбиением |
| **Module** | — | — | молча пропущен | **явно** объявлен не-потребителем + проверено |
| **Package** | — | — | молча пропущен | **явно** объявлен не-потребителем + проверено |

## Ключевое: множество берётся у ИСТОЧНИКА, а не у зеркала

`SubsystemUtils.acceptedTypeTokens()` выводится из `LOOKUP` — той самой карты, которую читает сам предикат (для этого добавлен `MetadataTypeUtils.typeAliases()`), и **никогда** из каталога вложенных видов, с которым сравнивается. `PredefinedWriter.acceptedKindTokens()` отдаёт тот же `KIND_TOKENS`, в котором `isPredefinedToken` теперь ищет токен, — принятое и опубликованное разойтись не могут. Множество, скопированное с другой стороны сравнения, делает сравнение пустым; это ровно та ошибка, которой были все три опровергнутых пина.

## Form/Handler: равенство недостижимо — и это сказано прямо

У этих двух потребителей **нет своего множества**: `isFormToken` → `isNestedKind` → `resolveNestedKind`, то есть они спрашивают сам каталог. Аксессор для них был бы копией каталога, а пин по копии — вакуумный. Поэтому:

* они **объявлены** в `CATALOG_DERIVED_KINDS` (не пропущены);
* закрепление — **разбиением**: по всему множеству опубликованных токенов видоспецифичный предикат обязан выбирать ровно алиасы своего вида. Это ловит подмену обращения к каталогу на захардкоженный список, который над- или недовыбирает. Ту же проверку получили `Subsystem` и `Predefined` — она строго сильнее равенства множеств.

**Что этим НЕ покрыто** (честно, а не подогнано): предикат, дополнительно принимающий токен, не принадлежащий **никакому** виду (захардкоженный `LegacyHandler`). Зонд идёт по опубликованным токенам, а перечислить множество, которого у потребителя нет, невозможно. Мутация «алиас только в каталог» для `Form`/`Handler` тоже не краснит — и не может: расхождение там непредставимо по построению, потребитель и каталог физически одна структура.

## Доказательство мутациями (полный прогон, 4443 теста каждый)

Гарнесс отличает «мутация не собралась» от «тест не поймал» — иначе он врёт.

| Мутация | Результат | Что краснеет |
|---|---|---|
| алиас только в каталог, `Subsystem` | 🔴 **1 тест** | `MetadataTypeUtilsTest:800` «the catalogue advertises 'subsystemzz' for Subsystem…» |
| токен только у потребителя, `Subsystem` (`MetadataTypeInfo.SUBSYSTEM.russianNames`) | 🔴 **1 тест** | `:849` «consumer and catalogue must accept EXACTLY the same tokens for Subsystem» |
| алиас только в каталог, `Predefined` | 🔴 **1 тест** | `:800` «…advertises 'predefinedzz' for Predefined…» |
| токен только у потребителя, `Predefined` (`KIND_TOKENS`) | 🔴 **1 тест** | `:849` «…EXACTLY the same tokens for Predefined» |
| **те же две «только у потребителя» против ПРЕЖНЕГО пина** | 🟢 **GREEN** | ← это и есть дыра из ишью |
| `isFormToken` начинает принимать чужой токен (`\|\| isNestedKind(token, "Handler")`) | 🔴 | `:899` разбиение для `Form`; плюс `FormElementWriterTest` — настоящее следствие мутации, не дубль сигнала |
| удалить регистрацию `Subsystem` из каталога вложенных видов | 🔴 | `:776` «a consumer is pinned against kind 'Subsystem', which the catalogue no longer publishes — the kind was removed, not the pin» |

Каждая из четырёх мутаций из критериев приёмки даёт **ровно один** падающий тест с сообщением, называющим причину.

## Самопроверка codex до push

Прогнал `codex` (read-only) по дифу; из четырёх находок **две настоящие**, обе исправлены до отправки:

1. **Проверка могла отключить сама себя.** Цикл шёл по `nestedKindCanonicalTokens()`, поэтому удаление вида из каталога уносило вместе с ним и его проверку равенства — та самая самоподтверждаемость, ради которой `MDCLASS_RESOLVED_KINDS` написан руками. Добавлено явное утверждение: объявленный вид обязан всё ещё публиковаться каталогом (мутация в таблице выше).
2. **Мёртвое утверждение.** Добавленный «положительный контроль» (прогон опубликованных токенов через предикат) не мог сработать первым ни при какой мутации: после равенства множеств те же токены уже проверены прямым циклом выше. Удалён, роль контроля описана в комментарии.

Две находки разобрал по коду и отклоняю:
3. «`reversePinned` — дизъюнкция, поэтому у вида с двумя потребителями достаточно одного» — верно как ограничение, но исчезновение группы токенов формы ловит соседний тест `testEveryFormKindIsSpelledInBothLanguagesAndPairedConsistently` (`assertFalse(tokens.isEmpty())`). Дефекта нет; ограничение оставляю осознанно.
4. «Проверка разбиением не видит токен вне каталога» — правда, и именно это написано в комментарии к проверке и в разделе «не покрыто» выше. Не подгонял формулировку под удобный ответ, а сузил её: исходный текст утверждал больше, чем проверяет, — переписан.

## Пересечения с открытыми PR

* **#374** (уборка javadoc) — трогает `MetadataTypeUtils.java` и `MetadataNodeResolver.java`. Мой `typeAliases()` вставлен сразу после `resolve()`, **вне** блока осиротевших javadoc перед `nestedKindCanonicalTokens()`, который правит #374. `MetadataNodeResolver.java` я не трогаю вовсе.
* **#372** — трогает `FormElementWriter.java`. Этот файл я **не изменял**: `Form`/`Handler` закреплены со стороны теста, аксессоры туда не добавлялись.

Порядок вливания значения не имеет: пересечений по строкам нет ни с одним из двух.

## Сборка

`bash source/compile.sh` → `BUILD SUCCESS`, `Tests run: 4443, Failures: 0, Errors: 0`.
