### PR TITLE
create_infobase: отчёт следует тому, что установил опрос, а не тому, что было запрошено (#412)

### DIFF
--- a/docs/tools/create_infobase.md
+++ b/docs/tools/create_infobase.md
@@ -65,7 +65,8 @@ Credentials for a registered standalone server are stored against the **applicat
 ### Prerequisites and result
 
 - Requires a **registered 1C standalone-server runtime** — a 1C:Enterprise platform **>= 8.3.23** with the standalone server (`ibsrv`/`ibcmd`), registered in EDT. The tool probes for it **before** the background Job and fails FAST with an actionable error if absent (no hang).
-- On success the result adds **`applicationKind='standaloneServer'`** and, **best-effort**, **`webUrl`** (the infobase web URL — use it for HTTP testing) and **`port`** (the ACTUAL auto-allocated web port, parsed from `webUrl`), alongside the usual `applications`, `applicationId`, and `message` fields. If EDT cannot resolve the web URL, `webUrl`/`port` are omitted — the server is still created and bound.
+- On success the result adds **`applicationKind='standaloneServer'`** and, **best-effort**, **`webUrl`** (the infobase web URL — use it for HTTP testing) and **`port`** (the ACTUAL auto-allocated web port, parsed from `webUrl`), alongside the same outcome-dependent `applications` / `applicationId` / `boundToProject` fields as the file path, and a `message`. If EDT cannot resolve the web URL, `webUrl`/`port` are omitted — the server is still created.
+- The standalone path reports the binding exactly like the file path (see "The three binding outcomes"): if the server application never appears, the call is an ERROR — and it still hands back `port`/`webUrl` (whenever EDT resolved them), because the server was registered regardless. Those two are the endpoint EDT **resolved**; the tool does not probe it.
 
 ```
 # Create an autonomous (standalone) server with a web URL:
@@ -81,8 +82,9 @@ Credentials for a registered standalone server are stored against the **applicat
 1. Resolves and validates the project and the `mode`.
 2. For `create`: probes for an available 1C platform runtime (fails fast when absent) and creates the target directory if it does not exist. For `register`: verifies the directory already contains a file infobase.
 3. For `create`: runs `IInfobaseCreationOperation.perform(...)` in a **background Eclipse Job** (up to 120 s) — it shells out to `1cv8`, never on the UI thread. For `register`: adds the reference directly via `IInfobaseManager.add(...)` (no platform launch, no Job).
-4. Associates the infobase with the project via `IInfobaseAssociationManager.associate(...)`. After this step `get_applications` returns the application.
-5. Returns the resulting application id so you can chain directly into `update_database`.
+4. Associates the infobase with the project via `IInfobaseAssociationManager.associate(...)`.
+5. **Reads the project's applications back** (a short bounded re-poll — the application surfaces asynchronously) and **reports what that read-back established**, not what was requested. Only a read-back that actually found the application reports the infobase as bound.
+6. Returns the resulting application id — whenever the platform gave the application one — so you can chain directly into `update_database`.
 
 ## Parameter details
 
@@ -97,7 +99,19 @@ Credentials for a registered standalone server are stored against the **applicat
 
 ## Result
 
-JSON with `action` (`'created'` for `create`, `'registered'` for `register`), `project`, `infobaseFile`, `infobaseName`, `applications` (same shape as `get_applications`), `applicationId` (for chaining into `update_database`), and a `message`.
+JSON with `action` (`'created'` for `create`, `'registered'` for `register`), `project`, `infobaseFile`, `infobaseName`, a `message` (on the refusal below that text is in `error` instead), and — depending on what the read-back below established — `applications` (same shape as `get_applications`; omitted when no read produced a snapshot at all), `applicationId` (for chaining into `update_database`; present whenever the application was found and the platform gave it an id) and `boundToProject`.
+
+### The three binding outcomes (issue #412)
+
+Creating the database and BINDING it to the project are two different facts, and the second one is established by the read-back — never assumed:
+
+| read-back | result | `boundToProject` |
+|---|---|---|
+| the new application was found | success, with "bound to project" in the message (and `applicationId`, whenever the platform gave the application one) | `true` |
+| the last read compared every application and none of them was it | **error** (the text is in `error`, not `message`) — the infobase exists and the payload keeps `action`, `infobaseFile`, `infobaseName`, `applications`, but the project has no application for it | `false` |
+| the comparison could not be completed — the read failed, the call was interrupted before the poll budget was spent, or an application's identity could not be read | success, message says the binding is **UNVERIFIED** and why | **absent** |
+
+The error case is not "nothing happened": the database is on disk and must not be created again. Until the application appears, `update_database` / `create_launch_config` / `debug_launch` refuse — they need an `applicationId`. Call `get_applications` to re-check; if it stays absent, the EDT error log is where to look next (the tool records that no application appeared; whether the platform logged a cause is up to it). Note that `delete_infobase` cannot clean this state up: it resolves its target only among the project's applications.
 
 ## Typical workflow
 
@@ -116,6 +130,7 @@ JSON with `action` (`'created'` for `create`, `'registered'` for `register`), `p
 - **`register` needs an existing infobase**: the path must contain a `1Cv8.1CD`; otherwise the tool errors and points you to `mode='create'`.
 - **FILE only**: passing a server/web connection string as `infobaseFile` is not supported — use the dedicated server creation tooling for that.
 - **Timeout**: the background Job waits up to 120 seconds. The tool reports an honest timeout, not a fake success.
+- **Created is not bound**: if the application never appears, the call is an ERROR even though the database was written (see "The three binding outcomes"). Branch on `boundToProject`, not on the message.
 - **Cleanup**: use `delete_infobase` to remove an infobase from the project and the EDT infobases list.
 - **State after creation**: a newly created infobase is empty — `get_applications` reports `FULL_UPDATE_REQUIRED` or similar. Call `update_database` to push the configuration into it.
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/create_infobase.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/create_infobase.md
@@ -46,7 +46,8 @@ Credentials for a registered standalone server are stored against the **applicat
 ### Prerequisites and result
 
 - Requires a **registered 1C standalone-server runtime** — a 1C:Enterprise platform **>= 8.3.23** with the standalone server (`ibsrv`/`ibcmd`), registered in EDT. The tool probes for it **before** the background Job and fails FAST with an actionable error if absent (no hang).
-- On success the result adds **`applicationKind='standaloneServer'`** and, **best-effort**, **`webUrl`** (the infobase web URL — use it for HTTP testing) and **`port`** (the ACTUAL auto-allocated web port, parsed from `webUrl`), alongside the usual `applications`, `applicationId`, and `message` fields. If EDT cannot resolve the web URL, `webUrl`/`port` are omitted — the server is still created and bound.
+- On success the result adds **`applicationKind='standaloneServer'`** and, **best-effort**, **`webUrl`** (the infobase web URL — use it for HTTP testing) and **`port`** (the ACTUAL auto-allocated web port, parsed from `webUrl`), alongside the same outcome-dependent `applications` / `applicationId` / `boundToProject` fields as the file path, and a `message`. If EDT cannot resolve the web URL, `webUrl`/`port` are omitted — the server is still created.
+- The standalone path reports the binding exactly like the file path (see "The three binding outcomes"): if the server application never appears, the call is an ERROR — and it still hands back `port`/`webUrl` (whenever EDT resolved them), because the server was registered regardless. Those two are the endpoint EDT **resolved**; the tool does not probe it.
 
 ```
 # Create an autonomous (standalone) server with a web URL:
@@ -62,8 +63,9 @@ Credentials for a registered standalone server are stored against the **applicat
 1. Resolves and validates the project and the `mode`.
 2. For `create`: probes for an available 1C platform runtime (fails fast when absent) and creates the target directory if it does not exist. For `register`: verifies the directory already contains a file infobase.
 3. For `create`: runs `IInfobaseCreationOperation.perform(...)` in a **background Eclipse Job** (up to 120 s) — it shells out to `1cv8`, never on the UI thread. For `register`: adds the reference directly via `IInfobaseManager.add(...)` (no platform launch, no Job).
-4. Associates the infobase with the project via `IInfobaseAssociationManager.associate(...)`. After this step `get_applications` returns the application.
-5. Returns the resulting application id so you can chain directly into `update_database`.
+4. Associates the infobase with the project via `IInfobaseAssociationManager.associate(...)`.
+5. **Reads the project's applications back** (a short bounded re-poll — the application surfaces asynchronously) and **reports what that read-back established**, not what was requested. Only a read-back that actually found the application reports the infobase as bound.
+6. Returns the resulting application id — whenever the platform gave the application one — so you can chain directly into `update_database`.
 
 ## Parameter details
 
@@ -78,7 +80,19 @@ Credentials for a registered standalone server are stored against the **applicat
 
 ## Result
 
-JSON with `action` (`'created'` for `create`, `'registered'` for `register`), `project`, `infobaseFile`, `infobaseName`, `applications` (same shape as `get_applications`), `applicationId` (for chaining into `update_database`), and a `message`.
+JSON with `action` (`'created'` for `create`, `'registered'` for `register`), `project`, `infobaseFile`, `infobaseName`, a `message` (on the refusal below that text is in `error` instead), and — depending on what the read-back below established — `applications` (same shape as `get_applications`; omitted when no read produced a snapshot at all), `applicationId` (for chaining into `update_database`; present whenever the application was found and the platform gave it an id) and `boundToProject`.
+
+### The three binding outcomes (issue #412)
+
+Creating the database and BINDING it to the project are two different facts, and the second one is established by the read-back — never assumed:
+
+| read-back | result | `boundToProject` |
+|---|---|---|
+| the new application was found | success, with "bound to project" in the message (and `applicationId`, whenever the platform gave the application one) | `true` |
+| the last read compared every application and none of them was it | **error** (the text is in `error`, not `message`) — the infobase exists and the payload keeps `action`, `infobaseFile`, `infobaseName`, `applications`, but the project has no application for it | `false` |
+| the comparison could not be completed — the read failed, the call was interrupted before the poll budget was spent, or an application's identity could not be read | success, message says the binding is **UNVERIFIED** and why | **absent** |
+
+The error case is not "nothing happened": the database is on disk and must not be created again. Until the application appears, `update_database` / `create_launch_config` / `debug_launch` refuse — they need an `applicationId`. Call `get_applications` to re-check; if it stays absent, the EDT error log is where to look next (the tool records that no application appeared; whether the platform logged a cause is up to it). Note that `delete_infobase` cannot clean this state up: it resolves its target only among the project's applications.
 
 ## Typical workflow
 
@@ -97,5 +111,6 @@ JSON with `action` (`'created'` for `create`, `'registered'` for `register`), `p
 - **`register` needs an existing infobase**: the path must contain a `1Cv8.1CD`; otherwise the tool errors and points you to `mode='create'`.
 - **FILE only**: passing a server/web connection string as `infobaseFile` is not supported — use the dedicated server creation tooling for that.
 - **Timeout**: the background Job waits up to 120 seconds. The tool reports an honest timeout, not a fake success.
+- **Created is not bound**: if the application never appears, the call is an ERROR even though the database was written (see "The three binding outcomes"). Branch on `boundToProject`, not on the message.
 - **Cleanup**: use `delete_infobase` to remove an infobase from the project and the EDT infobases list.
 - **State after creation**: a newly created infobase is empty — `get_applications` reports `FULL_UPDATE_REQUIRED` or similar. Call `update_database` to push the configuration into it.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
@@ -55,6 +55,11 @@ import com.google.gson.JsonObject;
  * Creates a new FILE infobase (1C:Enterprise database) and binds it to a configuration
  * project so it appears as an application in {@code get_applications}.
  *
+ * <p>The two steps below are two separate FACTS, and the second one is not implied by the first:
+ * {@code associate} returning without an exception does not mean the project has the application.
+ * The tool therefore reads the applications back and reports what that read-back established —
+ * bound, measured absent (an error that still says the database exists), or unverified (issue #412).
+ *
  * <p>The operation decomposes into two distinct steps:
  * <ol>
  *   <li>Create the infobase on disk via {@code IInfobaseCreationOperation} (which shells out to
@@ -96,6 +101,19 @@ public class CreateInfobaseTool implements IMcpTool
 
     /** Output key: applications bound to the project after creation. */
     private static final String KEY_APPLICATIONS = "applications"; //$NON-NLS-1$
+
+    /**
+     * Output key: whether the infobase actually surfaced as an application of the project, as
+     * ESTABLISHED by the post-association read-back (issue #412). Omitted when the read-back itself
+     * could not be completed — a failed read does not establish absence.
+     */
+    private static final String KEY_BOUND_TO_PROJECT = "boundToProject"; //$NON-NLS-1$
+
+    /** {@code action} value (and message verb) for mode='create'. */
+    private static final String ACTION_CREATED = "created"; //$NON-NLS-1$
+
+    /** {@code action} value (and message verb) for mode='register'. */
+    private static final String ACTION_REGISTERED = "registered"; //$NON-NLS-1$
 
     /** Output key: the application update state. */
     private static final String KEY_UPDATE_STATE = "updateState"; //$NON-NLS-1$
@@ -269,11 +287,21 @@ public class CreateInfobaseTool implements IMcpTool
                 "applicationKind='standaloneServer' only: the infobase web URL for HTTP testing. " //$NON-NLS-1$
                 + "Best-effort: absent if EDT could not resolve the URL (the server is still created).") //$NON-NLS-1$
             .integerProperty("port", //$NON-NLS-1$
-                "applicationKind='standaloneServer' only: the ACTUAL web port the server was " //$NON-NLS-1$
-                + "published on (parsed from webUrl; EDT auto-allocates it). Absent if webUrl could " //$NON-NLS-1$
-                + "not be resolved.") //$NON-NLS-1$
+                "applicationKind='standaloneServer' only: the ACTUAL web port EDT allocated, parsed " //$NON-NLS-1$
+                + "from the resolved webUrl (the endpoint is read from EDT's configuration, not " //$NON-NLS-1$
+                + "probed). Absent if webUrl could not be resolved.") //$NON-NLS-1$
             .objectArrayProperty(KEY_APPLICATIONS,
                 "Applications bound to the project after creation (same shape as get_applications).") //$NON-NLS-1$
+            .booleanProperty(KEY_BOUND_TO_PROJECT,
+                "Whether the infobase actually appeared as an application of the project, as " //$NON-NLS-1$
+                + "ESTABLISHED by the read-back that follows the association. true = the application " //$NON-NLS-1$
+                + "is there (applicationId is echoed whenever the platform gave it one). false = the " //$NON-NLS-1$
+                + "read-back completed and the " //$NON-NLS-1$
+                + "application is NOT there, so the call is reported as an error - the database " //$NON-NLS-1$
+                + "itself still exists (see 'action' and 'infobaseFile'). ABSENT = the applications " //$NON-NLS-1$
+                + "could not be compared (the read failed, the call was interrupted before the poll " //$NON-NLS-1$
+                + "budget was spent, or an application's identity was unreadable), so the binding " //$NON-NLS-1$
+                + "is unverified: call get_applications to confirm it.") //$NON-NLS-1$
             .stringProperty(McpKeys.APPLICATION_ID,
                 "ID of the newly created application (for chaining into update_database).") //$NON-NLS-1$
             .stringProperty(McpKeys.MESSAGE, "Human-readable status message.") //$NON-NLS-1$
@@ -479,8 +507,11 @@ public class CreateInfobaseTool implements IMcpTool
         }
     }
 
-    /** The infobase connection credentials (#194); any field may be {@code null}/empty when not supplied. */
-    private static final class Credentials
+    /**
+     * The infobase connection credentials (#194); any field may be {@code null}/empty when not
+     * supplied. Package-visible so the unit tests can drive the result builders.
+     */
+    static final class Credentials
     {
         final String user;
         final String password;
@@ -543,23 +574,22 @@ public class CreateInfobaseTool implements IMcpTool
         }
 
         // --- 7. Associate with the project ---
-        String associateError = associateInfobase(assocManager, project, ibRef, infobaseDir, projectName);
+        String associateError =
+            associateInfobase(assocManager, project, ibRef, infobaseDir, projectName, register);
         if (associateError != null)
         {
             return associateError;
         }
 
-        // --- 8. Optionally set as default ---
-        String setDefaultNote = setDefault ? applySetDefault(appManager, project, ibRef) : null;
-
-        // --- 8.5 Optionally store infobase connection credentials (#194) ---
+        // --- 8. Optionally store infobase connection credentials (#194) ---
         String credNote = storeCredentialsIfRequested(ibRef, credentials, register);
 
-        // --- 9. Read back and return ---
+        // --- 9. Read back, apply setDefault to what the read-back FOUND, and return ---
+        // setDefault is applied AFTER the read-back on purpose (issue #412): it used to run its own
+        // one-shot lookup BEFORE the bounded re-poll, so it could report "could not be set as default"
+        // for an application the re-poll then found. One observation feeds one report.
         ResultContext rc = new ResultContext(projectName, infobaseDir, infobaseName, appManager, project);
-        String note = (setDefaultNote != null ? setDefaultNote : "") //$NON-NLS-1$
-            + (credNote != null ? credNote : ""); //$NON-NLS-1$
-        return buildSuccessResult(rc, ibRef, note.isEmpty() ? null : note, register);
+        return buildSuccessResult(rc, ibRef, setDefault, register, credNote);
     }
 
     /**
@@ -567,7 +597,8 @@ public class CreateInfobaseTool implements IMcpTool
      * supplied any of {@code user}/{@code password}/{@code access} (#194), returning a note to append
      * to the result message — a success note, a non-fatal WARNING when the store failed, or
      * {@code null} when no credentials were requested. Credential storage never fails the
-     * infobase creation itself (the base is already created and bound).
+     * infobase creation itself (the base is already created; whether it is BOUND is established
+     * later, by the read-back).
      *
      * @param ibRef the new infobase reference (the access-settings key)
      * @param credentials the requested connection credentials (any field may be {@code null}/empty)
@@ -752,9 +783,14 @@ public class CreateInfobaseTool implements IMcpTool
      * Associates the infobase with the project (step 7): the {@code associate} side effect stays inline
      * here at the SAME sequence point. Returns a ready error tool-result JSON on the SAME failure case
      * the inline code produced, else {@code null}.
+     *
+     * <p>A {@code null} return means only that {@code associate} did not throw — NOT that the project
+     * now has the application. Whether the binding materialized is established later, by the read-back
+     * in {@link #buildSuccessResult} (issue #412), so neither the log line nor the return value claims
+     * more than that here.
      */
     private static String associateInfobase(IInfobaseAssociationManager assocManager, IProject project,
-            InfobaseReference ibRef, Path infobaseDir, String projectName)
+            InfobaseReference ibRef, Path infobaseDir, String projectName, boolean register)
     {
         try
         {
@@ -763,40 +799,47 @@ public class CreateInfobaseTool implements IMcpTool
         catch (Exception e)
         {
             Activator.logError("create_infobase: association failed for project " + projectName, e); //$NON-NLS-1$
-            return ToolResult.error("Infobase was created at '" + infobaseDir //$NON-NLS-1$
-                + "' but could not be associated with project '" + projectName //$NON-NLS-1$
+            return ToolResult.error("Infobase at '" + infobaseDir //$NON-NLS-1$
+                + "' was " + (register ? ACTION_REGISTERED : ACTION_CREATED) //$NON-NLS-1$
+                + " but could not be associated with project '" + projectName //$NON-NLS-1$
                 + "': " + e.getMessage() //$NON-NLS-1$
-                + ". Use delete_infobase to clean up if needed.").toJson(); //$NON-NLS-1$
+                + ". The database itself is intact - do not create it again.").toJson(); //$NON-NLS-1$
         }
-        Activator.logInfo("create_infobase: associated with project " + projectName); //$NON-NLS-1$
+        Activator.logInfo("create_infobase: associate() returned without error for project " //$NON-NLS-1$
+            + projectName + " (the binding is verified by the read-back)"); //$NON-NLS-1$
         return null;
     }
 
     /**
-     * Optionally sets the new infobase as the project's default application (step 8): the
-     * {@code setDefaultApplication} side effect stays inline here at the SAME sequence point. Non-fatal —
-     * returns the SAME nullable {@code setDefaultNote} the inline code produced ({@code null} when the
-     * default was set or the failure was swallowed; a note when the new app was not found yet).
+     * Optionally sets the new infobase as the project's default application, using the application the
+     * read-back actually FOUND (issue #412) instead of a second, earlier lookup of its own. Non-fatal:
+     * returns a note to append to the message, or {@code null} when the default was set.
+     *
+     * <p>Every note here is about {@code setDefault} ONLY. The reason there is no application to set —
+     * and whether that is even established — is reported by the caller, not blamed on this flag.
      */
     private static String applySetDefault(IApplicationManager appManager, IProject project,
-            InfobaseReference ibRef)
+            ApplicationReadBack readBack)
     {
+        if (readBack.app == null)
+        {
+            Activator.logInfo("create_infobase: setDefault not applied - no application to set (" //$NON-NLS-1$
+                + readBack.outcome + ")"); //$NON-NLS-1$
+            return readBack.outcome == BindingOutcome.NOT_BOUND
+                ? " setDefault was not applied: the project has no application for this infobase." //$NON-NLS-1$
+                : " setDefault was not applied: the new application could not be read back - check " //$NON-NLS-1$
+                    + "get_applications and set it manually."; //$NON-NLS-1$
+        }
         try
         {
-            IApplication newApp = findNewApplication(appManager, project, ibRef);
-            if (newApp == null)
-            {
-                Activator.logError("create_infobase: setDefault skipped — new app not found yet", //$NON-NLS-1$
-                    null);
-                return "; the new infobase was created but could not be set as " //$NON-NLS-1$
-                    + "default yet - set it manually or retry"; //$NON-NLS-1$
-            }
-            appManager.setDefaultApplication(project, newApp);
+            appManager.setDefaultApplication(project, readBack.app);
         }
         catch (Exception e)
         {
-            // Non-fatal: the infobase was created and associated; only the default-setting failed.
+            // Non-fatal: the infobase was created and is bound; only the default-setting failed. Say so
+            // instead of swallowing it — the failure was established, and the caller asked for it.
             Activator.logError("create_infobase: setDefault failed", e); //$NON-NLS-1$
+            return " setDefault failed: " + e.getMessage() + " - set it manually or retry."; //$NON-NLS-1$ //$NON-NLS-2$
         }
         return null;
     }
@@ -1898,64 +1941,87 @@ public class CreateInfobaseTool implements IMcpTool
 
     /**
      * Reads back the applications for the project, finds the new {@code wst-server} application, and
-     * builds the success JSON for the standalone-server path. Uses the same short bounded re-poll as
-     * the file path to absorb the provision-delegate listener race.
+     * builds the result for the standalone-server path. Uses the same short bounded re-poll as the
+     * file path to absorb the provision-delegate listener race, and the same three-way report
+     * (issue #412): bound, measured absent (an ERROR that keeps the payload and the endpoint), or
+     * unverified. Package-visible so the unit tests can drive all three outcomes.
      */
-    private static String buildStandaloneServerResult(ResultContext rc, int actualPort, String webUrl,
+    static String buildStandaloneServerResult(ResultContext rc, int actualPort, String webUrl,
             boolean setDefault, boolean register, Credentials credentials)
     {
         // Read back the applications (bounded re-poll) and locate the just-created wst-server.
-        ServerReadBack readBack =
-            pollForNewServerApplication(rc.appManager, rc.project, rc.infobaseName);
-        JsonArray appsArray = readBack.appsArray;
-        String newAppId = readBack.newAppId;
-        IApplication newApp = readBack.newApp;
+        ApplicationReadBack readBack = pollForNewApplication(rc.appManager, rc.project,
+            app -> isMatchingNewServerApp(app, rc.infobaseName));
 
         // Optionally set the new standalone server as the project's default application. A wst-server
         // application is an ordinary IApplication, so the same setDefaultApplication API the file path
-        // uses works here too. Non-fatal: the server is already created and bound.
-        String setDefaultNote = null;
-        if (setDefault)
-        {
-            if (newApp != null)
-            {
-                try
-                {
-                    rc.appManager.setDefaultApplication(rc.project, newApp);
-                }
-                catch (Exception e)
-                {
-                    Activator.logError("create_infobase: setDefault failed", e); //$NON-NLS-1$
-                    setDefaultNote = "; the server was created but could not be set as default - " //$NON-NLS-1$
-                        + "set it manually or retry"; //$NON-NLS-1$
-                }
-            }
-            else
-            {
-                setDefaultNote = "; the server was created but could not be set as default yet " //$NON-NLS-1$
-                    + "(the application was not visible yet) - set it manually or retry"; //$NON-NLS-1$
-                Activator.logError("create_infobase: setDefault skipped — new server app not found yet", //$NON-NLS-1$
-                    null);
-            }
-        }
+        // uses works here too. Non-fatal: the server itself is already created.
+        String setDefaultNote = setDefault ? applySetDefault(rc.appManager, rc.project, readBack) : null;
 
         // Optionally store infobase connection credentials (issue #275): standaloneServer +
         // mode='register' ONLY — execute() already rejects credentials with mode='create'. Targets
         // the READ-BACK wst-server IApplication (not the FILE ibRef built earlier for the create
         // call) — InfobaseAccessSupport.storeCredentials(IApplication, ...) adapts IT to the
         // InfobaseReference that EDT's own launch path (ServerApplicationBehaviourDelegate) resolves.
-        String credNote = register ? storeStandaloneCredentialsIfRequested(newApp, credentials) : null;
+        String credNote = register ? storeStandaloneCredentialsIfRequested(readBack.app, credentials) : null;
+
+        String note = concatNotes(setDefaultNote, credNote);
+        String verb = register ? ACTION_REGISTERED : ACTION_CREATED;
+        String subject = standaloneServerSubject(rc.infobaseName, rc.infobaseDir, register);
+
+        // Same three-way report as the file path (issue #412): the standalone server surfaces through
+        // the SAME provision-delegate listener, so it has the same "requested, never appeared" state.
+        if (readBack.outcome == BindingOutcome.NOT_BOUND)
+        {
+            ToolResult error = notBoundResult(rc, verb, readBack, subject,
+                notBoundMessage(subject, rc.projectName, register) + note)
+                    .put(KEY_APPLICATION_KIND, KIND_STANDALONE_SERVER);
+            putStandaloneEndpoint(error, actualPort, webUrl);
+            return error.toJson();
+        }
 
         ToolResult result = ToolResult.success()
-            .put(McpKeys.ACTION, register ? "registered" : "created") //$NON-NLS-1$ //$NON-NLS-2$
+            .put(McpKeys.ACTION, verb)
             .put(KEY_APPLICATION_KIND, KIND_STANDALONE_SERVER)
             .put(McpKeys.PROJECT, rc.projectName)
             .put(KEY_INFOBASE_FILE, rc.infobaseDir.toAbsolutePath().toString())
-            .put(KEY_INFOBASE_NAME, rc.infobaseName)
-            .put(KEY_APPLICATIONS, appsArray);
+            .put(KEY_INFOBASE_NAME, rc.infobaseName);
+        putApplications(result, readBack);
 
-        // Report the ACTUAL auto-allocated port only when we could resolve it from the web URL; // NOSONAR explanatory comment, not commented-out code
-        // never echo the requested/hint port (EDT ignores it for a FILE-backed standalone server).
+        putStandaloneEndpoint(result, actualPort, webUrl);
+        String newAppId = readBack.appId();
+        if (newAppId != null)
+        {
+            result.put(McpKeys.APPLICATION_ID, newAppId);
+        }
+
+        String message;
+        if (readBack.outcome == BindingOutcome.BOUND)
+        {
+            result.put(KEY_BOUND_TO_PROJECT, true);
+            message = buildStandaloneServerMessage(rc.projectName, subject, actualPort, webUrl,
+                note.isEmpty() ? null : note, register);
+        }
+        else
+        {
+            // UNVERIFIED: boundToProject is deliberately ABSENT — we did not establish either answer.
+            message = unverifiedMessage(standaloneServerSubjectWithEndpoint(subject, actualPort, webUrl),
+                rc.projectName, readBack.unverifiedReason) + note;
+        }
+        result.put(McpKeys.MESSAGE, message);
+
+        return result.toJson();
+    }
+
+    /**
+     * Adds the standalone server's endpoint to a result: the ACTUAL auto-allocated port (only when it
+     * could be resolved from the web URL — the requested/hint port is never echoed, EDT ignores it for
+     * a FILE-backed standalone server) and the web URL itself. Also carried on the not-bound error, so
+     * a caller keeps the endpoint of a server that was registered but has no project application.
+     * Resolved, not probed: the URL is what EDT configured, not proof that anything answers on it.
+     */
+    private static void putStandaloneEndpoint(ToolResult result, int actualPort, String webUrl)
+    {
         if (actualPort > 0)
         {
             result.put("port", actualPort); //$NON-NLS-1$
@@ -1964,31 +2030,34 @@ public class CreateInfobaseTool implements IMcpTool
         {
             result.put("webUrl", webUrl); //$NON-NLS-1$
         }
-        if (newAppId != null)
-        {
-            result.put(McpKeys.APPLICATION_ID, newAppId);
-        }
+    }
 
-        String combinedNote = (setDefaultNote != null ? setDefaultNote : "") //$NON-NLS-1$
-            + (credNote != null ? credNote : ""); //$NON-NLS-1$
-        result.put(McpKeys.MESSAGE, buildStandaloneServerMessage(rc.projectName, rc.infobaseDir,
-            rc.infobaseName, actualPort, webUrl, combinedNote.isEmpty() ? null : combinedNote, register));
-
-        return result.toJson();
+    /**
+     * Whether the application is the JUST-created standalone server, identified by the wst-server type
+     * plus an exact name match against the new infobase — NOT merely the first wst-server app, which
+     * could be a pre-existing standalone server already bound to this project. Read-only.
+     */
+    private static MatchResult isMatchingNewServerApp(IApplication app, String infobaseName)
+    {
+        String typeId = app.getType() != null ? app.getType().getId() : null;
+        // Always decidable: the identity is the type plus the name, both plain reads that cannot
+        // half-fail, so there is no UNDECIDABLE case here.
+        return StandaloneServerSupport.WST_SERVER_APP_TYPE.equals(typeId)
+            && infobaseName.equals(app.getName()) ? MatchResult.MATCH : MatchResult.NO_MATCH;
     }
 
     /**
      * Stores infobase connection credentials against the READ-BACK wst-server application (issue
      * #275) when the caller supplied any of {@code user}/{@code password}/{@code access}, returning
      * a note to append to the result message — a success note, a non-fatal WARNING when the store
-     * failed (or the application was not visible yet within the read-back poll budget), or
+     * failed (or the read-back produced no application to store them against), or
      * {@code null} when no credentials were requested. Credential storage never fails the
-     * standalone-server registration itself (the server is already registered and bound). Mirrors
+     * standalone-server registration itself (the server itself is already registered). Mirrors
      * {@link #storeCredentialsIfRequested(InfobaseReference, Credentials, boolean)}, the plain
      * file-infobase equivalent.
      *
-     * @param application the read-back wst-server application ({@code null} if not found within the
-     *            poll budget)
+     * @param application the read-back wst-server application ({@code null} when the read-back
+     *            produced none — measured absent, unreadable or interrupted)
      * @param credentials the requested connection credentials (any field may be {@code null}/empty)
      * @return a message note, or {@code null} when no credentials were requested
      */
@@ -2001,9 +2070,11 @@ public class CreateInfobaseTool implements IMcpTool
         }
         if (application == null)
         {
+            // Why it was not available (measured absent, unreadable, interrupted) is the read-back's
+            // story, told by the message this note is appended to — do not restate it as a fact here.
             return " WARNING: connection credentials were NOT stored: the new standalone-server " //$NON-NLS-1$
-                + "application was not visible yet within the read-back poll budget - retry with " //$NON-NLS-1$
-                + "set_infobase_credentials once it appears in get_applications."; //$NON-NLS-1$
+                + "application was not available from the read-back - check get_applications and " //$NON-NLS-1$
+                + "store them with set_infobase_credentials."; //$NON-NLS-1$
         }
         String error = InfobaseAccessSupport.storeCredentials(application, credentials.user, credentials.password,
             InfobaseAccessSupport.parseAccess(credentials.access));
@@ -2013,88 +2084,6 @@ public class CreateInfobaseTool implements IMcpTool
         }
         return " Stored connection credentials for user '" + (credentials.user == null ? "" : credentials.user) //$NON-NLS-1$ //$NON-NLS-2$
             + "' (change them later with set_infobase_credentials)."; //$NON-NLS-1$
-    }
-
-    /**
-     * Reads back the project's applications with the same short bounded re-poll the file path uses
-     * (to absorb the provision-delegate listener race) and locates the JUST-created standalone server
-     * — a {@code wst-server} application whose name matches {@code infobaseName} (NOT merely the first
-     * wst-server, which could be a pre-existing one). Read-only: it only reads applications and builds
-     * the {@code appsArray} echo. Returns a {@link ServerReadBack} carrying the JSON array plus the new
-     * application id/handle ({@code null} when not found within the poll budget).
-     */
-    private static ServerReadBack pollForNewServerApplication(IApplicationManager appManager,
-            IProject project, String infobaseName)
-    {
-        JsonArray appsArray = new JsonArray();
-        IApplication[] newAppHolder = new IApplication[1];
-
-        for (int poll = 0; poll < READ_BACK_MAX_POLLS; poll++) // NOSONAR intentional multiple loop exits; restructuring with flags would reduce readability
-        {
-            appsArray = new JsonArray();
-            newAppHolder[0] = null;
-
-            if (!readBackServerApplications(appManager, project, infobaseName, appsArray, newAppHolder))
-            {
-                break; // Read failed (logged) — stop re-polling.
-            }
-
-            if (newAppHolder[0] != null)
-            {
-                break; // Found the new server — no need to re-poll.
-            }
-
-            if (poll < READ_BACK_MAX_POLLS - 1 && !sleepBetweenPolls())
-            {
-                break; // Interrupted — stop re-polling.
-            }
-        }
-
-        IApplication newApp = newAppHolder[0];
-        String newAppId = newApp != null ? newApp.getId() : null;
-        return new ServerReadBack(appsArray, newAppId, newApp);
-    }
-
-    /**
-     * Reads the project's applications once, populating {@code appsArray} with one JSON object per
-     * application (same shape as {@code get_applications}) and storing the JUST-created standalone
-     * server — a {@code wst-server} application whose name matches {@code infobaseName} (NOT merely the
-     * first wst-server, which could be a pre-existing one) — in {@code newAppHolder[0]} (left
-     * {@code null} when not yet visible). Read-only.
-     *
-     * @return {@code true} if the read completed (whether or not the new server was found),
-     *         {@code false} if reading the applications failed (already logged) so the caller stops
-     *         re-polling
-     */
-    private static boolean readBackServerApplications(IApplicationManager appManager, IProject project,
-            String infobaseName, JsonArray appsArray, IApplication[] newAppHolder)
-    {
-        try
-        {
-            List<IApplication> applications = appManager.getApplications(project);
-            if (applications != null)
-            {
-                for (IApplication app : applications)
-                {
-                    appsArray.add(toApplicationJson(appManager, app));
-                    // Identify the JUST-created standalone server by its name (a wst-server app whose
-                    // name matches the new infobase) — NOT merely the first wst-server app, which could
-                    // be a pre-existing standalone server already bound to this project.
-                    String typeId = app.getType() != null ? app.getType().getId() : null;
-                    if (newAppHolder[0] == null && StandaloneServerSupport.WST_SERVER_APP_TYPE.equals(typeId)
-                        && infobaseName.equals(app.getName()))
-                    {
-                        newAppHolder[0] = app;
-                    }
-                }
-            }
-            return true;
-        }
-        catch (ApplicationException e)
-        {
-            Activator.logError("create_infobase: error reading back applications", e); //$NON-NLS-1$
-            return false;
-        }
     }
 
     /**
@@ -2116,46 +2105,50 @@ public class CreateInfobaseTool implements IMcpTool
     }
 
     /**
-     * Builds the human-readable status message for the standalone-server success result (read-only
-     * string assembly). For mode='create' it says the server CREATED a new infobase; for mode='register'
-     * it says the server was REGISTERED over the EXISTING infobase (no new database was written).
-     * Appends {@code setDefaultNote} when non-null.
+     * What happened to the DATABASE on the standalone-server path, without any claim about the project
+     * binding: for mode='create' the server CREATED a new infobase, for mode='register' it was
+     * REGISTERED over the EXISTING one (no new database was written). The binding clause is added by
+     * the caller only when the read-back established it (issue #412).
      */
-    private static String buildStandaloneServerMessage(String projectName, Path infobaseDir,
-            String infobaseName, int actualPort, String webUrl, String setDefaultNote, boolean register)
+    private static String standaloneServerSubject(String infobaseName, Path infobaseDir, boolean register)
     {
-        String lead = register
+        return register
             ? "Registered a standalone server over the existing infobase '" + infobaseName //$NON-NLS-1$
-                + "' at '" + infobaseDir.toAbsolutePath() //$NON-NLS-1$
-                + "' and bound it to project '" + projectName + "'" //$NON-NLS-1$ //$NON-NLS-2$
+                + "' at '" + infobaseDir.toAbsolutePath() + "'" //$NON-NLS-1$ //$NON-NLS-2$
             : "Standalone server for infobase '" + infobaseName //$NON-NLS-1$
-                + "' created at '" + infobaseDir.toAbsolutePath() //$NON-NLS-1$
-                + "' and bound to project '" + projectName + "'"; //$NON-NLS-1$ //$NON-NLS-2$
+                + "' created at '" + infobaseDir.toAbsolutePath() + "'"; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * The same subject plus the resolved endpoint, so the unverified-binding wording still reports the
+     * ACTUAL auto-allocated web port and URL (the registration happened even when the project binding
+     * could not be read back). The endpoint is the one EDT resolved, not one this tool probed.
+     */
+    private static String standaloneServerSubjectWithEndpoint(String subject, int actualPort, String webUrl)
+    {
+        return subject
+            + (actualPort > 0 ? " (web port " + actualPort + ")" : "") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            + (webUrl != null ? ", web URL " + webUrl : ""); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Builds the human-readable status message for the standalone-server result when the read-back
+     * ESTABLISHED the binding (read-only string assembly). Appends {@code note} (the setDefault and
+     * credentials notes, already joined) when non-null.
+     */
+    private static String buildStandaloneServerMessage(String projectName, String subject,
+            int actualPort, String webUrl, String note, boolean register)
+    {
+        String lead = subject
+            + (register ? " and bound it to project '" : " and bound to project '") //$NON-NLS-1$ //$NON-NLS-2$
+            + projectName + "'"; //$NON-NLS-1$
         return lead
             + (actualPort > 0 ? " (web port " + actualPort + ")" : "") + "." //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
             + (webUrl != null ? " Web URL for HTTP testing: " + webUrl + "." : "") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             + " To load the configuration, use the coordinated launch flow (debug_launch or " //$NON-NLS-1$
             + "run_yaxunit_tests with updateBeforeLaunch=true) rather than a bare update_database, " //$NON-NLS-1$
             + "which would start the server in RUN mode." //$NON-NLS-1$
-            + (setDefaultNote != null ? setDefaultNote : ""); //$NON-NLS-1$
-    }
-
-    /**
-     * Holder for the standalone-server read-back: the {@code applications} JSON echo plus the
-     * just-created server's id/handle ({@code null} when it was not found within the poll budget).
-     */
-    private static final class ServerReadBack
-    {
-        final JsonArray appsArray;
-        final String newAppId;
-        final IApplication newApp;
-
-        ServerReadBack(JsonArray appsArray, String newAppId, IApplication newApp)
-        {
-            this.appsArray = appsArray;
-            this.newAppId = newAppId;
-            this.newApp = newApp;
-        }
+            + (note != null ? note : ""); //$NON-NLS-1$
     }
 
     /**
@@ -2163,9 +2156,9 @@ public class CreateInfobaseTool implements IMcpTool
      * builders ({@link #buildSuccessResult} and {@link #buildStandaloneServerResult}): the project
      * name/handle, the infobase directory and display name, and the {@link IApplicationManager} used
      * for the application read-back. Keeps those builders under the parameter-count threshold without
-     * changing what they compute.
+     * changing what they compute. Package-visible so the unit tests can drive the result builders.
      */
-    private static final class ResultContext
+    static final class ResultContext
     {
         final String projectName;
         final Path infobaseDir;
@@ -2270,25 +2263,6 @@ public class CreateInfobaseTool implements IMcpTool
         }
     }
 
-    /**
-     * Finds the newly created infobase application by matching the infobase reference.
-     * Best-effort: returns {@code null} if not found.
-     */
-    private static IApplication findNewApplication(IApplicationManager appManager,
-            IProject project, InfobaseReference ibRef)
-    {
-        try
-        {
-            Optional<IApplication> found =
-                appManager.findApplicationByInfobaseAndProject(ibRef, project);
-            return found.orElse(null);
-        }
-        catch (Exception e)
-        {
-            return null;
-        }
-    }
-
     /** Maximum re-poll attempts for the provision-delegate listener race after associate(). */
     private static final int READ_BACK_MAX_POLLS = 5;
 
@@ -2296,100 +2270,372 @@ public class CreateInfobaseTool implements IMcpTool
     private static final long READ_BACK_POLL_DELAY_MS = 300;
 
     /**
-     * Reads back the applications for the project and builds the success JSON.
-     * Uses a short bounded re-poll to handle the provision-delegate listener race
-     * that can cause the new application to not yet appear immediately after associate().
-     *
-     * @param setDefaultNote optional note appended to the message when setDefault could not be
-     *        completed (null = no note)
+     * What the post-association read-back ESTABLISHED about the binding (issue #412). The tool used to
+     * collapse all three into one unconditional success that claimed the infobase was "bound to
+     * project" even when its own read-back had just shown it was not.
      */
-    private static String buildSuccessResult(ResultContext rc, InfobaseReference ibRef,
-            String setDefaultNote, boolean register)
+    private enum BindingOutcome
     {
-        JsonArray appsArray = new JsonArray();
-        String newAppId = null;
+        /** The new application was read back: the infobase IS an application of the project. */
+        BOUND,
+        /**
+         * The poll budget was spent and the LAST read compared every application without finding
+         * this one: absence is MEASURED, not assumed. (Only the last read has to be fully
+         * comparable — each read is a whole snapshot, so an earlier one that could not identify
+         * something is superseded, not carried forward.)
+         */
+        NOT_BOUND,
+        /**
+         * Nothing was established: the read-back failed, or was cut short before the budget was
+         * spent, or it listed an application whose identity could not be compared with the new
+         * infobase. None of those is evidence of a missing application.
+         */
+        UNVERIFIED
+    }
 
-        // Short bounded re-poll: the provision-delegate listener fires asynchronously after
-        // associate(), so the new IInfobaseApplication may not be visible on the first read.
-        for (int poll = 0; poll < READ_BACK_MAX_POLLS; poll++) // NOSONAR intentional multiple loop exits; restructuring with flags would reduce readability
+    /**
+     * What comparing ONE application against the new infobase produced. A comparison that could not be
+     * made is deliberately NOT folded into {@link #NO_MATCH}: since the read-back now decides whether
+     * the call succeeds, "I could not tell" must not be reported as "it is not there" (issue #412).
+     */
+    private enum MatchResult
+    {
+        /** This application IS the one that was just created/registered. */
+        MATCH,
+        /** This application is decidably a different one. */
+        NO_MATCH,
+        /** The comparison could not be made (missing/unreadable identity), so nothing was established. */
+        UNDECIDABLE
+    }
+
+    /** Identifies the JUST-created application among the project's applications (tri-state). */
+    private interface ApplicationMatcher
+    {
+        MatchResult match(IApplication app);
+    }
+
+    /**
+     * Outcome of the bounded application read-back: the {@code applications} echo (the LAST snapshot a
+     * read actually produced — {@code null} when no read produced one), the matched new application
+     * ({@code null} unless {@link BindingOutcome#BOUND}), and what that read-back established.
+     */
+    private static final class ApplicationReadBack
+    {
+        final JsonArray appsArray;
+        final IApplication app;
+        final BindingOutcome outcome;
+        /** Why nothing was established; {@code null} unless {@link BindingOutcome#UNVERIFIED}. */
+        final String unverifiedReason;
+
+        ApplicationReadBack(JsonArray appsArray, IApplication app, BindingOutcome outcome,
+                String unverifiedReason)
         {
-            appsArray = new JsonArray();
-            newAppId = null;
-            String[] newAppIdHolder = new String[1];
-
-            if (!readBackApplications(rc.appManager, rc.project, ibRef, appsArray, newAppIdHolder))
-            {
-                break; // Read failed (logged) — stop re-polling.
-            }
-            newAppId = newAppIdHolder[0];
-
-            if (newAppId != null)
-            {
-                break; // Found the new application — no need to re-poll.
-            }
-
-            if (poll < READ_BACK_MAX_POLLS - 1 && !sleepBetweenPolls())
-            {
-                break; // Interrupted — stop re-polling.
-            }
+            this.appsArray = appsArray;
+            this.app = app;
+            this.outcome = outcome;
+            this.unverifiedReason = unverifiedReason;
         }
 
-        String verb = register ? "registered" : "created"; //$NON-NLS-1$ //$NON-NLS-2$
+        /**
+         * The matched application's id, or {@code null} when nothing matched OR the platform gave the
+         * application no id. A matched application with a {@code null} id is still {@link
+         * BindingOutcome#BOUND}: the binding is established by the MATCH, not by the id.
+         */
+        String appId()
+        {
+            return app != null ? app.getId() : null;
+        }
+    }
+
+    /**
+     * Reads back the applications for the project and builds the result for the file-infobase path.
+     * Uses a short bounded re-poll to absorb the provision-delegate listener race that can keep the
+     * new application invisible immediately after associate().
+     *
+     * <p>The report follows what the read-back ESTABLISHED (issue #412), instead of claiming the
+     * infobase is "bound to project" unconditionally:
+     * <ul>
+     *   <li>{@link BindingOutcome#BOUND} — success, {@code boundToProject:true}, and
+     *       {@code applicationId} whenever the platform gave the application one;</li>
+     *   <li>{@link BindingOutcome#NOT_BOUND} — an ERROR carrying {@code boundToProject:false} and the
+     *       full payload (what happened to the database, where it is, its name), because the database
+     *       exists and the caller must not be told otherwise;</li>
+     *   <li>{@link BindingOutcome#UNVERIFIED} — success WITHOUT {@code boundToProject}: a read that
+     *       failed, a poll cut short by an interrupt, or an application whose identity could not be
+     *       compared does not establish absence, and a false refusal costs more than a missing
+     *       claim.</li>
+     * </ul>
+     *
+     * <p>Package-visible so the unit tests can drive all three outcomes through a stubbed
+     * {@link IApplicationManager}.
+     *
+     * @param setDefault whether the caller asked for the new application to become the project default
+     * @param credNote optional credentials note to append to the message ({@code null} = none)
+     */
+    static String buildSuccessResult(ResultContext rc, InfobaseReference ibRef, boolean setDefault,
+            boolean register, String credNote)
+    {
+        ApplicationReadBack readBack = pollForNewApplication(rc.appManager, rc.project,
+            app -> isMatchingNewInfobaseApp(app, ibRef));
+
+        String setDefaultNote = setDefault ? applySetDefault(rc.appManager, rc.project, readBack) : null;
+        String note = concatNotes(setDefaultNote, credNote);
+        String verb = register ? ACTION_REGISTERED : ACTION_CREATED;
+        String subject = "Infobase '" + rc.infobaseName + "' " + verb + " at '" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            + rc.infobaseDir.toAbsolutePath() + "'"; //$NON-NLS-1$
+
+        if (readBack.outcome == BindingOutcome.NOT_BOUND)
+        {
+            return notBoundResult(rc, verb, readBack, subject,
+                notBoundMessage(subject, rc.projectName, register) + note).toJson();
+        }
+
         ToolResult result = ToolResult.success()
             .put(McpKeys.ACTION, verb)
             .put(McpKeys.PROJECT, rc.projectName)
             .put(KEY_INFOBASE_FILE, rc.infobaseDir.toAbsolutePath().toString())
-            .put(KEY_INFOBASE_NAME, rc.infobaseName)
-            .put(KEY_APPLICATIONS, appsArray);
+            .put(KEY_INFOBASE_NAME, rc.infobaseName);
+        putApplications(result, readBack);
 
+        String newAppId = readBack.appId();
         if (newAppId != null)
         {
             result.put(McpKeys.APPLICATION_ID, newAppId);
         }
 
-        String message = "Infobase '" + rc.infobaseName //$NON-NLS-1$
-            + "' " + verb + " at '" + rc.infobaseDir.toAbsolutePath() //$NON-NLS-1$ //$NON-NLS-2$
-            + "' and bound to project '" + rc.projectName //$NON-NLS-1$
-            + "'. Use update_database to push the configuration into the infobase." //$NON-NLS-1$
-            + (setDefaultNote != null ? setDefaultNote : ""); //$NON-NLS-1$
-        result.put(McpKeys.MESSAGE, message);
+        String message;
+        if (readBack.outcome == BindingOutcome.BOUND)
+        {
+            result.put(KEY_BOUND_TO_PROJECT, true);
+            // The chaining advice needs an applicationId to chain WITH. It is present in every case
+            // the platform gives the application an id (so this text is unchanged for real callers),
+            // but a bound application without one cannot be handed to update_database yet.
+            message = subject + " and bound to project '" + rc.projectName //$NON-NLS-1$
+                + (newAppId != null
+                    ? "'. Use update_database to push the configuration into the infobase." //$NON-NLS-1$
+                    : "'. The read-back reported no id for the application - look it up with " //$NON-NLS-1$
+                        + "get_applications before update_database."); //$NON-NLS-1$
+        }
+        else
+        {
+            // UNVERIFIED: boundToProject is deliberately ABSENT — we did not establish either answer.
+            message = unverifiedMessage(subject, rc.projectName, readBack.unverifiedReason);
+        }
+        result.put(McpKeys.MESSAGE, message + note);
 
         return result.toJson();
     }
 
     /**
-     * Reads the project's applications once, populating {@code appsArray} with one JSON object per
-     * application and storing the matched new-infobase application id in {@code newAppIdHolder[0]}
-     * (left {@code null} when not yet visible). Read-only.
+     * Runs the bounded read-back and classifies what it established (issue #412). The loop is the
+     * original one — same budget, same early exits — but its exits are now told apart: a match is
+     * {@link BindingOutcome#BOUND}, a spent budget whose LAST read compared every application
+     * without a match is {@link BindingOutcome#NOT_BOUND}, and a failed or interrupted read is
+     * {@link BindingOutcome#UNVERIFIED} (it did not measure the full budget, so absence is not
+     * established) — with the reason carried along, because a failed read and an interrupted poll
+     * are different stories.
      *
-     * @return {@code true} if the read completed (whether or not the new application was found),
-     *         {@code false} if reading the applications failed (already logged) so the caller stops
-     *         re-polling
+     * @param matcher identifies the JUST-created application among the project's applications
+     */
+    private static ApplicationReadBack pollForNewApplication(IApplicationManager appManager,
+            IProject project, ApplicationMatcher matcher)
+    {
+        // Set when SOME application could not be compared with the new infobase: the reads then
+        // listed applications we could not identify, so "none of them is ours" was never established.
+        boolean[] undecidable = new boolean[1];
+        // The echo is the LAST snapshot a read actually produced, and stays null while there is
+        // none: a failed read must not be reported as an empty list of applications — that would
+        // re-encode "could not look" as "looked and found nothing", the very confusion this fixes.
+        JsonArray appsArray = null;
+        IApplication[] newAppHolder = new IApplication[1];
+        boolean readCompleted = false;
+        boolean cutShort = false;
+
+        // Short bounded re-poll: the provision-delegate listener fires asynchronously after
+        // associate(), so the new application may not be visible on the first read.
+        for (int poll = 0; poll < READ_BACK_MAX_POLLS; poll++) // NOSONAR intentional multiple loop exits; restructuring with flags would reduce readability
+        {
+            JsonArray attempt = new JsonArray();
+            newAppHolder[0] = null;
+
+            undecidable[0] = false;
+            readCompleted =
+                readBackApplications(appManager, project, matcher, attempt, newAppHolder, undecidable);
+            if (readCompleted)
+            {
+                appsArray = attempt;
+            }
+            else
+            {
+                break; // Read failed (logged) — stop re-polling; absence is NOT established.
+            }
+            if (newAppHolder[0] != null)
+            {
+                break; // Found the new application — no need to re-poll.
+            }
+            if (poll < READ_BACK_MAX_POLLS - 1 && !sleepBetweenPolls())
+            {
+                cutShort = true; // Interrupted — the budget was not spent, so absence is NOT established.
+                break;
+            }
+        }
+
+        if (newAppHolder[0] != null)
+        {
+            return new ApplicationReadBack(appsArray, newAppHolder[0], BindingOutcome.BOUND, null);
+        }
+        if (!readCompleted)
+        {
+            return new ApplicationReadBack(appsArray, null, BindingOutcome.UNVERIFIED,
+                "the application read-back could not be completed - the failure is in the EDT " //$NON-NLS-1$
+                    + "error log"); //$NON-NLS-1$
+        }
+        if (cutShort)
+        {
+            // Interrupted: the reads that DID run saw no application, but the budget that absorbs the
+            // listener race was not spent — and nothing failed, so there is no log entry to point at.
+            return new ApplicationReadBack(appsArray, null, BindingOutcome.UNVERIFIED,
+                "the read-back was interrupted before its budget was spent"); //$NON-NLS-1$
+        }
+        if (undecidable[0])
+        {
+            // The last read listed an application that could not be compared with the new infobase,
+            // so it was never established that none of them is ours.
+            return new ApplicationReadBack(appsArray, null, BindingOutcome.UNVERIFIED,
+                "one of the project's applications could not be compared with the new infobase " //$NON-NLS-1$
+                    + "(an identity could not be read)"); //$NON-NLS-1$
+        }
+        return new ApplicationReadBack(appsArray, null, BindingOutcome.NOT_BOUND, null);
+    }
+
+    /**
+     * Builds the ERROR result for {@link BindingOutcome#NOT_BOUND}: the infobase exists but the project
+     * has no application for it. The payload is deliberately kept (issue #412) — {@code action} says
+     * what happened to the DATABASE, {@code infobaseFile}/{@code infobaseName} say which one, and
+     * {@code applications} is the evidence — so that "this failed" can never be read as "nothing
+     * happened".
+     *
+     * @param subject what happened to the database, for the log line
+     * @param errorText the full error text (the not-bound wording plus any setDefault/credentials
+     *            notes); it is carried as {@code error}, which is also what the client shows as text —
+     *            no second {@code message} copy to drift from it
+     */
+    private static ToolResult notBoundResult(ResultContext rc, String verb,
+            ApplicationReadBack readBack, String subject, String errorText)
+    {
+        Activator.logError("create_infobase: " + subject //$NON-NLS-1$
+            + " but no application appeared for project " + rc.projectName //$NON-NLS-1$
+            + " within the read-back budget", null); //$NON-NLS-1$
+        ToolResult result = ToolResult.error(errorText)
+            .put(McpKeys.ACTION, verb)
+            .put(McpKeys.PROJECT, rc.projectName)
+            .put(KEY_INFOBASE_FILE, rc.infobaseDir.toAbsolutePath().toString())
+            .put(KEY_INFOBASE_NAME, rc.infobaseName)
+            .put(KEY_BOUND_TO_PROJECT, false);
+        putApplications(result, readBack);
+        return result;
+    }
+
+    /**
+     * Echoes the applications the read-back saw — and OMITS the key entirely when no read produced a
+     * snapshot at all. An empty array would say "the project has no applications", which is a claim
+     * a failed read never made.
+     */
+    private static void putApplications(ToolResult result, ApplicationReadBack readBack)
+    {
+        if (readBack.appsArray != null)
+        {
+            result.put(KEY_APPLICATIONS, readBack.appsArray);
+        }
+    }
+
+    /**
+     * The {@link BindingOutcome#NOT_BOUND} wording: both facts (the database is there, the application
+     * is not), what it blocks, and what to do next. It does NOT offer {@code delete_infobase} as the
+     * cure — that tool resolves its target only among the project's applications, so it cannot address
+     * an infobase that has none.
+     */
+    private static String notBoundMessage(String subject, String projectName, boolean register)
+    {
+        return subject + ", but it did NOT appear as an application of project '" + projectName //$NON-NLS-1$
+            + "': the association was requested and raised no error, yet the project's applications " //$NON-NLS-1$
+            + "were read back " + READ_BACK_MAX_POLLS + " times over " //$NON-NLS-1$ //$NON-NLS-2$
+            + (READ_BACK_MAX_POLLS - 1) * READ_BACK_POLL_DELAY_MS
+            + " ms, and the last read compared every one of them without finding it. " //$NON-NLS-1$
+            + (register
+                ? "The existing database is untouched. " //$NON-NLS-1$
+                : "The database files were created and are intact - do NOT create them again. ") //$NON-NLS-1$
+            + "Nothing can target this infobase until its application appears: update_database / " //$NON-NLS-1$
+            + "create_launch_config / debug_launch address an application by applicationId, and " //$NON-NLS-1$
+            + "this infobase has none. Call " //$NON-NLS-1$
+            + "get_applications('" + projectName //$NON-NLS-1$
+            + "') to re-check (applications surface asynchronously); if it stays absent, check the " //$NON-NLS-1$
+            + "EDT error log - the registration completed, but the project's application provider " //$NON-NLS-1$
+            + "did not surface it."; //$NON-NLS-1$
+    }
+
+    /**
+     * The {@link BindingOutcome#UNVERIFIED} wording: the binding was neither confirmed nor refuted. It
+     * claims nothing about the application, states the actual reason the read-back settled nothing
+     * (a failed read and an interrupted poll are different, and only one of them leaves a log entry),
+     * and names the one call that settles it.
+     */
+    private static String unverifiedMessage(String subject, String projectName, String reason)
+    {
+        return subject + ". The association with project '" + projectName //$NON-NLS-1$
+            + "' was requested and raised no error, but " + reason //$NON-NLS-1$
+            + ", so the binding is UNVERIFIED - this call did not establish whether the application " //$NON-NLS-1$
+            + "is there. Call get_applications('" + projectName //$NON-NLS-1$
+            + "') to confirm it before chaining into update_database / create_launch_config / " //$NON-NLS-1$
+            + "debug_launch."; //$NON-NLS-1$
+    }
+
+    /** Joins the two optional message notes, either of which may be {@code null}. */
+    private static String concatNotes(String first, String second)
+    {
+        return (first != null ? first : "") + (second != null ? second : ""); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Reads the project's applications once, populating {@code appsArray} with one JSON object per
+     * application (same shape as {@code get_applications}) and storing the first application the
+     * {@code matcher} accepts in {@code newAppHolder[0]} (left {@code null} when not yet visible).
+     * Read-only.
+     *
+     * @return {@code true} if the read produced a snapshot to inspect (whether or not the new
+     *         application was in it), {@code false} if reading the applications failed or produced no
+     *         snapshot at all (already logged) so the caller stops re-polling and reports UNVERIFIED
      */
     private static boolean readBackApplications(IApplicationManager appManager, IProject project,
-            InfobaseReference ibRef, JsonArray appsArray, String[] newAppIdHolder)
+            ApplicationMatcher matcher, JsonArray appsArray, IApplication[] newAppHolder,
+            boolean[] undecidable)
     {
         try
         {
             List<IApplication> applications = appManager.getApplications(project);
-            if (applications != null)
+            if (applications == null)
             {
-                for (IApplication app : applications)
+                // No snapshot at all is not the same as an empty one: it establishes nothing, so it
+                // must not be counted as a read that MEASURED the application to be absent.
+                Activator.logError("create_infobase: application read-back returned no list", null); //$NON-NLS-1$
+                return false;
+            }
+            for (IApplication app : applications)
+            {
+                appsArray.add(toApplicationJson(appManager, app));
+                // Identify the newly created application (by infobase reference for a file
+                // infobase, by type + name for a standalone server).
+                if (newAppHolder[0] == null)
                 {
-                    JsonObject appObj = new JsonObject();
-                    appObj.addProperty("id", app.getId()); //$NON-NLS-1$
-                    appObj.addProperty("name", app.getName()); //$NON-NLS-1$
-                    if (app.getType() != null)
+                    MatchResult match = matcher.match(app);
+                    if (match == MatchResult.MATCH)
                     {
-                        appObj.addProperty("type", app.getType().getId()); //$NON-NLS-1$
+                        newAppHolder[0] = app;
                     }
-                    addUpdateState(appObj, appManager, app);
-                    // Identify the newly created application by matching the infobase reference.
-                    if (newAppIdHolder[0] == null && isMatchingNewInfobaseApp(app, ibRef))
+                    else if (match == MatchResult.UNDECIDABLE)
                     {
-                        newAppIdHolder[0] = app.getId();
+                        undecidable[0] = true;
                     }
-                    appsArray.add(appObj);
                 }
             }
             return true;
@@ -2404,16 +2650,24 @@ public class CreateInfobaseTool implements IMcpTool
     /**
      * Whether the application is the newly created FILE infobase application, identified by type and
      * a connection-string match against {@code ibRef}. Read-only.
+     *
+     * <p>A different type is a decidable {@link MatchResult#NO_MATCH}; an infobase application whose
+     * identity cannot be read is {@link MatchResult#UNDECIDABLE}, so an unreadable connection string
+     * cannot masquerade as "this is not the one" and turn into a refusal (issue #412).
      */
-    private static boolean isMatchingNewInfobaseApp(IApplication app, InfobaseReference ibRef)
+    private static MatchResult isMatchingNewInfobaseApp(IApplication app, InfobaseReference ibRef)
     {
         if (!(app instanceof IInfobaseApplication)
             || !INFOBASE_APP_TYPE.equals(app.getType() != null ? app.getType().getId() : null))
         {
-            return false;
+            return MatchResult.NO_MATCH;
         }
-        IInfobaseApplication ibApp = (IInfobaseApplication) app;
-        return ibApp.getInfobase() != null && matchesRef(ibApp.getInfobase(), ibRef);
+        InfobaseReference appRef = ((IInfobaseApplication)app).getInfobase();
+        if (appRef == null)
+        {
+            return MatchResult.UNDECIDABLE;
+        }
+        return matchesRef(appRef, ibRef);
     }
 
     /**
@@ -2437,24 +2691,32 @@ public class CreateInfobaseTool implements IMcpTool
 
     /**
      * Checks whether two infobase references point to the same FILE infobase by
-     * comparing their connection-string file path. Best-effort: returns false on any
-     * failure so a match-miss only skips the applicationId echo.
+     * comparing their connection-string file path. A miss is what makes the read-back report
+     * NOT_BOUND (it no longer merely skips the applicationId echo), so a comparison that could not be
+     * made - an absent or unreadable connection string, or a failure while reading one - returns
+     * {@link MatchResult#UNDECIDABLE} rather than a confident "different".
      */
-    private static boolean matchesRef(InfobaseReference a, InfobaseReference b)
+    private static MatchResult matchesRef(InfobaseReference a, InfobaseReference b)
     {
         try
         {
             if (a.getConnectionString() == null || b.getConnectionString() == null)
             {
-                return false;
+                return MatchResult.UNDECIDABLE;
             }
             String ca = a.getConnectionString().asConnectionString();
             String cb = b.getConnectionString().asConnectionString();
-            return ca != null && ca.equalsIgnoreCase(cb);
+            if (ca == null || cb == null)
+            {
+                return MatchResult.UNDECIDABLE;
+            }
+            return ca.equalsIgnoreCase(cb) ? MatchResult.MATCH : MatchResult.NO_MATCH;
         }
         catch (Exception e)
         {
-            return false;
+            Activator.logError("create_infobase: could not compare an application's infobase " //$NON-NLS-1$
+                + "reference with the new one", e); //$NON-NLS-1$
+            return MatchResult.UNDECIDABLE;
         }
     }
 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseTool.java
@@ -47,6 +47,7 @@ import com.e1c.g5.dt.applications.ApplicationException;
 import com.e1c.g5.dt.applications.ApplicationUpdateState;
 import com.e1c.g5.dt.applications.IApplication;
 import com.e1c.g5.dt.applications.IApplicationManager;
+import com.e1c.g5.dt.applications.IApplicationType;
 import com.e1c.g5.dt.applications.infobases.IInfobaseApplication;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -291,7 +292,11 @@ public class CreateInfobaseTool implements IMcpTool
                 + "from the resolved webUrl (the endpoint is read from EDT's configuration, not " //$NON-NLS-1$
                 + "probed). Absent if webUrl could not be resolved.") //$NON-NLS-1$
             .objectArrayProperty(KEY_APPLICATIONS,
-                "Applications bound to the project after creation (same shape as get_applications).") //$NON-NLS-1$
+                "Applications bound to the project after creation (same shape as get_applications). " //$NON-NLS-1$
+                + "Lists the applications the read-back could read; an application whose properties " //$NON-NLS-1$
+                + "could not be read is left out, and - unless the new application was already " //$NON-NLS-1$
+                + "matched - makes boundToProject absent. The key itself is omitted when the " //$NON-NLS-1$
+                + "applications could not be listed at all.") //$NON-NLS-1$
             .booleanProperty(KEY_BOUND_TO_PROJECT,
                 "Whether the infobase actually appeared as an application of the project, as " //$NON-NLS-1$
                 + "ESTABLISHED by the read-back that follows the association. true = the application " //$NON-NLS-1$
@@ -613,8 +618,8 @@ public class CreateInfobaseTool implements IMcpTool
         {
             return null;
         }
-        String error = InfobaseAccessSupport.storeCredentials(ibRef, credentials.user, credentials.password,
-            InfobaseAccessSupport.parseAccess(credentials.access));
+        String error = storeSafely(() -> InfobaseAccessSupport.storeCredentials(ibRef, credentials.user,
+            credentials.password, InfobaseAccessSupport.parseAccess(credentials.access)));
         if (error != null)
         {
             return " WARNING: connection credentials were NOT stored: " + error; //$NON-NLS-1$
@@ -629,6 +634,32 @@ public class CreateInfobaseTool implements IMcpTool
                 + "only after a matching infobase user is added."; //$NON-NLS-1$
         return " Stored connection credentials for user '" + (credentials.user == null ? "" : credentials.user) //$NON-NLS-1$ //$NON-NLS-2$
             + "' (change them later with set_infobase_credentials)." + userNote; //$NON-NLS-1$
+    }
+
+    /**
+     * Runs a credentials store and turns any exception into the message it is supposed to produce.
+     *
+     * <p>Both credential helpers promise that storing credentials never fails the creation or the
+     * registration itself — the database is already there, and a rejected password must not undo it.
+     * That promise cannot rest on the store never throwing: reading a stale application, or the
+     * secure storage refusing, would otherwise turn a completed creation into an internal tool error.
+     * Here it is structural (and logged, so a real failure stays visible).
+     *
+     * @param store the store call, returning its own error text or {@code null} on success
+     * @return the error text to report, or {@code null} when the credentials were stored
+     */
+    private static String storeSafely(java.util.function.Supplier<String> store)
+    {
+        try
+        {
+            return store.get();
+        }
+        catch (Exception e)
+        {
+            Activator.logError("create_infobase: storing the connection credentials failed", e); //$NON-NLS-1$
+            String reason = e.getMessage();
+            return (reason != null && !reason.trim().isEmpty()) ? reason : e.getClass().getSimpleName();
+        }
     }
 
     /**
@@ -2039,11 +2070,17 @@ public class CreateInfobaseTool implements IMcpTool
      */
     private static MatchResult isMatchingNewServerApp(IApplication app, String infobaseName)
     {
-        String typeId = app.getType() != null ? app.getType().getId() : null;
-        // Always decidable: the identity is the type plus the name, both plain reads that cannot
-        // half-fail, so there is no UNDECIDABLE case here.
-        return StandaloneServerSupport.WST_SERVER_APP_TYPE.equals(typeId)
-            && infobaseName.equals(app.getName()) ? MatchResult.MATCH : MatchResult.NO_MATCH;
+        MatchResult byType = matchesApplicationType(app, StandaloneServerSupport.WST_SERVER_APP_TYPE);
+        if (byType != MatchResult.MATCH)
+        {
+            return byType; // A readable, different type is a real miss; an unreadable one is not.
+        }
+        String name = app.getName();
+        if (name == null)
+        {
+            return MatchResult.UNDECIDABLE; // The other half of this identity could not be read.
+        }
+        return infobaseName.equals(name) ? MatchResult.MATCH : MatchResult.NO_MATCH;
     }
 
     /**
@@ -2076,8 +2113,8 @@ public class CreateInfobaseTool implements IMcpTool
                 + "application was not available from the read-back - check get_applications and " //$NON-NLS-1$
                 + "store them with set_infobase_credentials."; //$NON-NLS-1$
         }
-        String error = InfobaseAccessSupport.storeCredentials(application, credentials.user, credentials.password,
-            InfobaseAccessSupport.parseAccess(credentials.access));
+        String error = storeSafely(() -> InfobaseAccessSupport.storeCredentials(application,
+            credentials.user, credentials.password, InfobaseAccessSupport.parseAccess(credentials.access)));
         if (error != null)
         {
             return " WARNING: connection credentials were NOT stored: " + error; //$NON-NLS-1$
@@ -2288,7 +2325,8 @@ public class CreateInfobaseTool implements IMcpTool
         /**
          * Nothing was established: the read-back failed, or was cut short before the budget was
          * spent, or it listed an application whose identity could not be compared with the new
-         * infobase. None of those is evidence of a missing application.
+         * infobase. None of those is evidence of a missing application. (A positive match already
+         * made is not undone by any of them — it is evidence in its own right, and wins.)
          */
         UNVERIFIED
     }
@@ -2302,7 +2340,17 @@ public class CreateInfobaseTool implements IMcpTool
     {
         /** This application IS the one that was just created/registered. */
         MATCH,
-        /** This application is decidably a different one. */
+        /**
+         * This application is decidably a different one.
+         *
+         * <p><strong>The rule for every matcher:</strong> {@code NO_MATCH} is an ASSERTION — both
+         * sides were read and they differ. Anything that is not an established difference (an
+         * absent or unreadable type, name or infobase reference, or a failure while reading one)
+         * is {@link #UNDECIDABLE}. This is what keeps a refusal ({@code boundToProject:false})
+         * reachable only from a comparison that actually happened; the mechanism enforces it —
+         * {@link #matchesApplicationType} is the only type test, and
+         * {@link CreateInfobaseTool#readOneApplication} is the only place an application is read.
+         */
         NO_MATCH,
         /** The comparison could not be made (missing/unreadable identity), so nothing was established. */
         UNDECIDABLE
@@ -2312,6 +2360,29 @@ public class CreateInfobaseTool implements IMcpTool
     private interface ApplicationMatcher
     {
         MatchResult match(IApplication app);
+    }
+
+    /**
+     * The ONLY type test in the read-back, shared by both matchers so neither can regress on its own:
+     * a type that is present and different is an established {@link MatchResult#NO_MATCH}, while a
+     * type that cannot be read at all is {@link MatchResult#UNDECIDABLE} — "I could not see what this
+     * is" is not "this is not it".
+     */
+    private static MatchResult matchesApplicationType(IApplication app, String expectedTypeId)
+    {
+        IApplicationType type = app.getType();
+        if (type == null)
+        {
+            return MatchResult.UNDECIDABLE;
+        }
+        // Read the id ONCE: comparing a second read would let a value that arrived null decide
+        // "different", which is the very substitution this gate exists to prevent.
+        String typeId = type.getId();
+        if (typeId == null)
+        {
+            return MatchResult.UNDECIDABLE;
+        }
+        return expectedTypeId.equals(typeId) ? MatchResult.MATCH : MatchResult.NO_MATCH;
     }
 
     /**
@@ -2326,12 +2397,15 @@ public class CreateInfobaseTool implements IMcpTool
         final BindingOutcome outcome;
         /** Why nothing was established; {@code null} unless {@link BindingOutcome#UNVERIFIED}. */
         final String unverifiedReason;
+        /** The matched application's id AS ECHOED; {@code null} when it had none. */
+        private final String appId;
 
-        ApplicationReadBack(JsonArray appsArray, IApplication app, BindingOutcome outcome,
+        ApplicationReadBack(JsonArray appsArray, IApplication app, String appId, BindingOutcome outcome,
                 String unverifiedReason)
         {
             this.appsArray = appsArray;
             this.app = app;
+            this.appId = appId;
             this.outcome = outcome;
             this.unverifiedReason = unverifiedReason;
         }
@@ -2340,10 +2414,14 @@ public class CreateInfobaseTool implements IMcpTool
          * The matched application's id, or {@code null} when nothing matched OR the platform gave the
          * application no id. A matched application with a {@code null} id is still {@link
          * BindingOutcome#BOUND}: the binding is established by the MATCH, not by the id.
+         *
+         * <p>It is the id that was ECHOED in {@code applications}, captured during the same guarded
+         * read — never re-read afterwards, so the result cannot report "no id" beside an echo that
+         * shows one (nor fail while trying).
          */
         String appId()
         {
-            return app != null ? app.getId() : null;
+            return appId;
         }
     }
 
@@ -2448,6 +2526,7 @@ public class CreateInfobaseTool implements IMcpTool
         // re-encode "could not look" as "looked and found nothing", the very confusion this fixes.
         JsonArray appsArray = null;
         IApplication[] newAppHolder = new IApplication[1];
+        String[] newAppIdHolder = new String[1];
         boolean readCompleted = false;
         boolean cutShort = false;
 
@@ -2457,15 +2536,20 @@ public class CreateInfobaseTool implements IMcpTool
         {
             JsonArray attempt = new JsonArray();
             newAppHolder[0] = null;
+            newAppIdHolder[0] = null;
 
             undecidable[0] = false;
-            readCompleted =
-                readBackApplications(appManager, project, matcher, attempt, newAppHolder, undecidable);
-            if (readCompleted)
+            readCompleted = readBackApplications(appManager, project, matcher, attempt, newAppHolder,
+                newAppIdHolder, undecidable);
+            if (readCompleted || newAppHolder[0] != null)
             {
+                // Keep the snapshot the answer actually came from. A listing that failed AFTER
+                // identifying our application still identified it - the match is positive evidence,
+                // unaffected by the later failure - and its echo must be the one reported, or the
+                // result would name an application that is missing from its own evidence.
                 appsArray = attempt;
             }
-            else
+            if (!readCompleted)
             {
                 break; // Read failed (logged) — stop re-polling; absence is NOT established.
             }
@@ -2482,11 +2566,12 @@ public class CreateInfobaseTool implements IMcpTool
 
         if (newAppHolder[0] != null)
         {
-            return new ApplicationReadBack(appsArray, newAppHolder[0], BindingOutcome.BOUND, null);
+            return new ApplicationReadBack(appsArray, newAppHolder[0], newAppIdHolder[0],
+                BindingOutcome.BOUND, null);
         }
         if (!readCompleted)
         {
-            return new ApplicationReadBack(appsArray, null, BindingOutcome.UNVERIFIED,
+            return new ApplicationReadBack(appsArray, null, null, BindingOutcome.UNVERIFIED,
                 "the application read-back could not be completed - the failure is in the EDT " //$NON-NLS-1$
                     + "error log"); //$NON-NLS-1$
         }
@@ -2494,18 +2579,18 @@ public class CreateInfobaseTool implements IMcpTool
         {
             // Interrupted: the reads that DID run saw no application, but the budget that absorbs the
             // listener race was not spent — and nothing failed, so there is no log entry to point at.
-            return new ApplicationReadBack(appsArray, null, BindingOutcome.UNVERIFIED,
+            return new ApplicationReadBack(appsArray, null, null, BindingOutcome.UNVERIFIED,
                 "the read-back was interrupted before its budget was spent"); //$NON-NLS-1$
         }
         if (undecidable[0])
         {
             // The last read listed an application that could not be compared with the new infobase,
             // so it was never established that none of them is ours.
-            return new ApplicationReadBack(appsArray, null, BindingOutcome.UNVERIFIED,
+            return new ApplicationReadBack(appsArray, null, null, BindingOutcome.UNVERIFIED,
                 "one of the project's applications could not be compared with the new infobase " //$NON-NLS-1$
                     + "(an identity could not be read)"); //$NON-NLS-1$
         }
-        return new ApplicationReadBack(appsArray, null, BindingOutcome.NOT_BOUND, null);
+        return new ApplicationReadBack(appsArray, null, null, BindingOutcome.NOT_BOUND, null);
     }
 
     /**
@@ -2598,9 +2683,10 @@ public class CreateInfobaseTool implements IMcpTool
 
     /**
      * Reads the project's applications once, populating {@code appsArray} with one JSON object per
-     * application (same shape as {@code get_applications}) and storing the first application the
-     * {@code matcher} accepts in {@code newAppHolder[0]} (left {@code null} when not yet visible).
-     * Read-only.
+     * application THAT COULD BE READ (same shape as {@code get_applications}; an application that
+     * cannot be rendered is left out of the echo and makes the read undecidable) and storing the first
+     * application the {@code matcher} accepts in {@code newAppHolder[0]}, with its echoed id in
+     * {@code newAppIdHolder[0]} (both left {@code null} when not yet visible). Read-only.
      *
      * @return {@code true} if the read produced a snapshot to inspect (whether or not the new
      *         application was in it), {@code false} if reading the applications failed or produced no
@@ -2608,7 +2694,7 @@ public class CreateInfobaseTool implements IMcpTool
      */
     private static boolean readBackApplications(IApplicationManager appManager, IProject project,
             ApplicationMatcher matcher, JsonArray appsArray, IApplication[] newAppHolder,
-            boolean[] undecidable)
+            String[] newAppIdHolder, boolean[] undecidable)
     {
         try
         {
@@ -2622,29 +2708,78 @@ public class CreateInfobaseTool implements IMcpTool
             }
             for (IApplication app : applications)
             {
-                appsArray.add(toApplicationJson(appManager, app));
-                // Identify the newly created application (by infobase reference for a file
-                // infobase, by type + name for a standalone server).
-                if (newAppHolder[0] == null)
+                if (!readOneApplication(appManager, app, matcher, appsArray, newAppHolder,
+                    newAppIdHolder))
                 {
-                    MatchResult match = matcher.match(app);
-                    if (match == MatchResult.MATCH)
-                    {
-                        newAppHolder[0] = app;
-                    }
-                    else if (match == MatchResult.UNDECIDABLE)
-                    {
-                        undecidable[0] = true;
-                    }
+                    undecidable[0] = true;
                 }
             }
             return true;
         }
-        catch (ApplicationException e)
+        catch (Exception e)
         {
+            // Failing to obtain the snapshot AT ALL (the manager's own ApplicationException, or any
+            // other failure of the listing itself) means this read established nothing. Logged, then
+            // reported as UNVERIFIED rather than escaping as an internal tool failure or passing for
+            // a completed read. A single unreadable application does NOT come through here - it is
+            // confined by readOneApplication, which keeps the rest of the snapshot.
             Activator.logError("create_infobase: error reading back applications", e); //$NON-NLS-1$
             return false;
         }
+    }
+
+    /**
+     * Reads EVERYTHING about ONE application — its echo entry and its identity — in a single guarded
+     * place, so that an application which cannot be read costs exactly that application: it is
+     * reported as undecidable and the read moves on to the rest of the snapshot. This is the whole
+     * mechanism behind the rule on {@link MatchResult#NO_MATCH}: there is no second place where a
+     * failed read of an application could be mistaken for a decided one, and no path on which such a
+     * failure escapes as an internal tool error. The failure is logged, so a real defect stays
+     * visible instead of being swallowed.
+     *
+     * @return {@code false} when this application could not be read or could not be compared, so the
+     *         caller marks the read undecidable — which decides the outcome only when no match was
+     *         established
+     */
+    private static boolean readOneApplication(IApplicationManager appManager, IApplication app,
+            ApplicationMatcher matcher, JsonArray appsArray, IApplication[] newAppHolder,
+            String[] newAppIdHolder)
+    {
+        try
+        {
+            JsonObject rendered = toApplicationJson(appManager, app);
+            appsArray.add(rendered);
+            if (newAppHolder[0] != null)
+            {
+                return true; // Already found; the rest is echo only, and decides nothing.
+            }
+            // Identify the newly created application (by infobase reference for a file infobase,
+            // by type + name for a standalone server).
+            MatchResult match = matcher.match(app);
+            if (match == MatchResult.MATCH)
+            {
+                newAppHolder[0] = app;
+                newAppIdHolder[0] = renderedId(rendered);
+            }
+            return match != MatchResult.UNDECIDABLE;
+        }
+        catch (Exception e)
+        {
+            Activator.logError("create_infobase: could not read one of the project's applications " //$NON-NLS-1$
+                + "while looking for the new infobase", e); //$NON-NLS-1$
+            return false;
+        }
+    }
+
+    /**
+     * The id from an application's ALREADY-RENDERED echo entry ({@code null} when it has none), so the
+     * reported {@code applicationId} and the {@code applications} echo can never disagree.
+     */
+    private static String renderedId(JsonObject rendered)
+    {
+        return rendered.has("id") && !rendered.get("id").isJsonNull() //$NON-NLS-1$ //$NON-NLS-2$
+            ? rendered.get("id").getAsString() //$NON-NLS-1$
+            : null;
     }
 
     /**
@@ -2657,10 +2792,16 @@ public class CreateInfobaseTool implements IMcpTool
      */
     private static MatchResult isMatchingNewInfobaseApp(IApplication app, InfobaseReference ibRef)
     {
-        if (!(app instanceof IInfobaseApplication)
-            || !INFOBASE_APP_TYPE.equals(app.getType() != null ? app.getType().getId() : null))
+        MatchResult byType = matchesApplicationType(app, INFOBASE_APP_TYPE);
+        if (byType != MatchResult.MATCH)
         {
-            return MatchResult.NO_MATCH;
+            return byType; // A readable, different type is a real miss; an unreadable one is not.
+        }
+        if (!(app instanceof IInfobaseApplication))
+        {
+            // It claims to BE an infobase application but does not expose one, so its infobase
+            // identity cannot be read - which is not the same as being a different infobase.
+            return MatchResult.UNDECIDABLE;
         }
         InfobaseReference appRef = ((IInfobaseApplication)app).getInfobase();
         if (appRef == null)

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseToolTest.java
@@ -13,14 +13,33 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.eclipse.core.resources.IProject;
 import org.junit.Test;
 
+import com._1c.g5.v8.dt.platform.services.model.FileConnectionString;
+import com._1c.g5.v8.dt.platform.services.model.InfobaseReference;
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+import com.e1c.g5.dt.applications.ApplicationException;
+import com.e1c.g5.dt.applications.IApplication;
+import com.e1c.g5.dt.applications.IApplicationManager;
+import com.e1c.g5.dt.applications.IApplicationType;
+import com.e1c.g5.dt.applications.infobases.IInfobaseApplication;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 /**
  * Tests for {@link CreateInfobaseTool}.
@@ -705,5 +724,672 @@ public class CreateInfobaseToolTest
         {
             return configuration;
         }
+    }
+
+    // ==================== #412: the report follows what the read-back ESTABLISHED ====================
+    //
+    // The tool polls the application manager after associate() precisely because the binding surfaces
+    // asynchronously. These tests drive that read-back through a stubbed IApplicationManager and pin
+    // the three outcomes apart: found (bound), measured absent (an error that still says the database
+    // exists), and unreadable (success WITHOUT a binding claim - a failed read proves nothing).
+
+    /** Project name used by the read-back tests. */
+    private static final String RB_PROJECT = "ReadBackProject"; //$NON-NLS-1$
+
+    /** Infobase display name used by the read-back tests. */
+    private static final String RB_INFOBASE = "ReadBackBase"; //$NON-NLS-1$
+
+    /** Connection string shared by the new-infobase reference and its matching application. */
+    private static final String RB_CONNECTION = "File=\"C:\\infobases\\ReadBack\";"; //$NON-NLS-1$
+
+    /** A readable connection string that is decidably NOT the new infobase. */
+    private static final String OTHER_CONNECTION = "File=\"D:/other\";"; //$NON-NLS-1$
+
+    /** The claim the tool must never make on its own: it is only true when the read-back found the app. */
+    private static final String BOUND_CLAIM = "bound to project"; //$NON-NLS-1$
+
+    @Test
+    public void testOutputSchemaDeclaresBoundToProject()
+    {
+        // The binding fact must be machine-readable, not only prose (#412).
+        String schema = new CreateInfobaseTool().getOutputSchema();
+        assertTrue("outputSchema must declare boundToProject", //$NON-NLS-1$
+            schema.contains("\"boundToProject\"")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMeasuredMissingApplicationIsAnErrorNotABoundClaim() throws Exception
+    {
+        // Every read-back completes and none lists the new application: absence is MEASURED. The tool
+        // must not report success, and must not claim the infobase is bound to the project.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplications(project)).thenReturn(Collections.emptyList());
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertFalse("a measured missing application must not be reported as success", //$NON-NLS-1$
+            json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertTrue("the established fact must be machine-readable", //$NON-NLS-1$
+            json.has("boundToProject")); //$NON-NLS-1$
+        assertFalse("boundToProject must say false, not be omitted", //$NON-NLS-1$
+            json.get("boundToProject").getAsBoolean()); //$NON-NLS-1$
+        assertFalse("the tool must not claim a binding it just measured to be absent", //$NON-NLS-1$
+            json.get("error").getAsString().contains(BOUND_CLAIM)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMeasuredMissingApplicationErrorStillReportsTheDatabase() throws Exception
+    {
+        // The refusal must not read as "nothing happened": the database WAS created, and the payload
+        // has to say so - what happened to it, where it is, and under which name.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplications(project)).thenReturn(Collections.emptyList());
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertEquals("created", json.get("action").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(RB_INFOBASE, json.get("infobaseName").getAsString()); //$NON-NLS-1$
+        assertEquals(readBackDir().toString(), json.get("infobaseFile").getAsString()); //$NON-NLS-1$
+        assertTrue("the applications read-back is the evidence and must be echoed", //$NON-NLS-1$
+            json.has("applications")); //$NON-NLS-1$
+        String error = json.get("error").getAsString(); //$NON-NLS-1$
+        assertTrue("the error must say the database files are intact", //$NON-NLS-1$
+            error.contains("do NOT create them again")); //$NON-NLS-1$
+        assertTrue("the error must name the call that settles it", //$NON-NLS-1$
+            error.contains("get_applications('" + RB_PROJECT + "')")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the error must name what is now blocked", //$NON-NLS-1$
+            error.contains("create_launch_config")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMeasuredMissingApplicationSaysTheExistingDatabaseIsUntouchedOnRegister()
+        throws Exception
+    {
+        // mode='register' did not create anything, so the refusal must not claim it did.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplications(project)).thenReturn(Collections.emptyList());
+
+        JsonObject json = readBackResult(mgr, project, false, true, null);
+
+        assertEquals("registered", json.get("action").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+        String error = json.get("error").getAsString(); //$NON-NLS-1$
+        assertTrue("register mode must say the existing database is untouched", //$NON-NLS-1$
+            error.contains("The existing database is untouched")); //$NON-NLS-1$
+        assertFalse("register mode must not claim files were created", //$NON-NLS-1$
+            error.contains("were created and are intact")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testUnreadableApplicationsAreUnverifiedNotAbsent() throws Exception
+    {
+        // The read-back itself fails: absence was NOT established. A false refusal costs more than a
+        // missing claim, so this stays a success - but it must not claim the binding either, and the
+        // machine-readable flag must be ABSENT rather than guessing false.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplications(project)).thenThrow(new ApplicationException("index is cold")); //$NON-NLS-1$
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertTrue("a failed read does not disprove the binding - keep the call successful", //$NON-NLS-1$
+            json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertFalse("boundToProject must be ABSENT: neither answer was established", //$NON-NLS-1$
+            json.has("boundToProject")); //$NON-NLS-1$
+        String message = json.get("message").getAsString(); //$NON-NLS-1$
+        assertFalse("the tool must not claim a binding it could not read", //$NON-NLS-1$
+            message.contains(BOUND_CLAIM));
+        assertTrue("the message must name the state", message.contains("UNVERIFIED")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the message must name the call that settles it", //$NON-NLS-1$
+            message.contains("get_applications('" + RB_PROJECT + "')")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testFoundApplicationReportsTheBindingAndTheApplicationId() throws Exception
+    {
+        // The read-back finds the new application: this is the ONE case that may claim the binding.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        List<IApplication> found = Collections.singletonList(matchingInfobaseApp("app-42")); //$NON-NLS-1$
+        when(mgr.getApplications(project)).thenReturn(found);
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertTrue(json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertTrue("a found application must be reported as bound", //$NON-NLS-1$
+            json.get("boundToProject").getAsBoolean()); //$NON-NLS-1$
+        assertEquals("app-42", json.get("applicationId").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the success message may state the binding here", //$NON-NLS-1$
+            json.get("message").getAsString().contains(BOUND_CLAIM)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBoundMessageIsUnchangedForExistingCallers() throws Exception
+    {
+        // The whole point of the three-way report is that the HEALTHY case is untouched: a caller
+        // that gets its application today must see byte-for-byte the same message.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        List<IApplication> found = Collections.singletonList(matchingInfobaseApp("app-1")); //$NON-NLS-1$
+        when(mgr.getApplications(project)).thenReturn(found);
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertEquals("Infobase '" + RB_INFOBASE + "' created at '" + readBackDir() //$NON-NLS-1$ //$NON-NLS-2$
+            + "' and bound to project '" + RB_PROJECT //$NON-NLS-1$
+            + "'. Use update_database to push the configuration into the infobase.", //$NON-NLS-1$
+            json.get("message").getAsString()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFoundApplicationWithoutIdIsStillReportedAsBound() throws Exception
+    {
+        // The binding is established by the MATCH, not by the id: an application the platform gave no
+        // id is still an application of the project, and dropping that fact was the same defect.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        List<IApplication> found = Collections.singletonList(matchingInfobaseApp(null));
+        when(mgr.getApplications(project)).thenReturn(found);
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertTrue(json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertTrue("a matched application without an id is still bound", //$NON-NLS-1$
+            json.get("boundToProject").getAsBoolean()); //$NON-NLS-1$
+        assertFalse("there is no id to echo", json.has("applicationId")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testSetDefaultNoteIsAboutSetDefaultNotTheMissingApplication() throws Exception
+    {
+        // The old note blamed the MISSING APPLICATION on the setDefault flag ("could not be set as
+        // default yet"), which reads as cosmetic. setDefault talks about setDefault only.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplications(project)).thenReturn(Collections.emptyList());
+
+        JsonObject json = readBackResult(mgr, project, true, false, null);
+
+        String error = json.get("error").getAsString(); //$NON-NLS-1$
+        assertTrue("setDefault must report its own outcome", //$NON-NLS-1$
+            error.contains("setDefault was not applied")); //$NON-NLS-1$
+        assertFalse("the missing application must not be dressed up as a setDefault hiccup", //$NON-NLS-1$
+            error.contains("could not be set as default yet")); //$NON-NLS-1$
+        assertFalse("the note must read as a sentence, not be glued on with '.;'", //$NON-NLS-1$
+            error.contains(".;")); //$NON-NLS-1$
+        verify(mgr, never()).setDefaultApplication(any(IProject.class), any(IApplication.class));
+    }
+
+    @Test
+    public void testSetDefaultUsesTheApplicationTheReadBackFound() throws Exception
+    {
+        // setDefault now runs AFTER the read-back and on the application it found - it no longer does
+        // its own earlier lookup that could miss an application the re-poll then sees.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        IApplication app = matchingInfobaseApp("app-7"); //$NON-NLS-1$
+        List<IApplication> found = Collections.singletonList(app);
+        when(mgr.getApplications(project)).thenReturn(found);
+
+        JsonObject json = readBackResult(mgr, project, true, false, null);
+
+        verify(mgr).setDefaultApplication(project, app);
+        assertFalse("nothing failed, so no setDefault note", //$NON-NLS-1$
+            json.get("message").getAsString().contains("setDefault")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testStandaloneServerMeasuredMissingApplicationIsAnErrorToo() throws Exception
+    {
+        // The mirror path surfaces through the SAME provision-delegate listener, so it has the same
+        // "requested, never appeared" state and must report it the same way - while still handing back
+        // the endpoint EDT resolved for the server it did register.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplications(project)).thenReturn(Collections.emptyList());
+
+        String raw = CreateInfobaseTool.buildStandaloneServerResult(readBackContext(mgr, project), 8314,
+            "http://localhost:8314/base", false, false, //$NON-NLS-1$
+            new CreateInfobaseTool.Credentials(null, null, null));
+        JsonObject json = JsonParser.parseString(raw).getAsJsonObject();
+
+        assertFalse("a measured missing application must not be reported as success", //$NON-NLS-1$
+            json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertFalse(json.get("boundToProject").getAsBoolean()); //$NON-NLS-1$
+        assertFalse("the tool must not claim a binding it just measured to be absent", //$NON-NLS-1$
+            json.get("error").getAsString().contains(BOUND_CLAIM)); //$NON-NLS-1$
+        assertEquals("standaloneServer", json.get("applicationKind").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(8314, json.get("port").getAsInt()); //$NON-NLS-1$
+        assertEquals("http://localhost:8314/base", json.get("webUrl").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testNoApplicationListAtAllIsUnverifiedNotAbsent() throws Exception
+    {
+        // A null snapshot is not an empty snapshot: it inspected nothing, so it cannot MEASURE the
+        // application to be absent. Counting it as a clean empty read would turn "we do not know"
+        // into a refusal.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplications(project)).thenReturn(null);
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertTrue("a missing snapshot must not refuse the call", //$NON-NLS-1$
+            json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertFalse("boundToProject must be ABSENT: nothing was established", //$NON-NLS-1$
+            json.has("boundToProject")); //$NON-NLS-1$
+        assertFalse("an empty applications echo would claim the project has none - " //$NON-NLS-1$
+            + "a read that produced no snapshot never said that", json.has("applications")); //$NON-NLS-1$
+        assertTrue(json.get("message").getAsString().contains("UNVERIFIED")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testLaterReadFailureKeepsTheSnapshotTheEarlierReadProduced() throws Exception
+    {
+        // A read that failed on a LATER poll must not erase what the earlier, successful read saw:
+        // the echo is evidence, and throwing it away would leave the caller with less than we know.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        List<IApplication> others = Collections.singletonList(unrelatedApp("other-app")); //$NON-NLS-1$
+        when(mgr.getApplications(project)).thenReturn(others)
+            .thenThrow(new ApplicationException("index went cold")); //$NON-NLS-1$
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertTrue(json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertFalse(json.has("boundToProject")); //$NON-NLS-1$
+        assertTrue("the earlier snapshot must survive the later failure", //$NON-NLS-1$
+            json.has("applications")); //$NON-NLS-1$
+        assertTrue("the reason must be that the read-back could not COMPLETE", //$NON-NLS-1$
+            json.get("message").getAsString() //$NON-NLS-1$
+                .contains("the application read-back could not be completed")); //$NON-NLS-1$
+        assertEquals(1, json.get("applications").getAsJsonArray().size()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testApplicationAppearingOnALaterPollIsStillBound() throws Exception
+    {
+        // The whole point of the bounded re-poll: the application surfaces asynchronously. A first
+        // empty read must not decide the outcome.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        List<IApplication> found = Collections.singletonList(matchingInfobaseApp("late-app")); //$NON-NLS-1$
+        when(mgr.getApplications(project)).thenReturn(Collections.emptyList()).thenReturn(found);
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertTrue("a late application is still a bound application", //$NON-NLS-1$
+            json.get("boundToProject").getAsBoolean()); //$NON-NLS-1$
+        assertEquals("late-app", json.get("applicationId").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testInterruptedReadBackDoesNotBlameAReadFailure() throws Exception
+    {
+        // Interrupted before the budget was spent: the reads that ran saw nothing, but nothing FAILED
+        // either - so the message must not send the caller to the EDT error log for an entry that was
+        // never written.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplications(project)).thenReturn(Collections.emptyList());
+
+        JsonObject json;
+        Thread.currentThread().interrupt();
+        try
+        {
+            json = readBackResult(mgr, project, false, false, null);
+        }
+        finally
+        {
+            Thread.interrupted(); // clear the flag the poll restored, so later tests are unaffected
+        }
+
+        assertTrue("an interrupted read-back establishes no absence", //$NON-NLS-1$
+            json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertFalse(json.has("boundToProject")); //$NON-NLS-1$
+        String message = json.get("message").getAsString(); //$NON-NLS-1$
+        assertTrue("the message must name the real reason", //$NON-NLS-1$
+            message.contains("interrupted before its budget was spent")); //$NON-NLS-1$
+        assertFalse("nothing failed, so do not promise an EDT log entry", //$NON-NLS-1$
+            message.contains("EDT error log")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testUnreadableApplicationIdentityIsUnverifiedNotAbsence() throws Exception
+    {
+        // An infobase application whose connection string cannot be read is NOT evidence that our
+        // infobase is missing - it is evidence that we could not tell. Folding that into "no match"
+        // would re-create exactly the reported defect, with the verdict flipped: a confident
+        // boundToProject:false while the application may well be there.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        List<IApplication> opaque = Collections.singletonList(opaqueInfobaseApp());
+        when(mgr.getApplications(project)).thenReturn(opaque);
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertTrue("an uncomparable identity must not produce a refusal", //$NON-NLS-1$
+            json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertFalse("boundToProject must be ABSENT: the comparison established nothing", //$NON-NLS-1$
+            json.has("boundToProject")); //$NON-NLS-1$
+        String message = json.get("message").getAsString(); //$NON-NLS-1$
+        assertTrue("the message must say what could not be done", //$NON-NLS-1$
+            message.contains("could not be compared with the new infobase")); //$NON-NLS-1$
+        assertFalse(message.contains(BOUND_CLAIM));
+    }
+
+    @Test
+    public void testStandaloneServerFoundApplicationReportsTheBinding() throws Exception
+    {
+        // The standalone success path has its own message builder, so it needs its own proof that a
+        // found application is reported as bound (and carries the endpoint).
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        List<IApplication> found = Collections.singletonList(matchingServerApp("ServerApplication.X")); //$NON-NLS-1$
+        when(mgr.getApplications(project)).thenReturn(found);
+
+        String raw = CreateInfobaseTool.buildStandaloneServerResult(readBackContext(mgr, project), 8314,
+            "http://localhost:8314/base", false, false, //$NON-NLS-1$
+            new CreateInfobaseTool.Credentials(null, null, null));
+        JsonObject json = JsonParser.parseString(raw).getAsJsonObject();
+
+        assertTrue(json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertTrue(json.get("boundToProject").getAsBoolean()); //$NON-NLS-1$
+        assertEquals("ServerApplication.X", json.get("applicationId").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(json.get("message").getAsString().contains(BOUND_CLAIM)); //$NON-NLS-1$
+        assertEquals(8314, json.get("port").getAsInt()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testUnreadableConnectionStringIsUnverifiedNotAbsence() throws Exception
+    {
+        // The other half of "identity could not be read": the application HAS an infobase reference,
+        // but reading its connection string throws. Same rule - we could not tell, so we do not say.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        List<IApplication> opaque = Collections.singletonList(infobaseAppWithRef(throwingRef()));
+        when(mgr.getApplications(project)).thenReturn(opaque);
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertTrue(json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertFalse(json.has("boundToProject")); //$NON-NLS-1$
+        assertTrue(json.get("message").getAsString() //$NON-NLS-1$
+            .contains("an identity could not be read")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testDifferentInfobaseIsADecidableMissAndRefuses() throws Exception
+    {
+        // The opposite of the two tests above: a READABLE identity that is decidably a different
+        // infobase is exactly the case the refusal is for. Without this, "undecidable" could swallow
+        // the whole feature and nothing would notice.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        List<IApplication> others =
+            Collections.singletonList(infobaseAppWithRef(fileRef(OTHER_CONNECTION)));
+        when(mgr.getApplications(project)).thenReturn(others);
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertFalse("a decidably different infobase is a measured absence", //$NON-NLS-1$
+            json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertFalse(json.get("boundToProject").getAsBoolean()); //$NON-NLS-1$
+        assertEquals("the other application must still be echoed as evidence", //$NON-NLS-1$
+            1, json.get("applications").getAsJsonArray().size()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testAnEarlierUndecidableReadDoesNotPoisonALaterCompleteOne() throws Exception
+    {
+        // Each poll is a WHOLE snapshot of the project's applications, so an earlier poll that could
+        // not identify something is irrelevant once a later poll compared every application. The
+        // undecidable flag is therefore per-poll, and the last poll decides.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        List<IApplication> opaque = Collections.singletonList(opaqueInfobaseApp());
+        List<IApplication> readable =
+            Collections.singletonList(infobaseAppWithRef(fileRef(OTHER_CONNECTION)));
+        when(mgr.getApplications(project)).thenReturn(opaque).thenReturn(readable);
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertFalse("the later complete comparison decides", //$NON-NLS-1$
+            json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertFalse(json.get("boundToProject").getAsBoolean()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testBoundApplicationWithoutIdDoesNotSendTheCallerToUpdateDatabase() throws Exception
+    {
+        // update_database is addressed BY applicationId, so advising it without one is advice that
+        // cannot be followed.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        List<IApplication> found = Collections.singletonList(matchingInfobaseApp(null));
+        when(mgr.getApplications(project)).thenReturn(found);
+
+        String message = readBackResult(mgr, project, false, false, null)
+            .get("message").getAsString(); //$NON-NLS-1$
+
+        assertFalse("there is no id to chain with", message.contains("Use update_database")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the message must say how to get one", //$NON-NLS-1$
+            message.contains("look it up with get_applications")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingConnectionStringIsUnverifiedNotAbsence() throws Exception
+    {
+        // The third undecidable shape: the reference exists but carries no connection string at all.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        InfobaseReference ref = mock(InfobaseReference.class);
+        when(ref.getConnectionString()).thenReturn(null);
+        List<IApplication> opaque = Collections.singletonList(infobaseAppWithRef(ref));
+        when(mgr.getApplications(project)).thenReturn(opaque);
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertTrue(json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertFalse(json.has("boundToProject")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRefusalCarriesItsTextInErrorOnly() throws Exception
+    {
+        // The refusal's text lives in `error` - a second `message` copy could drift from it, and a
+        // caller reading only `message` would see nothing at all.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplications(project)).thenReturn(Collections.emptyList());
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertTrue(json.has("error")); //$NON-NLS-1$
+        assertFalse("no second copy of the text to drift from `error`", //$NON-NLS-1$
+            json.has("message")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSetDefaultUnderUnverifiedDoesNotAssumeTheApplicationIsMissing() throws Exception
+    {
+        // UNVERIFIED established nothing, so the setDefault note must not tell the caller to wait for
+        // an application that may well be there already.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplications(project)).thenThrow(new ApplicationException("index is cold")); //$NON-NLS-1$
+
+        String message = readBackResult(mgr, project, true, false, null)
+            .get("message").getAsString(); //$NON-NLS-1$
+
+        assertTrue("setDefault must report its own outcome", //$NON-NLS-1$
+            message.contains("setDefault was not applied")); //$NON-NLS-1$
+        assertFalse("nothing established the application to be missing", //$NON-NLS-1$
+            message.contains("once get_applications lists it")); //$NON-NLS-1$
+        verify(mgr, never()).setDefaultApplication(any(IProject.class), any(IApplication.class));
+    }
+
+    @Test
+    public void testSetDefaultFailureIsReportedInsteadOfSwallowed() throws Exception
+    {
+        // The caller ASKED for the default to be set and the failure was established - saying nothing
+        // (the old behaviour on this path) is the same class of silence this issue is about.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        List<IApplication> found = Collections.singletonList(matchingInfobaseApp("app-9")); //$NON-NLS-1$
+        when(mgr.getApplications(project)).thenReturn(found);
+        org.mockito.Mockito.doThrow(new ApplicationException("no default for you")) //$NON-NLS-1$
+            .when(mgr).setDefaultApplication(any(IProject.class), any(IApplication.class));
+
+        String message = readBackResult(mgr, project, true, false, null)
+            .get("message").getAsString(); //$NON-NLS-1$
+
+        assertTrue("the established failure must be reported", //$NON-NLS-1$
+            message.contains("setDefault failed: no default for you")); //$NON-NLS-1$
+        assertTrue("the binding itself still holds", message.contains(BOUND_CLAIM)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStandaloneServerUnreadableApplicationsAreUnverified() throws Exception
+    {
+        // The standalone path assembles its own UNVERIFIED message, so it needs its own proof.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        when(mgr.getApplications(project)).thenThrow(new ApplicationException("index is cold")); //$NON-NLS-1$
+
+        String raw = CreateInfobaseTool.buildStandaloneServerResult(readBackContext(mgr, project), 8314,
+            "http://localhost:8314/base", false, false, //$NON-NLS-1$
+            new CreateInfobaseTool.Credentials(null, null, null));
+        JsonObject json = JsonParser.parseString(raw).getAsJsonObject();
+
+        assertTrue(json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertFalse("boundToProject must be ABSENT: nothing was established", //$NON-NLS-1$
+            json.has("boundToProject")); //$NON-NLS-1$
+        String message = json.get("message").getAsString(); //$NON-NLS-1$
+        assertTrue(message.contains("UNVERIFIED")); //$NON-NLS-1$
+        assertFalse(message.contains(BOUND_CLAIM));
+        assertTrue("the resolved endpoint is still reported", //$NON-NLS-1$
+            message.contains("web port 8314")); //$NON-NLS-1$
+    }
+
+    // -------------------- #412 helpers --------------------
+
+    /** The infobase directory the read-back tests report (absolute, so it is platform-independent). */
+    private static Path readBackDir()
+    {
+        return Paths.get("infobases", "ReadBack").toAbsolutePath(); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /** The identity/read-back inputs shared by the result builders. */
+    private static CreateInfobaseTool.ResultContext readBackContext(IApplicationManager mgr, IProject project)
+    {
+        return new CreateInfobaseTool.ResultContext(RB_PROJECT, readBackDir(), RB_INFOBASE, mgr, project);
+    }
+
+    /** Runs the file-infobase result builder against the stubbed manager and parses its JSON. */
+    private static JsonObject readBackResult(IApplicationManager mgr, IProject project, boolean setDefault,
+            boolean register, String credNote)
+    {
+        String raw = CreateInfobaseTool.buildSuccessResult(readBackContext(mgr, project),
+            infobaseRef(), setDefault, register, credNote);
+        return JsonParser.parseString(raw).getAsJsonObject();
+    }
+
+    /** The new infobase's reference: a FILE reference carrying {@link #RB_CONNECTION}. */
+    private static InfobaseReference infobaseRef()
+    {
+        return fileRef(RB_CONNECTION);
+    }
+
+    /** A FILE infobase reference carrying the given connection string. */
+    private static InfobaseReference fileRef(String connectionString)
+    {
+        FileConnectionString connection = mock(FileConnectionString.class);
+        when(connection.asConnectionString()).thenReturn(connectionString);
+        InfobaseReference ref = mock(InfobaseReference.class);
+        when(ref.getConnectionString()).thenReturn(connection);
+        return ref;
+    }
+
+    /** A reference whose connection string cannot be read at all. */
+    private static InfobaseReference throwingRef()
+    {
+        FileConnectionString connection = mock(FileConnectionString.class);
+        when(connection.asConnectionString()).thenThrow(new IllegalStateException("detached")); //$NON-NLS-1$
+        InfobaseReference ref = mock(InfobaseReference.class);
+        when(ref.getConnectionString()).thenReturn(connection);
+        return ref;
+    }
+
+    /** An infobase application of the right TYPE holding the given reference. */
+    private static IInfobaseApplication infobaseAppWithRef(InfobaseReference reference)
+    {
+        IApplicationType type = mock(IApplicationType.class);
+        when(type.getId()).thenReturn("com.e1c.g5.dt.applications.type.infobase"); //$NON-NLS-1$
+        IInfobaseApplication app = mock(IInfobaseApplication.class);
+        when(app.getId()).thenReturn("other-infobase"); //$NON-NLS-1$
+        when(app.getName()).thenReturn("Other"); //$NON-NLS-1$
+        when(app.getType()).thenReturn(type);
+        when(app.getInfobase()).thenReturn(reference);
+        return app;
+    }
+
+    /** An infobase application of the right TYPE whose identity cannot be read at all. */
+    private static IInfobaseApplication opaqueInfobaseApp()
+    {
+        IApplicationType type = mock(IApplicationType.class);
+        when(type.getId()).thenReturn("com.e1c.g5.dt.applications.type.infobase"); //$NON-NLS-1$
+        IInfobaseApplication app = mock(IInfobaseApplication.class);
+        when(app.getId()).thenReturn("opaque"); //$NON-NLS-1$
+        when(app.getName()).thenReturn("Opaque"); //$NON-NLS-1$
+        when(app.getType()).thenReturn(type);
+        when(app.getInfobase()).thenReturn(null);
+        return app;
+    }
+
+    /** The just-created standalone server: the wst-server type plus the new infobase's name. */
+    private static IApplication matchingServerApp(String id)
+    {
+        IApplicationType type = mock(IApplicationType.class);
+        when(type.getId()).thenReturn("com.e1c.g5.dt.applications.type.wst-server"); //$NON-NLS-1$
+        IApplication app = mock(IApplication.class);
+        when(app.getId()).thenReturn(id);
+        when(app.getName()).thenReturn(RB_INFOBASE);
+        when(app.getType()).thenReturn(type);
+        return app;
+    }
+
+    /** An application of another type, which the read-back must NOT match. */
+    private static IApplication unrelatedApp(String id)
+    {
+        IApplicationType type = mock(IApplicationType.class);
+        when(type.getId()).thenReturn("com.e1c.g5.dt.applications.type.wst-server"); //$NON-NLS-1$
+        IApplication app = mock(IApplication.class);
+        when(app.getId()).thenReturn(id);
+        when(app.getName()).thenReturn("Unrelated"); //$NON-NLS-1$
+        when(app.getType()).thenReturn(type);
+        return app;
+    }
+
+    /**
+     * An application the read-back must match: the infobase application type, holding an infobase
+     * reference with the SAME connection string as {@link #infobaseRef()}.
+     *
+     * @param id the application id, or {@code null} to model a platform that gave it none
+     */
+    private static IInfobaseApplication matchingInfobaseApp(String id)
+    {
+        IApplicationType type = mock(IApplicationType.class);
+        when(type.getId()).thenReturn("com.e1c.g5.dt.applications.type.infobase"); //$NON-NLS-1$
+        InfobaseReference reference = infobaseRef();
+        IInfobaseApplication app = mock(IInfobaseApplication.class);
+        when(app.getId()).thenReturn(id);
+        when(app.getName()).thenReturn(RB_INFOBASE);
+        when(app.getType()).thenReturn(type);
+        when(app.getInfobase()).thenReturn(reference);
+        return app;
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateInfobaseToolTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -1275,6 +1276,274 @@ public class CreateInfobaseToolTest
             message.contains("web port 8314")); //$NON-NLS-1$
     }
 
+    @Test
+    public void testUnreadableApplicationTypeIsUnverifiedNotAbsence() throws Exception
+    {
+        // "I could not see what this application is" is not "this is not the one". If the entry with
+        // the unreadable type IS the new infobase, calling it a miss produces exactly the false
+        // refusal this issue is about - with the verdict flipped.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        List<IApplication> untyped = Collections.singletonList(infobaseAppWithType(null));
+        when(mgr.getApplications(project)).thenReturn(untyped);
+
+        assertUnverified(readBackResult(mgr, project, false, false, null));
+    }
+
+    @Test
+    public void testUnreadableApplicationTypeIdIsUnverifiedNotAbsence() throws Exception
+    {
+        // Same rule one level down: the type object is there but yields no id.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        IApplicationType type = mock(IApplicationType.class);
+        when(type.getId()).thenReturn(null);
+        List<IApplication> untyped = Collections.singletonList(infobaseAppWithType(type));
+        when(mgr.getApplications(project)).thenReturn(untyped);
+
+        assertUnverified(readBackResult(mgr, project, false, false, null));
+    }
+
+    @Test
+    public void testUnreadableApplicationDuringTheReadIsUnverifiedNotAnInternalError() throws Exception
+    {
+        // A stale application that THROWS while being read (here: while its echo entry is built).
+        // The promised third outcome has to actually happen: not an exception out of the tool, and
+        // not a refusal.
+        //
+        // It is also CONFINED to that one application: the rest of the snapshot is still read and
+        // echoed. That is what separates "one entry is opaque" from "the read failed" - two states
+        // that would otherwise be indistinguishable, and only one of them keeps the evidence.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        IApplication hostile = mock(IApplication.class);
+        when(hostile.getId()).thenReturn("hostile"); //$NON-NLS-1$
+        when(hostile.getName()).thenReturn("Hostile"); //$NON-NLS-1$
+        when(hostile.getType()).thenThrow(new IllegalStateException("proxy is detached")); //$NON-NLS-1$
+        List<IApplication> snapshot = Arrays.asList(hostile, unrelatedApp("readable")); //$NON-NLS-1$
+        when(mgr.getApplications(project)).thenReturn(snapshot);
+
+        // Must not throw: the read-back has to CLASSIFY the failure, not propagate it.
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertUnverified(json);
+        assertTrue("the rest of the snapshot must survive one opaque entry", //$NON-NLS-1$
+            json.has("applications")); //$NON-NLS-1$
+        assertEquals("the readable application is still there; only the opaque one is missing", //$NON-NLS-1$
+            1, json.get("applications").getAsJsonArray().size()); //$NON-NLS-1$
+        assertEquals("readable", json.get("applications").getAsJsonArray().get(0) //$NON-NLS-1$ //$NON-NLS-2$
+            .getAsJsonObject().get("id").getAsString()); //$NON-NLS-1$
+        assertTrue("the reason must be the failed COMPARISON, not a failed listing", //$NON-NLS-1$
+            json.get("message").getAsString() //$NON-NLS-1$
+                .contains("could not be compared with the new infobase")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testUnrenderableApplicationIsUnverifiedNotAbsence() throws Exception
+    {
+        // An application that cannot even be rendered was still an application: reporting the read
+        // as complete-and-empty would state exactly what it failed to check. The listing succeeded,
+        // so the (empty) echo is honest - but the outcome must be unverified, and the message has to
+        // say that one application could not be read, or the empty echo would be read as "none".
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        IApplication hostile = mock(IApplication.class);
+        when(hostile.getId()).thenThrow(new IllegalStateException("proxy is detached")); //$NON-NLS-1$
+        when(mgr.getApplications(project)).thenReturn(Collections.singletonList(hostile));
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertUnverified(json);
+        assertTrue("the message must not leave an empty echo to speak for itself", //$NON-NLS-1$
+            json.get("message").getAsString() //$NON-NLS-1$
+                .contains("could not be compared with the new infobase")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStandaloneServerUnreadableTypeIsUnverifiedNotAbsence() throws Exception
+    {
+        // The mirror path shares the type gate, so it must inherit the same answer.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        IApplication untyped = mock(IApplication.class);
+        when(untyped.getId()).thenReturn("srv"); //$NON-NLS-1$
+        when(untyped.getName()).thenReturn(RB_INFOBASE);
+        when(untyped.getType()).thenReturn(null);
+        when(mgr.getApplications(project)).thenReturn(Collections.singletonList(untyped));
+
+        String raw = CreateInfobaseTool.buildStandaloneServerResult(readBackContext(mgr, project), 8314,
+            "http://localhost:8314/base", false, false, //$NON-NLS-1$
+            new CreateInfobaseTool.Credentials(null, null, null));
+
+        assertUnverified(JsonParser.parseString(raw).getAsJsonObject());
+    }
+
+    @Test
+    public void testStandaloneServerUnreadableNameIsUnverifiedNotAbsence() throws Exception
+    {
+        // The other half of the server's identity: right type, unreadable name.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        IApplicationType type = mock(IApplicationType.class);
+        when(type.getId()).thenReturn("com.e1c.g5.dt.applications.type.wst-server"); //$NON-NLS-1$
+        IApplication nameless = mock(IApplication.class);
+        when(nameless.getId()).thenReturn("srv"); //$NON-NLS-1$
+        when(nameless.getName()).thenReturn(null);
+        when(nameless.getType()).thenReturn(type);
+        when(mgr.getApplications(project)).thenReturn(Collections.singletonList(nameless));
+
+        String raw = CreateInfobaseTool.buildStandaloneServerResult(readBackContext(mgr, project), 8314,
+            "http://localhost:8314/base", false, false, //$NON-NLS-1$
+            new CreateInfobaseTool.Credentials(null, null, null));
+
+        assertUnverified(JsonParser.parseString(raw).getAsJsonObject());
+    }
+
+    @Test
+    public void testUnreadableIdOfTheFoundApplicationStillReportsTheBinding() throws Exception
+    {
+        // The MATCH established the binding; losing the id echo afterwards must not turn a
+        // successful call into an internal failure.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        IApplicationType type = mock(IApplicationType.class);
+        when(type.getId()).thenReturn("com.e1c.g5.dt.applications.type.infobase"); //$NON-NLS-1$
+        InfobaseReference reference = fileRef(RB_CONNECTION);
+        IInfobaseApplication app = mock(IInfobaseApplication.class);
+        when(app.getName()).thenReturn(RB_INFOBASE);
+        when(app.getType()).thenReturn(type);
+        when(app.getInfobase()).thenReturn(reference);
+        when(app.getId()).thenReturn("app-x").thenThrow(new IllegalStateException("detached")); //$NON-NLS-1$ //$NON-NLS-2$
+        List<IApplication> found = Collections.singletonList(app);
+        when(mgr.getApplications(project)).thenReturn(found);
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertTrue(json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertTrue("the match established the binding", //$NON-NLS-1$
+            json.get("boundToProject").getAsBoolean()); //$NON-NLS-1$
+        assertEquals("the id echoed by the first (successful) read is the one reported", //$NON-NLS-1$
+            "app-x", json.get("applicationId").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testCredentialStoreFailureIsANoteNotAFailedCreation() throws Exception
+    {
+        // The credentials note is documented as never failing the registration - the server is
+        // already registered, so a store that throws must not undo that. The promise has to hold by
+        // construction, not by the store happening not to throw.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        IApplication hostile = mock(IApplication.class);
+        IApplicationType type = mock(IApplicationType.class);
+        when(type.getId()).thenReturn("com.e1c.g5.dt.applications.type.wst-server"); //$NON-NLS-1$
+        when(hostile.getName()).thenReturn(RB_INFOBASE);
+        when(hostile.getType()).thenReturn(type);
+        // The store reads the application; a stale one throws instead of answering.
+        when(hostile.getId()).thenReturn("srv") //$NON-NLS-1$
+            .thenThrow(new IllegalStateException("proxy is detached")); //$NON-NLS-1$
+        when(mgr.getApplications(project)).thenReturn(Collections.singletonList(hostile));
+
+        String raw = CreateInfobaseTool.buildStandaloneServerResult(readBackContext(mgr, project), 8314,
+            "http://localhost:8314/base", false, true, //$NON-NLS-1$
+            new CreateInfobaseTool.Credentials("Admin", "secret", null)); //$NON-NLS-1$ //$NON-NLS-2$
+        JsonObject json = JsonParser.parseString(raw).getAsJsonObject();
+
+        assertTrue("a failed credentials store must not undo the registration", //$NON-NLS-1$
+            json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertTrue("and it must be reported, not swallowed", //$NON-NLS-1$
+            json.get("message").getAsString().contains("credentials were NOT stored")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testComparisonItselfThrowingIsUnverified() throws Exception
+    {
+        // The echo renders fine and the COMPARISON is what throws - the path the previous test could
+        // not reach, because there the identity failed while being rendered.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        IApplicationType type = mock(IApplicationType.class);
+        when(type.getId()).thenReturn("com.e1c.g5.dt.applications.type.infobase"); //$NON-NLS-1$
+        IInfobaseApplication app = mock(IInfobaseApplication.class);
+        when(app.getId()).thenReturn("rendersFine"); //$NON-NLS-1$
+        when(app.getName()).thenReturn("RendersFine"); //$NON-NLS-1$
+        when(app.getType()).thenReturn(type);
+        when(app.getInfobase()).thenThrow(new IllegalStateException("proxy is detached")); //$NON-NLS-1$
+        when(mgr.getApplications(project)).thenReturn(Collections.singletonList(app));
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertUnverified(json);
+        assertTrue("the entry rendered, so the echo keeps it", json.has("applications")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(1, json.get("applications").getAsJsonArray().size()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testReportedApplicationIdIsTheOneEchoed() throws Exception
+    {
+        // The id is captured from the echo entry during the same guarded read, so the two can never
+        // disagree - and reading it cannot fail later, after the binding was already established.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        InfobaseReference reference = fileRef(RB_CONNECTION);
+        IApplicationType type = mock(IApplicationType.class);
+        when(type.getId()).thenReturn("com.e1c.g5.dt.applications.type.infobase"); //$NON-NLS-1$
+        IInfobaseApplication app = mock(IInfobaseApplication.class);
+        when(app.getName()).thenReturn(RB_INFOBASE);
+        when(app.getType()).thenReturn(type);
+        when(app.getInfobase()).thenReturn(reference);
+        // A second read of the id answers DIFFERENTLY: only an implementation that reports the id it
+        // echoed can pass, so re-reading the application later would be caught here.
+        when(app.getId()).thenReturn("app-echo").thenReturn("different"); //$NON-NLS-1$ //$NON-NLS-2$
+        List<IApplication> found = Collections.singletonList(app);
+        when(mgr.getApplications(project)).thenReturn(found);
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertEquals("app-echo", json.get("applicationId").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(json.get("applications").getAsJsonArray().get(0).getAsJsonObject() //$NON-NLS-1$
+            .get("id").getAsString(), json.get("applicationId").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testAMatchSurvivesAListingThatFailsAfterIt() throws Exception
+    {
+        // The listing yields our application and THEN breaks. The match is positive evidence that the
+        // later failure cannot undo - and the echo reported must be the one the match came from, or
+        // the result would name an application missing from its own evidence.
+        IProject project = mock(IProject.class);
+        IApplicationManager mgr = mock(IApplicationManager.class);
+        IApplication matching = matchingInfobaseApp("app-then-boom"); //$NON-NLS-1$
+        when(mgr.getApplications(project)).thenReturn(new java.util.AbstractList<IApplication>()
+        {
+            @Override
+            public IApplication get(int index)
+            {
+                if (index == 0)
+                {
+                    return matching;
+                }
+                throw new IllegalStateException("the listing broke after the first entry"); //$NON-NLS-1$
+            }
+
+            @Override
+            public int size()
+            {
+                return 2;
+            }
+        });
+
+        JsonObject json = readBackResult(mgr, project, false, false, null);
+
+        assertTrue("a positive match is not undone by a later failure", //$NON-NLS-1$
+            json.get("boundToProject").getAsBoolean()); //$NON-NLS-1$
+        assertEquals("app-then-boom", json.get("applicationId").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the echo must be the snapshot the match came from", //$NON-NLS-1$
+            json.has("applications")); //$NON-NLS-1$
+        assertEquals("app-then-boom", json.get("applications").getAsJsonArray().get(0) //$NON-NLS-1$ //$NON-NLS-2$
+            .getAsJsonObject().get("id").getAsString()); //$NON-NLS-1$
+    }
+
     // -------------------- #412 helpers --------------------
 
     /** The infobase directory the read-back tests report (absolute, so it is platform-independent). */
@@ -1302,6 +1571,35 @@ public class CreateInfobaseToolTest
     private static InfobaseReference infobaseRef()
     {
         return fileRef(RB_CONNECTION);
+    }
+
+    /**
+     * The one assertion every "could not read an identity" case has to satisfy: the call SUCCEEDS
+     * (a failed comparison is not evidence of a missing application), it makes no binding claim
+     * either way, and it is not the refusal - that separation is the entire point of the change.
+     */
+    private static void assertUnverified(JsonObject json)
+    {
+        assertTrue("an inability to compare must not refuse the call", //$NON-NLS-1$
+            json.get("success").getAsBoolean()); //$NON-NLS-1$
+        assertFalse("unverified must never become the refusal", json.has("error")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("boundToProject must be ABSENT: nothing was established", //$NON-NLS-1$
+            json.has("boundToProject")); //$NON-NLS-1$
+        String message = json.get("message").getAsString(); //$NON-NLS-1$
+        assertTrue("the message must name the state", message.contains("UNVERIFIED")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("and must not claim the binding", message.contains(BOUND_CLAIM)); //$NON-NLS-1$
+    }
+
+    /** An infobase-named application carrying the given (possibly null) type. */
+    private static IInfobaseApplication infobaseAppWithType(IApplicationType type)
+    {
+        InfobaseReference reference = fileRef(RB_CONNECTION);
+        IInfobaseApplication app = mock(IInfobaseApplication.class);
+        when(app.getId()).thenReturn("untyped"); //$NON-NLS-1$
+        when(app.getName()).thenReturn("Untyped"); //$NON-NLS-1$
+        when(app.getType()).thenReturn(type);
+        when(app.getInfobase()).thenReturn(reference);
+        return app;
     }
 
     /** A FILE infobase reference carrying the given connection string. */

--- a/tests/e2e/tools/test_create_infobase.py
+++ b/tests/e2e/tools/test_create_infobase.py
@@ -14,9 +14,22 @@ RESPONSE SHAPE
 --------------
 JSON tool (getResponseType() == JSON); payload in r.structured:
   success path: {"success": true, "action": "created", "project", "infobaseFile",
-                 "infobaseName", "applications": [...], ["applicationId": "..."],
-                 "message"}
-  error path:   {"success": false, "error": "..."}
+                 "infobaseName", ["applications": [...]], ["applicationId": "..."],
+                 ["boundToProject": true], "message"}
+  error path:   {"success": false, "error": "..."} - and, for the not-bound refusal below,
+                the same action/infobaseFile/infobaseName/applications payload plus
+                "boundToProject": false
+
+  boundToProject (issue #412) reports what the post-association read-back ESTABLISHED,
+  and the tool never claims the binding on its own: true = the application was found;
+  false = the poll budget was spent and the LAST read compared every application without
+  finding it, which is reported as an ERROR that
+  still carries action/infobaseFile/infobaseName/applications (the database exists, so
+  the refusal must not read as "nothing happened"); ABSENT = the comparison could not be
+  completed (the read failed, the call was interrupted before the poll budget was spent,
+  or an application's identity was unreadable), so the call stays successful and the
+  message says UNVERIFIED. The applications echo itself is omitted when no read produced
+  a snapshot at all.
 
 CI / HEADLESS STRATEGY (IMPORTANT)
 -----------------------------------
@@ -228,8 +241,9 @@ def test_live_create_verify_delete_roundtrip():
 
     This test:
     1. Creates a new FILE infobase at a temp directory.
-    2. Verifies it appears in get_applications as type …type.infobase with an
-       applicationId in the result.
+    2. Verifies it appears in get_applications as type …type.infobase, and that the
+       create result's applicationId — echoed whenever the platform gave the
+       application one — matches it.
     3. Removes it via delete_infobase (preview, then confirm).
     4. Verifies it is gone from get_applications.
     5. Cleans up the temp directory.

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -392,6 +392,9 @@
           },
           "type": "array"
         },
+        "boundToProject": {
+          "type": "boolean"
+        },
         "infobaseFile": {
           "type": "string"
         },


### PR DESCRIPTION
Closes #412

## Что было

`create_infobase` **сам устанавливал** факт и тут же его выбрасывал. После `associate` инструмент опрашивает менеджер приложений — 5 раз по 300 мс, именно потому, что приложение появляется асинхронно. Но результат от этого опроса не зависел: `success` не ветвился, фраза «and bound to project» печаталась безусловно, а `applicationId` при отсутствии приложения просто **опускался**. Единственный сигнал существовал только при `setDefault=true` (умолчание — `false`) и списывал отсутствие приложения на флаг «сделать основной».

Снято на одноразовом стенде (EDT 2026.2) **до** правки, вызов с умолчаниями:

```
success: true, applications: [], applicationId — отсутствует
message: "Infobase 'Probe412A' created at 'E:\AI\edt-stand\ib-412a' and bound to project
          'TestConfiguration'. Use update_database to push the configuration into the infobase."
```

Файлы базы при этом реально созданы (`1Cv8.1CD`, 3.2 МБ), а следующий шаг того же сценария отвечает `isError:true`: «Project 'TestConfiguration' has no applications (infobases). Create an infobase first». Инструмент противоречит сам себе через один вызов.

## Что стало

Отчёт следует тому, что опрос **установил**, — три состояния вместо одного:

| опрос | ответ | `boundToProject` |
|---|---|---|
| приложение найдено | успех, `applicationId`, прежнее сообщение | `true` |
| все чтения прошли, приложения нет — **измеренное** отсутствие | **отказ**, но с полной полезной нагрузкой: `action` (что случилось с БАЗОЙ), `infobaseFile`, `infobaseName`, `applications` | `false` |
| прочитать приложения не удалось / опрос прерван | успех, в сообщении «UNVERIFIED» и причина | **ключ отсутствует** |

То же сообщение на стенде **после** правки:

```
isError: true, boundToProject: false, action: "created", infobaseFile: "E:\AI\edt-stand\ib-412c"
error: "Infobase 'Probe412C' created at 'E:\AI\edt-stand\ib-412c', but it did NOT appear as an
        application of project 'TestConfiguration': the association was requested and raised no
        error, yet the project's applications were read back 5 times over 1200 ms and none of them
        lists it. The database files were created and are intact - do NOT create them again. Until
        the application appears, update_database / create_launch_config / debug_launch on this
        project will refuse, because they need an applicationId. Call
        get_applications('TestConfiguration') to re-check (applications surface asynchronously);
        if it stays absent, check the EDT error log - the registration completed, but the project's
        application provider did not surface it."
```

## Почему отказ, а не успех с признаком

1. **Это не новый отказ, а снятие противоречия.** При том же конечном состоянии инструмент **уже сегодня** возвращает ошибку — когда `associate` бросает исключение (там же, рядом, с текстом «создана, но не привязана»). Отчёт не может переворачиваться в зависимости от того, вскрикнула EDT или промолчала.
2. **Это заявленный контракт инструмента:** его собственное описание — «bind it to a configuration project **so it appears in get_applications**». Не появилось — постусловие не выполнено.
3. **Успех, которым нечего продолжить.** Гайд велит цепляться в `update_database` по `applicationId`, а в этом ответе его физически нет.

**Третье состояние** («не проверено») — обратная сторона того же правила: неудавшееся чтение отсутствия **не доказывает**, а ложный отказ дороже пропуска. Поэтому там остаётся успех, но без утверждения о привязке и без признака `boundToProject` — вместо того чтобы угадать `false`. Различаются и причины: провалившееся чтение оставляет запись в журнале EDT, прерванный опрос — нет, и сообщение обещает журнал только в первом случае.

## Это не регресс для существующих вызывающих

Кто сегодня получает успех в этом состоянии, получает **ложный** успех и уже сломан — просто молча, а обнаруживает это шагом позже, на чужой ошибке. Здоровый путь не тронут: сообщение при найденном приложении **побайтово прежнее** (закреплено тестом `testBoundMessageIsUnchangedForExistingCallers`), ни один ключ из успешного ответа не исчез, `boundToProject` — добавленный ключ.

## Что ещё вошло (тот же дефект рядом)

- **Зеркальный путь `applicationKind='standaloneServer'`** — то же самое: приложение сервера появляется через того же слушателя. В отказе сохраняются `port`/`webUrl` — сам сервер-то поднят.
- **Порядок `setDefault`.** Он делал СВОЙ одноразовый поиск ДО опроса и потому мог писать «не удалось сделать основным» для приложения, которое опрос затем находил. Теперь `setDefault` применяется к тому, что нашёл опрос, и его приписка говорит **только про `setDefault`**. Заодно: неудача `setDefaultApplication` больше не проглатывается молча, а на файловом пути опрос хранит сам объект приложения, а не только идентификатор (приложение без идентификатора считалось ненайденным — тот же дефект двумя уровнями глубже).
- **«Не удалось сравнить» ≠ «это не оно».** Сопоставление приложения с новой инфобазой стало трёхзначным: у приложения нужного типа, чью строку соединения прочитать не удалось, ответ — «не установлено», а не уверенное «другое». Иначе правка воспроизводила бы ровно тот же дефект с обратным знаком: уверенное `boundToProject:false` при живом приложении. До этой правки промах сопоставления лишь опускал `applicationId`, а теперь он решает исход вызова — значит и цена у него другая.
- **Пустой снимок ≠ отсутствие:** `getApplications`, вернувший `null`, больше не засчитывается как чтение, измерившее отсутствие; а чтение, упавшее на позднем опросе, не стирает снимок, который успел получить предыдущий опрос (эхо `applications` вообще опускается, если снимка не было ни одного, — пустой массив утверждал бы «у проекта нет приложений»).
- **Две мелочи, отмеченные в ишью:** запись в лог «associated with project» печаталась до всякой проверки (теперь она говорит ровно то, что произошло — `associate()` не бросил), и ветка исключения в режиме `register` утверждала «was created», хотя базу мы только зарегистрировали.
- Оба пути опроса объединены (`pollForNewApplication` + предикат совпадения) — они были почти дословными копиями и разъезжались.

## Доказательства

- **Юнит-тесты** (26 новых, `CreateInfobaseToolTest`, менеджер приложений подменён): измеренное отсутствие → отказ без утверждения о привязке; отказ сохраняет путь/имя/`action`/`applications`; режим `register` не говорит «файлы созданы»; нечитаемый список → «не проверено» без признака; нечитаемая ЛИЧНОСТЬ приложения → «не проверено», а не отказ; прерванный опрос не обещает запись в журнале; `null`-список → «не проверено» и без эха `applications`; позднее падение чтения сохраняет ранний снимок; приложение, появившееся на позднем опросе, → привязано; приложение без идентификатора → привязано; приписка `setDefault` не подменяет диагностику и не приклеивается через `.;`; `setDefault` применяется к найденному приложению; зеркальный путь отдельного сервера в обе стороны; сообщение здорового пути побайтово прежнее.
- **Мутация точек решения** (обе проверены отдельно, прогон целевого модуля с ненулевым `Tests run`): вернуть ветку `NOT_BOUND` файлового пути к безусловному успеху → краснеют 4 теста; то же для пути отдельного сервера → краснеет его тест; свести «не удалось сравнить» к «не совпало» → краснеет `…UnreadableApplicationIdentity…`. После каждой мутации файл возвращался к прежнему состоянию с проверкой контрольной суммы.
- **Сборка:** `source/compile.sh` — `BUILD SUCCESS`, 4841 юнит-тест, 0 падений.
- **Стенд:** оба режима сняты до и после правки (см. выше); снимок `tools/list` и `docs/tools/create_infobase.md` перегенерированы со стенда, не руками.

## Что осознанно НЕ менял

Описание инструмента и первая строка гайда по-прежнему говорят «binds it to a configuration project **so it appears in get_applications**». Это не оговорка, а формулировка контракта — и именно на неё опирается довод, почему непоявившееся приложение обязано быть отказом: инструмент теперь этот контракт **проверяет и обеспечивает**, а не декларирует. Переписать её на «запрашивает привязку» значило бы ослабить обещание ровно тогда, когда мы впервые начали его выполнять. Если предпочитаете другую формулировку — скажите, поправлю (это заденет снимок `tools/list`).

## Наблюдение (отдельную ишью не заводил)

В состоянии «база есть, приложения нет» её **нечем убрать**: `delete_infobase` резолвит цель только среди приложений проекта (и по `applicationId`, и по `infobaseName`), поэтому при нуле приложений отвечает «не найдено». Поэтому сообщение об отказе не обещает очистку — только проверку `get_applications` и журнал EDT. Если считаете нужным — заведу.
