### PR TITLE
Группы ломаются с плагином Комфорт: детекция поиска по паттерну, а не по наличию фильтра (#380)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupedObjectsFilter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupedObjectsFilter.java
@@ -24,6 +24,10 @@ import com.ditrix.edt.mcp.server.tags.TagUtils;
  * not in the main collection list. This filter ensures that when viewing the
  * original collection (e.g., Common Modules), objects that have been added to
  * a group are hidden from the list.</p>
+ *
+ * <p>While a text search narrows the tree the filter switches itself off (see
+ * {@link NavigatorSearchState}): the search hides the virtual group folders, so a grouped
+ * object has to stay visible in its original location to remain findable.</p>
  */
 public class GroupedObjectsFilter extends ViewerFilter {
     
@@ -35,7 +39,7 @@ public class GroupedObjectsFilter extends ViewerFilter {
 
         // Check if search/filter is active on the viewer
         // When search is active, we should show all objects (disable group filtering)
-        if (isSearchActive(viewer)) {
+        if (NavigatorSearchState.isSearchActive(viewer, this)) {
             return true;
         }
         
@@ -77,43 +81,8 @@ public class GroupedObjectsFilter extends ViewerFilter {
             return true; // Service not available, show object
         }
         Group containingGroup = service.findGroupForObject(project, fqn);
-        
+
         // If object is in a group, hide it from the original location
         return containingGroup == null;
-    }
-    
-    /**
-     * Checks if a text search filter is currently active on the viewer.
-     * When text search is active, we disable group filtering to allow finding objects in groups.
-     * Note: Tag filter (TagSearchFilter) does NOT disable group filtering - it handles groups itself.
-     */
-    private boolean isSearchActive(Viewer viewer) {
-        if (viewer == null) {
-            return false;
-        }
-        
-        // Check if there are any PatternFilter-like filters active on the viewer
-        if (viewer instanceof org.eclipse.jface.viewers.StructuredViewer sv) {
-            ViewerFilter[] filters = sv.getFilters();
-            for (ViewerFilter filter : filters) { // NOSONAR intentional multiple loop exits; restructuring with flags would reduce readability
-                // Skip ourselves
-                if (filter == this) {
-                    continue;
-                }
-                // Skip TagSearchFilter - it handles groups itself (use instanceof for type safety)
-                if (filter instanceof com.ditrix.edt.mcp.server.tags.ui.TagSearchFilter) {
-                    continue;
-                }
-                // Check for common text search filter types by class name
-                String className = filter.getClass().getName();
-                if (className.contains("Pattern") || className.contains("Search") || 
-                    className.contains("Quick") || className.contains("Text")) {
-                    // This is a text search filter - our filter should be disabled
-                    return true;
-                }
-            }
-        }
-        
-        return false;
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/NavigatorSearchState.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/NavigatorSearchState.java
@@ -76,7 +76,10 @@ public final class NavigatorSearchState {
      * @return {@code true} while a non-empty search pattern is applied
      */
     static boolean isSearchActive(String navigatorPattern, ViewerFilter[] filters, ViewerFilter self) {
-        if (navigatorPattern != null && !navigatorPattern.isBlank()) {
+        // Emptiness is decided exactly as the native search filter decides it (isEmpty, not
+        // isBlank): a whitespace-only pattern still narrows the tree, and treating it as "no
+        // search" would hide grouped objects from a result set that no longer shows their group.
+        if (navigatorPattern != null && !navigatorPattern.isEmpty()) {
             return true;
         }
 
@@ -86,7 +89,7 @@ public final class NavigatorSearchState {
             }
             String pattern = readPattern(filter);
             if (pattern != null) {
-                if (!pattern.isBlank()) {
+                if (!pattern.isEmpty()) {
                     return true;
                 }
             } else if (navigatorPattern == null) {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/NavigatorSearchState.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/NavigatorSearchState.java
@@ -1,0 +1,200 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.groups.ui;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+import org.eclipse.ui.navigator.CommonNavigator;
+import org.eclipse.ui.navigator.CommonViewer;
+
+import com.ditrix.edt.mcp.server.tags.ui.TagSearchFilter;
+import com.ditrix.edt.mcp.server.utils.ReflectionUtils;
+
+/**
+ * Tells whether a text search is currently narrowing the Navigator tree.
+ *
+ * <p>Group-aware filters must switch themselves off while a search is running: the search
+ * hides the virtual group folders, so an object that is only shown inside a group would
+ * become unreachable.</p>
+ *
+ * <p>The signal is the search pattern itself, not the presence of a search filter on the
+ * viewer. The native EDT search filter decides the very same way ("empty pattern = I filter
+ * nothing"), so reading its pattern keeps both filters in step no matter who attached the
+ * filter or when. Presence-based detection does not: a plugin that keeps the native filter
+ * attached permanently (with an empty pattern) would pin the answer to "always searching"
+ * and group filtering would stay off forever.</p>
+ */
+public final class NavigatorSearchState {
+
+    /** Methods that expose the active pattern, on a filter or on its state holder. */
+    private static final String[] PATTERN_ACCESSORS = {"getActivePattern", "getPattern", "getSearchText"}; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+    /** Methods that expose the state holder carrying the active pattern. */
+    private static final String[] STATE_ACCESSORS = {"getSearchFilterState", "getSearchHistory", "getState"}; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+    /** Class-name markers of a text search filter - the last-resort heuristic. */
+    private static final String[] SEARCH_FILTER_MARKERS = {"Pattern", "Search", "Quick", "Text"}; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+
+    private static final Map<MethodKey, Optional<Method>> METHOD_CACHE = new ConcurrentHashMap<>();
+
+    private NavigatorSearchState() {
+        // Utility class
+    }
+
+    /**
+     * Checks whether a text search is narrowing the given viewer.
+     *
+     * @param viewer the viewer being filtered, may be {@code null}
+     * @param self the calling filter, excluded from the scan, may be {@code null}
+     * @return {@code true} while a non-empty search pattern is applied
+     */
+    public static boolean isSearchActive(Viewer viewer, ViewerFilter self) {
+        if (viewer == null) {
+            return false;
+        }
+        ViewerFilter[] filters = viewer instanceof StructuredViewer sv ? sv.getFilters() : new ViewerFilter[0];
+        return isSearchActive(readNavigatorPattern(viewer), filters, self);
+    }
+
+    /**
+     * The SWT-free decision, unit-tested directly.
+     *
+     * @param navigatorPattern the Navigator's own search pattern, or {@code null} when it
+     *            could not be read (then the filters themselves are questioned)
+     * @param filters the filters currently attached to the viewer
+     * @param self the calling filter, excluded from the scan, may be {@code null}
+     * @return {@code true} while a non-empty search pattern is applied
+     */
+    static boolean isSearchActive(String navigatorPattern, ViewerFilter[] filters, ViewerFilter self) {
+        if (navigatorPattern != null && !navigatorPattern.isBlank()) {
+            return true;
+        }
+
+        for (ViewerFilter filter : filters) {
+            if (filter == null || filter == self || !isTextSearchFilter(filter)) {
+                continue;
+            }
+            String pattern = readPattern(filter);
+            if (pattern != null) {
+                if (!pattern.isBlank()) {
+                    return true;
+                }
+            } else if (navigatorPattern == null) {
+                // Neither the Navigator nor the filter can be asked - stay on the safe side
+                // and keep grouped objects visible in their original location.
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Reads the Navigator's own search pattern - the state the native search filter reads too.
+     *
+     * @param viewer the viewer being filtered
+     * @return the active pattern (possibly empty), or {@code null} if it cannot be read
+     */
+    static String readNavigatorPattern(Viewer viewer) {
+        if (!(viewer instanceof CommonViewer commonViewer)) {
+            return null;
+        }
+        CommonNavigator navigator = commonViewer.getCommonNavigator();
+        return navigator == null ? null : readPattern(navigator);
+    }
+
+    /**
+     * Reads the active pattern from a search filter or a navigator, directly or through its
+     * state holder. The types live in EDT-internal packages, hence reflection.
+     *
+     * @param holder the filter or navigator to question
+     * @return the active pattern (possibly empty), or {@code null} if it cannot be read
+     */
+    static String readPattern(Object holder) {
+        if (holder == null) {
+            return null;
+        }
+        String direct = readPatternDirectly(holder);
+        if (direct != null) {
+            return direct;
+        }
+        for (String accessor : STATE_ACCESSORS) {
+            String pattern = readPatternDirectly(invoke(holder, accessor));
+            if (pattern != null) {
+                return pattern;
+            }
+        }
+        return null;
+    }
+
+    private static String readPatternDirectly(Object holder) {
+        if (holder == null) {
+            return null;
+        }
+        for (String accessor : PATTERN_ACCESSORS) {
+            if (invoke(holder, accessor) instanceof String pattern) {
+                return pattern;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Recognises a text search filter by its class name. Only decides whether the filter is
+     * worth questioning - the answer always comes from its pattern when there is one.
+     */
+    private static boolean isTextSearchFilter(ViewerFilter filter) {
+        // The tag filter handles groups itself, it must never disable group filtering.
+        if (filter instanceof TagSearchFilter) {
+            return false;
+        }
+        String className = filter.getClass().getName();
+        for (String marker : SEARCH_FILTER_MARKERS) {
+            if (className.contains(marker)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Object invoke(Object target, String methodName) {
+        if (target == null) {
+            return null;
+        }
+        Optional<Method> method = METHOD_CACHE.computeIfAbsent(new MethodKey(target.getClass(), methodName),
+                key -> Optional.ofNullable(accessibleMethod(key)));
+        if (method.isEmpty()) {
+            return null;
+        }
+        try {
+            return method.get().invoke(target);
+        } catch (Exception e) { // NOSONAR a filter that cannot answer is "unknown", never a broken tree
+            return null;
+        }
+    }
+
+    private static Method accessibleMethod(MethodKey key) {
+        Method method = ReflectionUtils.findMethod(key.type(), key.name());
+        if (method == null) {
+            return null;
+        }
+        try {
+            method.setAccessible(true); // NOSONAR reflective access is required (EDT internals, no Require-Bundle)
+            return method;
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    private record MethodKey(Class<?> type, String name) {
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/groups/ui/NavigatorSearchStateTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/groups/ui/NavigatorSearchStateTest.java
@@ -1,0 +1,234 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.groups.ui;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+import org.junit.Test;
+
+/**
+ * Unit tests for the SWT-free core of {@link NavigatorSearchState} - the decision that tells
+ * {@link GroupedObjectsFilter} whether a text search is narrowing the Navigator tree.
+ *
+ * <p>The regression these lock down: detection used to be presence-based (a filter whose class
+ * name contains "Search" is attached =&gt; a search is running). The EDT Comfort plugin keeps the
+ * native EDT search filter attached to the CommonViewer permanently, with an empty pattern, so
+ * group filtering stayed off forever and every grouped object showed up twice - inside its group
+ * and in the root collection (issue #380).</p>
+ *
+ * <p>The stubs are top-level classes on purpose: as nested classes their binary names would carry
+ * the "...SearchStateTest$..." prefix and every one of them would match the class-name heuristic.</p>
+ *
+ * <p>The live wiring (reading the pattern off the real EDT Navigator) is verified in EDT.</p>
+ */
+public class NavigatorSearchStateTest
+{
+    private static ViewerFilter[] filters(ViewerFilter... viewerFilters)
+    {
+        return viewerFilters;
+    }
+
+    // ------------------------------------------------------- the Navigator pattern decides
+
+    @Test
+    public void testAttachedNativeFilterWithEmptyPatternIsNotASearch()
+    {
+        // The EDT Comfort layout: the native search filter never leaves the viewer (issue #380).
+        assertFalse(NavigatorSearchState.isSearchActive("", //$NON-NLS-1$
+            filters(new NavigatorSearchFilterStub("")), null)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNavigatorPatternMakesItASearch()
+    {
+        assertTrue(NavigatorSearchState.isSearchActive("ГуглПереводчик", //$NON-NLS-1$
+            filters(new NavigatorSearchFilterStub("ГуглПереводчик")), null)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBlankNavigatorPatternIsNotASearch()
+    {
+        assertFalse(NavigatorSearchState.isSearchActive("   ", filters(), null)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNavigatorPatternWinsOverAnOpaqueFilter()
+    {
+        // The Navigator answered "nothing is being searched" - an unreadable filter cannot veto it.
+        assertFalse(NavigatorSearchState.isSearchActive("", filters(new OpaqueSearchFilterStub()), null)); //$NON-NLS-1$
+    }
+
+    // --------------------------------------------- no Navigator pattern: question the filters
+
+    @Test
+    public void testFilterPatternIsUsedWhenTheNavigatorCannotBeRead()
+    {
+        assertTrue(NavigatorSearchState.isSearchActive(null,
+            filters(new NavigatorSearchFilterStub("Гугл")), null)); //$NON-NLS-1$
+        assertFalse(NavigatorSearchState.isSearchActive(null, filters(new NavigatorSearchFilterStub("")), null)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testPatternIsReadThroughAStateHolder()
+    {
+        assertTrue(NavigatorSearchState.isSearchActive(null,
+            filters(new SearchFilterWithHistoryStub("Обмен")), null)); //$NON-NLS-1$
+        assertFalse(NavigatorSearchState.isSearchActive(null, filters(new SearchFilterWithHistoryStub("")), null)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testOpaqueSearchFilterKeepsTheConservativeAnswer()
+    {
+        // Nothing can be asked: assume a search rather than hide a grouped object from the results.
+        assertTrue(NavigatorSearchState.isSearchActive(null, filters(new OpaqueSearchFilterStub()), null));
+    }
+
+    @Test
+    public void testNonSearchFilterIsIgnored()
+    {
+        assertFalse(NavigatorSearchState.isSearchActive(null, filters(new SubsystemsFilterStub()), null));
+    }
+
+    @Test
+    public void testNoFiltersMeansNoSearch()
+    {
+        assertFalse(NavigatorSearchState.isSearchActive(null, filters(), null));
+    }
+
+    // ------------------------------------------------------------------------ scan exclusions
+
+    @Test
+    public void testCallingFilterIsSkipped()
+    {
+        ViewerFilter self = new OpaqueSearchFilterStub();
+        assertFalse(NavigatorSearchState.isSearchActive(null, filters(self), self));
+    }
+
+    @Test
+    public void testNullFilterEntryIsSkipped()
+    {
+        assertFalse(NavigatorSearchState.isSearchActive(null, filters((ViewerFilter)null), null));
+    }
+
+    // -------------------------------------------------------------------------- readPattern
+
+    @Test
+    public void testReadPatternReadsDirectAccessor()
+    {
+        assertEquals("Справочник", //$NON-NLS-1$
+            NavigatorSearchState.readPattern(new NavigatorSearchFilterStub("Справочник"))); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testReadPatternReadsStateHolder()
+    {
+        assertEquals("Справочник", //$NON-NLS-1$
+            NavigatorSearchState.readPattern(new SearchFilterWithHistoryStub("Справочник"))); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testReadPatternReturnsNullWhenNothingCanBeAsked()
+    {
+        assertNull(NavigatorSearchState.readPattern(new OpaqueSearchFilterStub()));
+        assertNull(NavigatorSearchState.readPattern(null));
+    }
+
+    @Test
+    public void testReadNavigatorPatternIgnoresPlainViewers()
+    {
+        assertNull(NavigatorSearchState.readNavigatorPattern(null));
+    }
+}
+
+/** Stands in for the native EDT search filter: named like one, answers with its own pattern. */
+class NavigatorSearchFilterStub
+    extends ViewerFilter
+{
+    private final String pattern;
+
+    NavigatorSearchFilterStub(String pattern)
+    {
+        this.pattern = pattern;
+    }
+
+    public String getActivePattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public boolean select(Viewer viewer, Object parentElement, Object element)
+    {
+        return true;
+    }
+}
+
+/** Named like a search filter but exposes no pattern at all - the unknown case. */
+class OpaqueSearchFilterStub
+    extends ViewerFilter
+{
+    @Override
+    public boolean select(Viewer viewer, Object parentElement, Object element)
+    {
+        return true;
+    }
+}
+
+/** Not a search filter by name; must never be questioned. */
+class SubsystemsFilterStub
+    extends ViewerFilter
+{
+    @Override
+    public boolean select(Viewer viewer, Object parentElement, Object element)
+    {
+        return true;
+    }
+}
+
+/** Exposes its pattern through a state holder, the way SearchFilterWithHistory does. */
+class SearchFilterWithHistoryStub
+    extends ViewerFilter
+{
+    private final String pattern;
+
+    SearchFilterWithHistoryStub(String pattern)
+    {
+        this.pattern = pattern;
+    }
+
+    public Object getSearchHistory()
+    {
+        return new SearchHistoryStub(pattern);
+    }
+
+    @Override
+    public boolean select(Viewer viewer, Object parentElement, Object element)
+    {
+        return true;
+    }
+}
+
+/** The state holder behind {@link SearchFilterWithHistoryStub}. */
+class SearchHistoryStub
+{
+    private final String pattern;
+
+    SearchHistoryStub(String pattern)
+    {
+        this.pattern = pattern;
+    }
+
+    public String getActivePattern()
+    {
+        return pattern;
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/groups/ui/NavigatorSearchStateTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/groups/ui/NavigatorSearchStateTest.java
@@ -55,9 +55,18 @@ public class NavigatorSearchStateTest
     }
 
     @Test
-    public void testBlankNavigatorPatternIsNotASearch()
+    public void testEmptyNavigatorPatternIsNotASearch()
     {
-        assertFalse(NavigatorSearchState.isSearchActive("   ", filters(), null)); //$NON-NLS-1$
+        assertFalse(NavigatorSearchState.isSearchActive("", filters(), null)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testWhitespaceOnlyPatternIsASearch()
+    {
+        // The native filter bypasses on isEmpty(), so whitespace still narrows the tree - and a
+        // narrowed tree no longer shows the group folders. Same rule in the filter fallback.
+        assertTrue(NavigatorSearchState.isSearchActive("   ", filters(), null)); //$NON-NLS-1$
+        assertTrue(NavigatorSearchState.isSearchActive(null, filters(new NavigatorSearchFilterStub("   ")), null)); //$NON-NLS-1$
     }
 
     @Test


### PR DESCRIPTION
Fixes #380 (и tormozit/EDT.Comfort#239).

## Причина

`GroupedObjectsFilter.isSearchActive()` определял «идёт ли текстовый поиск» **по факту присутствия** на `CommonViewer` фильтра, в имени класса которого есть `Pattern`/`Search`/`Quick`/`Text`. Нашёлся — фильтр групп самоотключался.

В чистом EDT это работало случайно: штатный `com._1c.g5.v8.dt.internal.navigator.ui.filters.NavigatorSearchFilter` — это `commonFilter`, который EDT навешивает и снимает динамически по содержимому строки поиска (`Navigator.searchPerformer` → `NavigatorUtil.applyFilterNonBlockingUi` / `deactivateFilter`).

Плагин Комфорт (`NavigatorFilterHook.NavigatorNativeSearchBridge.install` → `ensureNativeFilterOnViewer`) держит этот фильтр на viewer'е **постоянно** — он подменяет в нём `searchEngine` на свой. Эвристика залипала на «поиск идёт всегда», фильтр групп выключался навсегда, и объект показывался и в группе, и в корне.

## Исправление

Решение принимается по **самому паттерну поиска** — тому же состоянию, из которого читает штатный фильтр:

```java
// NavigatorSearchFilter.select()
String searchPattern = this.getState().getActivePattern();
if (searchPattern.isEmpty()) { ... return true; }   // фильтр ничего не фильтрует
```

Новый `NavigatorSearchState`:

1. **Основной сигнал** — `CommonViewer.getCommonNavigator()` → `getSearchFilterState().getActivePattern()` (рефлексия: класс `Navigator` во внутреннем пакете EDT). Непустой паттерн = поиск идёт, кем бы и когда бы фильтр ни был навешен. Это же состояние читает и сам Комфорт (`NavigatorFilterHook.readNativeActivePattern`), и оно же наполняется штатным `SearchBox.addToHistory()` — то есть мы по построению согласованы со штатным фильтром.
2. **Fallback** — спросить паттерн у самого фильтра (`getActivePattern`/`getPattern`/`getSearchText`, в т.ч. через `getSearchFilterState`/`getSearchHistory`/`getState`).
3. **Последний рубеж** — прежняя эвристика по имени класса, только когда спросить нечего.

`Method` кэшируются (`select()` вызывается на каждый элемент дерева), любые сбои рефлексии = «не знаю» и никогда не ломают дерево.

Сам guard «во время поиска не прятать» остаётся: при активном поиске штатный фильтр прячет виртуальные папки-группы, и сгруппированный объект должен оставаться видимым на своём штатном месте, иначе его не найти.

## Тесты

`NavigatorSearchStateTest` — 15 тестов на SWT-free ядро: навешенный «поисковый» фильтр с пустым паттерном (сценарий Комфорта) больше не считается поиском; непустой паттерн навигатора считается; чтение паттерна напрямую и через state-holder; неопрашиваемый фильтр без состояния навигатора сохраняет прежнее консервативное поведение; фильтры не-поиска и сам вызывающий фильтр пропускаются.

Локальная сборка: `BUILD SUCCESS`, 4521 тест, 0 падений.

## Что осталось проверить живьём

Связки «EDT + Комфорт» на стенде нет, поэтому финальная проверка сценария из issue #239 (объект только в папке БСП, а не в корне) — за автором issue. Логика фикса выведена из исходников обоих плагинов, ссылки на конкретные места — выше.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
