### PR TITLE
run_yaxunit_tests: ключ прогона и ключ подготовки несут всё, что решает, что именно выполнится (#411)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
@@ -939,9 +939,12 @@ public class RunYaxunitTestsTool implements IMcpTool
             // The tool thread waits on the job's latch; if the prep is not done
             // within the budget it returns a "Pending (preparation)" response and
             // the caller retries with the same arguments. The launch (Phase 3) is
-            // NEVER run in the background — only the prep. A single in-flight
-            // entry per (project, applicationId) prevents a second job from
-            // starting while one is already running.
+            // NEVER run in the background — only the prep. One in-flight entry
+            // per PREPARATION (see PrepRequest.prepKey: the project and the
+            // application, plus the conflict policy and the rebuild scope)
+            // prevents a second job for the same one from starting while it
+            // is already running — and lets two calls that asked for DIFFERENT
+            // preparations of the same infobase each get the one they asked for.
             //
             // Phase 3 (spawn) still runs under the per-key lock — this serialises
             // the spawn across both YAXUnit tools for the same IB and closes the
@@ -1806,8 +1809,11 @@ public class RunYaxunitTestsTool implements IMcpTool
          * scopes shared one job and the first to start won. Deriving the key here, from the
          * object the preparation consumes, means a call site can no longer state a DIFFERENT
          * project, application, policy or scope than the one it is about to prepare with. It is
-         * not a proof that the whole request is captured: the three fields below are excluded
-         * deliberately, and their reasons are what carries that part.
+         * not a proof that the whole request is captured: the fields below are excluded
+         * deliberately, and their reasons are what carries that part. In particular {@code project}
+         * is excluded because BOTH call sites derive it from {@code projectName} — the type does
+         * not enforce that, so a future call site that passed an unrelated project would key it
+         * under the wrong name.
          *
          * <p>Keyed: {@code projectName} + {@code applicationId} (via
          * {@link LaunchLifecycleUtils#prepKeyFor}, the same string as the per-infobase lock), the
@@ -2513,7 +2519,11 @@ public class RunYaxunitTestsTool implements IMcpTool
     }
 
     /**
-     * Computes a short hex SHA-1 hash for filter parts so the runKey is bounded.
+     * Computes a short hex SHA-1 hash of the framed run-key identity (target, filter,
+     * conflict policy and pre-launch chain) so the runKey stays bounded in length.
+     *
+     * <p>Six digest bytes: the key is therefore not injective, and {@link #buildRunKey}
+     * explains why that is accepted.
      */
     private static String sha1(String input)
     {
@@ -2547,6 +2557,10 @@ public class RunYaxunitTestsTool implements IMcpTool
      * ({@code ЗначениеЗаполнено}), so an empty list and an absent key mean the same thing to the
      * framework — "do not filter on this" — and writing an empty array would be a promise the
      * framework does not keep.
+     *
+     * <p>"Non-empty" is decided on the raw comma-string, not on the parsed list, so one input
+     * does still write {@code []}: a value made only of separators ({@code ","}). Left as is —
+     * the file it produces is what {@link #filterKeyPart} keys on, and the two must agree.
      *
      * <p>Package-private and static so the generated filter can be asserted directly; this is the
      * method both the RUN and the DEBUG path call, and it reads the filter families off the request

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
@@ -842,7 +842,8 @@ public class RunYaxunitTestsTool implements IMcpTool
      *
      * Non-blocking with state tracking. Behaviour:
      * <ol>
-     *   <li>Compute stable runKey from the launch config name + filter.</li>
+     *   <li>Compute the stable runKey (see {@link #buildRunKey}) — the launch config name plus
+     *       everything that decides what the run executes.</li>
      *   <li>If a launch is already running for this key — poll up to {@code timeout}s, return result or "Pending".</li>
      *   <li>If no active launch but this key has an UNDELIVERED Pending result — deliver it ONCE, then
      *       forget the key so the next call re-runs.</li>
@@ -907,7 +908,7 @@ public class RunYaxunitTestsTool implements IMcpTool
                     appManager, launchManager, req, deadlineMs, state);
             }
 
-            String runKey = buildRunKey(matchingConfig.getName(), req);
+            String runKey = buildRunKey(matchingConfig.getName(), projectName, applicationId, req);
             Path reportDir = stableReportDir(runKey);
 
             // If a launch is already running for this key, just poll it.
@@ -952,17 +953,16 @@ public class RunYaxunitTestsTool implements IMcpTool
             {
                 if (req.updateBeforeLaunch)
                 {
-                    // The policy is part of the key: a piggybacking call must never inherit a
-                    // DIFFERENT caller's answer to the external-changes modal (one of the answers
-                    // rewrites project sources). Same project+application+policy still share one prep.
-                    String prepKey = LaunchLifecycleUtils.prepKeyFor(projectName, applicationId)
-                        + "|" + req.externalChanges.wireValue(); //$NON-NLS-1$
+                    // What identifies this preparation is derived from the request that drives it
+                    // (see PrepRequest.prepKey): a piggybacking call must never inherit a DIFFERENT
+                    // caller's answer to the external-changes modal (one of the answers rewrites
+                    // project sources) nor a DIFFERENT rebuild scope.
                     final PreLaunchResult[] resultHolder = new PreLaunchResult[1];
                     PrepRequest prepReq = new PrepRequest(projectName, launchManager, project,
                         applicationId, appManager, req.updateScope, req.externalChanges,
                         "YAXUnit pre-launch preparation for " + projectName); //$NON-NLS-1$
 
-                    String pendingOrError = awaitPreparedOrPending(prepKey, prepReq, resultHolder,
+                    String pendingOrError = awaitPreparedOrPending(prepReq, resultHolder,
                         deadlineMs, state);
                     if (pendingOrError != null)
                     {
@@ -1527,14 +1527,12 @@ public class RunYaxunitTestsTool implements IMcpTool
         PreLaunchResult preLaunch = null;
         if (req.updateBeforeLaunch)
         {
-            String prepKey = LaunchLifecycleUtils.prepKeyFor(projectName, applicationId)
-                + "|" + req.externalChanges.wireValue(); //$NON-NLS-1$
             final PreLaunchResult[] resultHolder = new PreLaunchResult[1];
             PrepRequest prepReq = new PrepRequest(projectName, launchManager, project,
                 applicationId, appManager, req.updateScope, req.externalChanges,
                 "YAXUnit debug pre-launch preparation for " + projectName); //$NON-NLS-1$
 
-            String pendingOrError = awaitPreparedOrPending(prepKey, prepReq, resultHolder,
+            String pendingOrError = awaitPreparedOrPending(prepReq, resultHolder,
                 deadlineMs, state);
             if (pendingOrError != null)
             {
@@ -1648,9 +1646,9 @@ public class RunYaxunitTestsTool implements IMcpTool
     /**
      * Shared in-flight / budget / pending block for both the RUN and DEBUG paths.
      *
-     * <p>Acquires (or creates) a {@link PrepInFlight} entry for {@code prepKey}
+     * <p>Acquires (or creates) a {@link PrepInFlight} entry for {@link PrepRequest#prepKey()}
      * via {@link java.util.concurrent.ConcurrentMap#computeIfAbsent}, ensuring only ONE
-     * background Job is ever scheduled for a given {@code (project, applicationId)} key
+     * background Job is ever scheduled for a given preparation key
      * regardless of how many concurrent tool threads arrive: the thread that wins the
      * {@link PrepInFlight#started} CAS constructs and schedules the Job; every other
      * thread simply awaits {@link PrepInFlight#latch} on the same entry.
@@ -1673,7 +1671,11 @@ public class RunYaxunitTestsTool implements IMcpTool
      *       {@code resultHolder[0]} and return {@code null} so the caller proceeds.</li>
      * </ol>
      *
-     * @param prepKey          the in-flight map key (project\u0000applicationId)
+     * <p>The in-flight key is NOT a parameter: it is derived from the request itself via
+     * {@link PrepRequest#prepKey()}, so no caller can guard a preparation with a key that
+     * describes a different one. It used to be spelled out at each of the two call sites, which
+     * is why the missing {@code updateScope} of #411 had to be found and fixed in BOTH.
+     *
      * @param req              the pre-launch preparation pass-throughs (project name,
      *                         launch manager, project, application id, application
      *                         manager and updateScope forwarded to
@@ -1692,9 +1694,10 @@ public class RunYaxunitTestsTool implements IMcpTool
      *         {@code null} when preparation completed successfully and the caller
      *         may proceed
      */
-    static String awaitPreparedOrPending(String prepKey, PrepRequest req, // NOSONAR package-private for the bounded-wait ratchet, which must drive this wait directly
+    static String awaitPreparedOrPending(PrepRequest req, // NOSONAR package-private for the bounded-wait ratchet, which must drive this wait directly
             PreLaunchResult[] resultHolder, long deadlineMs, CallState state)
     {
+        String prepKey = req.prepKey();
         // Stale-entry eviction loop: if an expired or done-with-error entry is in
         // the map, remove it atomically so the computeIfAbsent below creates a fresh
         // one. At most two iterations: one to detect + remove, one to proceed.
@@ -1791,6 +1794,56 @@ public class RunYaxunitTestsTool implements IMcpTool
             this.updateScope = updateScope;
             this.externalChanges = externalChanges;
             this.jobName = jobName;
+        }
+
+        /**
+         * The {@link LaunchLifecycleUtils#PREP_INFLIGHT} key for THIS preparation.
+         *
+         * <p>Derived from the request instead of chosen by the caller. That is the whole point:
+         * the RUN path and the DEBUG path each spelled this string out themselves, and
+         * {@code updateScope} was handed to the preparation without being part of the identity
+         * of that preparation — in both copies — so two concurrent calls with different rebuild
+         * scopes shared one job and the first to start won. Deriving the key here, from the
+         * object the preparation consumes, means a call site can no longer state a DIFFERENT
+         * project, application, policy or scope than the one it is about to prepare with. It is
+         * not a proof that the whole request is captured: the three fields below are excluded
+         * deliberately, and their reasons are what carries that part.
+         *
+         * <p>Keyed: {@code projectName} + {@code applicationId} (via
+         * {@link LaunchLifecycleUtils#prepKeyFor}, the same string as the per-infobase lock), the
+         * external-changes policy — one of its answers rewrites project sources, so a piggybacking
+         * call must never inherit a different caller's answer — and the
+         * {@linkplain LaunchLifecycleUtils#canonicalUpdateScope canonical} update scope, which
+         * decides which projects are rebuilt.
+         *
+         * <p>NOT keyed, deliberately:
+         * <ul>
+         *   <li>{@code jobName} — the ONLY field that differs between the RUN and the DEBUG call
+         *       site. Keying it would give the two tools separate entries and run the preparation
+         *       twice for one infobase, losing the single-in-flight guarantee this map exists
+         *       for;</li>
+         *   <li>{@code project} — it IS {@code ProjectContext.of(projectName).project()}, so
+         *       {@code projectName} already keys it;</li>
+         *   <li>{@code launchManager} / {@code appManager} — platform service handles, not inputs.
+         *       {@code appManager} in particular is tracked through an OSGi {@code ServiceTracker}
+         *       and may legitimately be a different object between two calls; keying it would
+         *       start a duplicate preparation on a service rebind instead of joining the running
+         *       one.</li>
+         * </ul>
+         *
+         * <p>The test filter is not keyed either — it does not affect preparation at all.
+         *
+         * @return the in-flight preparation key; never {@code null}
+         */
+        String prepKey()
+        {
+            // NUL-joined exactly like prepKeyFor's own separator: neither a project nor an
+            // application name can contain it, so the readable prefix can never be confused
+            // with the framed suffix.
+            return LaunchLifecycleUtils.prepKeyFor(projectName, applicationId)
+                + '\u0000'
+                + framed(externalChanges == null ? null : externalChanges.wireValue(),
+                    LaunchLifecycleUtils.canonicalUpdateScope(updateScope));
         }
     }
 
@@ -2307,36 +2360,156 @@ public class RunYaxunitTestsTool implements IMcpTool
     }
 
     /**
-     * Builds the stable run key that identifies one (launch config + filter + conflict policy)
-     * combination.
+     * Builds the stable run key that identifies one (launch target + filter + freshness
+     * guarantee) combination.
      *
      * <p>The launch config name is the key root — stable across the
      * {@code (project, applicationId)} and {@code launchConfigurationName} call styles. Everything
-     * that changes WHICH tests run, or under what answer to EDT's conflict modal they run, is
-     * folded into the hash: the key governs active-launch reuse ({@link #ACTIVE_LAUNCHES}),
-     * once-only pending delivery ({@link #PENDING_FETCH}) and the report directory
-     * ({@link #stableReportDir}). A filter that is NOT in the key would let a run started under
-     * one selection be polled by — and have its report delivered to — a call that asked for a
-     * different one.
+     * that changes WHICH tests run, WHERE they run, or WHAT code they run against is folded into
+     * the hash, because the key governs active-launch reuse ({@link #ACTIVE_LAUNCHES}), once-only
+     * pending delivery ({@link #PENDING_FETCH}) and the report directory
+     * ({@link #stableReportDir}), and all three reuse checks happen BEFORE preparation. A term
+     * that is NOT in the key lets a run started under one request be polled by — and have its
+     * report delivered to — a call that asked for a different one, and the answer is
+     * indistinguishable from an honest fresh run.
+     *
+     * <p>Every term, and why it changes the outcome:
+     * <ul>
+     *   <li>the RESOLVED {@code applicationId} — the config name does NOT pin it: a named launch
+     *       configuration is returned BY NAME, and a caller-supplied {@code applicationId} then
+     *       overrides the config's own binding (see {@code deriveLaunchContext}) and is stamped
+     *       onto the launch working copy. Two calls naming one config and two applications run
+     *       against two infobases;</li>
+     *   <li>the RESOLVED {@code projectName} — the project the pre-launch chain recompiles and
+     *       locks on. (It is NOT the project the client launches with: that one comes from the
+     *       launch configuration itself.) Keying the RESOLVED values rather than the request's is
+     *       also what keeps the two call styles that reach one target sharing a run;</li>
+     *   <li>{@code extensions} / {@code modules} / {@code tests} / {@code tags} — WHICH tests run;
+     *       normalised through {@link #filterKeyPart} so two requests that generate a
+     *       byte-identical {@code xUnitParams.json} filter are one run;</li>
+     *   <li>the auto-chain — {@code updateBeforeLaunch} and {@code updateScope} as a single
+     *       {@linkplain #preLaunchKeyPart term}: whether the extension is recomputed and the
+     *       infobase updated before the run, and which projects that covers. A call asking for
+     *       a refresh must never be answered by a run started without one: that report came
+     *       from a possibly STALE {@code .cfe} and reads exactly like an honest one;</li>
+     *   <li>{@code externalChanges} — how EDT's conflict modal is answered; one of the answers
+     *       rewrites project sources. Kept UNCONDITIONAL, unlike the scope: its contract states
+     *       no applicability condition, so there is nothing declared to lean on. Today the code
+     *       happens to make it inert with the chain off (no preparation runs, and both arm paths
+     *       null the policy), but that is an implementation detail no test or contract holds in
+     *       place; narrowing the key on it would turn a future change into a silently wrong
+     *       report, while keeping it costs at most one extra run.</li>
+     * </ul>
+     *
+     * <p>Deliberately NOT keyed: {@code timeout} (the caller's waiting window — keying it would
+     * drop a Pending report the moment a caller retried with a longer one) and {@code debug} (the
+     * DEBUG path returns before any run key exists). The request's own
+     * {@code configName}/{@code projectName}/{@code applicationId} are not keyed either; their
+     * RESOLVED counterparts are, above.
+     *
+     * <p>Terms are {@linkplain #framed length-framed} rather than joined with a separator. Most
+     * of them are caller-controlled strings, and a separator join is forgeable across any two
+     * adjacent parts whenever one ENDS with the separator and the next BEGINS with it: under
+     * the previous literal {@code "|"} joiner, {@code extensions="a|", modules="b"} and
+     * {@code extensions="a", modules="|b"} were the same key. A collision here is a false HIT —
+     * the quietest failure this method has, since it is served as a successful report. With a
+     * length there is nothing to impersonate. (The digest is then truncated to 48 bits, so the
+     * key is not injective in the cryptographic sense; the framing removes what a caller can hit
+     * by accident, which is the threat model — a caller can always ask for another run directly,
+     * so there is no boundary to attack.)
      *
      * <p>Package-private and static so a test can pin the PRODUCTION formula: this is the exact
-     * method the run path calls, not a reconstruction of it. A test that rebuilt the string itself
-     * would keep passing if the call site dropped an argument.
-     *
-     * <p>It takes the whole {@link RunRequest} rather than the individual fields on purpose: a
-     * call site that had to list them could silently omit one, and an omitted filter fails as a
-     * SHARED run identity — the quietest failure this method has. Passing the request makes that
-     * unrepresentable, and lets the test drive the same object the run path does.
+     * method the run path calls, not a reconstruction of it. It takes the whole {@link RunRequest}
+     * rather than its individual fields on purpose — a call site listing them could silently omit
+     * one, and an omitted term fails as a SHARED run identity. The resolved trio is passed
+     * separately because the request deliberately does not carry the resolved values.
      *
      * @param configName resolved launch configuration name
-     * @param req the request whose filter and conflict policy identify the run
+     * @param projectName the RESOLVED project name the run targets
+     * @param applicationId the RESOLVED application id the run targets (may be empty)
+     * @param req the request whose filter, freshness guarantee and conflict policy identify the run
      * @return the run key
      */
-    static String buildRunKey(String configName, RunRequest req)
+    static String buildRunKey(String configName, String projectName, String applicationId,
+            RunRequest req)
     {
         return configName + ":" //$NON-NLS-1$
-            + sha1(safe(req.extensions) + "|" + safe(req.modules) + "|" + safe(req.tests) //$NON-NLS-1$ //$NON-NLS-2$
-                + "|" + safe(req.tags) + "|" + safe(req.externalChanges.wireValue())); //$NON-NLS-1$ //$NON-NLS-2$
+            + sha1(framed(projectName, applicationId, filterKeyPart(req.extensions),
+                filterKeyPart(req.modules), filterKeyPart(req.tests), filterKeyPart(req.tags),
+                req.externalChanges.wireValue(), preLaunchKeyPart(req)));
+    }
+
+    /**
+     * The pre-launch auto-chain term of the run key: WHETHER the run refreshes what it executes,
+     * and HOW MUCH of it.
+     *
+     * <p>{@code updateBeforeLaunch} and {@code updateScope} are ONE decision, so they are one
+     * term. Writing them as two — a boolean plus a scope that empties itself when the boolean is
+     * false — makes each of them redundant with the other: dropping either one leaves the key
+     * still telling the two cases apart, so neither can be shown to be load-bearing and a
+     * regression in either is invisible to a test. (Measured, not assumed: with both terms
+     * present, deleting the boolean from the formula broke nothing.)
+     *
+     * <p>The scope is folded in only when the chain is on, because the parameter's own contract
+     * says so — "Only applies when updateBeforeLaunch=true", see
+     * {@link #UPDATE_SCOPE_DESCRIPTION} — and the implementation agrees: with the chain off no
+     * preparation is scheduled at all, on either the RUN or the DEBUG path. Keying a scope that
+     * applies to nothing would split requests the tool itself declares identical, and every such
+     * call would re-run the whole suite instead of joining the run already in flight.
+     */
+    private static String preLaunchKeyPart(RunRequest req)
+    {
+        return req.updateBeforeLaunch
+            ? "chain:" + LaunchLifecycleUtils.canonicalUpdateScope(req.updateScope) //$NON-NLS-1$
+            : "no-chain"; //$NON-NLS-1$
+    }
+
+    /**
+     * The key term for one filter family: empty when the family is absent, otherwise {@code "+"}
+     * plus the family exactly as {@link #buildParamsJson} would write it.
+     *
+     * <p>Two requests get the same term precisely when the generated {@code xUnitParams.json}
+     * carries the same filter for that family — no more and no less. That needs both halves:
+     * {@link #splitToList} (trim, drop empty tokens) because {@code " smoke "} and {@code "smoke"}
+     * generate the same array and must be one run, and the {@code "+"} presence marker because
+     * {@code null} (family omitted) and {@code ","} (family written as an empty array) generate
+     * DIFFERENT files.
+     *
+     * <p>The framework very likely treats those two files alike ({@link #buildParamsJson} explains
+     * why an empty list is not a filter), so the marker probably costs one re-run for a caller who
+     * passes a filter of nothing but separators. The identity deliberately stops at what this file
+     * can prove — the bytes it writes — rather than at an assumption about the framework: being
+     * wrong that way costs a re-run, being wrong the other way serves the wrong report. The
+     * previous formula kept these two apart as well, so nothing is lost either.
+     */
+    private static String filterKeyPart(String value)
+    {
+        if (value == null || value.isEmpty())
+        {
+            return ""; //$NON-NLS-1$
+        }
+        return "+" + String.join(",", splitToList(value)); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Length-frames the parts of a key so the concatenation is injective for arbitrary content.
+     *
+     * <p>Each part is written as {@code <length>:<value>} (netstring framing), so no value can
+     * impersonate a separator: with a plain joiner, a part ENDING in that joiner and the next
+     * part BEGINNING with it produce one key — and a key collision here is served as a
+     * successful, wrong report. The framing is injective over the values it frames; {@code null}
+     * is normalised to the empty string FIRST, deliberately, because every caller of this method
+     * treats an absent value and an empty one as the same thing.
+     */
+    private static String framed(String... parts)
+    {
+        StringBuilder sb = new StringBuilder();
+        for (String part : parts)
+        {
+            String value = safe(part);
+            sb.append(value.length()).append(':').append(value);
+        }
+        return sb.toString();
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
@@ -8,6 +8,7 @@ package com.ditrix.edt.mcp.server.utils;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -119,8 +120,9 @@ public final class LaunchLifecycleUtils
     public static final String PHASE_DB_UPDATE = "db-update"; //$NON-NLS-1$
 
     /**
-     * Live state of a background pre-launch preparation job keyed by the same
-     * {@code project\u0000applicationId} string as {@link #KEY_LOCKS}.
+     * Live state of a background pre-launch preparation job, keyed by everything that decides
+     * what the preparation DOES (see {@link #PREP_INFLIGHT}), of which the project and
+     * application part is the same string as {@link #KEY_LOCKS}.
      *
      * <p>A tool thread that starts the prep job sets {@code startedAtMs} and adds
      * this entry to {@link #PREP_INFLIGHT}. The background job updates
@@ -275,8 +277,11 @@ public final class LaunchLifecycleUtils
     }
 
     /**
-     * In-flight preparation map. Keyed by {@code project\u0000applicationId}
-     * (the same string as {@link #KEY_LOCKS}).
+     * In-flight preparation map. Keyed by everything that decides WHAT a preparation does:
+     * {@link #prepKeyFor(String, String)} (the same NUL-joined project+application string as
+     * {@link #KEY_LOCKS}), the external-changes policy, and the canonical update scope. That key
+     * is built by {@code RunYaxunitTestsTool.PrepRequest.prepKey()} FROM the request the
+     * preparation consumes, so it cannot describe a preparation other than the one it guards.
      *
      * <p>Entries are created via {@link ConcurrentMap#computeIfAbsent}; the
      * thread that wins the {@link PrepInFlight#started} CAS schedules the
@@ -919,6 +924,71 @@ public final class LaunchLifecycleUtils
         // only on the success paths so that a failed or aborted prepare never
         // records its content state as prepared.
         return snapshot;
+    }
+
+    /**
+     * Canonical form of an {@code updateScope} value: for scopes that pass
+     * {@link #validateUpdateScope}, sharing this string means asking {@link #resolveUpdateScope}
+     * for the same preparation. The converse does not hold — two scopes can mean the same
+     * preparation and still canonicalise apart; the accepted cases are listed below.
+     *
+     * <p>Exists so a reuse key can carry the scope without splitting requests that mean the same
+     * thing. The scope has a real grammar — {@code null}, {@code ""}, {@code "all"} and
+     * {@code " ALL "} are one value; {@code "A"} is {@code "extension:A"}; {@code "A,B"} is
+     * {@code "B, A"} — so a raw string in a key would be a FALSE MISS: two identical requests
+     * would each start their own run. It lives here, next to the resolver and the validator, and
+     * is built on the SAME {@link #parseRequestedExtensionNames} grammar, so the key asks the
+     * question of the same function the behaviour asks it of instead of re-deriving the answer.
+     *
+     * <p>The four output spaces are disjoint by construction ({@code "all"},
+     * {@code "configuration"}, {@code "extension:<names>"} with a non-empty suffix, and
+     * {@code "raw:<value>"}), so no two differently-behaving scopes can canonicalise together:
+     * <ul>
+     *   <li>{@code null} / blank / {@code all} (case-insensitive) → {@code "all"};</li>
+     *   <li>{@code configuration} (case-insensitive) → {@code "configuration"};</li>
+     *   <li>a token list that yields at least one requested name → {@code "extension:"} plus the
+     *       SORTED, de-duplicated names. Sorted because {@link #resolveUpdateScope} tests
+     *       MEMBERSHIP in that set and takes its ordering from the project list, not from the
+     *       scope string; names are compared case-SENSITIVELY there, so they are not lowercased
+     *       here either;</li>
+     *   <li>a token list that yields no name → {@code "raw:"} plus the trimmed input. That branch
+     *       always fails {@link #validateUpdateScope}, and the error quotes the caller's own
+     *       string, so scopes that are unusable for DIFFERENT reasons ({@code "extension:"} and
+     *       {@code ","}) stay apart instead of one caller receiving the other's message. Two
+     *       unusable scopes differing only in surrounding whitespace, or two unknown names in a
+     *       different order, still share a key and therefore share one failure: the message then
+     *       quotes whichever arrived first. That is error TEXT on input that can never launch,
+     *       not a run served to the wrong caller.</li>
+     * </ul>
+     *
+     * <p>Deliberately topology-INDEPENDENT: it does not ask the workspace which extension projects
+     * exist. That leaves two accepted false misses — {@code "all"} versus {@code "configuration"}
+     * for a configuration with no dependent extensions, and {@code "all"} versus a list naming
+     * every extension — each costing one extra run and never a wrong report. The alternative,
+     * resolving the scope against the live project graph at key time, would make the key change
+     * under the caller's feet between a Pending and its retry.
+     *
+     * @param updateScope the raw {@code updateScope} parameter value (may be {@code null})
+     * @return the canonical form; never {@code null}
+     */
+    public static String canonicalUpdateScope(String updateScope)
+    {
+        String scope = updateScope != null ? updateScope.trim() : ""; //$NON-NLS-1$
+        if (scope.isEmpty() || "all".equalsIgnoreCase(scope)) //$NON-NLS-1$
+        {
+            return "all"; //$NON-NLS-1$
+        }
+        if ("configuration".equalsIgnoreCase(scope)) //$NON-NLS-1$
+        {
+            return "configuration"; //$NON-NLS-1$
+        }
+        List<String> names = new ArrayList<>(parseRequestedExtensionNames(scope));
+        if (names.isEmpty())
+        {
+            return "raw:" + scope; //$NON-NLS-1$
+        }
+        Collections.sort(names);
+        return "extension:" + String.join(",", names); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     /**

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsToolTest.java
@@ -13,12 +13,21 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import static org.mockito.Mockito.mock;
+
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.debug.core.ILaunchManager;
 import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
@@ -27,6 +36,7 @@ import com.ditrix.edt.mcp.server.utils.InfobaseAuthDialogSuppressor;
 import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils;
 import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils.PreLaunchResult;
 import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils.PrepInFlight;
+import com.e1c.g5.dt.applications.IApplicationManager;
 
 /**
  * Tests for {@link RunYaxunitTestsTool}.
@@ -472,7 +482,13 @@ public class RunYaxunitTestsToolTest
         // The entry's latch is never counted down, so the ONLY thing that can end this wait is
         // the deadline. The test therefore also carries its own ceiling: an unbounded wait fails
         // it by the elapsed assertion rather than hanging the suite.
-        String prepKey = "ratchet-357-" + System.nanoTime(); //$NON-NLS-1$
+        // The key is the PRODUCTION one, derived from the request itself (#411) — the entry has
+        // to be injected under exactly the key the method will compute, and the project name
+        // carries a nonce so a concurrent test can never land on the same one.
+        RunYaxunitTestsTool.PrepRequest req = new RunYaxunitTestsTool.PrepRequest(
+            "TestConfiguration-" + System.nanoTime(), null, null, "TestConfiguration.SomeApp", //$NON-NLS-1$ //$NON-NLS-2$
+            null, null, ExternalInfobaseChangesPolicy.DEFAULT, "ratchet"); //$NON-NLS-1$
+        String prepKey = req.prepKey();
         PrepInFlight entry = new PrepInFlight(System.currentTimeMillis());
         // Pretend the job is already running: the CAS is spent, so no Job is scheduled and this
         // call is a pure waiter — exactly the "second identical call" of the bug report.
@@ -481,14 +497,11 @@ public class RunYaxunitTestsToolTest
         LaunchLifecycleUtils.PREP_INFLIGHT.put(prepKey, entry);
         try
         {
-            RunYaxunitTestsTool.PrepRequest req = new RunYaxunitTestsTool.PrepRequest(
-                "TestConfiguration", null, null, "TestConfiguration.SomeApp", //$NON-NLS-1$ //$NON-NLS-2$
-                null, null, ExternalInfobaseChangesPolicy.DEFAULT, "ratchet"); //$NON-NLS-1$
             RunYaxunitTestsTool.CallState phase = new RunYaxunitTestsTool.CallState();
             long budgetMs = 2_000L;
 
             long startedAt = System.currentTimeMillis();
-            String pending = RunYaxunitTestsTool.awaitPreparedOrPending(prepKey, req,
+            String pending = RunYaxunitTestsTool.awaitPreparedOrPending(req,
                 new PreLaunchResult[1], System.currentTimeMillis() + budgetMs, phase);
             long elapsedMs = System.currentTimeMillis() - startedAt;
 
@@ -1012,9 +1025,9 @@ public class RunYaxunitTestsToolTest
     @Test
     public void testRunKeyDistinguishesTagSelections()
     {
-        String smoke = RunYaxunitTestsTool.buildRunKey("Cfg", req(null, null, null, "smoke"));
-        String slow = RunYaxunitTestsTool.buildRunKey("Cfg", req(null, null, null, "slow"));
-        String none = RunYaxunitTestsTool.buildRunKey("Cfg", req(null, null, null, null));
+        String smoke = key(req(null, null, null, "smoke"));
+        String slow = key(req(null, null, null, "slow"));
+        String none = key(req(null, null, null, null));
 
         assertFalse("two different tag filters must not share a run key", smoke.equals(slow));
         // The load-bearing one: if tags were dropped from the formula, a tag-filtered run would
@@ -1023,11 +1036,497 @@ public class RunYaxunitTestsToolTest
             smoke.equals(none));
         assertTrue("the launch config name stays the key root", smoke.startsWith("Cfg:"));
         assertEquals("the same tag filter must be the same run", smoke,
-            RunYaxunitTestsTool.buildRunKey("Cfg", req(null, null, null, "smoke")));
+            key(req(null, null, null, "smoke")));
 
-        // The families are hashed in a fixed order separated by '|': the same word must mean a
+        // The families occupy distinct, length-framed positions: the same word must mean a
         // different run depending on which family it was passed in.
         assertFalse("the same word in a different filter family must be a different run",
-            smoke.equals(RunYaxunitTestsTool.buildRunKey("Cfg", req(null, "smoke", null, null))));
+            smoke.equals(key(req(null, "smoke", null, null))));
+    }
+    // ---------------------------------------------------------------------
+    // Reuse keys (#411)
+    //
+    // Two keys decide whether one call is served by another call's work: the RUN key
+    // (ACTIVE_LAUNCHES, once-only PENDING_FETCH delivery and the report directory — all three
+    // consulted BEFORE preparation) and the PREPARATION key (the single in-flight
+    // recompute+update job). A term missing from either is not a slow path: it is a wrong answer
+    // that looks exactly like a right one.
+    //
+    // The two ratchets are two-WAY on purpose. A field that changes what runs but is absent from
+    // a key hands one caller another caller's report; a field that changes nothing but is present
+    // stops reuse from ever matching, so every call re-runs the whole suite. Both are silent.
+    // ---------------------------------------------------------------------
+
+    /** The RESOLVED launch target the keys below are built for. */
+    private static final String CFG = "Cfg";
+    private static final String PROJ = "Proj";
+    private static final String APP = "App";
+
+    /** A Job display name; the preparation key must not care which one. */
+    private static final String JOB = "YAXUnit pre-launch preparation for Proj";
+
+    /** Builds the request the run path builds, with every field spelled out. */
+    private static RunYaxunitTestsTool.RunRequest request(String extensions, String modules, // NOSONAR the point of this helper is that every field is visible at the call site
+            String tests, String tags, int timeout, boolean updateBeforeLaunch, String updateScope,
+            ExternalInfobaseChangesPolicy policy, boolean debug)
+    {
+        return new RunYaxunitTestsTool.RunRequest(CFG, PROJ, APP, extensions, modules, tests, tags,
+            timeout, updateBeforeLaunch, updateScope, policy, debug);
+    }
+
+    /** The default request every variant below differs from in exactly one field. */
+    private static RunYaxunitTestsTool.RunRequest baseline()
+    {
+        return request(null, null, null, null, 45, true, null,
+            ExternalInfobaseChangesPolicy.OVERRIDE, false);
+    }
+
+    /** The baseline with only {@code updateScope} changed. */
+    private static RunYaxunitTestsTool.RunRequest scoped(String updateScope)
+    {
+        return request(null, null, null, null, 45, true, updateScope,
+            ExternalInfobaseChangesPolicy.OVERRIDE, false);
+    }
+
+    /** The PRODUCTION run key for the resolved target these tests share. */
+    private static String key(RunYaxunitTestsTool.RunRequest req)
+    {
+        return RunYaxunitTestsTool.buildRunKey(CFG, PROJ, APP, req);
+    }
+
+    /** A preparation request with only the fields the key can possibly care about set. */
+    private static RunYaxunitTestsTool.PrepRequest prep(String projectName, String applicationId,
+            String updateScope, ExternalInfobaseChangesPolicy policy, String jobName)
+    {
+        return new RunYaxunitTestsTool.PrepRequest(projectName, null, null, applicationId, null,
+            updateScope, policy, jobName);
+    }
+
+    /**
+     * A call that asked for a FRESH run must never be served by a run that did not refresh.
+     */
+    @Test
+    public void testRunKeyDistinguishesTheFreshnessGuarantee()
+    {
+        String withChain = key(baseline());
+        String withoutChain = key(request(null, null, null, null, 45, false, null,
+            ExternalInfobaseChangesPolicy.OVERRIDE, false));
+
+        assertFalse("updateBeforeLaunch=true asks for a recompiled extension and an updated "
+            + "infobase. A run started with false may have executed a stale .cfe, and its report "
+            + "is indistinguishable from an honest fresh one, so the two must not share a run",
+            withChain.equals(withoutChain));
+    }
+
+    /**
+     * The rebuild scope decides WHICH projects are regenerated and loaded before the run, i.e.
+     * which code the tests execute.
+     */
+    @Test
+    public void testRunKeyDistinguishesTheRebuildScope()
+    {
+        String all = key(baseline());
+        String extA = key(scoped("extension:ExtA"));
+        String extB = key(scoped("extension:ExtB"));
+        String configurationOnly = key(scoped("configuration"));
+
+        assertFalse("a run that rebuilt only ExtA must not answer a call that asked for ExtB",
+            extA.equals(extB));
+        assertFalse("a narrowed rebuild must not answer a call that asked for the full one",
+            extA.equals(all));
+        assertFalse("'configuration' skips the extensions entirely — a different run",
+            configurationOnly.equals(all));
+    }
+
+    /**
+     * The scope is NORMALISED, not stringified. It has a grammar, and spellings that ask for the
+     * same preparation must stay one run: keying the raw string would make an identical retry
+     * start a second full test run.
+     */
+    @Test
+    public void testRunKeyTreatsEquivalentScopesAsOneRun()
+    {
+        String all = key(baseline());
+
+        assertEquals("an omitted scope IS 'all'", all, key(scoped("all")));
+        assertEquals("the keyword is case-insensitive and trimmed", all, key(scoped("  ALL  ")));
+        assertEquals("an empty scope is an omitted scope", all, key(scoped("")));
+        assertEquals("a bare name is the same intent as extension:<name>",
+            key(scoped("extension:ExtA")), key(scoped("ExtA")));
+        assertEquals("the scope names a SET of projects, so the order it was written in is not a "
+            + "different preparation", key(scoped("extension:ExtA,extension:ExtB")),
+            key(scoped(" extension:ExtB , ExtA ")));
+        assertEquals("a repeated name is still one project", key(scoped("extension:ExtA")),
+            key(scoped("ExtA,extension:ExtA")));
+    }
+
+    /**
+     * With the auto-chain off the scope applies to nothing, and the parameter's own contract says
+     * so ("Only applies when updateBeforeLaunch=true"). Keying it anyway would split requests the
+     * tool itself declares identical.
+     */
+    @Test
+    public void testRunKeyIgnoresTheRebuildScopeWhenTheChainIsOff()
+    {
+        ExternalInfobaseChangesPolicy override = ExternalInfobaseChangesPolicy.OVERRIDE;
+        String extA = key(request(null, null, null, null, 45, false, "extension:ExtA", override,
+            false));
+        String extB = key(request(null, null, null, null, 45, false, "extension:ExtB", override,
+            false));
+        String noScope = key(request(null, null, null, null, 45, false, null, override, false));
+
+        assertEquals("with updateBeforeLaunch=false nothing is rebuilt, so the scope cannot make "
+            + "these two different runs", extA, extB);
+        assertEquals("an ignored scope must not split the key away from not passing one at all",
+            extA, noScope);
+    }
+
+    /**
+     * The launch configuration NAME does not pin the target. A caller may pass
+     * {@code applicationId} alongside {@code launchConfigurationName}, and it overrides the
+     * config's own binding, so two calls on one config can execute against two infobases.
+     */
+    @Test
+    public void testRunKeyDistinguishesTheResolvedTarget()
+    {
+        RunYaxunitTestsTool.RunRequest req = baseline();
+        String here = RunYaxunitTestsTool.buildRunKey(CFG, PROJ, APP, req);
+
+        assertFalse("a run against one application must not deliver its report to a call that "
+            + "asked for another", here.equals(RunYaxunitTestsTool.buildRunKey(CFG, PROJ,
+                "OtherApp", req)));
+        assertFalse("nor may a run in one project answer a call about another",
+            here.equals(RunYaxunitTestsTool.buildRunKey(CFG, "OtherProj", APP, req)));
+        assertTrue("the launch config name stays the readable key root", here.startsWith("Cfg:"));
+    }
+
+    /**
+     * Key parts are LENGTH-framed, not joined by a separator character.
+     *
+     * <p>A run-key collision is not a slow path: it is served as a successful, wrong report. The
+     * parts are caller-controlled strings, and with a literal {@code '|'} between them a value
+     * ending in the separator and the next value beginning with it produce ONE key.
+     */
+    @Test
+    public void testRunKeyPartsCannotImpersonateASeparator()
+    {
+        // The pair that collides under the pre-fix formula, where the filter families were
+        // joined with a literal pipe: ("a|", "b") and ("a", "|b") both flatten to "a||b".
+        assertFalse("a separator character inside a filter value must not merge two different "
+            + "requests into one run",
+            key(req("a|", "b", null, null)).equals(key(req("a", "|b", null, null))));
+
+        // And the pair only the FRAMING defends. Every filter family carries a marker of its
+        // own, so a joiner is already unforgeable across those; the resolved project and
+        // application sit next to each other with nothing between them but the separator.
+        // Measured, not assumed: with this assertion written on the filter families instead,
+        // replacing the framing with a plain joiner broke nothing.
+        assertFalse("the boundary between the resolved project and application must be a "
+            + "length, not a character their values can contain",
+            RunYaxunitTestsTool.buildRunKey(CFG, "Proj|", "App", baseline())
+                .equals(RunYaxunitTestsTool.buildRunKey(CFG, "Proj", "|App", baseline())));
+    }
+
+    /**
+     * A filter family's key term is defined by what {@code buildParamsJson} writes for it: two
+     * requests that generate the same file are one run, and two that generate different files are
+     * not. Both directions are asserted, because either alone would be a coincidence.
+     */
+    @Test
+    public void testRunKeyFollowsTheGeneratedFilterExactly()
+    {
+        String padded = "  smoke  ";
+        assertEquals("padding is stripped when the filter is generated...",
+            RunYaxunitTestsTool.buildParamsJson("/tmp/j.xml", req(null, null, null, "smoke")),
+            RunYaxunitTestsTool.buildParamsJson("/tmp/j.xml", req(null, null, null, padded)));
+        assertEquals("...so it must not start a second, identical run", key(req(null, null, null,
+            "smoke")), key(req(null, null, null, padded)));
+
+        // The other direction: an ABSENT family and a family written as an EMPTY array are
+        // different FILES. The identity stops at what this code can prove — the bytes it
+        // writes — rather than at an assumption about how the framework reads them; that way
+        // round the cost of being wrong is a re-run, not a wrong report. (The pre-fix formula
+        // kept them apart too, so this is not a new split.)
+        assertFalse("an absent tag filter and an empty one generate different files",
+            RunYaxunitTestsTool.buildParamsJson("/tmp/j.xml", req(null, null, null, null))
+                .equals(RunYaxunitTestsTool.buildParamsJson("/tmp/j.xml", req(null, null, null,
+                    ","))));
+        assertFalse("...so they must not share a run key",
+            key(req(null, null, null, null)).equals(key(req(null, null, null, ","))));
+    }
+
+    /**
+     * For every declared field of {@code RunRequest}: a request differing from {@link #baseline()}
+     * in EXACTLY that field.
+     */
+    private static Map<String, RunYaxunitTestsTool.RunRequest> runRequestVariants()
+    {
+        ExternalInfobaseChangesPolicy override = ExternalInfobaseChangesPolicy.OVERRIDE;
+        Map<String, RunYaxunitTestsTool.RunRequest> variants = new LinkedHashMap<>();
+        variants.put("configName", new RunYaxunitTestsTool.RunRequest("OtherCfg", PROJ, APP, null,
+            null, null, null, 45, true, null, override, false));
+        variants.put("projectName", new RunYaxunitTestsTool.RunRequest(CFG, "OtherProj", APP, null,
+            null, null, null, 45, true, null, override, false));
+        variants.put("applicationId", new RunYaxunitTestsTool.RunRequest(CFG, PROJ, "OtherApp",
+            null, null, null, null, 45, true, null, override, false));
+        variants.put("extensions", request("Ext", null, null, null, 45, true, null, override,
+            false));
+        variants.put("modules", request(null, "Mod", null, null, 45, true, null, override, false));
+        variants.put("tests", request(null, null, "Mod.Test", null, 45, true, null, override,
+            false));
+        variants.put("tags", request(null, null, null, "smoke", 45, true, null, override, false));
+        variants.put("timeout", request(null, null, null, null, 30, true, null, override, false));
+        variants.put("updateBeforeLaunch", request(null, null, null, null, 45, false, null,
+            override, false));
+        variants.put("updateScope", request(null, null, null, null, 45, true, "configuration",
+            override, false));
+        variants.put("externalChanges", request(null, null, null, null, 45, true, null,
+            ExternalInfobaseChangesPolicy.IMPORT, false));
+        variants.put("debug", request(null, null, null, null, 45, true, null, override, true));
+        return variants;
+    }
+
+    /** {@code RunRequest} fields that must NOT change the run key, each with its reason. */
+    private static Map<String, String> runKeyExclusions()
+    {
+        Map<String, String> excluded = new LinkedHashMap<>();
+        excluded.put("configName", "the RESOLVED config name is the key root; the request's own is "
+            + "null whenever the call addressed the run by project+application");
+        excluded.put("projectName", "the RESOLVED project is keyed instead, so both call styles "
+            + "that reach one target still share a run");
+        excluded.put("applicationId", "the RESOLVED application is keyed instead");
+        excluded.put("timeout", "the caller's waiting window, not what runs: keying it would drop "
+            + "a Pending report the moment a retry asked for a longer one");
+        excluded.put("debug", "the DEBUG path returns before a run key is ever built");
+        return excluded;
+    }
+
+    /**
+     * The ratchet: every field of {@code RunRequest} is classified, and the classification is
+     * PROVED against the production formula in both directions.
+     */
+    @Test
+    public void testEveryRunRequestFieldIsClassifiedForTheRunKey()
+    {
+        Map<String, RunYaxunitTestsTool.RunRequest> variants = runRequestVariants();
+        Map<String, String> excluded = runKeyExclusions();
+        String base = key(baseline());
+        int classified = 0;
+        for (Field field : RunYaxunitTestsTool.RunRequest.class.getDeclaredFields())
+        {
+            if (field.isSynthetic() || Modifier.isStatic(field.getModifiers()))
+            {
+                continue;
+            }
+            String name = field.getName();
+            assertTrue("RunRequest." + name + " is new and nothing records what it means for the "
+                + "run key. Add a variant to runRequestVariants(), then either fold the field into "
+                + "buildRunKey or list it in runKeyExclusions() with the reason it cannot change "
+                + "what runs. Skipping that step is exactly how #409 and #411 happened.",
+                variants.containsKey(name));
+            assertEquals("the variant registered for RunRequest." + name + " must differ from the "
+                + "baseline in EXACTLY that field, or this loop proves nothing about it", name,
+                theOnlyChangedField(baseline(), variants.get(name)));
+            String varied = key(variants.get(name));
+            if (excluded.containsKey(name))
+            {
+                assertEquals("RunRequest." + name + " is excluded from the run key (" + excluded
+                    .get(name) + "), so varying it must NOT split the key: a key that is too wide "
+                    + "never matches, and every call re-runs the whole suite", base, varied);
+            }
+            else
+            {
+                assertFalse("RunRequest." + name + " changes what a run executes, so it must "
+                    + "change the run key. Otherwise a run started with one value can be polled "
+                    + "by — and have its report delivered to — a call that asked for another, and "
+                    + "the answer looks exactly like an honest one", base.equals(varied));
+            }
+            classified++;
+        }
+        assertEquals("runRequestVariants() lists a name RunRequest no longer declares", classified,
+            variants.size());
+        assertTrue("runKeyExclusions() names a field RunRequest does not declare",
+            variants.keySet().containsAll(excluded.keySet()));
+    }
+
+    /**
+     * Two concurrent calls asking to rebuild different things must not share one preparation.
+     */
+    @Test
+    public void testPrepKeyDistinguishesTheRebuildScope()
+    {
+        ExternalInfobaseChangesPolicy override = ExternalInfobaseChangesPolicy.OVERRIDE;
+        String extA = prep(PROJ, APP, "extension:ExtA", override, JOB).prepKey();
+        String extB = prep(PROJ, APP, "extension:ExtB", override, JOB).prepKey();
+        String all = prep(PROJ, APP, null, override, JOB).prepKey();
+
+        assertFalse("only ONE preparation job runs per key, so two scopes under one key means the "
+            + "second caller silently gets the preparation the first one asked for",
+            extA.equals(extB));
+        assertFalse("a narrowed rebuild is not the full one", extA.equals(all));
+    }
+
+    /** The same normalisation as the run key — and for the same reason. */
+    @Test
+    public void testPrepKeyTreatsEquivalentScopesAsOnePreparation()
+    {
+        ExternalInfobaseChangesPolicy override = ExternalInfobaseChangesPolicy.OVERRIDE;
+        String all = prep(PROJ, APP, null, override, JOB).prepKey();
+
+        assertEquals("an omitted scope IS 'all'", all, prep(PROJ, APP, "ALL", override, JOB)
+            .prepKey());
+        assertEquals("the scope is a set, not a spelling", prep(PROJ, APP, "extension:A,B",
+            override, JOB).prepKey(), prep(PROJ, APP, " B , extension:A ", override, JOB)
+                .prepKey());
+    }
+
+    /** The target and the conflict answer were already keyed; keep them pinned. */
+    @Test
+    public void testPrepKeyDistinguishesTheTargetAndTheConflictAnswer()
+    {
+        ExternalInfobaseChangesPolicy override = ExternalInfobaseChangesPolicy.OVERRIDE;
+        String here = prep(PROJ, APP, null, override, JOB).prepKey();
+
+        assertFalse("one of the answers rewrites project sources, so a piggybacking call must "
+            + "never inherit a different caller's answer", here.equals(prep(PROJ, APP, null,
+                ExternalInfobaseChangesPolicy.IMPORT, JOB).prepKey()));
+        assertFalse("a different application is a different infobase to prepare",
+            here.equals(prep(PROJ, "OtherApp", null, override, JOB).prepKey()));
+        assertFalse("a different project is a different preparation",
+            here.equals(prep("OtherProj", APP, null, override, JOB).prepKey()));
+    }
+
+    /**
+     * The RUN and the DEBUG path differ in ONE field — the Job's display name — and they are meant
+     * to share a preparation. Keying the label would give one infobase two in-flight preparations
+     * and run the recompute+update twice.
+     */
+    @Test
+    public void testPrepKeyIgnoresTheJobLabelSoRunAndDebugShareOnePreparation()
+    {
+        ExternalInfobaseChangesPolicy override = ExternalInfobaseChangesPolicy.OVERRIDE;
+        assertEquals("the run and debug preparations of one infobase must be the same entry",
+            prep(PROJ, APP, null, override, "YAXUnit pre-launch preparation for Proj").prepKey(),
+            prep(PROJ, APP, null, override, "YAXUnit debug pre-launch preparation for Proj")
+                .prepKey());
+    }
+
+    /**
+     * For every declared field of {@code PrepRequest}: a request differing from the baseline in
+     * EXACTLY that field.
+     */
+    private static Map<String, RunYaxunitTestsTool.PrepRequest> prepRequestVariants()
+    {
+        ExternalInfobaseChangesPolicy override = ExternalInfobaseChangesPolicy.OVERRIDE;
+        Map<String, RunYaxunitTestsTool.PrepRequest> variants = new LinkedHashMap<>();
+        variants.put("projectName", prep("OtherProj", APP, null, override, JOB));
+        variants.put("launchManager", new RunYaxunitTestsTool.PrepRequest(PROJ,
+            mock(ILaunchManager.class), null, APP, null, null, override, JOB));
+        variants.put("project", new RunYaxunitTestsTool.PrepRequest(PROJ, null,
+            mock(IProject.class), APP, null, null, override, JOB));
+        variants.put("applicationId", prep(PROJ, "OtherApp", null, override, JOB));
+        variants.put("appManager", new RunYaxunitTestsTool.PrepRequest(PROJ, null, null, APP,
+            mock(IApplicationManager.class), null, override, JOB));
+        variants.put("updateScope", prep(PROJ, APP, "configuration", override, JOB));
+        variants.put("externalChanges", prep(PROJ, APP, null,
+            ExternalInfobaseChangesPolicy.IMPORT, JOB));
+        variants.put("jobName", prep(PROJ, APP, null, override, "another job"));
+        return variants;
+    }
+
+    /** {@code PrepRequest} fields that must NOT change the preparation key, with their reasons. */
+    private static Map<String, String> prepKeyExclusions()
+    {
+        Map<String, String> excluded = new LinkedHashMap<>();
+        excluded.put("launchManager", "a platform service handle, not an input");
+        excluded.put("project", "it IS ProjectContext.of(projectName).project(), so projectName "
+            + "already keys it");
+        excluded.put("appManager", "tracked through an OSGi ServiceTracker and legitimately a "
+            + "different object between two calls; keying it would start a duplicate preparation "
+            + "on a service rebind instead of joining the running one");
+        excluded.put("jobName", "the only field that differs between the RUN and the DEBUG call "
+            + "site, which are meant to share one preparation");
+        return excluded;
+    }
+
+    /** The same two-way ratchet for the preparation key. */
+    @Test
+    public void testEveryPrepRequestFieldIsClassifiedForThePrepKey()
+    {
+        Map<String, RunYaxunitTestsTool.PrepRequest> variants = prepRequestVariants();
+        Map<String, String> excluded = prepKeyExclusions();
+        String base = prep(PROJ, APP, null, ExternalInfobaseChangesPolicy.OVERRIDE, JOB).prepKey();
+        int classified = 0;
+        for (Field field : RunYaxunitTestsTool.PrepRequest.class.getDeclaredFields())
+        {
+            if (field.isSynthetic() || Modifier.isStatic(field.getModifiers()))
+            {
+                continue;
+            }
+            String name = field.getName();
+            assertTrue("PrepRequest." + name + " is new and nothing records what it means for the "
+                + "preparation key. Add a variant to prepRequestVariants(), then either fold it "
+                + "into PrepRequest.prepKey() or list it in prepKeyExclusions() with the reason it "
+                + "cannot change what the preparation does.", variants.containsKey(name));
+            assertEquals("the variant registered for PrepRequest." + name + " must differ from the "
+                + "baseline in EXACTLY that field, or this loop proves nothing about it", name,
+                theOnlyChangedField(prep(PROJ, APP, null, ExternalInfobaseChangesPolicy.OVERRIDE,
+                    JOB), variants.get(name)));
+            String varied = variants.get(name).prepKey();
+            if (excluded.containsKey(name))
+            {
+                assertEquals("PrepRequest." + name + " is excluded from the preparation key ("
+                    + excluded.get(name) + "), so varying it must NOT split the key: only one "
+                    + "preparation may be in flight per infobase", base, varied);
+            }
+            else
+            {
+                assertFalse("PrepRequest." + name + " changes what the preparation does, so it "
+                    + "must change the key — one job runs per key, and the caller that arrives "
+                    + "second silently receives the first one's preparation",
+                    base.equals(varied));
+            }
+            classified++;
+        }
+        assertEquals("prepRequestVariants() lists a name PrepRequest no longer declares",
+            classified, variants.size());
+        assertTrue("prepKeyExclusions() names a field PrepRequest does not declare",
+            variants.keySet().containsAll(excluded.keySet()));
+    }
+
+    /**
+     * The name of the ONE field in which {@code variant} differs from {@code baseline}.
+     *
+     * <p>Without this, a ratchet built on a hand-written variant map proves less than it looks:
+     * a variant that changed some OTHER keyed field would satisfy the "must change the key" arm
+     * for a field the key actually ignores, and an "excluded" variant identical to the baseline
+     * would satisfy the "must not change the key" arm without varying anything at all.
+     *
+     * @return the single differing field name, or a description of how many differ when it is
+     *         not exactly one (so the assertion message names the real problem)
+     */
+    private static String theOnlyChangedField(Object baseline, Object variant)
+    {
+        List<String> changed = new ArrayList<>();
+        for (Field field : baseline.getClass().getDeclaredFields())
+        {
+            if (field.isSynthetic() || Modifier.isStatic(field.getModifiers()))
+            {
+                continue;
+            }
+            try
+            {
+                field.setAccessible(true);
+                if (!Objects.equals(field.get(baseline), field.get(variant)))
+                {
+                    changed.add(field.getName());
+                }
+            }
+            catch (ReflectiveOperationException e)
+            {
+                throw new IllegalStateException("cannot read " + field.getName(), e);
+            }
+        }
+        return changed.size() == 1 ? changed.get(0) : changed.toString();
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtilsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtilsTest.java
@@ -145,4 +145,79 @@ public class LaunchLifecycleUtilsTest
         assertTrue(result.isOk());
         assertNull(result.getError());
     }
+    // ---------------------------------------------------------------------
+    // canonicalUpdateScope (#411)
+    //
+    // The reuse keys of run_yaxunit_tests carry the update scope. The scope has a GRAMMAR, so a
+    // raw string in a key would split requests that ask for exactly the same preparation — and
+    // splitting them is not a slow path either: it means a retry starts a second full test run
+    // instead of joining the one already in flight.
+    //
+    // These pin the equivalences against the very grammar resolveUpdateScope resolves with.
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void testCanonicalUpdateScopeCollapsesEveryWayOfSayingAll()
+    {
+        assertEquals("an omitted scope IS 'all'", "all",
+            LaunchLifecycleUtils.canonicalUpdateScope(null));
+        assertEquals("an empty scope is an omitted scope", "all",
+            LaunchLifecycleUtils.canonicalUpdateScope(""));
+        assertEquals("blank is empty", "all", LaunchLifecycleUtils.canonicalUpdateScope("   "));
+        assertEquals("the keyword is case-insensitive and trimmed", "all",
+            LaunchLifecycleUtils.canonicalUpdateScope("  ALL "));
+        assertEquals("the other keyword too", "configuration",
+            LaunchLifecycleUtils.canonicalUpdateScope(" Configuration "));
+    }
+
+    @Test
+    public void testCanonicalUpdateScopeIsASetOfNamesNotASpelling()
+    {
+        // resolveUpdateScope tests MEMBERSHIP in the parsed set and takes its ordering from the
+        // project list, so order and repetition cannot make two different preparations.
+        assertEquals("order is not part of the request",
+            LaunchLifecycleUtils.canonicalUpdateScope("extension:A,extension:B"),
+            LaunchLifecycleUtils.canonicalUpdateScope("extension:B, extension:A"));
+        assertEquals("a bare token is the same intent as extension:<name>",
+            LaunchLifecycleUtils.canonicalUpdateScope("extension:A"),
+            LaunchLifecycleUtils.canonicalUpdateScope(" A "));
+        assertEquals("a repeated name is one project",
+            LaunchLifecycleUtils.canonicalUpdateScope("extension:A"),
+            LaunchLifecycleUtils.canonicalUpdateScope("A,extension:A"));
+    }
+
+    @Test
+    public void testCanonicalUpdateScopeKeepsDifferentRequestsApart()
+    {
+        assertFalse("two different extensions are two different preparations",
+            LaunchLifecycleUtils.canonicalUpdateScope("extension:A")
+                .equals(LaunchLifecycleUtils.canonicalUpdateScope("extension:B")));
+        assertFalse("'configuration' skips the extensions, 'all' does not",
+            LaunchLifecycleUtils.canonicalUpdateScope("configuration")
+                .equals(LaunchLifecycleUtils.canonicalUpdateScope("all")));
+        // Project names are case-SENSITIVE where resolveUpdateScope compares them, so they must
+        // not be folded here either.
+        assertFalse("an extension name differing only in case is a different name",
+            LaunchLifecycleUtils.canonicalUpdateScope("extension:Ext")
+                .equals(LaunchLifecycleUtils.canonicalUpdateScope("extension:ext")));
+    }
+
+    /**
+     * A scope that parses to no usable name always FAILS validation, and the error quotes the
+     * caller's own string — so two such scopes must not collapse into one key and hand one caller
+     * the other caller's message.
+     */
+    @Test
+    public void testCanonicalUpdateScopeKeepsUnusableScopesApart()
+    {
+        assertFalse("two unusable scopes are not interchangeable",
+            LaunchLifecycleUtils.canonicalUpdateScope("extension:")
+                .equals(LaunchLifecycleUtils.canonicalUpdateScope(",")));
+        // And an unusable scope can never be mistaken for a usable one: the four output spaces
+        // ('all', 'configuration', 'extension:<names>', 'raw:<value>') are disjoint.
+        assertTrue("an unusable scope lands in its own namespace",
+            LaunchLifecycleUtils.canonicalUpdateScope("extension:").startsWith("raw:"));
+        assertFalse("a name that merely looks like the namespace is still a name",
+            LaunchLifecycleUtils.canonicalUpdateScope("raw:").startsWith("raw:"));
+    }
 }


### PR DESCRIPTION
Closes #411

## Что было

У `run_yaxunit_tests` два ключа тождества, и оба описывали не всё, что решает, **что именно** выполнит прогон.

**Ключ прогона** адресует `ACTIVE_LAUNCHES`, однократную выдачу `PENDING_FETCH` и каталог отчёта, и все три проверки повторного использования происходят **до** подготовки. В нём не было:

- **`updateBeforeLaunch`** — вызов, попросивший свежий прогон, мог получить отчёт запуска, стартовавшего без пересборки, то есть по устаревшему `.cfe`. По ответу это неотличимо от честного свежего прогона;
- **`updateScope`** — какие проекты пересобираются и загружаются в базу перед прогоном, то есть какой код исполняют тесты;
- **разрешённой пары `(projectName, applicationId)`**. Корень ключа — имя конфигурации запуска, но имя её **не** фиксирует: `LaunchConfigUtils.resolveLaunchConfig` при заданном имени возвращает конфигурацию сразу (сверка проекта/приложения работает только когда имени нет), а `deriveLaunchContext` подставляет собственную привязку конфигурации, **только если** вызывающий не передал свою. Переданный `applicationId` затем штампуется в рабочую копию запуска и именно его использует делегат EDT. Два вызова с одним именем конфигурации и разными приложениями делили ключ, выполняясь против разных информационных баз;
- **однозначной склейки**: части соединялись литеральным `|`, а фильтры и область — строки от вызывающего. Значение, оканчивающееся на разделитель, и следующее, начинающееся с него, давали один ключ (`extensions="a|", modules="b"` ≡ `extensions="a", modules="|b"`). Коллизия здесь — ложное **попадание**, то есть успешный, но чужой отчёт.

**Ключ подготовки** не включал `updateScope`, хотя область передаётся в саму подготовку двумя строками ниже: два параллельных вызова с разными областями делили одну задачу, побеждала стартовавшая первой. И выражение ключа было **скопировано** в двух местах — RUN и DEBUG.

## Что сделано

### Ключ подготовки — по построению

`PrepRequest.prepKey()` выводит ключ **из самого запроса** — того объекта, который несёт `projectName`/`applicationId`/`updateScope`/`externalChanges` в подготовку. `awaitPreparedOrPending` больше не принимает ключ параметром, оба места вызова потеряли своё выражение ключа. Место вызова физически не может назвать в ключе не тот проект, приложение, политику или область, с которыми оно сейчас будет готовиться. Это не утверждение «весь запрос захвачен»: `launchManager`, `project` и `appManager` исключены сознательно, их причины записаны в javadoc и закреплены ратчетом.

`jobName` исключён намеренно — это **единственное** поле, которым различаются RUN и DEBUG, и именно его исключение сохраняет одну подготовку на обе ветки (иначе одна ИБ получила бы две одновременные пересборки).

### Ключ прогона — явные слагаемые плюс двусторонний ратчет

Полностью механический вывод ключа из всех полей запроса здесь **неверен**, и не из-за трудоёмкости:

- `timeout` в ключ нельзя: это окно ожидания вызывающего, и ключ по нему потерял бы отчёт Pending, как только повторный вызов попросил бы окно подлиннее;
- `updateScope` надо **нормализовать**, а не приводить к строке: `null`/`""`/`all`/`" ALL "` — одно и то же, `"A"` = `"extension:A"`, `"A,B"` = `"B, A"`;
- семейства фильтра надо нормализовать так же, как их нормализует `buildParamsJson`, иначе ключ разведёт запросы, порождающие побайтово одинаковый `xUnitParams.json`.

Равновесный автоматический вывод меняет тихое ложное попадание на тихий ложный промах. Поэтому: явные слагаемые + **двусторонний ратчет классификации**, который (1) идёт рефлексией по объявленным полям `RunRequest`/`PrepRequest` и падает на любом неклассифицированном поле, (2) для каждого поля «в ключе» доказывает, что его изменение меняет ключ, (3) для каждого исключённого — что **не** меняет. Третий пункт и делает его двусторонним: поле, просочившееся в ключ без обоснования, красит ратчет так же громко, как забытое. Дополнительно ратчет проверяет, что зарегистрированный вариант отличается от базового **ровно одним** полем — без этого карта вариантов, написанная руками, доказывала бы меньше, чем кажется.

**За каждое слагаемое — почему оно меняет исход:**

| слагаемое | почему |
|---|---|
| разрешённый `applicationId` | приложение (информационная база), против которого исполняются тесты; штампуется в запуск |
| разрешённый `projectName` | проект, который пересобирает пред-запусковая цепочка и на котором берётся блокировка. (Это **не** проект запуска клиента — тот берётся из самой конфигурации.) |
| `extensions`/`modules`/`tests`/`tags` | какие тесты выполняются (были и раньше) |
| авто-цепочка (`updateBeforeLaunch` + `updateScope` **одним** слагаемым) | обновляется ли то, что исполняется, и в каком объёме |
| `externalChanges` | как отвечено на модальное окно конфликта; один из ответов переписывает исходники проекта (был и раньше) |

**Почему `updateBeforeLaunch` и `updateScope` — одно слагаемое, а не два.** Измерено, а не предположено: пока они были двумя (булево + область, обнуляющаяся при выключенной цепочке), каждое дублировало другое — удаление булева из формулы **не сломало ничего**, потому что область и так кодировала флаг. Два взаимно резервирующих слагаемых означают, что ни одно не является несущим и регресс в любом из них тесту не виден. Теперь это один терм `preLaunchKeyPart`: `"chain:" + канонический scope` либо `"no-chain"`.

**Почему область гасится при `updateBeforeLaunch=false`, а политика — нет.** Правило — **собственный контракт параметра**, а не наше прочтение реализации. У `updateScope` в схеме написано «Only applies when updateBeforeLaunch=true», и реализация с этим согласна (подготовка не планируется вовсе — ни на RUN, ни на DEBUG), поэтому ключ по выключенной области разводил бы запросы, которые инструмент сам объявляет одинаковыми. У `externalInfobaseChanges` такого условия в контракте нет; сегодня код делает её инертной при выключенной цепочке, но это деталь реализации, которую ничто не удерживает, — сузить ключ на ней значит превратить будущую правку в тихо неверный отчёт, а оставить лишнее слагаемое стоит максимум одного лишнего прогона.

### Нормализация

- `LaunchLifecycleUtils.canonicalUpdateScope` — рядом с `resolveUpdateScope`/`validateUpdateScope` и на **той же** грамматике `parseRequestedExtensionNames`: ключ спрашивает ту же функцию, которую спрашивает поведение, а не выводит ответ заново. Четыре непересекающихся пространства: `all`, `configuration`, `extension:<отсортированные имена>`, `raw:<значение>` (последнее — для областей, не дающих ни одного имени: они всегда проваливают валидацию, а сообщение цитирует строку вызывающего, поэтому непригодные по **разным** причинам не должны схлопываться).
- `filterKeyPart` — та же нормализация, что у `buildParamsJson` (`splitToList`: trim, выброс пустых токенов) плюс маркер присутствия, так что два запроса получают одно слагаемое ровно тогда, когда порождают одинаковый фильтр в файле.
- `framed` — склейка длиной (`<длина>:<значение>`) вместо разделителя: границу нельзя подделать содержимым.

## Сознательно принятые ложные промахи (стоят лишнего прогона, но не чужого отчёта)

- `all` против `configuration` у конфигурации без расширений и `all` против списка, перечисляющего все расширения: подготовка та же, канонические формы разные. Каноническая форма намеренно **не зависит от топологии** — спрашивать рабочее пространство в момент построения ключа значит менять ключ под ногами вызывающего между Pending и повтором.
- Две непригодные области, различающиеся только внешними пробелами или порядком неизвестных имён, делят ключ и потому делят один отказ: сообщение процитирует ту, что пришла первой. Это текст ошибки на входе, который не может запуститься, а не прогон, отданный не тому.
- Разрешённое приложение берётся из `resolveDefaultApplicationId`, который спрашивает менеджер приложений на каждом вызове. Если приложение по умолчанию у проекта изменится между Pending и повтором, повтор — другой ключ (и это верно: он исполнялся бы против другой базы), а прежняя метка `PENDING_FETCH` осиротеет — так же, как при любой смене ключа. Альтернатива хуже и она и есть чинимый дефект: отдать вызывающему отчёт прежнего приложения.
- Вызов, передавший `launchConfigurationName` **и** отличающийся от конфигурации `projectName`, при `updateBeforeLaunch=false` теперь получит отдельный прогон, хотя запускает то же самое: с выключенной цепочкой проект решает только блокировку. Разводить в сомнительном случае — безопасное направление.
- Отсутствующее семейство фильтра и семейство, записанное пустым массивом, остаются разными ключами. Скорее всего фреймворк читает их одинаково (см. javadoc `buildParamsJson`), но тождество сознательно останавливается на том, что этот код может **доказать** — на байтах, которые он пишет. Прежняя формула разводила их так же, так что и нового расхождения тут нет.
- Итоговый ключ хешируется усечением до 48 бит, то есть не инъективен криптографически. Обрамление убирает то, во что вызывающий может попасть случайно или сконструировать тривиально; границы доверия тут нет — вызывающий и так может попросить другой прогон напрямую.

## Чем доказано

**Сборка:** `bash source/compile.sh` — `BUILD SUCCESS`, **4962 теста**, 0 падений.

**Красные на сегодняшнем master** (доказывают дефект, а не поведение): различение `updateBeforeLaunch`; различение `updateScope`; различение разрешённой пары `(project, application)`; равенство ключа при отступах в значении фильтра; ратчет `RunRequest` (оба поля авто-цепочки схлопываются в старой формуле); различение `updateScope` в ключе подготовки и ратчет `PrepRequest`.

**Остальные — сторожа, и они доказаны мутацией**, а не зелёным прогоном: тест равенства не может показать, что слагаемое несущее, поэтому каждое утверждение проверено удалением той точки, от которой оно зависит, — по одной мутации за раз, с восстановлением файла и сверкой контрольной суммы, и с отличением «мутация не собралась» от «тест не поймал». Матрица (13 мутаций, каждая поймана):

| мутация | тест, который покраснел |
|---|---|
| убрать слагаемое авто-цепочки | `testRunKeyDistinguishesTheFreshnessGuarantee`, `testRunKeyDistinguishesTheRebuildScope`, ратчет |
| убрать гейт цепочки (область всегда в ключе) | `testRunKeyDistinguishesTheFreshnessGuarantee`, `testRunKeyIgnoresTheRebuildScopeWhenTheChainIsOff`, ратчет |
| убрать область из слагаемого цепочки | `testRunKeyDistinguishesTheRebuildScope`, ратчет |
| убрать нормализацию области | `testRunKeyTreatsEquivalentScopesAsOneRun` |
| убрать `externalChanges` | ратчет `RunRequest` |
| убрать разрешённую пару | `testRunKeyDistinguishesTheResolvedTarget`, `testRunKeyPartsCannotImpersonateASeparator` |
| заменить обрамление на разделитель | `testRunKeyPartsCannotImpersonateASeparator` |
| убрать нормализацию фильтра | `testRunKeyFollowsTheGeneratedFilterExactly` |
| убрать маркер присутствия фильтра | `testRunKeyFollowsTheGeneratedFilterExactly` |
| убрать область из ключа подготовки | `testPrepKeyDistinguishesTheRebuildScope`, ратчет `PrepRequest` |
| внести `jobName` в ключ подготовки | `testPrepKeyIgnoresTheJobLabelSoRunAndDebugShareOnePreparation`, ратчет |
| внести `timeout` в ключ прогона | ратчет `RunRequest` (сторона «исключено») |
| поле без классификации | ратчет `RunRequest` |

Две находки пришли **именно от мутации**, а не от ревью: взаимная избыточность двух слагаемых авто-цепочки (удаление булева не ломало ничего) и то, что первый вариант теста на обрамление краснел от маркера фильтра, а не от обрамления — пару, которую защищает только обрамление, пришлось искать среди неразмеченных частей (проект/приложение).

## Что НЕ проверено

**Локального живого стенда не было** (`:8766` занят другим агентом, `:8765` — рабочая EDT пользователя), поэтому e2e руками против живого сервера по этой ветке **я не гонял**, и ни один сценарий не проверен на конкретной конфигурации вручную. Всё, что доказано мной, доказано юнит-тестами, мутацией и сборкой.

Живую часть закрыл CI: **E2E 2026.2 (4 шарда) — зелёный на обоих коммитах ветки** (`59fcc427` и `1a2a69da`), плюс Build, Conformance 2026.2 и code scanning. Это и есть единственное подтверждение поведения на работающем сервере в этой работе.

Проволочная поверхность не менялась — ни параметров, ни описаний, — поэтому golden `tools/list` и `docs/tools/` не тронуты (`git diff upstream/master` по ним пуст); зелёный e2e это подтверждает, отдельного запуска отпечатка не делалось.

## Вне области (названо явно)

- Два блока подготовки (RUN и DEBUG) остаются продублированными во всём, кроме ключа: их слияние требует передавать `LaunchContext` в `launchDebugMode`, а ключ — предмет этой ишью — после вывода из `PrepRequest` разойтись уже не может.
- Атрибуты конфигурации запуска, кроме имени (например, учётные данные), по-прежнему могут измениться под работающим ключом — это унаследованная дыра и отдельная тема.
- Рассматривался и отвергнут третий вариант для повторов: отдельная стабильная «личность запроса», привязанная к конкретной операции, чтобы повтор с тем же аргументом находил уже идущий прогон даже после смены приложения по умолчанию. Он возвращает более узкую версию того же тихого попадания (устаревшая привязка отдаёт отчёт прежнего приложения) и требует управления временем жизни привязки ради случая, который стоит одного лишнего прогона.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
