### PR TITLE
Распределение id формы: широкое чтение потолка, узкая запись целей (#373)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -5220,6 +5220,54 @@ public final class FormElementWriter
     }
 
     // ---- the form-wide id allocation ------------------------------------------------------------
+    //
+    // Two questions live here, and they have DIFFERENT answers. Conflating them is the mistake this
+    // block exists to prevent, so both answers are written down.
+    //
+    // 1. "Which ids are TAKEN?" -> the WHOLE LIVE FORM MODEL, computed branches included.
+    //    The platform's own allocator, FormIdentifierService.getMaxId (bundle
+    //    com._1c.g5.v8.dt.form), scans EcoreUtil.getAllContents(form, true) - the same unconditional
+    //    walk as eAllContents(), which descends into transient containments - and filters with
+    //    exactly FormItem / AbstractFormAttribute / FormCommand, reading exactly getId(). So the
+    //    max* scans below stay WIDE on purpose. This is not indifference to the computed branches:
+    //    AutoCommandBar, SelectedItemsActionsPanel and RowActionsPanel are FormItem subtypes, so the
+    //    objects behind the layouter-only containments carry real ids. Those containments are
+    //    CommandBarHolder.topCommandBar / bottomCommandBar / fABCommandBar,
+    //    SelectedItemsActionsPanelHolder.selectedItemsActionsPanel and
+    //    RowActionsPanelHolder.rowActionsPanel - all five declared "contains transient" (the last
+    //    two are additionally commented "// layouter only"; being transient is the part that matters
+    //    here). (CommandBarHolder.autoCommandBar, by contrast, is PERSISTED and reached by both
+    //    passes. Every command-bar holder declares one - a Table's is numbered like any other item;
+    //    only the instance owned by the form ROOT carries the -1 sentinel.) Narrowing the ITEM
+    //    ceiling would hand out an id the platform considers reserved.
+    //    For attributes and commands the ceiling is wide for PARITY, not for a measurable effect:
+    //    nothing transient reaches an AbstractFormAttribute or a FormCommand in the shipped
+    //    metamodel, so narrowing those two would be observationally identical today. They stay wide
+    //    so all three id spaces answer "which ids are taken" the same way the platform does.
+    //
+    // 2. "Which objects may be RENUMBERED?" -> the PERSISTED AUTHORED GRAPH ONLY.
+    //    The platform draws this line in a different place, and does so consistently. Its
+    //    form-invalid-item-id diagnostic (InvalidItemIdCheck, bundle com.e1c.dt.check.form) and its
+    //    merge-time repair (FormComparisonParticipant.checkUniqueItemIds) both collect their targets
+    //    with FormItemIterator, which follows autoCommandBar, contextMenu, extendedTooltip, items,
+    //    autoTable and the Additions - every one of them persisted - and never the transient bars or
+    //    panels. Its command and attribute repairs are narrower still, addressing
+    //    FormPackage.Literals.FORM__FORM_COMMANDS and FORM__ATTRIBUTES outright. Only then does it
+    //    allocate a replacement through the WIDE getNext*Id. Wide read, narrow write.
+    //
+    // Hence the shape below: the max* scans use eAllContents(), the three normalizeForm*Ids collect
+    // their targets through PersistedContents.descendants. Writing into a computed branch would be
+    // wrong twice over - it mutates an object that is never serialized, and, when a layouter item
+    // and an authored item collide on an id, it lets visit order decide which of the two is
+    // renumbered, so an ephemeral object can durably renumber authored content in Form.form.
+    //
+    // Only the FormItem pair makes this observable: no transient containment reaches an
+    // AbstractFormAttribute or a FormCommand (FormStandardCommand, the inferred one, extends Command
+    // and NOT FormCommand, and declares no id at all), so for those two the narrow collection is
+    // parity with the platform rather than a change in numbering.
+    //
+    // Verified against the shipped model/Form.xcore of EDT 2026.1.2+2 and 2026.2.0+289, which are
+    // identical on every declaration named above.
 
     /**
      * The next free form-attribute id = max existing {@code AbstractFormAttribute} id across the whole
@@ -5282,6 +5330,17 @@ public final class FormElementWriter
         return max;
     }
 
+    /**
+     * WIDE on purpose - question 1 of the block comment above: {@code eAllContents()} mirrors the
+     * platform's own {@code FormIdentifierService.getMaxId}, which scans
+     * {@code EcoreUtil.getAllContents(form, true)}.
+     *
+     * <p>For the command space this is PARITY rather than a measurable difference: the inferred
+     * {@code FormStandardCommand} is not a {@code FormCommand} and carries no {@code id}, and no
+     * other transient containment reaches one, so a narrowed scan would return the same number on
+     * any form the shipped metamodel can produce. It stays wide so that all three id spaces answer
+     * "which ids are taken" exactly as the platform does.</p>
+     */
     private static int maxCommandId(EObject formModel, EClass commandClass)
     {
         int max = 0;
@@ -5296,6 +5355,7 @@ public final class FormElementWriter
         return max;
     }
 
+    /** WIDE on purpose - see {@link #maxCommandId} and the block comment above. */
     private static int maxAttributeId(EObject formModel, EClass attributeClass)
     {
         int max = 0;
@@ -5322,7 +5382,13 @@ public final class FormElementWriter
         return reference != null && !reference.eIsProxy() ? reference : null;
     }
 
-    /** The next free form-item id = max existing {@code FormItem} id across the whole form + 1. */
+    /**
+     * The next free form-item id = max existing {@code FormItem} id across the whole form + 1.
+     * WIDE on purpose - see {@link #maxCommandId} and the block comment above. This is the one id
+     * space where the computed branches actually carry ids: the layouter's {@code AutoCommandBar},
+     * {@code SelectedItemsActionsPanel} and {@code RowActionsPanel} are {@code FormItem}s reachable
+     * only through transient containments, and the platform counts them as taken.
+     */
     private static int nextItemId(EObject formModel)
     {
         EClassifier formItem = formModel.eClass().getEPackage().getEClassifier(ECLASS_FORM_ITEM);
@@ -5349,6 +5415,13 @@ public final class FormElementWriter
      * the model. The designer allocates these ids through {@code getNextAttributeId}; attributes and
      * attribute columns share this attribute id space, but it is intentionally independent from
      * {@code FormItem.id}.
+     *
+     * <p>The ceiling is read WIDE and the repair targets are collected NARROW - see the block
+     * comment above. The platform repairs attribute ids by addressing
+     * {@code FormPackage.Literals.FORM__ATTRIBUTES} and the explicit column features outright, so
+     * only persisted attributes are eligible to be renumbered. No transient containment reaches an
+     * {@code AbstractFormAttribute} in the shipped metamodel, so this is parity with the platform
+     * rather than a change in the numbers produced.</p>
      * Package-visible for the headless unit test.
      */
     static void normalizeFormAttributeIds(EObject formModel)
@@ -5366,9 +5439,8 @@ public final class FormElementWriter
         {
             max = Math.max(max, maxAttributeIdForAllocation(extensionForm, attributeClass));
         }
-        for (TreeIterator<EObject> it = formModel.eAllContents(); it.hasNext();)
+        for (EObject obj : PersistedContents.descendants(formModel))
         {
-            EObject obj = it.next();
             if (!attributeClass.isInstance(obj))
             {
                 continue;
@@ -5398,6 +5470,14 @@ public final class FormElementWriter
      * Repairs the form-wide {@code FormCommand.id} invariant before validation/export sees the model.
      * The designer allocates these ids through {@code getNextCommandId}; commands have their own id
      * space, independent from form items and form attributes.
+     *
+     * <p>The ceiling is read WIDE and the repair targets are collected NARROW - see the block
+     * comment above. The platform repairs command ids by addressing
+     * {@code FormPackage.Literals.FORM__FORM_COMMANDS} outright. The inferred
+     * {@code FormStandardCommand} behind the transient {@code FormStandardCommandSource.commands}
+     * is NOT a {@code FormCommand} - it extends {@code Command} directly and declares no {@code id}
+     * - so it never entered this loop even before the narrowing; this is parity with the platform
+     * rather than a change in the numbers produced.</p>
      * Package-visible for the headless unit test.
      */
     static void normalizeFormCommandIds(EObject formModel)
@@ -5415,9 +5495,8 @@ public final class FormElementWriter
         {
             max = Math.max(max, maxCommandIdForAllocation(extensionForm, commandClass));
         }
-        for (TreeIterator<EObject> it = formModel.eAllContents(); it.hasNext();)
+        for (EObject obj : PersistedContents.descendants(formModel))
         {
-            EObject obj = it.next();
             if (!commandClass.isInstance(obj))
             {
                 continue;
@@ -5446,8 +5525,24 @@ public final class FormElementWriter
     /**
      * Repairs the form-wide {@code FormItem.id} invariant before validation/export sees the model.
      * The form root's predefined {@code autoCommandBar} has the platform sentinel {@code -1}; every
-     * other form item, including designer auto-children such as {@code contextMenu} and
-     * {@code extendedTooltip}, gets a positive id unique in the same form-wide space.
+     * other PERSISTED form item, including designer auto-children such as {@code contextMenu} and
+     * {@code extendedTooltip}, gets a positive id unique in the same form-wide space. Items that
+     * exist only behind a computed containment are left exactly as the layouter made them - they are
+     * counted when the ceiling is computed, but never rewritten.
+     *
+     * <p>This is the pair where the wide/narrow split is observable, so the two jobs run as two
+     * separate passes - see the block comment above. The ceiling comes from a WIDE pass, because the
+     * layouter's {@code AutoCommandBar}, {@code SelectedItemsActionsPanel} and
+     * {@code RowActionsPanel} are {@code FormItem}s that hold real ids behind transient
+     * containments and the platform counts them as taken. The repair targets come from a NARROW
+     * pass, because the platform's own validation and repair paths (its {@code form-invalid-item-id}
+     * diagnostic and its merge-time {@code checkUniqueItemIds}) judge and rewrite only what
+     * {@code FormItemIterator} yields, and that follows persisted children only. Renumbering a computed item would write into an object that
+     * is never serialized, and - worse - on an id collision between a layouter item and an authored
+     * one it would let visit order decide which of the two keeps its id.
+     *
+     * <p>The form root's own {@code autoCommandBar} is a PERSISTED containment, so it stays visible
+     * to the narrow pass and keeps its {@code -1} sentinel.</p>
      * Package-visible for the headless unit test.
      */
     static void normalizeFormItemIds(EObject formModel)
@@ -5461,19 +5556,13 @@ public final class FormElementWriter
 
         EClass formItemClass = (EClass)formItem;
         EObject rootAutoCommandBar = singleReference(formModel, FEATURE_AUTO_COMMAND_BAR);
+        int max = maxItemId(formModel, formItemClass, rootAutoCommandBar);
         List<EObject> items = new ArrayList<>();
-        int max = 0;
-        for (TreeIterator<EObject> it = formModel.eAllContents(); it.hasNext();)
+        for (EObject obj : PersistedContents.descendants(formModel))
         {
-            EObject obj = it.next();
-            if (!formItemClass.isInstance(obj))
+            if (formItemClass.isInstance(obj))
             {
-                continue;
-            }
-            items.add(obj);
-            if (obj != rootAutoCommandBar)
-            {
-                max = Math.max(max, intFeature(obj, FEATURE_ID));
+                items.add(obj);
             }
         }
 
@@ -5488,6 +5577,36 @@ public final class FormElementWriter
         {
             max = assignItemId(item, rootAutoCommandBar, seen, max);
         }
+    }
+
+    /**
+     * The highest {@code FormItem.id} anywhere in the LIVE form - the ceiling
+     * {@link #normalizeFormItemIds} numbers up from. WIDE on purpose: this answers "which ids are
+     * taken", which the platform decides over the whole live model
+     * ({@code FormIdentifierService.getMaxId} scans {@code EcoreUtil.getAllContents(form, true)}),
+     * so the layouter items behind transient containments must be counted here even though they are
+     * never eligible for renumbering.
+     *
+     * <p>{@code rootAutoCommandBar} is excluded because it carries the platform sentinel
+     * {@code -1} rather than an allocated id.</p>
+     *
+     * @param formModel the form root to scan
+     * @param formItemClass the resolved {@code FormItem} EClass
+     * @param rootAutoCommandBar the form root's own command bar, or {@code null}
+     * @return the highest id found, or {@code 0} when the form holds no numbered item
+     */
+    private static int maxItemId(EObject formModel, EClass formItemClass, EObject rootAutoCommandBar)
+    {
+        int max = 0;
+        for (TreeIterator<EObject> it = formModel.eAllContents(); it.hasNext();)
+        {
+            EObject obj = it.next();
+            if (formItemClass.isInstance(obj) && obj != rootAutoCommandBar)
+            {
+                max = Math.max(max, intFeature(obj, FEATURE_ID));
+            }
+        }
+        return max;
     }
 
     /**

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -2089,6 +2089,361 @@ public class FormElementWriterTest
         assertEquals(Integer.valueOf(9), group.eGet(feature(group, "id"))); //$NON-NLS-1$
     }
 
+    // ==== the id space: WIDE ceiling, NARROW renumbering targets (issue #373) ====
+    //
+    // The platform splits these two jobs and so do we. FormIdentifierService.getMaxId scans
+    // EcoreUtil.getAllContents(form, true) - the whole live model - to decide which ids are taken,
+    // while its validation and repair paths (the form-invalid-item-id diagnostic and the merge-time
+    // checkUniqueItemIds) judge and rewrite only what FormItemIterator yields, and that follows
+    // persisted children only.
+
+    /**
+     * The ceiling must keep counting the layouter's items. They are {@code FormItem}s carrying real
+     * ids that are reachable ONLY through a transient containment, and the platform holds those ids
+     * reserved - so an id handed out here has to clear them. This is the NEGATIVE control for the
+     * narrowing: point {@code maxItemId} at {@link PersistedContents} and the ceiling falls to the
+     * table's 3, so the authored group below is handed 4 - an id the layouter's bar range already
+     * covers. It deliberately passes on the pre-change code too; its job is to fail if the WIDE half
+     * of the split is ever narrowed along with the target pass.
+     */
+    @Test
+    public void testItemIdCeilingCountsLayouterItemsBehindTransientContainments()
+    {
+        EObject form = newForm();
+        EObject table = newObject(MODEL.table);
+        table.eSet(feature(table, "name"), "Items"); //$NON-NLS-1$ //$NON-NLS-2$
+        table.eSet(feature(table, "id"), Integer.valueOf(3)); //$NON-NLS-1$
+        addTo(form, "items", table); //$NON-NLS-1$
+        // The layouter's own command bar for that table - transient, so it never reaches Form.form,
+        // yet it holds an allocated id.
+        EObject layouterBar = newObject(MODEL.autoCommandBar);
+        layouterBar.eSet(feature(layouterBar, "name"), "TableTopCommandBar"); //$NON-NLS-1$ //$NON-NLS-2$
+        layouterBar.eSet(feature(layouterBar, "id"), Integer.valueOf(50)); //$NON-NLS-1$
+        table.eSet(feature(table, "topCommandBar"), layouterBar); //$NON-NLS-1$
+
+        EObject group = newObject(MODEL.formGroup);
+        group.eSet(feature(group, "name"), "Main"); //$NON-NLS-1$ //$NON-NLS-2$
+        group.eSet(feature(group, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        addTo(form, "items", group); //$NON-NLS-1$
+
+        FormElementWriter.normalizeFormItemIds(form);
+
+        assertEquals("the ceiling must clear the id the layouter item already holds", //$NON-NLS-1$
+            Integer.valueOf(51), group.eGet(feature(group, "id"))); //$NON-NLS-1$
+        assertEquals("an authored item with a good id keeps it", Integer.valueOf(3), //$NON-NLS-1$
+            table.eGet(feature(table, "id"))); //$NON-NLS-1$
+    }
+
+    /**
+     * On a form with NO computed content the split must be bit-for-bit what it always was, so the
+     * exact numbers are pinned rather than "unique and non-zero". The existing invariant assertions
+     * would survive a target pass that visited the same objects in a different ORDER, which would
+     * silently move ids between authored elements; these equalities would not.
+     *
+     * <p>Ceiling = 3 (the highest authored id, the root command bar excluded), then in document
+     * order: a zero takes 4, a good unique id is kept, the duplicate 3 takes 5, the last zero
+     * takes 6.</p>
+     */
+    @Test
+    public void testAuthoredOnlyFormIsNumberedExactlyAsBefore()
+    {
+        EObject form = newForm();
+        EObject zeroFirst = newObject(MODEL.formGroup);
+        zeroFirst.eSet(feature(zeroFirst, "name"), "ZeroFirst"); //$NON-NLS-1$ //$NON-NLS-2$
+        zeroFirst.eSet(feature(zeroFirst, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        addTo(form, "items", zeroFirst); //$NON-NLS-1$
+        EObject good = newObject(MODEL.formGroup);
+        good.eSet(feature(good, "name"), "Good"); //$NON-NLS-1$ //$NON-NLS-2$
+        good.eSet(feature(good, "id"), Integer.valueOf(3)); //$NON-NLS-1$
+        addTo(form, "items", good); //$NON-NLS-1$
+        EObject duplicate = newObject(MODEL.formGroup);
+        duplicate.eSet(feature(duplicate, "name"), "Duplicate"); //$NON-NLS-1$ //$NON-NLS-2$
+        duplicate.eSet(feature(duplicate, "id"), Integer.valueOf(3)); //$NON-NLS-1$
+        addTo(form, "items", duplicate); //$NON-NLS-1$
+        EObject zeroLast = newObject(MODEL.decoration);
+        zeroLast.eSet(feature(zeroLast, "name"), "ZeroLast"); //$NON-NLS-1$ //$NON-NLS-2$
+        zeroLast.eSet(feature(zeroLast, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        addTo(form, "items", zeroLast); //$NON-NLS-1$
+
+        FormElementWriter.normalizeFormItemIds(form);
+
+        assertEquals(Integer.valueOf(4), zeroFirst.eGet(feature(zeroFirst, "id"))); //$NON-NLS-1$
+        assertEquals(Integer.valueOf(3), good.eGet(feature(good, "id"))); //$NON-NLS-1$
+        assertEquals(Integer.valueOf(5), duplicate.eGet(feature(duplicate, "id"))); //$NON-NLS-1$
+        assertEquals(Integer.valueOf(6), zeroLast.eGet(feature(zeroLast, "id"))); //$NON-NLS-1$
+        EObject rootBar = (EObject)form.eGet(feature(form, "autoCommandBar")); //$NON-NLS-1$
+        assertEquals(Integer.valueOf(-1), rootBar.eGet(feature(rootBar, "id"))); //$NON-NLS-1$
+    }
+
+    /**
+     * The same exact-value parity pin for the attribute and command id spaces. Their existing tests
+     * assert only "positive and unique", which a reversed target order would satisfy while quietly
+     * swapping ids between authored objects; these equalities would not.
+     */
+    @Test
+    public void testAuthoredAttributesAndCommandsAreNumberedExactlyAsBefore()
+    {
+        EObject form = newForm();
+        EObject attrZero = newObject(MODEL.formAttribute);
+        attrZero.eSet(feature(attrZero, "name"), "AttrZero"); //$NON-NLS-1$ //$NON-NLS-2$
+        attrZero.eSet(feature(attrZero, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        addTo(form, "attributes", attrZero); //$NON-NLS-1$
+        EObject attrGood = newObject(MODEL.formAttribute);
+        attrGood.eSet(feature(attrGood, "name"), "AttrGood"); //$NON-NLS-1$ //$NON-NLS-2$
+        attrGood.eSet(feature(attrGood, "id"), Integer.valueOf(2)); //$NON-NLS-1$
+        addTo(form, "attributes", attrGood); //$NON-NLS-1$
+        EObject attrDup = newObject(MODEL.formAttribute);
+        attrDup.eSet(feature(attrDup, "name"), "AttrDup"); //$NON-NLS-1$ //$NON-NLS-2$
+        attrDup.eSet(feature(attrDup, "id"), Integer.valueOf(2)); //$NON-NLS-1$
+        addTo(form, "attributes", attrDup); //$NON-NLS-1$
+
+        EObject cmdZero = newObject(MODEL.formCommand);
+        cmdZero.eSet(feature(cmdZero, "name"), "CmdZero"); //$NON-NLS-1$ //$NON-NLS-2$
+        cmdZero.eSet(feature(cmdZero, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        addTo(form, "formCommands", cmdZero); //$NON-NLS-1$
+        EObject cmdGood = newObject(MODEL.formCommand);
+        cmdGood.eSet(feature(cmdGood, "name"), "CmdGood"); //$NON-NLS-1$ //$NON-NLS-2$
+        cmdGood.eSet(feature(cmdGood, "id"), Integer.valueOf(5)); //$NON-NLS-1$
+        addTo(form, "formCommands", cmdGood); //$NON-NLS-1$
+
+        FormElementWriter.normalizeFormAttributeIds(form);
+        FormElementWriter.normalizeFormCommandIds(form);
+
+        // Ceiling 2, then in document order: the zero takes 3, the good id is kept, the duplicate 4.
+        assertEquals(Integer.valueOf(3), attrZero.eGet(feature(attrZero, "id"))); //$NON-NLS-1$
+        assertEquals(Integer.valueOf(2), attrGood.eGet(feature(attrGood, "id"))); //$NON-NLS-1$
+        assertEquals(Integer.valueOf(4), attrDup.eGet(feature(attrDup, "id"))); //$NON-NLS-1$
+        // Ceiling 5, so the zero takes 6 and the good id is kept.
+        assertEquals(Integer.valueOf(6), cmdZero.eGet(feature(cmdZero, "id"))); //$NON-NLS-1$
+        assertEquals(Integer.valueOf(5), cmdGood.eGet(feature(cmdGood, "id"))); //$NON-NLS-1$
+    }
+
+    /**
+     * A layouter item is never a renumbering target. Writing into it would mutate an object that is
+     * never serialized, and the platform's own repair iterator does not admit it either.
+     */
+    @Test
+    public void testLayouterItemsAreNeverRenumbered()
+    {
+        EObject form = newForm();
+        EObject table = newObject(MODEL.table);
+        table.eSet(feature(table, "name"), "Items"); //$NON-NLS-1$ //$NON-NLS-2$
+        table.eSet(feature(table, "id"), Integer.valueOf(5)); //$NON-NLS-1$
+        addTo(form, "items", table); //$NON-NLS-1$
+        // id 0 is exactly what the layouter leaves behind (ModelAccessHelper attaches these panels
+        // without ever allocating one), so this is the value the old walk would have "repaired".
+        EObject panel = newObject(modelClass("SelectedItemsActionsPanel")); //$NON-NLS-1$
+        panel.eSet(feature(panel, "name"), "SelectedItemsActionsPanel"); //$NON-NLS-1$ //$NON-NLS-2$
+        panel.eSet(feature(panel, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        table.eSet(feature(table, "selectedItemsActionsPanel"), panel); //$NON-NLS-1$
+
+        FormElementWriter.normalizeFormItemIds(form);
+
+        assertEquals("a computed item must keep the id the layouter gave it", Integer.valueOf(0), //$NON-NLS-1$
+            panel.eGet(feature(panel, "id"))); //$NON-NLS-1$
+        assertEquals("an authored item with a good id keeps it", Integer.valueOf(5), //$NON-NLS-1$
+            table.eGet(feature(table, "id"))); //$NON-NLS-1$
+    }
+
+    /**
+     * The hazard the narrowing removes: when a layouter item and an AUTHORED item hold the same id,
+     * the wide walk let visit order pick the loser. Here the layouter bar sits under an earlier
+     * sibling, so depth-first reaches it first, claims id 7 for a throw-away object and renumbers the
+     * authored group - a change that lands in {@code Form.form} and outlives the layouter entirely.
+     */
+    @Test
+    public void testAuthoredItemKeepsItsIdWhenALayouterItemSharesIt()
+    {
+        EObject form = newForm();
+        EObject table = newObject(MODEL.table);
+        table.eSet(feature(table, "name"), "Items"); //$NON-NLS-1$ //$NON-NLS-2$
+        table.eSet(feature(table, "id"), Integer.valueOf(3)); //$NON-NLS-1$
+        addTo(form, "items", table); //$NON-NLS-1$
+        EObject layouterBar = newObject(MODEL.autoCommandBar);
+        layouterBar.eSet(feature(layouterBar, "name"), "TableTopCommandBar"); //$NON-NLS-1$ //$NON-NLS-2$
+        layouterBar.eSet(feature(layouterBar, "id"), Integer.valueOf(7)); //$NON-NLS-1$
+        table.eSet(feature(table, "topCommandBar"), layouterBar); //$NON-NLS-1$
+
+        // Visited AFTER the table's computed subtree, so this is the one the old walk renumbered.
+        EObject group = newObject(MODEL.formGroup);
+        group.eSet(feature(group, "name"), "Main"); //$NON-NLS-1$ //$NON-NLS-2$
+        group.eSet(feature(group, "id"), Integer.valueOf(7)); //$NON-NLS-1$
+        addTo(form, "items", group); //$NON-NLS-1$
+
+        FormElementWriter.normalizeFormItemIds(form);
+
+        assertEquals("an ephemeral item must not renumber authored content", Integer.valueOf(7), //$NON-NLS-1$
+            group.eGet(feature(group, "id"))); //$NON-NLS-1$
+        assertEquals("and the computed item is left exactly as it was", Integer.valueOf(7), //$NON-NLS-1$
+            layouterBar.eGet(feature(layouterBar, "id"))); //$NON-NLS-1$
+    }
+
+    /**
+     * The form root's own {@code autoCommandBar} is a PERSISTED containment, so narrowing the target
+     * pass must not lose it - it still gets the platform sentinel {@code -1}.
+     */
+    @Test
+    public void testRootAutoCommandBarKeepsItsSentinelUnderTheNarrowedPass()
+    {
+        EObject form = newForm();
+        EObject bar = (EObject)form.eGet(feature(form, "autoCommandBar")); //$NON-NLS-1$
+        bar.eSet(feature(bar, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        EObject group = newObject(MODEL.formGroup);
+        group.eSet(feature(group, "name"), "Main"); //$NON-NLS-1$ //$NON-NLS-2$
+        group.eSet(feature(group, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        addTo(form, "items", group); //$NON-NLS-1$
+
+        FormElementWriter.normalizeFormItemIds(form);
+
+        assertEquals("the root command bar keeps the platform sentinel", Integer.valueOf(-1), //$NON-NLS-1$
+            bar.eGet(feature(bar, "id"))); //$NON-NLS-1$
+        assertEquals("and an authored item is still numbered from 1", Integer.valueOf(1), //$NON-NLS-1$
+            group.eGet(feature(group, "id"))); //$NON-NLS-1$
+    }
+
+    /**
+     * PARITY, not a numeric difference - and the distinction is deliberate. The shipped metamodel has
+     * NO transient containment that reaches an {@code AbstractFormAttribute}, so on a real form this
+     * narrowing changes nothing at all; claiming otherwise would be inventing evidence. What this
+     * pins is the RULE - which traversal decides the targets - so that a metamodel that later grows
+     * such a path does not silently start renumbering computed attributes.
+     */
+    @Test
+    public void testComputedAttributeIsNotARenumberingTarget()
+    {
+        EObject form = newForm();
+        EObject authored = newObject(MODEL.formAttribute);
+        authored.eSet(feature(authored, "name"), "Customer"); //$NON-NLS-1$ //$NON-NLS-2$
+        authored.eSet(feature(authored, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        addTo(form, "attributes", authored); //$NON-NLS-1$
+        // TWO computed attributes, because one cannot pin both halves of the split - measured, not
+        // assumed. A ghost with a good unique id pins the CEILING (drop it from the maximum and the
+        // authored attribute below falls to 1) but says nothing about the target pass, since the
+        // repair keeps any id that is positive and unique. A ghost with id 0 pins the TARGET PASS
+        // (the wide loop would allocate one for it) but says nothing about the ceiling, since 0
+        // raises no maximum.
+        EObject computedHigh = newObject(MODEL.formAttribute);
+        computedHigh.eSet(feature(computedHigh, "name"), "ComputedHigh"); //$NON-NLS-1$ //$NON-NLS-2$
+        computedHigh.eSet(feature(computedHigh, "id"), Integer.valueOf(40)); //$NON-NLS-1$
+        addTo(form, "ghostAttributes", computedHigh); //$NON-NLS-1$
+        EObject computedZero = newObject(MODEL.formAttribute);
+        computedZero.eSet(feature(computedZero, "name"), "ComputedZero"); //$NON-NLS-1$ //$NON-NLS-2$
+        computedZero.eSet(feature(computedZero, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        addTo(form, "ghostAttributes", computedZero); //$NON-NLS-1$
+
+        FormElementWriter.normalizeFormAttributeIds(form);
+
+        assertEquals("the ceiling must still count the computed attribute", Integer.valueOf(41), //$NON-NLS-1$
+            authored.eGet(feature(authored, "id"))); //$NON-NLS-1$
+        assertEquals("a computed attribute is never written to", Integer.valueOf(40), //$NON-NLS-1$
+            computedHigh.eGet(feature(computedHigh, "id"))); //$NON-NLS-1$
+        assertEquals("not even one the repair would consider unnumbered", Integer.valueOf(0), //$NON-NLS-1$
+            computedZero.eGet(feature(computedZero, "id"))); //$NON-NLS-1$
+    }
+
+    /**
+     * PARITY for the command id space, on the same terms as
+     * {@link #testComputedAttributeIsNotARenumberingTarget}. On a real form the inferred
+     * {@code FormStandardCommand} behind {@code FormStandardCommandSource.commands} is not even a
+     * {@code FormCommand} - it extends {@code Command} directly and declares no {@code id} - so it
+     * never entered this loop. The fixture supplies a computed command anyway, to pin which
+     * traversal chooses the targets.
+     */
+    @Test
+    public void testComputedCommandIsNotARenumberingTarget()
+    {
+        EObject form = newForm();
+        EObject authored = newObject(MODEL.formCommand);
+        authored.eSet(feature(authored, "name"), "Run"); //$NON-NLS-1$ //$NON-NLS-2$
+        authored.eSet(feature(authored, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        addTo(form, "formCommands", authored); //$NON-NLS-1$
+        // Two of them, for the reason spelled out in the attribute test: a good unique id pins the
+        // ceiling, a zero pins the target pass, and neither pins both.
+        EObject computedHigh = newObject(MODEL.formCommand);
+        computedHigh.eSet(feature(computedHigh, "name"), "ComputedHigh"); //$NON-NLS-1$ //$NON-NLS-2$
+        computedHigh.eSet(feature(computedHigh, "id"), Integer.valueOf(60)); //$NON-NLS-1$
+        addTo(form, "ghostCommands", computedHigh); //$NON-NLS-1$
+        EObject computedZero = newObject(MODEL.formCommand);
+        computedZero.eSet(feature(computedZero, "name"), "ComputedZero"); //$NON-NLS-1$ //$NON-NLS-2$
+        computedZero.eSet(feature(computedZero, "id"), Integer.valueOf(0)); //$NON-NLS-1$
+        addTo(form, "ghostCommands", computedZero); //$NON-NLS-1$
+
+        FormElementWriter.normalizeFormCommandIds(form);
+
+        assertEquals("the ceiling must still count the computed command", Integer.valueOf(61), //$NON-NLS-1$
+            authored.eGet(feature(authored, "id"))); //$NON-NLS-1$
+        assertEquals("a computed command is never written to", Integer.valueOf(60), //$NON-NLS-1$
+            computedHigh.eGet(feature(computedHigh, "id"))); //$NON-NLS-1$
+        assertEquals("not even one the repair would consider unnumbered", Integer.valueOf(0), //$NON-NLS-1$
+            computedZero.eGet(feature(computedZero, "id"))); //$NON-NLS-1$
+    }
+
+    /**
+     * The before/after measurement on a form of known composition. Six authored objects hang off
+     * persisted containments (the root command bar, a table, a group and its field, one attribute,
+     * one command) and six more are reachable only through transient ones (the table's layouter
+     * command bar and the button under it, its two actions panels, a computed attribute and a
+     * computed command). The wide walk enumerates all twelve; the target pass enumerates the six
+     * that can actually be written back to disk.
+     */
+    @Test
+    public void testPersistedWalkEnumeratesOnlyTheAuthoredHalfOfTheForm()
+    {
+        EObject form = newForm();
+        EObject table = newObject(MODEL.table);
+        table.eSet(feature(table, "name"), "Items"); //$NON-NLS-1$ //$NON-NLS-2$
+        addTo(form, "items", table); //$NON-NLS-1$
+        EObject layouterBar = newObject(MODEL.autoCommandBar);
+        layouterBar.eSet(feature(layouterBar, "name"), "TableTopCommandBar"); //$NON-NLS-1$ //$NON-NLS-2$
+        table.eSet(feature(table, "topCommandBar"), layouterBar); //$NON-NLS-1$
+        EObject layouterButton = newObject(MODEL.decoration);
+        layouterButton.eSet(feature(layouterButton, "name"), "LayouterButton"); //$NON-NLS-1$ //$NON-NLS-2$
+        addTo(layouterBar, "items", layouterButton); //$NON-NLS-1$
+        EObject selected = newObject(modelClass("SelectedItemsActionsPanel")); //$NON-NLS-1$
+        selected.eSet(feature(selected, "name"), "Selected"); //$NON-NLS-1$ //$NON-NLS-2$
+        table.eSet(feature(table, "selectedItemsActionsPanel"), selected); //$NON-NLS-1$
+        EObject rows = newObject(modelClass("RowActionsPanel")); //$NON-NLS-1$
+        rows.eSet(feature(rows, "name"), "Rows"); //$NON-NLS-1$ //$NON-NLS-2$
+        table.eSet(feature(table, "rowActionsPanel"), rows); //$NON-NLS-1$
+
+        EObject group = newObject(MODEL.formGroup);
+        group.eSet(feature(group, "name"), "Main"); //$NON-NLS-1$ //$NON-NLS-2$
+        addTo(form, "items", group); //$NON-NLS-1$
+        EObject field = newObject(MODEL.decoration);
+        field.eSet(feature(field, "name"), "Price"); //$NON-NLS-1$ //$NON-NLS-2$
+        addTo(group, "items", field); //$NON-NLS-1$
+
+        EObject attribute = newObject(MODEL.formAttribute);
+        attribute.eSet(feature(attribute, "name"), "Customer"); //$NON-NLS-1$ //$NON-NLS-2$
+        addTo(form, "attributes", attribute); //$NON-NLS-1$
+        EObject command = newObject(MODEL.formCommand);
+        command.eSet(feature(command, "name"), "Run"); //$NON-NLS-1$ //$NON-NLS-2$
+        addTo(form, "formCommands", command); //$NON-NLS-1$
+        EObject ghostAttribute = newObject(MODEL.formAttribute);
+        ghostAttribute.eSet(feature(ghostAttribute, "name"), "GhostAttribute"); //$NON-NLS-1$ //$NON-NLS-2$
+        addTo(form, "ghostAttributes", ghostAttribute); //$NON-NLS-1$
+        EObject ghostCommand = newObject(MODEL.formCommand);
+        ghostCommand.eSet(feature(ghostCommand, "name"), "GhostCommand"); //$NON-NLS-1$ //$NON-NLS-2$
+        addTo(form, "ghostCommands", ghostCommand); //$NON-NLS-1$
+
+        int wide = 0;
+        for (TreeIterator<EObject> it = form.eAllContents(); it.hasNext(); it.next())
+        {
+            wide++;
+        }
+        int narrow = 0;
+        for (EObject each : PersistedContents.descendants(form))
+        {
+            if (each != null)
+            {
+                narrow++;
+            }
+        }
+
+        assertEquals("the wide walk still sees the whole live form", 12, wide); //$NON-NLS-1$
+        assertEquals("the target pass sees only what can be written back", 6, narrow); //$NON-NLS-1$
+    }
+
     @Test
     public void testAutoChildrenRussianSuffixes()
     {
@@ -3344,6 +3699,19 @@ public class FormElementWriterTest
                 containment(f, "searchControlAddition", addition, false)); //$NON-NLS-1$
             pkg.getEClassifiers().add(addition);
 
+            // The LAYOUTER-ONLY children (issue #373). In the shipped Form.xcore these sit on
+            // CommandBarHolder / SelectedItemsActionsPanelHolder / RowActionsPanelHolder and are
+            // declared "contains transient" - transient with derived=false,
+            // which is the shape that makes an isDerived()-only check useless. They are ordinary
+            // stored slots that simply never reach Form.form, so a test populates them with eSet,
+            // exactly as the layouter does at runtime.
+            table.getEStructuralFeatures().add(
+                layouterContainment(f, "topCommandBar", autoCommandBar, false)); //$NON-NLS-1$
+            table.getEStructuralFeatures().add(
+                layouterContainment(f, "selectedItemsActionsPanel", selectedItemsActionsPanel, false)); //$NON-NLS-1$
+            table.getEStructuralFeatures().add(
+                layouterContainment(f, "rowActionsPanel", rowActionsPanel, false)); //$NON-NLS-1$
+
             form = f.createEClass();
             form.setName("Form"); //$NON-NLS-1$
             form.getEStructuralFeatures().add(containment(f, "items", formItem, true)); //$NON-NLS-1$
@@ -3352,6 +3720,16 @@ public class FormElementWriterTest
                 containment(f, "attributes", formAttribute, true)); //$NON-NLS-1$
             form.getEStructuralFeatures().add(
                 containment(f, "autoCommandBar", autoCommandBar, false)); //$NON-NLS-1$
+            form.getEStructuralFeatures().add(
+                layouterContainment(f, "topCommandBar", autoCommandBar, false)); //$NON-NLS-1$
+            // NOT in the shipped metamodel: no transient containment reaches an AbstractFormAttribute
+            // or a FormCommand today. These two exist so the RULE ("a computed object is never a
+            // renumbering target") can be pinned for those id spaces as well - see the tests that
+            // use them, which say so explicitly rather than claiming an observable difference.
+            form.getEStructuralFeatures().add(
+                layouterContainment(f, "ghostAttributes", formAttribute, true)); //$NON-NLS-1$
+            form.getEStructuralFeatures().add(
+                layouterContainment(f, "ghostCommands", formCommand, true)); //$NON-NLS-1$
 
             pkg.getEClassifiers().add(form);
             // The owner that holds several forms: the level the orphan-item scan must NOT climb to,
@@ -3468,6 +3846,20 @@ public class FormElementWriterTest
             reference.setEType(type);
             reference.setContainment(true);
             reference.setUpperBound(many ? -1 : 1);
+            return reference;
+        }
+
+        /**
+         * A containment the model keeps in memory but never writes - the layouter-only shape of
+         * the real metamodel. TRANSIENT with {@code derived} left FALSE on purpose: that is how EDT
+         * declares every computed form containment, so a check that asked only about
+         * {@code isDerived()} would let all of these through.
+         */
+        private static EReference layouterContainment(EcoreFactory f, String name, EClass type,
+            boolean many)
+        {
+            EReference reference = containment(f, name, type, many);
+            reference.setTransient(true);
             return reference;
         }
     }


### PR DESCRIPTION
Closes #373.

## Ответ на вопрос задачи

Задача ставила выбор из двух: пространство идентификаторов формы определено **над персистентными
авторскими объектами** или **над всей живой моделью**. Ответ — **вопрос склеивает два разных вопроса,
и платформа отвечает на них по-разному**:

| вопрос | ответ | у нас было | стало |
|---|---|---|---|
| какие id **заняты** (потолок) | вся живая модель | широко | **широко** (без изменений) |
| какие объекты можно **перенумеровать** (цели) | только персистентный авторский граф | широко | **узко** |

EDT делает ровно так: **широкое чтение, узкая запись.** Наши шесть мест были широкими в обоих
качествах, и неверна именно вторая половина.

## Доказательства (байткод и метамодель EDT 2026.2.0+289 и 2026.1.2+2)

**Потолок — широкий.** `FormIdentifierService.getMaxId` (`com._1c.g5.v8.dt.form_32.0.0.jar`) обходит
`EcoreUtil.getAllContents(form, true)` — тот же безусловный обход, что и `eAllContents()`, со спуском
в транзиентные containment'ы. Предикаты — ровно `FormItem` / `AbstractFormAttribute` / `FormCommand`,
экстрактор — ровно `getId()`. Это те самые `getNextItemId` / `getNextAttributeId` / `getNextCommandId`,
на которые ссылаются наши javadoc. Сузить потолок = выдать id, который платформа считает занятым.

**Цели — узкие.** Два независимых места:
- `InvalidItemIdCheck` (диагностика `form-invalid-item-id`, `com.e1c.dt.check.form_0.12.0.jar`) —
  собирает через `FormItemIterator` + `hasValidId`;
- `FormComparisonParticipant` (`com._1c.g5.v8.dt.form.compare_7.0.1.jar`): `checkUniqueItemIds` —
  через `FormItemIterator`; `checkUniqueFormCommandIds` — по `FormPackage.Literals.FORM__FORM_COMMANDS`;
  `checkUniqueAttributeIds` — по `FORM__ATTRIBUTES` и явным колоночным фичам.

`FormItemIterator.computationItemIterator` идёт ровно по `autoCommandBar`, `contextMenu`,
`extendedTooltip`, `items`, `autoTable` и трём `Addition` — все персистентные; ссылок на
`topCommandBar` / `bottomCommandBar` / `fABCommandBar` / `selectedItemsActionsPanel` /
`rowActionsPanel` в нём нет ни одной.

**Три свидетельства, которых не хватало в задаче:**
1. `Form.xcore` поставляется прямо в jar (`model/Form.xcore`). `int ^id` объявлен ровно на трёх
   классах — `AbstractFormAttribute`, `FormCommand`, `FormItem`; **общего предка с `id` нет**.
2. **`FormStandardCommand extends DuallyNamedElement, Command` — это НЕ `FormCommand`, и `id` у него
   нет вообще**, поэтому транзиентный `FormStandardCommandSource.commands` не даёт в командное
   пространство ничего.
3. Контракт распределителя — см. выше.

Попутно: в форменной метамодели **ноль** `derived`-фич (значим только `transient`), и уточнение к
тексту задачи — **`CommandBarHolder.autoCommandBar` персистентный**, транзиентны только
`topCommandBar` / `bottomCommandBar` / `fABCommandBar` и две панели. 2026.1 и 2026.2 по всем этим
объявлениям идентичны.

## Что изменено

- `maxCommandId`, `maxAttributeId` и потолок внутри `nextItemId` — **оставлены широкими**, со ссылкой
  на `FormIdentifierService.getMaxId`.
- Циклы сбора трёх `normalizeForm*Ids` переведены на `PersistedContents.descendants` (помощник из
  #372 **переиспользован**, не скопирован).
- `normalizeFormItemIds` расщеплён на широкий проход потолка (новый `maxItemId`) и персистентный
  проход целей; sentinel `-1` на персистентном корневом `autoCommandBar` сохранён.
- Ответ записан в код комментарием у `// ---- the form-wide id allocation ----`.

## 🚨 Почему пункт AC про «пары» не выполняется

Пункт acceptance criteria из задачи:

> Счётчики и их нормализаторы изменены **парами** (`max*` + соответствующий `normalizeForm*Ids`) —
> сузить один цикл, оставив широкий максимум, нельзя.

**Сделано ровно наоборот**, и это осознанно. Премиса пункта — «единственный эффект цикла
нормализатора в том, какие id он считает» — неверна. У цикла есть второй, независимый эффект:
**в какие объекты мы пишем**. `normalizeForm*Ids` не только читают максимум, они делают `eSet`
идентификатора в каждый найденный объект с нулевым или задублированным id.

Поэтому «сузить цикл, оставив широкий максимум» — не бессмысленная половина правки, а **единственная
правка, которая здесь нужна**; платформа сама разделяет эти две работы (см. доказательства выше).

Широкий набор записи давал две вещи:
1. запись id в объект, который никогда не сериализуется (`eSet` идёт через BM EStore и его нотификации);
2. хуже: при совпадении id транзиентного и авторского элемента **порядок обхода решал, кого
   перенумеровать**, — и авторский элемент мог быть необратимо перенумерован в записанном
   `Form.form` из-за эфемерного объекта layouter'а. Итератор починки EDT такой объект в конфликтный
   набор не пускает вообще.

Пункт AC писали мы; об отмене написано в самой задаче до вливания, чтобы была возможность возразить.

## Чем доказано в тестах

Девять новых тестов в `FormElementWriterTest` (195 -> 204). Фикстура `FormLikeModel` дополнена настоящими
layouter-фичами (`topCommandBar` на `Form` и `Table`, `selectedItemsActionsPanel` / `rowActionsPanel`
на `Table`) — **`transient` с `derived = false`**, то есть именно та форма, на которой проверка одного
`isDerived()` бесполезна.

Каждая мутация применялась **по одной**, с восстановлением файла и сверкой sha256 после каждой;
вердикт принимается **только если тесты действительно выполнились** (иначе `INCONCLUSIVE`).

| мутация | что делает | вердикт | поймана |
|---|---|---|---|
| M1 | цикл целей `normalizeFormItemIds` -> широкий | KILLED | `testAuthoredItemKeepsItsIdWhenALayouterItemSharesIt` (ждали 7, получили **8**) и `testLayouterItemsAreNeverRenumbered` (ждали 0, получили 6) |
| M2 | цикл целей `normalizeFormAttributeIds` -> широкий | KILLED | `testComputedAttributeIsNotARenumberingTarget` (ждали 0, получили 42) |
| M3 | цикл целей `normalizeFormCommandIds` -> широкий | KILLED | `testComputedCommandIsNotARenumberingTarget` (ждали 0, получили 62) |
| M4 | **потолок** элементов -> узкий | KILLED | `testItemIdCeilingCountsLayouterItemsBehindTransientContainments` (ждали 51, получили 4) |
| M5 | **потолок** реквизитов -> узкий | KILLED | `testComputedAttributeIsNotARenumberingTarget` (ждали 41, получили 1) |
| M6 | **потолок** команд -> узкий | KILLED | `testComputedCommandIsNotARenumberingTarget` (ждали 61, получили 1) |

M4/M5/M6 — **отрицательные контроли**: широкий максимум не «оставлен по умолчанию», а закреплён;
сузишь его — тест краснеет.

Самое важное показание — M1: `an ephemeral item must not renumber authored content expected:<7> but
was:<8>`. То есть на старом коде **авторский элемент реально получал другой id** только потому, что
эфемерный объект layouter'а попался обходу раньше.

⚠️ **Одного вычисленного объекта на пространство не хватает — это измерено, а не предположено.**
Первая версия тестов давала призраку id 40/60 (чтобы закрепить потолок) — и мутации M2/M3
**ВЫЖИЛИ**: призрак с положительным уникальным id починка не трогает в любом случае. Поэтому в каждом
пространстве теперь **два** вычисленных объекта: с большим уникальным id (закрепляет потолок) и с
нулевым (закрепляет набор целей).

**Паритет для формы без вычисленного содержимого закреплён точными числами**, а не «уникальны и
ненулевые»: `testAuthoredOnlyFormIsNumberedExactlyAsBefore` (элементы — 4 / 3 / 5 / 6 и `-1` на
корневой панели) и `testAuthoredAttributesAndCommandsAreNumberedExactlyAsBefore` (реквизиты — 3 / 2 / 4,
команды — 6 / 5). Прежние утверждения пережили бы перестановку порядка целей, эти — нет.

## Замер до/после

`testPersistedWalkEnumeratesOnlyTheAuthoredHalfOfTheForm`, форма известного состава: шесть авторских
объектов на персистентных containment'ах (корневая командная панель, таблица, группа и её поле, один
реквизит, одна команда) и шесть достижимых только через транзиентные (командная панель layouter'а у
таблицы и кнопка под ней, две панели действий, вычисленный реквизит, вычисленная команда).

**Широкий обход — 12 объектов, проход целей — 6.**

## Честно о непроверенном

- **Наблюдаема только пара элементов.** У реквизитов и команд транзиентного пути до
  `AbstractFormAttribute` / `FormCommand` в поставленной метамодели **нет**, поэтому там сужение
  численно не меняет ничего — это **паритет правила**, а не изменение нумерации. Мутационный тест,
  «доказывающий» там разницу, был бы подгонкой; вместо него тест закрепляет, **какой обход** выбирает
  цели, и фикстура для этого сознательно содержит путь, которого в реальной метамодели нет (в
  javadoc тестов это сказано прямо).
- **Живая проба на стенде выполнена, и она НЕ показала транзиентного содержимого.** На чистой форме
  создан элемент (получил id 1–2), затем вызван `get_form_layout_snapshot`, затем второй элемент —
  он получил **3**, то есть ровно `persistedMax + 1`. Раз `nextItemId` широкий, это значит, что за
  пределами персистентного дерева обход **не нашёл ни одного** id-носителя: транзиентные
  containment'ы в нашем headless-контексте не заполнены.
  ⚠️ **Но проба слабее, чем хотелось бы, и выдавать её за доказательство «этого не бывает» нельзя:**
  снапшот вернулся с `elementCount: 0` и предупреждением «may not be fully rendered» — на стенде нет
  JVM-флага `-DnativeFormBufferedLayoutRender=true`, то есть WYSIWYG-layouter фактически не
  отработал. Так что проба показывает: **в обычном headless-пути записи транзиентных элементов нет**;
  окно риска — сессия, где layouter по этой форме действительно отработал (открытый редактор формы),
  и вот его воспроизвести не удалось.

## Вынесено отдельно

Найдено попутно, подтверждено по байткоду, в этот PR **не входит**, чтобы не размывать доказательство:
1. предикат валидности id у нас строже платформенного (`hasValidId` = `getId() != 0` против нашего
   `id > 0`);
2. мы не синхронизируем кэш-счётчики EDT в BM (`FORM_ITEM_CURRENT_ID` и др.), а `FormIdentifierService`
   в типичном случае модель вообще не сканирует — поэтому платформа может выдать id, который мы только
   что заняли. Это самостоятельный источник коллизий, остающийся при любом ответе на вопрос #373.

## Проверено

- `bash source/compile.sh` — `BUILD SUCCESS`, юнит-тесты BUILD_TESTS (0 failures).
- Мутации — по одной, с восстановлением файла и сверкой sha256 после каждой; вердикт выносится только
  при фактически выполненных тестах (иначе `INCONCLUSIVE`).
- Срезы e2e на стенде 2026.2 (`:8766`), **без единой правки самих тестов**: `--filter form` —
  **187/187**, `fixture clean: True`; `--filter create_metadata` — **118/118**, `fixture clean: True`.
- Anti-stale: маркером взят **новый** символ `maxItemId` в серверном бандле. Показание снято ДО
  выкладки — в лежавшем jar его **0**, в выложенном **1**; положительный контроль
  (`normalizeFormItemIds`, существовал и раньше) — **1** в обоих, то есть проверка не молчит впустую.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
