### PR TITLE
e2e: shard the suite across runners by test (~60m → ~17m) (#385)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -421,9 +421,15 @@ jobs:
           # (measured: "Completed tools/call: rename_metadata_object in 301090ms, outcome=ok"
           # right after "Client connection lost: Broken pipe"). The tool now drains the
           # pipeline first, so that path should not be reached — but 300 sat EXACTLY on the
-          # boundary, which is why every collision cost a run. Keep the budget clear of it,
-          # and below the per-test timeout below.
-          MCP_CALL_TIMEOUT: "600"
+          # boundary, which is why every collision cost a run.
+          #
+          # Sharding (issue #385) makes the metadata-write lanes DENSE — back-to-back
+          # clean_project writes keep EDT's DD pipeline busy, so the heaviest renames take
+          # longer and their two happy-path tests now pass an explicit 900s tool `timeout`.
+          # This socket budget must sit ABOVE that so it doesn't cut the call first; 1200s
+          # clears the 900s tool bound and still stays under the per-test wall-clock cap
+          # (MCP_TEST_TIMEOUT, default 3600).
+          MCP_CALL_TIMEOUT: "1200"
           # Bound what reset_model may spend BEFORE and AFTER its clean_project. Left to default
           # it inherits E2E_PROJECT_READY_TIMEOUT (1200 above, sized for the COLD first index),
           # and reset_model can spend it twice per test - which alone exceeds the per-test cap and

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,10 +11,13 @@ name: E2E Tests (reusable)
 # against the local :8765.
 #
 # The `e2e` job is a SHARD MATRIX (issue #385): each matrix job is a full independent
-# runner (own checkout, EDT install, workspace, git fixture) that runs one --shard I/N
-# slice of the suite, cutting the ~60-min serial gate to ~17 min wall-clock. Stock
-# ubuntu-latest runners give that isolation for free. The `report` job merges the
-# per-shard JUnit reports into ONE "E2E Test Results" check.
+# runner (own checkout, EDT install, workspace, git fixture) that runs one NAMED shard
+# lane (`--shard <name>`) of the suite, cutting the ~60-min serial gate to ~17 min
+# wall-clock. Stock ubuntu-latest runners give that isolation for free. The lane names
+# ("read-action", "metadata-write-N") come from run_all.py — the `shards` job reads them
+# with `--list-shards` so the matrix has a single source of truth (add a lane in Python
+# and the matrix follows). The `report` job merges the per-lane JUnit reports into ONE
+# "E2E Test Results" check.
 #
 # Scope: skips the live-infobase round-trip (requires_live_infobase) by default, so
 # it needs NO licensed 1C platform — EDT indexes the project model without one. The
@@ -64,6 +67,21 @@ on:
         type: string
 
 jobs:
+  # Read the shard lane names straight from run_all.py so the matrix has ONE source of
+  # truth: add/rename a lane in Python and this matrix follows, no workflow edit needed.
+  shards:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      names: ${{ steps.list.outputs.names }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: List shard lanes
+        id: list
+        run: echo "names=$(python3 tests/e2e/run_all.py --list-shards)" >> "$GITHUB_OUTPUT"
+
   build:
     runs-on: ubuntu-latest
     permissions:
@@ -115,24 +133,23 @@ jobs:
           if-no-files-found: error
 
   e2e:
-    needs: build
+    needs: [build, shards]
     runs-on: ubuntu-latest
     permissions:
       contents: read
     # Shard the suite across independent runners for wall-clock: each matrix job gets its
     # OWN runner, checkout, EDT install, workspace and git fixture, so nothing is shared and
-    # the reset_fixture serialisation only has to hold WITHIN a shard (see issue #385). The
-    # split is by TEST, not by file (run_all.py --shard I/N), so the one heavy tool
-    # (modify_metadata ≈ 40% of the run) is spread across shards rather than pinning one.
-    # fail-fast: false so a red shard does not cancel the others — we want every shard's
-    # report, and the merge job (report) stitches them into one check.
-    #
-    # Denominator N is `${{ strategy.job-total }}` (the matrix size), so changing the shard
-    # count is a one-line edit to this list — nothing else references the number.
+    # the reset_fixture serialisation only has to hold WITHIN a shard (see issue #385). Lanes
+    # are NAMED areas (run_all.py --shard <name>) so a red shard says WHERE it failed; routing
+    # is by test `kind`, and the one heavy tool (modify_metadata ≈ 40% of the run) is spread
+    # across the metadata-write lanes rather than pinning one. The lane list comes from the
+    # `shards` job (--list-shards), so this matrix needs no edit when a lane is added.
+    # fail-fast: false so a red lane does not cancel the others — we want every lane's report,
+    # and the merge job (report) stitches them into one check.
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: ${{ fromJSON(needs.shards.outputs.names) }}
     # The EDT setup below is INLINED (instead of the ./.github/actions/setup-edt
     # composite) so each phase shows as its own step in the Actions UI — you can see at
     # a glance which steps are cached/skipped vs which run. These env values mirror the
@@ -420,8 +437,8 @@ jobs:
         run: |
           python -u tests/e2e/run_all.py \
             --project TestConfiguration \
-            --shard ${{ matrix.shard }}/${{ strategy.job-total }} \
-            --junit-xml tests/e2e/e2e-results-shard${{ matrix.shard }}.xml
+            --shard "${{ matrix.shard }}" \
+            --junit-xml "tests/e2e/e2e-results-${{ matrix.shard }}.xml"
 
       # Coverage: dump the in-memory JaCoCo data out of the still-running EDT JVM (the
       # agent is in tcpserver mode), then upload it for the Coverage workflow to merge
@@ -436,16 +453,16 @@ jobs:
           # overwrite each other and only one shard's coverage would survive the merge.
           java -jar "$JACOCO_CLI" dump \
             --address 127.0.0.1 --port 6300 \
-            --destfile "$RUNNER_TEMP/e2e-jacoco-shard${{ matrix.shard }}.exec" \
+            --destfile "$RUNNER_TEMP/e2e-jacoco-${{ matrix.shard }}.exec" \
             || echo "[coverage] jacoco dump failed (agent unreachable / EDT not up)"
-          ls -la "$RUNNER_TEMP/e2e-jacoco-shard${{ matrix.shard }}.exec" 2>/dev/null || echo "[coverage] no e2e exec produced"
+          ls -la "$RUNNER_TEMP/e2e-jacoco-${{ matrix.shard }}.exec" 2>/dev/null || echo "[coverage] no e2e exec produced"
 
       - name: "Coverage · upload e2e JaCoCo exec"
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: e2e-jacoco-exec-${{ inputs.edt }}-shard${{ matrix.shard }}
-          path: ${{ runner.temp }}/e2e-jacoco-shard${{ matrix.shard }}.exec
+          name: e2e-jacoco-exec-${{ inputs.edt }}-${{ matrix.shard }}
+          path: ${{ runner.temp }}/e2e-jacoco-${{ matrix.shard }}.exec
           if-no-files-found: warn
 
       - name: Dump EDT IDE log (the real boot/index log — separate from this console)
@@ -470,15 +487,15 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: e2e-test-results-${{ inputs.edt }}-shard${{ matrix.shard }}
-          path: tests/e2e/e2e-results-shard${{ matrix.shard }}.xml
+          name: e2e-test-results-${{ inputs.edt }}-${{ matrix.shard }}
+          path: tests/e2e/e2e-results-${{ matrix.shard }}.xml
           if-no-files-found: ignore
 
       - name: Upload EDT log
         if: ${{ always() && env.edt_log != '' }}
         uses: actions/upload-artifact@v7
         with:
-          name: e2e-edt-log-${{ inputs.edt }}-shard${{ matrix.shard }}
+          name: e2e-edt-log-${{ inputs.edt }}-${{ matrix.shard }}
           path: ${{ env.edt_log }}
           if-no-files-found: ignore
 
@@ -502,7 +519,7 @@ jobs:
       - name: Download all shard test reports
         uses: actions/download-artifact@v8
         with:
-          pattern: e2e-test-results-${{ inputs.edt }}-shard*
+          pattern: e2e-test-results-${{ inputs.edt }}-*
           path: e2e-reports
           merge-multiple: true
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -436,6 +436,15 @@ jobs:
           # turns a legitimately slow cleanup into a reported hang. A post-write settle is not a
           # cold index; 600 is generous for it.
           E2E_MODEL_SETTLE_TIMEOUT: "600"
+          # Per-TEST wall-clock cap (run_all.py --test-timeout). It MUST sit ABOVE the worst
+          # legit call-and-reset chain, or the outer timer abandons a healthy slow test and
+          # SKIPS the rest of the shard. That chain grew when MCP_CALL_TIMEOUT went 600 → 1200:
+          # a heavy write-metadata test can now spend the call budget (up to 1200, or 900 for a
+          # rename) and then reset_model() — settle 600 + clean_project (up to 1200) + settle 600
+          # ≈ 2400 — which sums to ~3600, i.e. the OLD default cap exactly (no headroom). 5400
+          # restores the margin (covers the chain plus one clean_project retry) while still
+          # bounding a true hang. Raising the call budget without this is the gap Codex flagged.
+          MCP_TEST_TIMEOUT: "5400"
           # Unbuffer stdout: otherwise Python block-buffers in CI (stdout is a pipe), so
           # the readiness-wait countdown only appears when the process exits — which looks
           # like a hang during the (long) index wait. -u/PYTHONUNBUFFERED stream it live.
@@ -515,7 +524,7 @@ jobs:
   # workflow (and so blocks the coverage.yml workflow_run, which requires success) — this
   # job only owns the single-check presentation, never the pass/fail verdict.
   report:
-    needs: e2e
+    needs: [e2e, shards]
     if: always()
     runs-on: ubuntu-latest
     permissions:
@@ -528,6 +537,31 @@ jobs:
           pattern: e2e-test-results-${{ inputs.edt }}-*
           path: e2e-reports
           merge-multiple: true
+
+      # A shard whose runner dies before run_all.py writes JUnit (EDT never ready, setup
+      # cleanup failed) uploads nothing (if-no-files-found: ignore), so the merge below would
+      # otherwise show GREEN from the surviving shards while a whole shard silently produced no
+      # results. Synthesize a FAILING report for any expected lane whose XML is absent, so the
+      # merged check can never look green with a shard missing. The matrix job is red separately;
+      # this keeps the single presentation check honest too.
+      - name: Fail the merged check for any shard that produced no report
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p e2e-reports
+          missing=0
+          for name in $(echo '${{ needs.shards.outputs.names }}' | jq -r '.[]'); do
+            if [ ! -f "e2e-reports/e2e-results-$name.xml" ]; then
+              echo "::error::E2E shard '$name' produced no JUnit report (runner aborted before writing results)."
+              missing=$((missing + 1))
+              printf '%s\n' \
+                '<?xml version="1.0" encoding="UTF-8"?>' \
+                "<testsuite name=\"edt-mcp-e2e-shard-$name\" tests=\"1\" failures=\"1\">" \
+                "  <testcase name=\"shard::$name::report_missing\" time=\"0.0\"><failure>Shard '$name' produced no JUnit report; its runner aborted before run_all.py wrote results (e.g. EDT never became ready). Counted as a failure so the merged check is not falsely green.</failure></testcase>" \
+                '</testsuite>' > "e2e-reports/e2e-results-$name-MISSING.xml"
+            fi
+          done
+          echo "shards with no report: $missing"
 
       - name: Publish E2E Test Results (merged across shards)
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,15 +1,20 @@
 name: E2E Tests (reusable)
 
 # REUSABLE workflow (on: workflow_call) — invoked by the thin caller workflow
-# e2e-2026.2.yml (parameterized by EDT version so it stays ready for a future matrix),
-# which gives the gate its OWN status badge. Black-box e2e gate on a STOCK
-# GitHub-hosted runner (ubuntu-latest):
+# e2e-2026.2.yml (parameterized by EDT version), which gives the gate its OWN status
+# badge. Black-box e2e gate on a STOCK GitHub-hosted runner (ubuntu-latest):
 # no docker image, no self-hosted runner. The `build` job builds the plugin; the `e2e`
 # job boots a headless EDT (inlined setup, numbered steps 1/8…8/8 — each phase is a
 # separate line in the Actions UI so you can see what is cached vs what runs),
 # force-starts the MCP server (EDT_MCP_AUTO_START), imports the TestConfiguration
 # fixtures into an empty workspace (EDT_MCP_IMPORT_PROJECTS), then runs the suite
 # against the local :8765.
+#
+# The `e2e` job is a SHARD MATRIX (issue #385): each matrix job is a full independent
+# runner (own checkout, EDT install, workspace, git fixture) that runs one --shard I/N
+# slice of the suite, cutting the ~60-min serial gate to ~17 min wall-clock. Stock
+# ubuntu-latest runners give that isolation for free. The `report` job merges the
+# per-shard JUnit reports into ONE "E2E Test Results" check.
 #
 # Scope: skips the live-infobase round-trip (requires_live_infobase) by default, so
 # it needs NO licensed 1C platform — EDT indexes the project model without one. The
@@ -114,8 +119,20 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      checks: write
-      pull-requests: write
+    # Shard the suite across independent runners for wall-clock: each matrix job gets its
+    # OWN runner, checkout, EDT install, workspace and git fixture, so nothing is shared and
+    # the reset_fixture serialisation only has to hold WITHIN a shard (see issue #385). The
+    # split is by TEST, not by file (run_all.py --shard I/N), so the one heavy tool
+    # (modify_metadata ≈ 40% of the run) is spread across shards rather than pinning one.
+    # fail-fast: false so a red shard does not cancel the others — we want every shard's
+    # report, and the merge job (report) stitches them into one check.
+    #
+    # Denominator N is `${{ strategy.job-total }}` (the matrix size), so changing the shard
+    # count is a one-line edit to this list — nothing else references the number.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     # The EDT setup below is INLINED (instead of the ./.github/actions/setup-edt
     # composite) so each phase shows as its own step in the Actions UI — you can see at
     # a glance which steps are cached/skipped vs which run. These env values mirror the
@@ -403,7 +420,8 @@ jobs:
         run: |
           python -u tests/e2e/run_all.py \
             --project TestConfiguration \
-            --junit-xml tests/e2e/e2e-results.xml
+            --shard ${{ matrix.shard }}/${{ strategy.job-total }} \
+            --junit-xml tests/e2e/e2e-results-shard${{ matrix.shard }}.xml
 
       # Coverage: dump the in-memory JaCoCo data out of the still-running EDT JVM (the
       # agent is in tcpserver mode), then upload it for the Coverage workflow to merge
@@ -413,18 +431,21 @@ jobs:
         shell: bash
         run: |
           set -uxo pipefail
+          # Per-shard inner filename: coverage.yml downloads every e2e-jacoco-exec-* artifact
+          # with merge-multiple, which flattens them into one dir — identical inner names would
+          # overwrite each other and only one shard's coverage would survive the merge.
           java -jar "$JACOCO_CLI" dump \
             --address 127.0.0.1 --port 6300 \
-            --destfile "$RUNNER_TEMP/e2e-jacoco.exec" \
+            --destfile "$RUNNER_TEMP/e2e-jacoco-shard${{ matrix.shard }}.exec" \
             || echo "[coverage] jacoco dump failed (agent unreachable / EDT not up)"
-          ls -la "$RUNNER_TEMP/e2e-jacoco.exec" 2>/dev/null || echo "[coverage] no e2e exec produced"
+          ls -la "$RUNNER_TEMP/e2e-jacoco-shard${{ matrix.shard }}.exec" 2>/dev/null || echo "[coverage] no e2e exec produced"
 
       - name: "Coverage · upload e2e JaCoCo exec"
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: e2e-jacoco-exec-${{ inputs.edt }}
-          path: ${{ runner.temp }}/e2e-jacoco.exec
+          name: e2e-jacoco-exec-${{ inputs.edt }}-shard${{ matrix.shard }}
+          path: ${{ runner.temp }}/e2e-jacoco-shard${{ matrix.shard }}.exec
           if-no-files-found: warn
 
       - name: Dump EDT IDE log (the real boot/index log — separate from this console)
@@ -441,30 +462,54 @@ jobs:
             echo "(no EDT IDE log at $LOG)"
           fi
 
-      - name: Publish E2E Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
-        continue-on-error: true
-        with:
-          check_name: "E2E Test Results (EDT ${{ inputs.edt }})"
-          files: tests/e2e/e2e-results.xml
-
+      # NB: no per-shard "Publish E2E Test Results" here — a shard only ran a SLICE of the
+      # suite, so publishing per shard would post N partial checks. Each shard uploads its
+      # JUnit XML as an artifact; the `report` job below downloads all of them and publishes
+      # ONE merged "E2E Test Results" check.
       - name: Upload test report
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: e2e-test-results-${{ inputs.edt }}
-          path: tests/e2e/e2e-results.xml
+          name: e2e-test-results-${{ inputs.edt }}-shard${{ matrix.shard }}
+          path: tests/e2e/e2e-results-shard${{ matrix.shard }}.xml
           if-no-files-found: ignore
 
       - name: Upload EDT log
         if: ${{ always() && env.edt_log != '' }}
         uses: actions/upload-artifact@v7
         with:
-          name: e2e-edt-log-${{ inputs.edt }}
+          name: e2e-edt-log-${{ inputs.edt }}-shard${{ matrix.shard }}
           path: ${{ env.edt_log }}
           if-no-files-found: ignore
 
       - name: Stop EDT
         if: always()
         run: kill "${edt_pid:-0}" 2>/dev/null || true
+
+  # Merge the per-shard JUnit reports into ONE "E2E Test Results" check. Runs after every
+  # shard (if: always() so it still stitches together whatever ran when a shard failed).
+  # The `e2e` matrix job's own conclusion still gates the workflow — a red shard fails the
+  # workflow (and so blocks the coverage.yml workflow_run, which requires success) — this
+  # job only owns the single-check presentation, never the pass/fail verdict.
+  report:
+    needs: e2e
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+    steps:
+      - name: Download all shard test reports
+        uses: actions/download-artifact@v8
+        with:
+          pattern: e2e-test-results-${{ inputs.edt }}-shard*
+          path: e2e-reports
+          merge-multiple: true
+
+      - name: Publish E2E Test Results (merged across shards)
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        continue-on-error: true
+        with:
+          check_name: "E2E Test Results (EDT ${{ inputs.edt }})"
+          files: e2e-reports/**/*.xml

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,5 +1,6 @@
 # e2e run artifacts (debug output, not source of truth)
 tools_list.actual.json
 e2e-results.xml
+e2e-results-shard*.xml
 _*.log
 __pycache__/

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,6 +1,6 @@
 # e2e run artifacts (debug output, not source of truth)
 tools_list.actual.json
 e2e-results.xml
-e2e-results-shard*.xml
+e2e-results-*.xml
 _*.log
 __pycache__/

--- a/tests/e2e/SKILL.md
+++ b/tests/e2e/SKILL.md
@@ -41,7 +41,7 @@ tests/e2e/
 - **`tools/test_<tool>.py`** — one file per MCP tool. It contains the test functions for that one tool: the happy path(s) **and** the negative matrix. Because each agent owns one file, there are **no merge conflicts** when many agents work in parallel.
 - **`run_all.py`** — discovers every `@e2e_test` function, runs them **one at a time** (see §3 — execution is serial), resets the fixture before each, and emits a `--junit-xml` report.
 
-**Golden rule of parallelism:** writing the test files can be parallelized across agents. **Running** them cannot be parallelized *within one workspace* — every test mutates the same `TestConfiguration` project and the same git working tree, so the orchestrator runs them serially with a hard reset between each. Parallelism comes from running MULTIPLE workspaces: CI shards the suite across independent runners (`--shard I/N`, §8), each with its own EDT + git fixture, and each shard still runs its slice serially.
+**Golden rule of parallelism:** writing the test files can be parallelized across agents. **Running** them cannot be parallelized *within one workspace* — every test mutates the same `TestConfiguration` project and the same git working tree, so the orchestrator runs them serially with a hard reset between each. Parallelism comes from running MULTIPLE workspaces: CI shards the suite into **named lanes** across independent runners (`--shard <name>`, §8), each with its own EDT + git fixture, and each lane still runs its slice serially.
 
 ---
 
@@ -181,6 +181,8 @@ assert_error_quality(e,
 - `kind="write-metadata"` — create/add/delete/rename metadata. Verify with MODEL READ-BACK (call a read tool) AND on-disk structure (`poll_diff_contains` of the element, or `poll_disk_path_gone`/`poll_disk_lacks` for delete). The orchestrator runs `reset_fixture()`+`reset_model()` after each such test (you don't).
 - `kind="action"` — clean/revalidate/import/export/update_database. Usually `assert_no_diff()` + status.
 
+> **`kind` also picks the CI shard lane** (§8). It is the one field that decides *where a test runs*: `read`/`write`/`action` go to the cheap `read-action` lane, `write-metadata` is spread across the `metadata-write-N` lanes (it dominates the runtime). So pick the **honest** kind — a metadata mutation mis-tagged `read` lands in the wrong lane, skips the `reset_model()` a write needs, AND unbalances the shards. You never edit a shard map: the right `kind` routes the test for you. (`python run_all.py --list-shards` shows the lanes; routing lives in `run_all.py`.)
+
 The orchestrator discovers `@e2e_test` functions, runs them serially, `reset_fixture()` **before each**, and enforces final cleanliness.
 
 ```python
@@ -234,7 +236,7 @@ The suite requires the **live server up** on `:8765` with `TestConfiguration` lo
 python tests/e2e/run_all.py --project TestConfiguration --junit-xml tests/e2e/e2e-results.xml
 ```
 
-- Execution is **serial WITHIN a workspace** (see §3). Do not try to parallelize a single run. To parallelize across CI, shard: `--shard I/N` runs shard I of N (1-based) — a deterministic disjoint slice split BY TEST (a stride over tests sorted by tool+name, so the heavy `modify_metadata` spreads across shards, not by file). Applied after `--filter`. N independent runners with N workspaces cover the suite; `e2e-tests.yml` runs a 4-shard matrix and merges the reports into one check.
+- Execution is **serial WITHIN a workspace** (see §3). Do not try to parallelize a single run. To parallelize across CI, shard into **named lanes**: `--shard <name>` runs one lane; `--list-shards` prints them (JSON). Lanes are **areas, not numbers**, so a red shard says *where* it failed and a new test routes itself — routing is by the test's `kind` (§3): `read`/`write`/`action` → the one `read-action` lane; `write-metadata` → spread across `metadata-write-N` lanes (that kind is ~96% of the runtime and one tool, `modify_metadata`, is ~40%, so it cannot fit a single named lane — the file-sharding ceiling issue #385 is about). **Adding a tool needs no shard edit** — pick the right `kind` and it lands in the right lane; only if a genuinely new heavy area appears do you add a lane (bump `_METADATA_LANES` or extend the routing in `run_all.py`, and CI's matrix follows via `--list-shards`). `e2e-tests.yml` runs this matrix and merges the per-lane reports into one check.
 - The run **mutates** `TestConfiguration` and reverts it; on a clean checkout that is expected. The final state must be clean.
 - The existing `.github/workflows/e2e-tests.yml` invokes the runner against a running server; keep its CLI flags (`--host/--port/--project/--junit-xml`) stable.
 - **No new dependencies** — Python **stdlib only** (`urllib`, `json`, `subprocess` for git, `re`). Do not add pip packages. (Research-backed: the official MCP SDK's in-memory transport doesn't fit a server that lives inside EDT; the hand-rolled client is kept spec-conformant instead — initialize + notifications/initialized handshake, Mcp-Session-Id + MCP-Protocol-Version headers, robust SSE.)

--- a/tests/e2e/SKILL.md
+++ b/tests/e2e/SKILL.md
@@ -41,7 +41,7 @@ tests/e2e/
 - **`tools/test_<tool>.py`** — one file per MCP tool. It contains the test functions for that one tool: the happy path(s) **and** the negative matrix. Because each agent owns one file, there are **no merge conflicts** when many agents work in parallel.
 - **`run_all.py`** — discovers every `@e2e_test` function, runs them **one at a time** (see §3 — execution is serial), resets the fixture before each, and emits a `--junit-xml` report.
 
-**Golden rule of parallelism:** writing the test files can be parallelized across agents. **Running** them cannot — every test mutates the same `TestConfiguration` project and the same git working tree, so the orchestrator runs them serially with a hard reset between each.
+**Golden rule of parallelism:** writing the test files can be parallelized across agents. **Running** them cannot be parallelized *within one workspace* — every test mutates the same `TestConfiguration` project and the same git working tree, so the orchestrator runs them serially with a hard reset between each. Parallelism comes from running MULTIPLE workspaces: CI shards the suite across independent runners (`--shard I/N`, §8), each with its own EDT + git fixture, and each shard still runs its slice serially.
 
 ---
 
@@ -234,7 +234,7 @@ The suite requires the **live server up** on `:8765` with `TestConfiguration` lo
 python tests/e2e/run_all.py --project TestConfiguration --junit-xml tests/e2e/e2e-results.xml
 ```
 
-- Execution is **serial** (see §3). Do not try to parallelize the run.
+- Execution is **serial WITHIN a workspace** (see §3). Do not try to parallelize a single run. To parallelize across CI, shard: `--shard I/N` runs shard I of N (1-based) — a deterministic disjoint slice split BY TEST (a stride over tests sorted by tool+name, so the heavy `modify_metadata` spreads across shards, not by file). Applied after `--filter`. N independent runners with N workspaces cover the suite; `e2e-tests.yml` runs a 4-shard matrix and merges the reports into one check.
 - The run **mutates** `TestConfiguration` and reverts it; on a clean checkout that is expected. The final state must be clean.
 - The existing `.github/workflows/e2e-tests.yml` invokes the runner against a running server; keep its CLI flags (`--host/--port/--project/--junit-xml`) stable.
 - **No new dependencies** — Python **stdlib only** (`urllib`, `json`, `subprocess` for git, `re`). Do not add pip packages. (Research-backed: the official MCP SDK's in-memory transport doesn't fit a server that lives inside EDT; the hand-rolled client is kept spec-conformant instead — initialize + notifications/initialized handshake, Mcp-Session-Id + MCP-Protocol-Version headers, robust SSE.)

--- a/tests/e2e/run_all.py
+++ b/tests/e2e/run_all.py
@@ -3,13 +3,22 @@
 EDT-MCP e2e orchestrator.
 
 Discovers every @e2e_test in tests/e2e/tools/test_*.py and runs them SERIALLY
-(all tests mutate the same TestConfiguration + git tree, so they cannot run in
-parallel). Resets the fixture before EVERY test, enforces a clean final state,
-and emits a JUnit XML report. See SKILL.md.
+(all tests mutate the same TestConfiguration + git tree, so within ONE workspace
+they cannot run in parallel). Resets the fixture before EVERY test, enforces a
+clean final state, and emits a JUnit XML report. See SKILL.md.
+
+Parallelism across MULTIPLE workspaces is done by sharding: `--shard I/N` runs
+only shard I of N (1-based). Each shard is a disjoint slice of the whole test
+list, so N shards on N independent runners (each with its own EDT + git fixture)
+cover the suite with no shared state. Sharding is BY TEST, not by file: the slice
+is a stride over the tests sorted by (tool, name), so a single heavy tool
+(modify_metadata is ~40% of the run) is spread across shards instead of pinning
+one shard to its total. See issue #385.
 
 Usage:
     python tests/e2e/run_all.py [--host H] [--port P] [--project NAME]
                                 [--junit-xml PATH] [--filter SUBSTR]
+                                [--shard I/N]
 
 Python stdlib only.
 """
@@ -31,6 +40,10 @@ def parse_args():
     ap.add_argument("--project", default=os.environ.get("MCP_PROJECT", "TestConfiguration"))
     ap.add_argument("--junit-xml", dest="junit", default=None)
     ap.add_argument("--filter", default=None, help="substring filter on test name or tool")
+    ap.add_argument("--shard", default=None,
+                    help="run only shard I of N as 'I/N' (1-based, e.g. 2/4). The suite is split "
+                         "deterministically by TEST (a stride over tests sorted by tool+name), so a "
+                         "single heavy tool is spread across shards. Applied AFTER --filter.")
     ap.add_argument("--test-timeout", type=float,
                     default=float(os.environ.get("MCP_TEST_TIMEOUT", "3600")),
                     help="per-test wall-clock timeout in seconds (default 3600). Must exceed the "
@@ -44,6 +57,33 @@ def parse_args():
                          "must never do: it FAILS the test and SKIPS all the rest. No auto-relaunch "
                          "- restart EDT and re-run.")
     return ap.parse_args()
+
+
+def parse_shard(spec):
+    """Parse a '--shard I/N' spec into (index, total) with 1 <= index <= total.
+
+    Raises SystemExit with an actionable message on a malformed spec, so a typo in the
+    CI matrix fails the job loudly instead of silently running the whole suite (or none).
+    """
+    parts = spec.split("/")
+    if len(parts) != 2:
+        raise SystemExit("--shard must be 'I/N' (e.g. 2/4), got %r" % spec)
+    try:
+        index, total = int(parts[0]), int(parts[1])
+    except ValueError:
+        raise SystemExit("--shard I/N must be integers (e.g. 2/4), got %r" % spec)
+    if total < 1 or index < 1 or index > total:
+        raise SystemExit("--shard I/N requires 1 <= I <= N (got %r)" % spec)
+    return index, total
+
+
+def select_shard(tests, index, total):
+    """Deterministic 1-based shard: the stride tests[index-1::total] over tests sorted by
+    (tool, name). A stride (not a contiguous chunk) spreads a heavy tool — whose tests are
+    adjacent once sorted — evenly across shards, so no shard is pinned to one tool's total.
+    Order within a shard does not matter: the run resets the fixture before every test."""
+    ordered = sorted(tests, key=lambda t: (t["tool"], t["name"]))
+    return ordered[index - 1::total]
 
 
 def write_junit(results, path, final_clean, cleanup_failed=False):
@@ -215,7 +255,15 @@ def main():
     if args.filter:
         tests = [t for t in tests if args.filter in t["name"] or args.filter in t["tool"]]
 
-    print("EDT-MCP e2e: %d test(s) against %s, project=%s" % (len(tests), harness.MCP_URL, harness.PROJECT))
+    shard_note = ""
+    if args.shard:
+        index, total = parse_shard(args.shard)
+        selected = len(tests)
+        tests = select_shard(tests, index, total)
+        shard_note = " [shard %d/%d: %d of %d test(s)]" % (index, total, len(tests), selected)
+
+    print("EDT-MCP e2e: %d test(s) against %s, project=%s%s"
+          % (len(tests), harness.MCP_URL, harness.PROJECT, shard_note))
     harness.wait_for_server()
     harness.initialize()     # proper MCP handshake (captures Mcp-Session-Id if issued)
     if not harness.wait_for_project_ready():

--- a/tests/e2e/run_all.py
+++ b/tests/e2e/run_all.py
@@ -84,11 +84,19 @@ def parse_args():
 # is about). The spread is a stable hash of "tool::name" (zlib.crc32 — deterministic across
 # machines, unlike the salted built-in hash()), so it is balanced and every runner agrees
 # which lane a test is in. Order within a lane never matters: the fixture resets before each
-# test. Bump _METADATA_LANES for more parallelism (CI reads the names via --list-shards).
-# 4 lanes puts each metadata lane (~3560s of write-metadata / 4) level with the single cheap
-# read-action lane (~850s + the modify_metadata stragglers), so the slowest shard is ~17 min
-# — the balance point for this suite. Add lanes to go faster, at the cost of runner-minutes.
-_METADATA_LANES = 4
+# test. CI reads the names via --list-shards, so changing this count needs no workflow edit.
+#
+# Why 8 and not 4 (issue #385, PR #390 CI): each write-metadata test ends in reset_model()
+# (a clean_project → full derived-data recompute), and packing ~90 of them back-to-back on
+# one 2-core runner keeps EDT's DD pipeline perpetually busy — it never gets the idle gaps
+# the interleaved serial run gave it. rename_metadata_object must BLOCK that pipeline to run
+# its cascade; on a saturated pipeline the block/apply overran the tool's 420s bound and the
+# lane went red ("DD pipeline has running computations left during block attempt"). Halving
+# the per-lane load (~90 → ~45 write tests) keeps each runner's EDT far less saturated when
+# its rename tests (which sort LATE in the lane) run. More lanes = healthier EDT per lane, at
+# the cost of runner-minutes (each lane re-pays the ~3-min EDT install) — the wall-clock/
+# machine-time trade issue #385 already signed up for.
+_METADATA_LANES = 8
 
 READ_ACTION_LANE = "read-action"
 

--- a/tests/e2e/run_all.py
+++ b/tests/e2e/run_all.py
@@ -7,30 +7,42 @@ Discovers every @e2e_test in tests/e2e/tools/test_*.py and runs them SERIALLY
 they cannot run in parallel). Resets the fixture before EVERY test, enforces a
 clean final state, and emits a JUnit XML report. See SKILL.md.
 
-Parallelism across MULTIPLE workspaces is done by sharding: `--shard I/N` runs
-only shard I of N (1-based). Each shard is a disjoint slice of the whole test
-list, so N shards on N independent runners (each with its own EDT + git fixture)
-cover the suite with no shared state. Sharding is BY TEST, not by file: the slice
-is a stride over the tests sorted by (tool, name), so a single heavy tool
-(modify_metadata is ~40% of the run) is spread across shards instead of pinning
-one shard to its total. See issue #385.
+Parallelism across MULTIPLE workspaces is done by sharding into NAMED lanes:
+`--shard <name>` runs only that lane. Each lane is a disjoint slice of the suite,
+so the lanes on independent runners (each with its own EDT + git fixture) cover
+everything with no shared state. See issue #385 and SHARDS below.
+
+Lanes are named by AREA, not by number, so a failing shard says WHAT failed and a
+new test lands in the right lane automatically — routing is by the `kind` already
+declared on every @e2e_test:
+  * read-action ..... reads, source writes, and actions — everything cheap
+                      (~4% of the runtime, all in one lane).
+  * metadata-write-N  the write-metadata kind (~96% of the runtime). One tool,
+                      modify_metadata, is ~40% of the whole suite on its own, so
+                      write-metadata cannot fit one named lane and is spread across
+                      N lanes by a stable hash of the test id (deterministic across
+                      runners). Bump _METADATA_LANES to add more parallelism.
+Adding a tool needs NO edit here: its `kind` routes it. `--list-shards` prints the
+lane names (JSON) so CI can build the matrix straight from this file.
 
 Usage:
     python tests/e2e/run_all.py [--host H] [--port P] [--project NAME]
                                 [--junit-xml PATH] [--filter SUBSTR]
-                                [--shard I/N]
+                                [--shard NAME | --list-shards]
 
 Python stdlib only.
 """
 
 import argparse
 import importlib
+import json
 import os
 import sys
 import threading
 import time
 import traceback
 import xml.sax.saxutils as su
+import zlib
 
 
 def parse_args():
@@ -40,10 +52,12 @@ def parse_args():
     ap.add_argument("--project", default=os.environ.get("MCP_PROJECT", "TestConfiguration"))
     ap.add_argument("--junit-xml", dest="junit", default=None)
     ap.add_argument("--filter", default=None, help="substring filter on test name or tool")
-    ap.add_argument("--shard", default=None,
-                    help="run only shard I of N as 'I/N' (1-based, e.g. 2/4). The suite is split "
-                         "deterministically by TEST (a stride over tests sorted by tool+name), so a "
-                         "single heavy tool is spread across shards. Applied AFTER --filter.")
+    ap.add_argument("--shard", default=None, metavar="NAME",
+                    help="run only the named shard lane (see --list-shards). Lanes are areas, not "
+                         "numbers: 'read-action' plus 'metadata-write-N'. Applied AFTER --filter.")
+    ap.add_argument("--list-shards", action="store_true",
+                    help="print the shard lane names as a JSON array and exit (CI reads this to "
+                         "build the matrix, so the lanes have a single source of truth).")
     ap.add_argument("--test-timeout", type=float,
                     default=float(os.environ.get("MCP_TEST_TIMEOUT", "3600")),
                     help="per-test wall-clock timeout in seconds (default 3600). Must exceed the "
@@ -59,31 +73,47 @@ def parse_args():
     return ap.parse_args()
 
 
-def parse_shard(spec):
-    """Parse a '--shard I/N' spec into (index, total) with 1 <= index <= total.
+# ── Named shard lanes (issue #385) ─────────────────────────────────────────────
+# A shard is a NAMED area, not a number, so a red shard says WHERE it failed and a new
+# test routes itself. Routing is by the `kind` already on every @e2e_test:
+#   - read / write / action  -> the single "read-action" lane (~4% of the runtime).
+#   - write-metadata         -> spread across _METADATA_LANES "metadata-write-N" lanes.
+# Why write-metadata is spread and not one named lane: it is ~96% of the runtime and one
+# tool (modify_metadata, 101 tests) is ~40% of the WHOLE suite, so no single lane can hold
+# it without becoming the bottleneck (this is exactly the file-sharding ceiling issue #385
+# is about). The spread is a stable hash of "tool::name" (zlib.crc32 — deterministic across
+# machines, unlike the salted built-in hash()), so it is balanced and every runner agrees
+# which lane a test is in. Order within a lane never matters: the fixture resets before each
+# test. Bump _METADATA_LANES for more parallelism (CI reads the names via --list-shards).
+# 4 lanes puts each metadata lane (~3560s of write-metadata / 4) level with the single cheap
+# read-action lane (~850s + the modify_metadata stragglers), so the slowest shard is ~17 min
+# — the balance point for this suite. Add lanes to go faster, at the cost of runner-minutes.
+_METADATA_LANES = 4
 
-    Raises SystemExit with an actionable message on a malformed spec, so a typo in the
-    CI matrix fails the job loudly instead of silently running the whole suite (or none).
-    """
-    parts = spec.split("/")
-    if len(parts) != 2:
-        raise SystemExit("--shard must be 'I/N' (e.g. 2/4), got %r" % spec)
-    try:
-        index, total = int(parts[0]), int(parts[1])
-    except ValueError:
-        raise SystemExit("--shard I/N must be integers (e.g. 2/4), got %r" % spec)
-    if total < 1 or index < 1 or index > total:
-        raise SystemExit("--shard I/N requires 1 <= I <= N (got %r)" % spec)
-    return index, total
+READ_ACTION_LANE = "read-action"
 
 
-def select_shard(tests, index, total):
-    """Deterministic 1-based shard: the stride tests[index-1::total] over tests sorted by
-    (tool, name). A stride (not a contiguous chunk) spreads a heavy tool — whose tests are
-    adjacent once sorted — evenly across shards, so no shard is pinned to one tool's total.
-    Order within a shard does not matter: the run resets the fixture before every test."""
-    ordered = sorted(tests, key=lambda t: (t["tool"], t["name"]))
-    return ordered[index - 1::total]
+def shard_names():
+    """The ordered list of lane names — the single source of truth CI builds its matrix from."""
+    return [READ_ACTION_LANE] + ["metadata-write-%d" % (i + 1) for i in range(_METADATA_LANES)]
+
+
+def route_shard(t):
+    """The one lane a test belongs to. Total by construction (an unknown/new kind falls to
+    read-action), so the lanes always PARTITION the suite — no test is dropped or double-run."""
+    if t.get("kind") == "write-metadata":
+        bucket = zlib.crc32(("%s::%s" % (t["tool"], t["name"])).encode("utf-8")) % _METADATA_LANES
+        return "metadata-write-%d" % (bucket + 1)
+    return READ_ACTION_LANE
+
+
+def select_shard(tests, name):
+    """Tests routed to lane `name`. Rejects an unknown lane loudly, so a typo in the CI
+    matrix fails the job instead of silently running nothing."""
+    valid = shard_names()
+    if name not in valid:
+        raise SystemExit("--shard must be one of: %s (got %r)" % (", ".join(valid), name))
+    return [t for t in tests if route_shard(t) == name]
 
 
 def write_junit(results, path, final_clean, cleanup_failed=False):
@@ -235,6 +265,10 @@ def _run_with_timeout(harness, t, timeout_s):
 
 def main():
     args = parse_args()
+    if args.list_shards:
+        # Pure metadata query — no server, no harness import. CI uses it to build the matrix.
+        print(json.dumps(shard_names()))
+        return
     # Set env BEFORE importing harness (it reads config once at import).
     os.environ["MCP_HOST"] = args.host
     os.environ["MCP_PORT"] = str(args.port)
@@ -257,10 +291,9 @@ def main():
 
     shard_note = ""
     if args.shard:
-        index, total = parse_shard(args.shard)
         selected = len(tests)
-        tests = select_shard(tests, index, total)
-        shard_note = " [shard %d/%d: %d of %d test(s)]" % (index, total, len(tests), selected)
+        tests = select_shard(tests, args.shard)
+        shard_note = " [shard '%s': %d of %d test(s)]" % (args.shard, len(tests), selected)
 
     print("EDT-MCP e2e: %d test(s) against %s, project=%s%s"
           % (len(tests), harness.MCP_URL, harness.PROJECT, shard_note))

--- a/tests/e2e/tools/test_rename_metadata_object.py
+++ b/tests/e2e/tools/test_rename_metadata_object.py
@@ -112,6 +112,12 @@ def test_confirm_renames_common_module_and_readback_shows_new_name():
         "objectFqn": "CommonModule.Calc",
         "newName": "Compute",
         "confirm": True,
+        # Headroom above the 420s default (issue #385 / PR #390): this cascade (BSL + forms +
+        # metadata) is the heaviest rename, and on a sharded metadata-write lane EDT's DD
+        # pipeline is busier, so the apply can run past 420s and the tool would report "did not
+        # finish". 900s (< the 3600 max) lets a legitimately-slower run complete; a true hang
+        # still fails the per-test wall-clock timeout.
+        "timeout": 900,
     })
     assert_ok(r, "execute rename CommonModule.Calc -> Compute")
     # Execute-mode markers (performRename): YAML action + completion header.
@@ -146,6 +152,7 @@ def test_confirm_renames_catalog_and_readback_shows_new_name():
         "objectFqn": "Catalog.Catalog",
         "newName": "Goods",
         "confirm": True,
+        "timeout": 900,  # sharded-lane headroom above the 420s default (see CommonModule rename)
     })
     assert_ok(r, "execute rename Catalog.Catalog -> Goods")
     assert_contains(r.text, "action: executed", "execute mode must emit YAML action: executed")

--- a/tests/e2e/tools/test_resync_to_disk.py
+++ b/tests/e2e/tools/test_resync_to_disk.py
@@ -174,7 +174,17 @@ def test_resync_in_sync_fixture_is_a_noop_and_does_not_mutate():
     assert_no_diff("default resync of an in-sync project must not change any tracked file")
 
 
-@e2e_test(tool="resync_to_disk", kind="action")
+# kind="write-metadata" (NOT "action") on purpose: fullExport=true force-exports EVERY top
+# object model->disk, and that export is ASYNC (it can land AFTER the test body returns), so
+# the test needs the write-metadata teardown — reset_fixture()+reset_model() — to settle the
+# export and re-sync the model, exactly like test_apply_quick_fix's teardown. As an action it
+# got NO teardown: in a serial run the next write-metadata test's reset_model() masked the
+# residue, but once the suite is sharded by kind (issue #385) this test lands in the cheap
+# read-action lane with no such neighbour, and its residue desynced the very next default
+# resync (test_report_only) into exporting a phantom -> a dirty tree. On success it still
+# rewrites identical bytes (assert_no_diff holds); the honest kind is about the async WRITE,
+# not the net byte diff.
+@e2e_test(tool="resync_to_disk", kind="write-metadata")
 def test_full_export_reexports_every_top_object():
     """fullExport=true opts back in to the export-everything refresh: every walked top
     object is force-exported (objectsExported == totalTopObjects > 0), the flag is

--- a/tests/e2e/tools/test_resync_to_disk.py
+++ b/tests/e2e/tools/test_resync_to_disk.py
@@ -85,6 +85,7 @@ from harness import (
     assert_no_diff,
     e2e_test,
     wait_for_project_ready,
+    reset_model,
     PROJECT,
     PROJECT_DIR,
 )
@@ -174,17 +175,7 @@ def test_resync_in_sync_fixture_is_a_noop_and_does_not_mutate():
     assert_no_diff("default resync of an in-sync project must not change any tracked file")
 
 
-# kind="write-metadata" (NOT "action") on purpose: fullExport=true force-exports EVERY top
-# object model->disk, and that export is ASYNC (it can land AFTER the test body returns), so
-# the test needs the write-metadata teardown — reset_fixture()+reset_model() — to settle the
-# export and re-sync the model, exactly like test_apply_quick_fix's teardown. As an action it
-# got NO teardown: in a serial run the next write-metadata test's reset_model() masked the
-# residue, but once the suite is sharded by kind (issue #385) this test lands in the cheap
-# read-action lane with no such neighbour, and its residue desynced the very next default
-# resync (test_report_only) into exporting a phantom -> a dirty tree. On success it still
-# rewrites identical bytes (assert_no_diff holds); the honest kind is about the async WRITE,
-# not the net byte diff.
-@e2e_test(tool="resync_to_disk", kind="write-metadata")
+@e2e_test(tool="resync_to_disk", kind="action")
 def test_full_export_reexports_every_top_object():
     """fullExport=true opts back in to the export-everything refresh: every walked top
     object is force-exported (objectsExported == totalTopObjects > 0), the flag is
@@ -197,8 +188,19 @@ def test_full_export_reexports_every_top_object():
 
     Mutation thinking: a fullExport that silently stayed on the subset path would
     report objectsExported==0 here; an export that produced different bytes for an
-    unchanged model would fail assert_no_diff."""
-    wait_for_project_ready()  # a slow runner may still be recomputing after a prior test
+    unchanged model would fail assert_no_diff.
+
+    Precondition (via reset_model, adopted from #325): this is the ONLY resync test that
+    writes the WHOLE model back to disk, so it is the only one that exposes a prior test
+    whose model was left ahead of the committed disk (git resets the DISK, not EDT's
+    in-memory model). Under sharding this bites harder: in the read-action lane there are
+    no write-metadata neighbours whose reset_model() used to re-sync the model, so a leaked
+    change would be re-exported here — and, worse, propagate a phantom into the NEXT default
+    resync (test_report_only) as a dirty tree. clean_project re-imports the committed disk,
+    so we re-establish the in-sync precondition ourselves and the check is deterministic
+    regardless of the preceding test. A genuinely non-idempotent export for an in-sync model
+    would STILL fail assert_no_diff below."""
+    reset_model()  # guarantee the model matches the committed disk before the idempotency check
     r = call("resync_to_disk", {"projectName": PROJECT, "fullExport": True, "overwriteDiskEdits": True})
     assert_ok(r, "resync_to_disk fullExport=true overwriteDiskEdits=true")
 


### PR DESCRIPTION
The full tests/e2e run is ~60 min and the longest CI gate. All tests share one EDT workspace + one git fixture, so they must run serially within a workspace — but stock ubuntu-latest runners give per-job isolation for free, so we parallelise across runners with a shard matrix.

- run_all.py: add `--shard I/N` (1-based). The slice is a deterministic stride over the tests sorted by (tool, name), applied after `--filter`. Sharding is BY TEST, not by file, so the one heavy tool (modify_metadata ≈ 40% of the run) spreads across shards instead of pinning one shard to its total. Malformed specs fail loudly via SystemExit.
- e2e-tests.yml: `e2e` becomes a 4-shard matrix (fail-fast: false), passing `--shard ${{ matrix.shard }}/${{ strategy.job-total }}`. JUnit, JaCoCo exec and EDT-log artifacts are shard-suffixed; the JaCoCo inner filename is per-shard so coverage.yml's merge-multiple download does not overwrite. A new `report` job merges the per-shard JUnit reports into ONE "E2E Test Results" check.
- SKILL.md / .gitignore: document sharding and ignore the sharded report files.


Claude-Session: https://claude.ai/code/session_011byhZ95vNHZGHoS5jtSKwn