### PR TITLE
Поверхность инструментов описана честно, и это удерживается ратчетами (#419, #420)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,19 +198,20 @@ Control which MCP tools are exposed to AI assistants. This lets you reduce conte
 
 ### Tool Groups
 
-All 67 tools are organized into 9 semantic groups:
+All tools are organized into 10 semantic groups:
 
 | Group | Description | Tools |
 |-------|-------------|-------|
-| **Core / Project** | EDT version, server self-diagnosis, on-demand tool guides, project listing, configuration, validation, XML export/import, project removal, project creation (configuration / extension / externalObjects) | `get_edt_version`, `get_server_status`, `get_tool_guide`, `list_projects`, `get_configuration_properties`, `clean_project`, `revalidate_objects`, `get_check_description`, `export_configuration_to_xml`, `import_configuration_from_xml`, `delete_project`, `create_project` |
-| **Errors & Problems** | Error reporting and workspace markers (bookmarks, tasks) | `get_problem_summary`, `get_project_errors`, `get_markers` |
-| **Code Intelligence** | Content assist, documentation, metadata browsing | `get_content_assist`, `get_platform_documentation`, `get_metadata_objects`, `get_metadata_details`, `list_subsystems`, `get_subsystem_content`, `find_references` |
-| **Tags** | Tag management | `get_tags`, `get_objects_by_tags` |
-| **Applications & Testing** | App management, infobase create/delete, database updates, launch, termination, testing | `get_applications`, `create_infobase`, `delete_infobase`, `list_configurations`, `update_database`, `debug_launch`, `terminate_launch`, `run_yaxunit_tests` |
-| **Debugging** | Breakpoints, stepping, variable inspection and modification | `set_breakpoint`, `remove_breakpoint`, `list_breakpoints`, `wait_for_break`, `get_variables`, `set_variable`, `step`, `resume`, `evaluate_expression`, `debug_yaxunit_tests`, `debug_status`, `start_profiling`, `stop_profiling`, `get_profiling_results` |
-| **BSL Code** | Module browsing, code reading/writing, search, form layout inspection | `read_module_source`, `write_module_source`, `get_module_structure`, `list_modules`, `search_in_code`, `read_method_source`, `get_method_call_hierarchy`, `go_to_definition`, `get_symbol_info`, `get_form_layout_snapshot`, `get_form_screenshot`, `get_template_screenshot`, `validate_query` |
-| **Refactoring** | Metadata create (objects, members and form members), rename, delete, set properties, adopt into an extension | `create_metadata`, `rename_metadata_object`, `delete_metadata`, `modify_metadata`, `adopt_metadata_object` |
+| **Core / Project** | Essential server, project, configuration, history, and XML export/import tools | `get_edt_version`, `get_server_status`, `get_tool_guide`, `list_toolsets`, `enable_toolset`, `list_projects`, `get_configuration_properties`, `clean_project`, `revalidate_objects`, `resync_to_disk`, `get_check_description`, `export_configuration_to_xml`, `import_configuration_from_xml`, `delete_project`, `create_project`, `get_event_log`, `get_mcp_history` |
+| **Errors & Problems** | Error reporting, validation, and workspace markers (bookmarks, tasks) | `get_problem_summary`, `get_project_errors`, `get_markers`, `apply_quick_fix`, `validate_xdto_package` |
+| **Code Intelligence** | Content assist, documentation, metadata and common-picture browsing, and references | `get_content_assist`, `get_platform_documentation`, `get_metadata_objects`, `get_metadata_details`, `list_subsystems`, `get_subsystem_content`, `find_references`, `list_common_pictures`, `export_common_picture` |
+| **Tags** | Metadata tag management | `get_tags`, `get_objects_by_tags` |
+| **Applications & Testing** | Application and infobase management, external-object builds, launch, testing, and Workmate | `get_applications`, `list_configurations`, `create_launch_config`, `delete_launch_config`, `create_infobase`, `delete_infobase`, `update_database`, `debug_launch`, `terminate_launch`, `run_yaxunit_tests`, `ask_workmate`, `build_external_objects`, `set_infobase_credentials` |
+| **Debugging** | Breakpoints, stepping, variables, expression evaluation, and profiling | `set_breakpoint`, `remove_breakpoint`, `list_breakpoints`, `wait_for_break`, `get_variables`, `set_variable`, `step`, `resume`, `evaluate_expression`, `debug_yaxunit_tests`, `debug_status`, `start_profiling`, `stop_profiling`, `get_profiling_results` |
+| **BSL Code** | Module source reading/writing, structure, search, call hierarchy, navigation, and forms | `read_module_source`, `write_module_source`, `get_module_structure`, `list_modules`, `search_in_code`, `read_method_source`, `get_method_call_hierarchy`, `get_outgoing_structures`, `go_to_definition`, `get_symbol_info`, `get_form_layout_snapshot`, `get_form_screenshot`, `get_template_screenshot`, `validate_query` |
+| **Refactoring** | Metadata create, rename, adopt, delete, and property management | `rename_metadata_object`, `delete_metadata`, `create_metadata`, `modify_metadata`, `adopt_metadata_object` |
 | **Translation (LanguageTool)** | Translation strings generation, configuration synchronization, project info | `generate_translation_strings`, `translate_configuration`, `get_translation_project_info` |
+| **Git** | Git operations: the `git` command tool (disabled by default), branch listing/switching, and the branch-to-infobase binding | `git`, `list_git_branches`, `switch_git_branch`, `create_git_branch`, `set_branch_infobase` |
 
 Enable or disable entire groups or individual tools from the **Tools** tab in **Window → Preferences → MCP Server**. Disabled tools are filtered out of `tools/list` responses. If a client calls a disabled tool directly through `tools/call`, the server returns a message explaining that the tool is disabled.
 
@@ -220,7 +221,7 @@ Quickly switch between common tool configurations using presets:
 
 | Preset | Description |
 |--------|-------------|
-| **All Tools** | All 67 tools enabled (default) |
+| **All Tools** | All tools enabled (default) |
 | **Analysis Only** | Read-only analysis — Core, Errors, Code Intelligence, Tags |
 | **Code Review** | Analysis + BSL code reading (excludes `write_module_source`) |
 | **Development** | Full development without debugging tools |
@@ -256,7 +257,7 @@ When on, only the `core` toolset (navigation, source read, metadata discovery, a
 two management tools) appears in `tools/list`. To use more tools:
 
 1. Call **`list_toolsets`** to see the groups (`core`, `metadata`, `code`, `debug`,
-   `testing`, `profiling`, `forms`, `tags`, `translation`, `project`) and their tools.
+   `testing`, `profiling`, `forms`, `tags`, `translation`, `project`, `git`) and their tools.
 2. Call **`enable_toolset`** with `toolsets=[ids]` (e.g. `["code","debug"]`).
 3. **Re-request `tools/list`** — the revealed tools now appear.
 

--- a/docs/tools/git.md
+++ b/docs/tools/git.md
@@ -69,6 +69,13 @@ Anything else is **rejected** with an actionable error naming the supported set.
 
 Also rejected wherever they appear: the `--upload-pack` / `--receive-pack` / `--exec` remote/step-program options, the `--config` / `--config-env` inline-config, the `--git-dir` / `--work-tree` / `--exec-path` / `--namespace` repository redirections, and `--ext-diff` / `--output` / `--help` / `--no-index` (external driver / arbitrary file write / man viewer / reading files outside the repo), plus `--strategy` everywhere and a single-dash token that can carry `-s` on `merge`/`pull` - the cluster spells it too (`-nspwn` is `-n -s pwn`), while a value-taking letter ends it, so `-Xours` and `-mfixes` stay allowed, as do `cherry-pick -s`/`revert -s` (there `-s` is `--signoff`) (git runs the strategy as the program `git-<strategy>` from `PATH`; `-X`/`--strategy-option`, which only configures the built-in strategy, stays allowed), plus the options that take an arbitrary FILE as their value - `--contents` (`blame` prints it), `--file` / `-F` on `commit`/`tag`/`merge` (it lands in the message), `--template` and `--pathspec-from-file` - and any **global** option before the subcommand (e.g. `-c core.sshCommand=...`), since the first token must be a bare subcommand. Transports are restricted (`GIT_ALLOW_PROTOCOL`) to the safe set, so a `ext::` / `fd::` transport-helper remote (which would run an arbitrary command) is refused. A `file://` remote is refused too - git would read, and on a push WRITE, a repository anywhere on disk, and that path sits inside a URI where the repository-containment check cannot see it (a local remote written as a plain path is covered by that check).
 
+The blocked file/output options also include:
+
+- `--ignore-revs-file` - takes an arbitrary-file operand.
+- `--exclude-from` - takes an arbitrary-file operand.
+- `--exclude-per-directory` - resolves relative to every directory Git walks, so a value such as `../../x` can escape the work tree.
+- `--encoding` - can make Git emit non-UTF-8 bytes that defeat the credential redaction.
+
 ## Result
 JSON: `{ "success": <exit==0>, "exitCode": <n>, "command": "git ...", "output": "<combined stdout+stderr>" }`. A non-zero `exitCode` (a rejected push, a merge conflict, ...) is `success: false` with git's own message in `output` - never a false success. `output` is capped (`truncated: true` when it was cut). The op is bounded to 120 seconds; a stalled command is killed with a timeout error.
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/git.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/git.md
@@ -58,6 +58,13 @@ Anything else is **rejected** with an actionable error naming the supported set.
 
 Also rejected wherever they appear: the `--upload-pack` / `--receive-pack` / `--exec` remote/step-program options, the `--config` / `--config-env` inline-config, the `--git-dir` / `--work-tree` / `--exec-path` / `--namespace` repository redirections, and `--ext-diff` / `--output` / `--help` / `--no-index` (external driver / arbitrary file write / man viewer / reading files outside the repo), plus `--strategy` everywhere and a single-dash token that can carry `-s` on `merge`/`pull` - the cluster spells it too (`-nspwn` is `-n -s pwn`), while a value-taking letter ends it, so `-Xours` and `-mfixes` stay allowed, as do `cherry-pick -s`/`revert -s` (there `-s` is `--signoff`) (git runs the strategy as the program `git-<strategy>` from `PATH`; `-X`/`--strategy-option`, which only configures the built-in strategy, stays allowed), plus the options that take an arbitrary FILE as their value - `--contents` (`blame` prints it), `--file` / `-F` on `commit`/`tag`/`merge` (it lands in the message), `--template` and `--pathspec-from-file` - and any **global** option before the subcommand (e.g. `-c core.sshCommand=...`), since the first token must be a bare subcommand. Transports are restricted (`GIT_ALLOW_PROTOCOL`) to the safe set, so a `ext::` / `fd::` transport-helper remote (which would run an arbitrary command) is refused. A `file://` remote is refused too - git would read, and on a push WRITE, a repository anywhere on disk, and that path sits inside a URI where the repository-containment check cannot see it (a local remote written as a plain path is covered by that check).
 
+The blocked file/output options also include:
+
+- `--ignore-revs-file` - takes an arbitrary-file operand.
+- `--exclude-from` - takes an arbitrary-file operand.
+- `--exclude-per-directory` - resolves relative to every directory Git walks, so a value such as `../../x` can escape the work tree.
+- `--encoding` - can make Git emit non-UTF-8 bytes that defeat the credential redaction.
+
 ## Result
 JSON: `{ "success": <exit==0>, "exitCode": <n>, "command": "git ...", "output": "<combined stdout+stderr>" }`. A non-zero `exitCode` (a rejected push, a merge conflict, ...) is `success: false` with git's own message in `output` - never a false success. `output` is capped (`truncated: true` when it was cut). The op is bounded to 120 seconds; a stalled command is killed with a timeout error.
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/PreferenceConstants.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/PreferenceConstants.java
@@ -87,9 +87,10 @@ public final class PreferenceConstants
     /**
      * Migration version this build applies: 1 = the 'git' tool ships disabled; 2 = a stored
      * Analysis Only / Code Review preset (saved before {@code apply_quick_fix} existed) gains it in
-     * its disabled set, so an upgrading user's read-only preset stays read-only.
+     * its disabled set; 3 = {@code ask_workmate} ships disabled; 4 = stored preset shapes gain the
+     * tools newly disabled through group membership.
      */
-    public static final int TOOL_PREFS_MIGRATION_VERSION = 3;
+    public static final int TOOL_PREFS_MIGRATION_VERSION = 4;
 
     /** Default: all tools enabled (empty string = no disabled tools) */
     /** The raw {@code git} command tool is powerful, so it ships DISABLED by default (opt-in). */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolGroup.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolGroup.java
@@ -19,48 +19,55 @@ import java.util.Map;
 public enum ToolGroup
 {
     CORE("core", "Core / Project", //$NON-NLS-1$ //$NON-NLS-2$
-        "Essential project, configuration, and XML export/import tools", //$NON-NLS-1$
-        "get_edt_version", "list_projects", "get_configuration_properties", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        "Essential server, project, configuration, history, and XML export/import tools", //$NON-NLS-1$
+        "get_edt_version", "get_server_status", "get_tool_guide", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        "list_toolsets", "enable_toolset", "list_projects", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        "get_configuration_properties", //$NON-NLS-1$
         "clean_project", "revalidate_objects", "resync_to_disk", "get_check_description", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
         "export_configuration_to_xml", "import_configuration_from_xml", //$NON-NLS-1$ //$NON-NLS-2$
-        "delete_project", "create_project"), //$NON-NLS-1$ //$NON-NLS-2$
+        "delete_project", "create_project", "get_event_log", "get_mcp_history"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 
     PROBLEMS("problems", "Errors & Problems", //$NON-NLS-1$ //$NON-NLS-2$
-        "Error reporting and workspace markers (bookmarks, tasks)", //$NON-NLS-1$
-        "get_problem_summary", "get_project_errors", "get_markers", "apply_quick_fix"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        "Error reporting, validation, and workspace markers (bookmarks, tasks)", //$NON-NLS-1$
+        "get_problem_summary", "get_project_errors", "get_markers", "apply_quick_fix", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        "validate_xdto_package"), //$NON-NLS-1$
 
     CODE_INTELLIGENCE("codeIntelligence", "Code Intelligence", //$NON-NLS-1$ //$NON-NLS-2$
-        "Content assist, documentation, metadata browsing, and references", //$NON-NLS-1$
+        "Content assist, documentation, metadata and common-picture browsing, and references", //$NON-NLS-1$
         "get_content_assist", "get_platform_documentation", "get_metadata_objects", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        "get_metadata_details", "list_subsystems", "get_subsystem_content", "find_references"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        "get_metadata_details", "list_subsystems", "get_subsystem_content", "find_references", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        "list_common_pictures", "export_common_picture"), //$NON-NLS-1$ //$NON-NLS-2$
 
     TAGS("tags", "Tags", //$NON-NLS-1$ //$NON-NLS-2$
         "Metadata tag management", //$NON-NLS-1$
         "get_tags", "get_objects_by_tags"), //$NON-NLS-1$ //$NON-NLS-2$
 
     APPLICATIONS("applications", "Applications & Testing", //$NON-NLS-1$ //$NON-NLS-2$
-        "Application management, database update, launch, termination, testing, and Workmate", //$NON-NLS-1$
+        "Application and infobase management, external-object builds, launch, testing, and Workmate", //$NON-NLS-1$
         "get_applications", "list_configurations", "create_launch_config", "delete_launch_config", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
         "create_infobase", "delete_infobase", "update_database", "debug_launch", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-        "terminate_launch", "run_yaxunit_tests", "ask_workmate"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        "terminate_launch", "run_yaxunit_tests", "ask_workmate", "build_external_objects", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        "set_infobase_credentials"), //$NON-NLS-1$
 
     DEBUG("debug", "Debugging", //$NON-NLS-1$ //$NON-NLS-2$
         "Breakpoints, stepping, variables, expression evaluation, and profiling", //$NON-NLS-1$
         "set_breakpoint", "remove_breakpoint", "list_breakpoints", "wait_for_break", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
         "get_variables", "set_variable", "step", "resume", "evaluate_expression", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
-        "debug_yaxunit_tests", "debug_status", "start_profiling", "get_profiling_results"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        "debug_yaxunit_tests", "debug_status", "start_profiling", "stop_profiling", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        "get_profiling_results"), //$NON-NLS-1$
 
     BSL_CODE("bslCode", "BSL Code", //$NON-NLS-1$ //$NON-NLS-2$
         "Module source reading/writing, structure, search, call hierarchy, navigation, and forms", //$NON-NLS-1$
         "read_module_source", "write_module_source", "get_module_structure", "list_modules", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
         "search_in_code", "read_method_source", "get_method_call_hierarchy", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        "go_to_definition", "get_symbol_info", "get_form_layout_snapshot", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        "get_outgoing_structures", "go_to_definition", "get_symbol_info", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        "get_form_layout_snapshot", //$NON-NLS-1$
         "get_form_screenshot", "get_template_screenshot", "validate_query"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
     REFACTORING("refactoring", "Refactoring", //$NON-NLS-1$ //$NON-NLS-2$
-        "Metadata create, rename, delete and property management (objects, members and form members)", //$NON-NLS-1$
+        "Metadata create, rename, adopt, delete, and property management", //$NON-NLS-1$
         "rename_metadata_object", "delete_metadata", "create_metadata", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        "modify_metadata"), //$NON-NLS-1$
+        "modify_metadata", "adopt_metadata_object"), //$NON-NLS-1$ //$NON-NLS-2$
 
     TRANSLATION("translation", "Translation (LanguageTool)", //$NON-NLS-1$ //$NON-NLS-2$
         "LanguageTool: translation strings generation, configuration sync, project info", //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolPreset.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolPreset.java
@@ -130,9 +130,11 @@ public enum ToolPreset
     }
 
     /**
-     * Builds the Code Review preset: disable apps, debug, refactoring,
-     * write_module_source, apply_quick_fix, and the state-mutating workspace
-     * export/import tools (which sit in CORE alongside read-only project tools).
+     * Builds the Code Review preset: disable apps (including external-object builds and credential
+     * writes), debug, refactoring (including adoption into an extension), translation,
+     * write_module_source, apply_quick_fix, and the state-mutating workspace export/import tools.
+     * {@code export_common_picture} remains enabled: despite its name, it is a pure model read that
+     * returns the selected PNG as base64 and never writes a file.
      */
     private static Set<String> buildCodeReviewDisabled()
     {
@@ -149,11 +151,12 @@ public enum ToolPreset
     }
 
     /**
-     * Builds the Analysis Only preset: disable apps, debug, the entire BSL
-     * Code group (both read and write tools — analysis is metadata- and
-     * error-level only), refactoring, apply_quick_fix (a mutating write, though
-     * grouped with the read-only PROBLEMS tools), the state-mutating workspace
-     * export/import tools, and the LanguageTool translation tools.
+     * Builds the Analysis Only preset: disable apps (including external-object builds and credential
+     * writes), debug, the entire BSL Code group (both read and write tools — analysis is metadata-
+     * and error-level only), refactoring (including adoption into an extension), apply_quick_fix,
+     * the state-mutating workspace export/import tools, and the LanguageTool translation tools.
+     * {@code export_common_picture} remains enabled because it only reads model content and returns
+     * base64; it does not export to the filesystem.
      */
     private static Set<String> buildAnalysisOnlyDisabled()
     {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolSettingsService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolSettingsService.java
@@ -24,6 +24,22 @@ import com.ditrix.edt.mcp.server.Activator;
  */
 public final class ToolSettingsService // NOSONAR intentional singleton (Eclipse service / getInstance); a single instance is by design
 {
+    private static final Set<String> ANALYSIS_ONLY_V4_ADDITIONS = Set.of(
+        "adopt_metadata_object", //$NON-NLS-1$
+        "build_external_objects", //$NON-NLS-1$
+        "set_infobase_credentials", //$NON-NLS-1$
+        "stop_profiling", //$NON-NLS-1$
+        "get_outgoing_structures"); //$NON-NLS-1$
+
+    private static final Set<String> CODE_REVIEW_V4_ADDITIONS = Set.of(
+        "adopt_metadata_object", //$NON-NLS-1$
+        "build_external_objects", //$NON-NLS-1$
+        "set_infobase_credentials", //$NON-NLS-1$
+        "stop_profiling"); //$NON-NLS-1$
+
+    private static final Set<String> DEVELOPMENT_V4_ADDITIONS = Set.of(
+        "stop_profiling"); //$NON-NLS-1$
+
     private static final ToolSettingsService INSTANCE = new ToolSettingsService();
 
     private ToolSettingsService()
@@ -87,6 +103,13 @@ public final class ToolSettingsService // NOSONAR intentional singleton (Eclipse
      * still holds for a user who tightened such a preset further. A selection that merely OVERLAPS
      * one (without covering it) is left untouched. See
      * {@link #migrateApplyQuickFixIntoReadOnlyPreset} for why containment rather than equality.
+     * <p>
+     * Version 4 repairs stored preset shapes after previously ungrouped tools joined groups that
+     * those presets disable. It recognizes an older preset by containment after removing both the
+     * newly inherited names, which that store predates, and the default-disabled names, which the
+     * user may intentionally have enabled. Because the recognized shapes are nested, it tests the
+     * most restrictive shape first; otherwise a broader match would add only part of the tools owed
+     * to an Analysis Only store.
      *
      * @param store the preference store to migrate (never {@code null} here)
      */
@@ -126,6 +149,10 @@ public final class ToolSettingsService // NOSONAR intentional singleton (Eclipse
                 // reaches a cloud service and may then change the configuration with its
                 // own tools. That is a decision to opt into, not to inherit on upgrade.
                 changed |= disabled.add("ask_workmate"); //$NON-NLS-1$
+            }
+            if (storedVersion < 4)
+            {
+                changed |= migrateRegroupedToolsIntoPresets(disabled);
             }
             if (changed)
             {
@@ -188,6 +215,43 @@ public final class ToolSettingsService // NOSONAR intentional singleton (Eclipse
             }
         }
         return false;
+    }
+
+    /**
+     * Adds the version 4 group-inherited disabled names to the first stored preset shape that
+     * contains all of its older asserted tools.
+     *
+     * @param disabled the mutable stored disabled-tools set; modified in place
+     * @return {@code true} when at least one newly inherited name was added
+     */
+    private static boolean migrateRegroupedToolsIntoPresets(Set<String> disabled)
+    {
+        Set<String> optional = parseDisabledTools(PreferenceConstants.DEFAULT_DISABLED_TOOLS);
+        if (containsOldPresetShape(disabled, ToolPreset.ANALYSIS_ONLY,
+            ANALYSIS_ONLY_V4_ADDITIONS, optional))
+        {
+            return disabled.addAll(ANALYSIS_ONLY_V4_ADDITIONS);
+        }
+        if (containsOldPresetShape(disabled, ToolPreset.CODE_REVIEW,
+            CODE_REVIEW_V4_ADDITIONS, optional))
+        {
+            return disabled.addAll(CODE_REVIEW_V4_ADDITIONS);
+        }
+        if (containsOldPresetShape(disabled, ToolPreset.DEVELOPMENT,
+            DEVELOPMENT_V4_ADDITIONS, optional))
+        {
+            return disabled.addAll(DEVELOPMENT_V4_ADDITIONS);
+        }
+        return false;
+    }
+
+    private static boolean containsOldPresetShape(Set<String> disabled, ToolPreset preset,
+        Set<String> newlyDisabled, Set<String> optional)
+    {
+        Set<String> presetShape = new LinkedHashSet<>(preset.getDisabledTools());
+        presetShape.removeAll(newlyDisabled);
+        presetShape.removeAll(optional);
+        return disabled.containsAll(presetShape);
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolSettingsService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolSettingsService.java
@@ -12,7 +12,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
@@ -42,17 +41,77 @@ public final class ToolSettingsService // NOSONAR intentional singleton (Eclipse
         "stop_profiling"); //$NON-NLS-1$
 
     /*
-     * A migration predicate must describe the preset AS IT WAS WHEN THAT MIGRATION SHIPPED.
-     * ToolPreset definitions are live and grow with ToolGroup membership, so every preset name
-     * added after version 2 must also be added here or the older predicate will silently stop
-     * recognizing stores that could not yet contain it.
+     * Frozen recognition shapes: what any historical stored profile of this preset must contain.
+     * Never derive them from the live preset, which has grown over time. A shape is only ever
+     * extended after checking that every supported historical store still contains the new name.
+     *
+     * These are deliberately per-preset rather than a shared union. They omit the default-disabled
+     * tools, so a user who enabled git is still recognized, and apply_quick_fix is in none of them,
+     * so version 4 still recognizes a read-only store whose user deliberately re-enabled it.
      */
-    private static final Set<String> PRESET_ADDITIONS_AFTER_V2 = Stream.of(
-        ANALYSIS_ONLY_V4_ADDITIONS,
-        CODE_REVIEW_V4_ADDITIONS,
-        DEVELOPMENT_V4_ADDITIONS)
-        .flatMap(Set::stream)
-        .collect(Collectors.toUnmodifiableSet());
+    static final Set<String> ANALYSIS_ONLY_RECOGNITION_SHAPE = Set.of(
+        "debug_launch", //$NON-NLS-1$
+        "debug_status", //$NON-NLS-1$
+        "debug_yaxunit_tests", //$NON-NLS-1$
+        "evaluate_expression", //$NON-NLS-1$
+        "get_applications", //$NON-NLS-1$
+        "get_form_screenshot", //$NON-NLS-1$
+        "get_method_call_hierarchy", //$NON-NLS-1$
+        "get_module_structure", //$NON-NLS-1$
+        "get_profiling_results", //$NON-NLS-1$
+        "get_symbol_info", //$NON-NLS-1$
+        "get_variables", //$NON-NLS-1$
+        "go_to_definition", //$NON-NLS-1$
+        "list_breakpoints", //$NON-NLS-1$
+        "list_modules", //$NON-NLS-1$
+        "read_method_source", //$NON-NLS-1$
+        "read_module_source", //$NON-NLS-1$
+        "remove_breakpoint", //$NON-NLS-1$
+        "rename_metadata_object", //$NON-NLS-1$
+        "resume", //$NON-NLS-1$
+        "run_yaxunit_tests", //$NON-NLS-1$
+        "search_in_code", //$NON-NLS-1$
+        "set_breakpoint", //$NON-NLS-1$
+        "start_profiling", //$NON-NLS-1$
+        "step", //$NON-NLS-1$
+        "update_database", //$NON-NLS-1$
+        "validate_query", //$NON-NLS-1$
+        "wait_for_break", //$NON-NLS-1$
+        "write_module_source"); //$NON-NLS-1$
+
+    static final Set<String> CODE_REVIEW_RECOGNITION_SHAPE = Set.of(
+        "debug_launch", //$NON-NLS-1$
+        "debug_status", //$NON-NLS-1$
+        "debug_yaxunit_tests", //$NON-NLS-1$
+        "evaluate_expression", //$NON-NLS-1$
+        "get_applications", //$NON-NLS-1$
+        "get_profiling_results", //$NON-NLS-1$
+        "get_variables", //$NON-NLS-1$
+        "list_breakpoints", //$NON-NLS-1$
+        "remove_breakpoint", //$NON-NLS-1$
+        "rename_metadata_object", //$NON-NLS-1$
+        "resume", //$NON-NLS-1$
+        "run_yaxunit_tests", //$NON-NLS-1$
+        "set_breakpoint", //$NON-NLS-1$
+        "start_profiling", //$NON-NLS-1$
+        "step", //$NON-NLS-1$
+        "update_database", //$NON-NLS-1$
+        "wait_for_break", //$NON-NLS-1$
+        "write_module_source"); //$NON-NLS-1$
+
+    static final Set<String> DEVELOPMENT_RECOGNITION_SHAPE = Set.of(
+        "debug_status", //$NON-NLS-1$
+        "debug_yaxunit_tests", //$NON-NLS-1$
+        "evaluate_expression", //$NON-NLS-1$
+        "get_profiling_results", //$NON-NLS-1$
+        "get_variables", //$NON-NLS-1$
+        "list_breakpoints", //$NON-NLS-1$
+        "remove_breakpoint", //$NON-NLS-1$
+        "resume", //$NON-NLS-1$
+        "set_breakpoint", //$NON-NLS-1$
+        "start_profiling", //$NON-NLS-1$
+        "step", //$NON-NLS-1$
+        "wait_for_break"); //$NON-NLS-1$
 
     private static final ToolSettingsService INSTANCE = new ToolSettingsService();
 
@@ -111,19 +170,19 @@ public final class ToolSettingsService // NOSONAR intentional singleton (Eclipse
      * <p>
      * Version 2 covers a narrower case: {@code apply_quick_fix} is a normal (default-ON) tool, so it is
      * NOT added to every stored list the way {@code git} is - only to a list that already CONTAINS
-     * everything {@link ToolPreset#CODE_REVIEW} or {@link ToolPreset#ANALYSIS_ONLY} disables. That
-     * containment is the signature of a store saved by an older build under one of those two
-     * read-only presets, before this write-capable tool existed to be excluded from them - and it
-     * still holds for a user who tightened such a preset further. A selection that merely OVERLAPS
-     * one (without covering it) is left untouched. See
+     * the frozen recognition shape of Code Review or Analysis Only. That containment is the
+     * signature of a store saved by an older build under one of those two read-only presets, before
+     * this write-capable tool existed to be excluded from them - and it still holds for a user who
+     * tightened such a preset further. A selection that merely OVERLAPS one (without covering it)
+     * is left untouched. See
      * {@link #migrateApplyQuickFixIntoReadOnlyPreset} for why containment rather than equality.
      * <p>
      * Version 4 repairs stored preset shapes after previously ungrouped tools joined groups that
-     * those presets disable. It recognizes an older preset by containment after removing both the
-     * newly inherited names, which that store predates, and the default-disabled names, which the
-     * user may intentionally have enabled. Because the recognized shapes are nested, it tests the
-     * most restrictive shape first; otherwise a broader match would add only part of the tools owed
-     * to an Analysis Only store.
+     * those presets disable. It recognizes an older preset by containment of the frozen historical
+     * shape, which omits both names the store may predate and default-disabled names the user may
+     * intentionally have enabled. Because the recognized shapes are nested, it tests the most
+     * restrictive shape first; otherwise a broader match would add only part of the tools owed to
+     * an Analysis Only store.
      *
      * @param store the preference store to migrate (never {@code null} here)
      */
@@ -166,8 +225,8 @@ public final class ToolSettingsService // NOSONAR intentional singleton (Eclipse
             }
             if (storedVersion < 4)
             {
-                // The v4 read-only shapes intentionally still contain apply_quick_fix. Stores that
-                // also owe v2 gained it above in this same pass against this same mutable set.
+                // The v4 shapes intentionally omit apply_quick_fix, so this step recognizes a store
+                // whose user deliberately re-enabled it after version 2 without adding it back.
                 changed |= migrateRegroupedToolsIntoPresets(disabled);
             }
             if (changed)
@@ -181,8 +240,8 @@ public final class ToolSettingsService // NOSONAR intentional singleton (Eclipse
 
     /**
      * Adds {@code apply_quick_fix} to {@code disabled} when the stored list already expresses a
-     * no-write profile - i.e. it CONTAINS everything {@link ToolPreset#CODE_REVIEW} or
-     * {@link ToolPreset#ANALYSIS_ONLY} disables, whether or not it disables more on top.
+     * no-write profile - i.e. it CONTAINS the frozen recognition shape of Code Review or Analysis
+     * Only, whether or not it disables more on top.
      * <p>
      * A SUPERSET test, not an exact match, on purpose. Exact matching (via
      * {@link ToolPreset#matchPreset}) misses the ordinary case of someone who picked a read-only
@@ -200,15 +259,7 @@ public final class ToolSettingsService // NOSONAR intentional singleton (Eclipse
      * would make a hand-tuned CUSTOM selection claim to be "Code Review".
      * <p>
      * Stale/unknown names left in the stored list cannot defeat the check, which asks only whether
-     * the preset's own tools are all present.
-     * <p>
-     * The compared shape is frozen at version 2. It drops {@code apply_quick_fix}, every preset name
-     * added after version 2, and everything in
-     * {@link PreferenceConstants#DEFAULT_DISABLED_TOOLS}, which every preset merely inherits from
-     * the shipped defaults. These are all names a version-2 store either could not contain or may
-     * deliberately have switched ON. Demanding them here would make an ordinary historical store
-     * fail the containment test and miss the migration entirely, i.e. exactly the hazard this method
-     * exists to close.
+     * the frozen historical shape is present.
      *
      * @param disabled the mutable stored disabled-tools set; modified in place
      * @return {@code true} when {@code apply_quick_fix} was added
@@ -219,37 +270,15 @@ public final class ToolSettingsService // NOSONAR intentional singleton (Eclipse
         {
             return false;
         }
-        Set<String> optional = parseDisabledTools(PreferenceConstants.DEFAULT_DISABLED_TOOLS);
-        for (ToolPreset readOnly : new ToolPreset[] {ToolPreset.CODE_REVIEW, ToolPreset.ANALYSIS_ONLY})
+        if (disabled.containsAll(ANALYSIS_ONLY_RECOGNITION_SHAPE))
         {
-            Set<String> presetShape = version2PresetShape(readOnly, optional);
-            if (disabled.containsAll(presetShape))
-            {
-                return disabled.add("apply_quick_fix"); //$NON-NLS-1$
-            }
+            return disabled.add("apply_quick_fix"); //$NON-NLS-1$
+        }
+        if (disabled.containsAll(CODE_REVIEW_RECOGNITION_SHAPE))
+        {
+            return disabled.add("apply_quick_fix"); //$NON-NLS-1$
         }
         return false;
-    }
-
-    private static Set<String> version2PresetShape(ToolPreset preset, Set<String> optional)
-    {
-        Set<String> presetShape = new LinkedHashSet<>(preset.getDisabledTools());
-        presetShape.remove("apply_quick_fix"); //$NON-NLS-1$
-        presetShape.removeAll(PRESET_ADDITIONS_AFTER_V2);
-        presetShape.removeAll(optional);
-        return presetShape;
-    }
-
-    /**
-     * Test seam for the frozen version-2 predicate.
-     *
-     * @param preset the read-only preset whose version-2 shape is required
-     * @return the names a version-2 store must contain for that preset
-     */
-    static Set<String> version2PresetShapeForTest(ToolPreset preset)
-    {
-        return Set.copyOf(version2PresetShape(preset,
-            parseDisabledTools(PreferenceConstants.DEFAULT_DISABLED_TOOLS)));
     }
 
     /**
@@ -261,32 +290,19 @@ public final class ToolSettingsService // NOSONAR intentional singleton (Eclipse
      */
     private static boolean migrateRegroupedToolsIntoPresets(Set<String> disabled)
     {
-        Set<String> optional = parseDisabledTools(PreferenceConstants.DEFAULT_DISABLED_TOOLS);
-        if (containsOldPresetShape(disabled, ToolPreset.ANALYSIS_ONLY,
-            ANALYSIS_ONLY_V4_ADDITIONS, optional))
+        if (disabled.containsAll(ANALYSIS_ONLY_RECOGNITION_SHAPE))
         {
             return disabled.addAll(ANALYSIS_ONLY_V4_ADDITIONS);
         }
-        if (containsOldPresetShape(disabled, ToolPreset.CODE_REVIEW,
-            CODE_REVIEW_V4_ADDITIONS, optional))
+        if (disabled.containsAll(CODE_REVIEW_RECOGNITION_SHAPE))
         {
             return disabled.addAll(CODE_REVIEW_V4_ADDITIONS);
         }
-        if (containsOldPresetShape(disabled, ToolPreset.DEVELOPMENT,
-            DEVELOPMENT_V4_ADDITIONS, optional))
+        if (disabled.containsAll(DEVELOPMENT_RECOGNITION_SHAPE))
         {
             return disabled.addAll(DEVELOPMENT_V4_ADDITIONS);
         }
         return false;
-    }
-
-    private static boolean containsOldPresetShape(Set<String> disabled, ToolPreset preset,
-        Set<String> newlyDisabled, Set<String> optional)
-    {
-        Set<String> presetShape = new LinkedHashSet<>(preset.getDisabledTools());
-        presetShape.removeAll(newlyDisabled);
-        presetShape.removeAll(optional);
-        return disabled.containsAll(presetShape);
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolSettingsService.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolSettingsService.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
@@ -39,6 +40,19 @@ public final class ToolSettingsService // NOSONAR intentional singleton (Eclipse
 
     private static final Set<String> DEVELOPMENT_V4_ADDITIONS = Set.of(
         "stop_profiling"); //$NON-NLS-1$
+
+    /*
+     * A migration predicate must describe the preset AS IT WAS WHEN THAT MIGRATION SHIPPED.
+     * ToolPreset definitions are live and grow with ToolGroup membership, so every preset name
+     * added after version 2 must also be added here or the older predicate will silently stop
+     * recognizing stores that could not yet contain it.
+     */
+    private static final Set<String> PRESET_ADDITIONS_AFTER_V2 = Stream.of(
+        ANALYSIS_ONLY_V4_ADDITIONS,
+        CODE_REVIEW_V4_ADDITIONS,
+        DEVELOPMENT_V4_ADDITIONS)
+        .flatMap(Set::stream)
+        .collect(Collectors.toUnmodifiableSet());
 
     private static final ToolSettingsService INSTANCE = new ToolSettingsService();
 
@@ -152,6 +166,8 @@ public final class ToolSettingsService // NOSONAR intentional singleton (Eclipse
             }
             if (storedVersion < 4)
             {
+                // The v4 read-only shapes intentionally still contain apply_quick_fix. Stores that
+                // also owe v2 gained it above in this same pass against this same mutable set.
                 changed |= migrateRegroupedToolsIntoPresets(disabled);
             }
             if (changed)
@@ -186,13 +202,13 @@ public final class ToolSettingsService // NOSONAR intentional singleton (Eclipse
      * Stale/unknown names left in the stored list cannot defeat the check, which asks only whether
      * the preset's own tools are all present.
      * <p>
-     * The compared shape drops the tools a preset does not really assert: {@code apply_quick_fix}
-     * (today's presets exclude it, but the stored list predates it by definition) and everything in
+     * The compared shape is frozen at version 2. It drops {@code apply_quick_fix}, every preset name
+     * added after version 2, and everything in
      * {@link PreferenceConstants#DEFAULT_DISABLED_TOOLS}, which every preset merely inherits from
-     * the shipped defaults. Both are things the user may deliberately have switched ON - notably the
-     * opt-in {@code git} tool - and demanding them here would make an ordinary "Code Review, but I
-     * do use git" store fail the containment test and miss the migration entirely, i.e. exactly the
-     * hazard this method exists to close.
+     * the shipped defaults. These are all names a version-2 store either could not contain or may
+     * deliberately have switched ON. Demanding them here would make an ordinary historical store
+     * fail the containment test and miss the migration entirely, i.e. exactly the hazard this method
+     * exists to close.
      *
      * @param disabled the mutable stored disabled-tools set; modified in place
      * @return {@code true} when {@code apply_quick_fix} was added
@@ -206,15 +222,34 @@ public final class ToolSettingsService // NOSONAR intentional singleton (Eclipse
         Set<String> optional = parseDisabledTools(PreferenceConstants.DEFAULT_DISABLED_TOOLS);
         for (ToolPreset readOnly : new ToolPreset[] {ToolPreset.CODE_REVIEW, ToolPreset.ANALYSIS_ONLY})
         {
-            Set<String> presetShape = new LinkedHashSet<>(readOnly.getDisabledTools());
-            presetShape.remove("apply_quick_fix"); //$NON-NLS-1$
-            presetShape.removeAll(optional);
+            Set<String> presetShape = version2PresetShape(readOnly, optional);
             if (disabled.containsAll(presetShape))
             {
                 return disabled.add("apply_quick_fix"); //$NON-NLS-1$
             }
         }
         return false;
+    }
+
+    private static Set<String> version2PresetShape(ToolPreset preset, Set<String> optional)
+    {
+        Set<String> presetShape = new LinkedHashSet<>(preset.getDisabledTools());
+        presetShape.remove("apply_quick_fix"); //$NON-NLS-1$
+        presetShape.removeAll(PRESET_ADDITIONS_AFTER_V2);
+        presetShape.removeAll(optional);
+        return presetShape;
+    }
+
+    /**
+     * Test seam for the frozen version-2 predicate.
+     *
+     * @param preset the read-only preset whose version-2 shape is required
+     * @return the names a version-2 store must contain for that preset
+     */
+    static Set<String> version2PresetShapeForTest(ToolPreset preset)
+    {
+        return Set.copyOf(version2PresetShape(preset,
+            parseDisabledTools(PreferenceConstants.DEFAULT_DISABLED_TOOLS)));
     }
 
     /**

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupCoverageTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupCoverageTest.java
@@ -1,0 +1,103 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.preferences;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.tools.BuiltInToolRegistrar;
+import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.tools.McpToolRegistry;
+
+/**
+ * Registry-driven ratchet for the Tools preference model: every production tool must belong to
+ * exactly one {@link ToolGroup}, and every name declared by a group must still be registered.
+ */
+public class ToolGroupCoverageTest
+{
+    private McpToolRegistry registry;
+
+    @Before
+    public void setUp()
+    {
+        registry = McpToolRegistry.getInstance();
+        BuiltInToolRegistrar.registerAll(registry);
+    }
+
+    @After
+    public void tearDown()
+    {
+        registry.clear();
+    }
+
+    /** Sanity: production registration must run, otherwise both coverage checks pass vacuously. */
+    @Test
+    public void testRegistryIsPopulated()
+    {
+        assertTrue("registerAll() should register a non-trivial production tool set", //$NON-NLS-1$
+            registry.getToolCount() >= 50);
+    }
+
+    @Test
+    public void testEveryRegisteredToolBelongsToExactlyOneGroup()
+    {
+        List<String> violations = new ArrayList<>();
+        for (IMcpTool tool : registry.getAllTools())
+        {
+            int memberships = 0;
+            for (ToolGroup group : ToolGroup.values())
+            {
+                if (group.getToolNames().contains(tool.getName()))
+                {
+                    memberships++;
+                }
+            }
+            if (ToolGroup.getGroupForTool(tool.getName()) == null || memberships != 1)
+            {
+                violations.add(tool.getName() + " (memberships=" + memberships + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+            }
+        }
+
+        assertTrue("Registered tools must belong to exactly one ToolGroup: " + violations //$NON-NLS-1$
+            + ". Add each offending tool to the right group in ToolGroup and remove duplicates.", //$NON-NLS-1$
+            violations.isEmpty());
+    }
+
+    @Test
+    public void testEveryGroupedToolIsRegistered()
+    {
+        Set<String> registered = new HashSet<>();
+        for (IMcpTool tool : registry.getAllTools())
+        {
+            registered.add(tool.getName());
+        }
+
+        List<String> stale = new ArrayList<>();
+        for (ToolGroup group : ToolGroup.values())
+        {
+            for (String toolName : group.getToolNames())
+            {
+                if (!registered.contains(toolName))
+                {
+                    stale.add(toolName + " (" + group.name() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+                }
+            }
+        }
+
+        assertTrue("ToolGroup contains names that are not registered tools: " + stale //$NON-NLS-1$
+            + ". Replace each stale name and add the registered tool to the right group in ToolGroup.", //$NON-NLS-1$
+            stale.isEmpty());
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolGroupTest.java
@@ -165,7 +165,13 @@ public class ToolGroupTest
         assertTrue(tools.contains("delete_project"));
         assertTrue(tools.contains("resync_to_disk"));
         assertTrue(tools.contains("create_project"));
-        assertEquals(11, tools.size());
+        assertTrue(tools.contains("get_server_status")); //$NON-NLS-1$
+        assertTrue(tools.contains("get_tool_guide")); //$NON-NLS-1$
+        assertTrue(tools.contains("list_toolsets")); //$NON-NLS-1$
+        assertTrue(tools.contains("enable_toolset")); //$NON-NLS-1$
+        assertTrue(tools.contains("get_event_log")); //$NON-NLS-1$
+        assertTrue(tools.contains("get_mcp_history")); //$NON-NLS-1$
+        assertEquals(17, tools.size());
     }
 
     @Test
@@ -176,7 +182,8 @@ public class ToolGroupTest
         assertTrue(tools.contains("resume"));
         assertTrue(tools.contains("get_variables"));
         assertTrue(tools.contains("set_variable"));
-        assertEquals(13, tools.size());
+        assertTrue(tools.contains("stop_profiling")); //$NON-NLS-1$
+        assertEquals(14, tools.size());
     }
 
     @Test
@@ -216,11 +223,12 @@ public class ToolGroupTest
         // add_form_*/set_form_item_property/delete_form_item tools were folded into
         // create/modify/delete_metadata and removed in F4b).
         assertTrue(tools.contains("modify_metadata"));
+        assertTrue(tools.contains("adopt_metadata_object")); //$NON-NLS-1$
         assertFalse(tools.contains("add_form_attribute"));
         assertFalse(tools.contains("set_form_item_property"));
         assertFalse(tools.contains("add_form_command"));
         assertFalse(tools.contains("delete_form_item"));
         assertFalse(tools.contains("add_form_item"));
-        assertEquals(4, tools.size());
+        assertEquals(5, tools.size());
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolPresetTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolPresetTest.java
@@ -70,12 +70,20 @@ public class ToolPresetTest
         assertTrue("Should disable set_breakpoint", disabled.contains("set_breakpoint"));
         assertTrue("Should disable write_module_source", disabled.contains("write_module_source"));
         assertTrue("Should disable rename_metadata_object", disabled.contains("rename_metadata_object"));
+        assertTrue("Should disable adopt_metadata_object", //$NON-NLS-1$
+            disabled.contains("adopt_metadata_object")); //$NON-NLS-1$
+        assertTrue("Should disable build_external_objects", //$NON-NLS-1$
+            disabled.contains("build_external_objects")); //$NON-NLS-1$
+        assertTrue("Should disable set_infobase_credentials", //$NON-NLS-1$
+            disabled.contains("set_infobase_credentials")); //$NON-NLS-1$
 
         // Should NOT disable core, problems, code intelligence, tags
         assertFalse("Should not disable get_edt_version", disabled.contains("get_edt_version"));
         assertFalse("Should not disable get_project_errors", disabled.contains("get_project_errors"));
         assertFalse("Should not disable get_metadata_objects", disabled.contains("get_metadata_objects"));
         assertFalse("Should not disable get_tags", disabled.contains("get_tags"));
+        assertFalse("Should not disable the read-only export_common_picture", //$NON-NLS-1$
+            disabled.contains("export_common_picture")); //$NON-NLS-1$
     }
 
     // === CODE_REVIEW preset ===
@@ -94,6 +102,14 @@ public class ToolPresetTest
         // Should disable refactoring and debug
         assertTrue("Should disable rename_metadata_object", disabled.contains("rename_metadata_object"));
         assertTrue("Should disable set_breakpoint", disabled.contains("set_breakpoint"));
+        assertTrue("Should disable adopt_metadata_object", //$NON-NLS-1$
+            disabled.contains("adopt_metadata_object")); //$NON-NLS-1$
+        assertTrue("Should disable build_external_objects", //$NON-NLS-1$
+            disabled.contains("build_external_objects")); //$NON-NLS-1$
+        assertTrue("Should disable set_infobase_credentials", //$NON-NLS-1$
+            disabled.contains("set_infobase_credentials")); //$NON-NLS-1$
+        assertFalse("Should not disable the read-only export_common_picture", //$NON-NLS-1$
+            disabled.contains("export_common_picture")); //$NON-NLS-1$
     }
 
     // === DEVELOPMENT preset ===
@@ -107,6 +123,8 @@ public class ToolPresetTest
         // Should disable debug tools
         assertTrue("Should disable set_breakpoint", disabled.contains("set_breakpoint"));
         assertTrue("Should disable resume", disabled.contains("resume"));
+        assertTrue("Should disable stop_profiling", //$NON-NLS-1$
+            disabled.contains("stop_profiling")); //$NON-NLS-1$
 
         // Should NOT disable BSL code or refactoring
         assertFalse("Should not disable write_module_source", disabled.contains("write_module_source"));

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolSettingsServiceTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolSettingsServiceTest.java
@@ -8,11 +8,10 @@ package com.ditrix.edt.mcp.server.preferences;
 
 import static org.junit.Assert.*;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.eclipse.jface.preference.PreferenceStore;
 import org.junit.Test;
@@ -38,6 +37,71 @@ public class ToolSettingsServiceTest
 
     private static final Set<String> DEVELOPMENT_V4_ADDITIONS = Set.of(
         "stop_profiling"); //$NON-NLS-1$
+
+    /* Independent first-release fixtures: never derive these from the production constants. */
+    private static final Set<String> FIRST_RELEASE_ANALYSIS_ONLY_SHAPE = Set.of(
+        "debug_launch", //$NON-NLS-1$
+        "debug_status", //$NON-NLS-1$
+        "debug_yaxunit_tests", //$NON-NLS-1$
+        "evaluate_expression", //$NON-NLS-1$
+        "get_applications", //$NON-NLS-1$
+        "get_form_screenshot", //$NON-NLS-1$
+        "get_method_call_hierarchy", //$NON-NLS-1$
+        "get_module_structure", //$NON-NLS-1$
+        "get_profiling_results", //$NON-NLS-1$
+        "get_symbol_info", //$NON-NLS-1$
+        "get_variables", //$NON-NLS-1$
+        "go_to_definition", //$NON-NLS-1$
+        "list_breakpoints", //$NON-NLS-1$
+        "list_modules", //$NON-NLS-1$
+        "read_method_source", //$NON-NLS-1$
+        "read_module_source", //$NON-NLS-1$
+        "remove_breakpoint", //$NON-NLS-1$
+        "rename_metadata_object", //$NON-NLS-1$
+        "resume", //$NON-NLS-1$
+        "run_yaxunit_tests", //$NON-NLS-1$
+        "search_in_code", //$NON-NLS-1$
+        "set_breakpoint", //$NON-NLS-1$
+        "start_profiling", //$NON-NLS-1$
+        "step", //$NON-NLS-1$
+        "update_database", //$NON-NLS-1$
+        "validate_query", //$NON-NLS-1$
+        "wait_for_break", //$NON-NLS-1$
+        "write_module_source"); //$NON-NLS-1$
+
+    private static final Set<String> FIRST_RELEASE_CODE_REVIEW_SHAPE = Set.of(
+        "debug_launch", //$NON-NLS-1$
+        "debug_status", //$NON-NLS-1$
+        "debug_yaxunit_tests", //$NON-NLS-1$
+        "evaluate_expression", //$NON-NLS-1$
+        "get_applications", //$NON-NLS-1$
+        "get_profiling_results", //$NON-NLS-1$
+        "get_variables", //$NON-NLS-1$
+        "list_breakpoints", //$NON-NLS-1$
+        "remove_breakpoint", //$NON-NLS-1$
+        "rename_metadata_object", //$NON-NLS-1$
+        "resume", //$NON-NLS-1$
+        "run_yaxunit_tests", //$NON-NLS-1$
+        "set_breakpoint", //$NON-NLS-1$
+        "start_profiling", //$NON-NLS-1$
+        "step", //$NON-NLS-1$
+        "update_database", //$NON-NLS-1$
+        "wait_for_break", //$NON-NLS-1$
+        "write_module_source"); //$NON-NLS-1$
+
+    private static final Set<String> FIRST_RELEASE_DEVELOPMENT_SHAPE = Set.of(
+        "debug_status", //$NON-NLS-1$
+        "debug_yaxunit_tests", //$NON-NLS-1$
+        "evaluate_expression", //$NON-NLS-1$
+        "get_profiling_results", //$NON-NLS-1$
+        "get_variables", //$NON-NLS-1$
+        "list_breakpoints", //$NON-NLS-1$
+        "remove_breakpoint", //$NON-NLS-1$
+        "resume", //$NON-NLS-1$
+        "set_breakpoint", //$NON-NLS-1$
+        "start_profiling", //$NON-NLS-1$
+        "step", //$NON-NLS-1$
+        "wait_for_break"); //$NON-NLS-1$
 
     // === parseDisabledTools ===
 
@@ -171,361 +235,184 @@ public class ToolSettingsServiceTest
         }
     }
 
-    /**
-     * The migration is the ONLY thing that keeps a default-off tool disabled on an EXISTING
-     * installation: a stored list from before that tool existed does not contain it, and the shipped
-     * default no longer applies once anything was stored. Without this test a regression would
-     * silently enable the raw git tool for every upgrading user.
-     */
     @Test
     public void testMigrationAddsTheDefaultOffToolToAnExistingStoredList()
     {
-        PreferenceStore store = new PreferenceStore();
-        store.setDefault(PreferenceConstants.PREF_DISABLED_TOOLS,
-            PreferenceConstants.DEFAULT_DISABLED_TOOLS);
-        store.setDefault(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 0);
-        // An installation that stored its own selection before 'git' existed.
-        store.setValue(PreferenceConstants.PREF_DISABLED_TOOLS, "debug_launch,run_yaxunit_tests");
+        PreferenceStore store = storedDisabledToolsWithoutMigrationKey(
+            Set.of("debug_launch", "run_yaxunit_tests")); //$NON-NLS-1$ //$NON-NLS-2$
 
         ToolSettingsService.ensureMigratedForTest(store);
 
-        Set<String> disabled = ToolSettingsService.parseDisabledTools(
-            store.getString(PreferenceConstants.PREF_DISABLED_TOOLS));
-        assertTrue("the migration must add the default-off tool: " + disabled,
-            disabled.contains("git"));
-        assertTrue("it must keep what the user had chosen: " + disabled,
-            disabled.contains("debug_launch") && disabled.contains("run_yaxunit_tests"));
-        assertEquals("the migration must be recorded so it runs once",
-            PreferenceConstants.TOOL_PREFS_MIGRATION_VERSION,
+        Set<String> disabled = disabledTools(store);
+        assertTrue("the migration must add git: " + disabled, disabled.contains("git")); //$NON-NLS-1$
+        assertTrue("it must keep what the user chose: " + disabled,
+            disabled.contains("debug_launch") && disabled.contains("run_yaxunit_tests")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(PreferenceConstants.TOOL_PREFS_MIGRATION_VERSION,
             store.getInt(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION));
     }
 
-    /**
-     * ask_workmate hands the question to an external plugin that reaches a cloud service and
-     * can then change the configuration with its own tools, so it must arrive DISABLED both on
-     * a fresh install (the shipped default) and on an upgrade (the version 3 migration).
-     */
     @Test
     public void testAskWorkmateIsOffByDefaultAndOnUpgrade()
     {
         assertTrue("the shipped default must disable ask_workmate",
             ToolSettingsService.parseDisabledTools(PreferenceConstants.DEFAULT_DISABLED_TOOLS)
-                .contains("ask_workmate"));
+                .contains("ask_workmate")); //$NON-NLS-1$
 
-        PreferenceStore store = new PreferenceStore();
-        store.setDefault(PreferenceConstants.PREF_DISABLED_TOOLS,
-            PreferenceConstants.DEFAULT_DISABLED_TOOLS);
-        store.setDefault(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 0);
-        // A store saved before ask_workmate existed, already past the earlier migrations.
-        store.setValue(PreferenceConstants.PREF_DISABLED_TOOLS, "debug_launch");
-        store.setValue(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 2);
+        PreferenceStore store = storedDisabledTools(Set.of("debug_launch"), 2); //$NON-NLS-1$
 
         ToolSettingsService.ensureMigratedForTest(store);
 
-        Set<String> disabled = ToolSettingsService.parseDisabledTools(
-            store.getString(PreferenceConstants.PREF_DISABLED_TOOLS));
+        Set<String> disabled = disabledTools(store);
         assertTrue("the upgrade must disable ask_workmate: " + disabled,
-            disabled.contains("ask_workmate"));
-        assertTrue("it must keep what the user had chosen: " + disabled,
-            disabled.contains("debug_launch"));
-        // The earlier steps are past their own thresholds and must NOT re-run.
-        assertFalse("a git choice made earlier must survive: " + disabled,
-            disabled.contains("git"));
+            disabled.contains("ask_workmate")); //$NON-NLS-1$
+        assertFalse("the earlier git migration must not rerun: " + disabled,
+            disabled.contains("git")); //$NON-NLS-1$
     }
 
-    @Test
-    public void testMigrationDoesNotReAddAToolTheUserDeliberatelyEnabled()
-    {
-        PreferenceStore store = new PreferenceStore();
-        store.setDefault(PreferenceConstants.PREF_DISABLED_TOOLS,
-            PreferenceConstants.DEFAULT_DISABLED_TOOLS);
-        store.setDefault(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 0);
-        store.setValue(PreferenceConstants.PREF_DISABLED_TOOLS, "debug_launch");
-        // Already migrated: the user has since ENABLED git on purpose.
-        store.setValue(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION,
-            PreferenceConstants.TOOL_PREFS_MIGRATION_VERSION);
-
-        ToolSettingsService.ensureMigratedForTest(store);
-
-        Set<String> disabled = ToolSettingsService.parseDisabledTools(
-            store.getString(PreferenceConstants.PREF_DISABLED_TOOLS));
-        assertFalse("a one-time migration must not fight the user's choice: " + disabled,
-            disabled.contains("git"));
-    }
-
-    /**
-     * The regression this guards: the OLD code gated BOTH the v1 (git) and v2 (apply_quick_fix)
-     * steps behind a single "storedVersion &lt; CURRENT(=2)" check. For a store already at
-     * version 1 - meaning the v1 git-migration ALREADY ran once, and the user has SINCE
-     * deliberately removed git again - upgrading to a build with version 2 would re-enter that
-     * shared block and unconditionally re-add git, silently fighting the user's later choice.
-     * Each step must instead be gated by its OWN threshold ({@code storedVersion < 1} for git),
-     * so a store already past that threshold never re-runs it just because a LATER, unrelated
-     * migration also needs to apply.
-     */
     @Test
     public void testMigrationToVersion2DoesNotReAddGitRemovedAfterVersion1()
     {
-        PreferenceStore store = new PreferenceStore();
-        store.setDefault(PreferenceConstants.PREF_DISABLED_TOOLS,
-            PreferenceConstants.DEFAULT_DISABLED_TOOLS);
-        store.setDefault(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 0);
-        // An arbitrary custom selection WITHOUT git - the user's choice, made after the version 1
-        // migration (which this store already passed through) had added it.
-        store.setValue(PreferenceConstants.PREF_DISABLED_TOOLS, "debug_launch");
-        // Already at version 1 (NOT the current version, and NOT 0) - this is the exact
-        // intermediate state the bug required: past v1, still owing v2.
-        store.setValue(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 1);
+        PreferenceStore store = storedDisabledTools(Set.of("debug_launch"), 1); //$NON-NLS-1$
 
         ToolSettingsService.ensureMigratedForTest(store);
 
-        Set<String> disabled = ToolSettingsService.parseDisabledTools(
-            store.getString(PreferenceConstants.PREF_DISABLED_TOOLS));
-        assertFalse("a git choice made after version 1 must survive the version 2 migration: "
-            + disabled, disabled.contains("git"));
-        assertEquals("the store must still be recorded as fully migrated",
-            PreferenceConstants.TOOL_PREFS_MIGRATION_VERSION,
-            store.getInt(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION));
-    }
-
-    /**
-     * The companion of the regression test above: a store at version 1 whose selection was NOT
-     * touched since (still exactly the Code Review shape minus apply_quick_fix, git included -
-     * what the version 1 migration itself would have produced under Code Review) must still gain
-     * apply_quick_fix normally when the version 2 migration runs. Confirms the per-step version
-     * gating does not accidentally suppress a migration that legitimately still applies.
-     */
-    @Test
-    public void testMigrationToVersion2StillAppliesWhenNothingElseChangedSinceVersion1()
-    {
-        PreferenceStore store = new PreferenceStore();
-        store.setDefault(PreferenceConstants.PREF_DISABLED_TOOLS,
-            PreferenceConstants.DEFAULT_DISABLED_TOOLS);
-        store.setDefault(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 0);
-        Set<String> afterV1 = new HashSet<>(ToolPreset.CODE_REVIEW.getDisabledTools());
-        afterV1.remove("apply_quick_fix"); // not migrated in yet - that's version 2's own job
-        store.setValue(PreferenceConstants.PREF_DISABLED_TOOLS,
-            ToolSettingsService.serializeDisabledTools(afterV1));
-        store.setValue(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 1);
-
-        ToolSettingsService.ensureMigratedForTest(store);
-
-        Set<String> disabled = ToolSettingsService.parseDisabledTools(
-            store.getString(PreferenceConstants.PREF_DISABLED_TOOLS));
-        assertTrue("git must still be present (untouched since version 1): " + disabled,
-            disabled.contains("git"));
-        assertTrue("version 2's own migration must still apply normally: " + disabled,
-            disabled.contains("apply_quick_fix"));
+        Set<String> disabled = disabledTools(store);
+        assertFalse("a git choice made after version 1 must survive: " + disabled,
+            disabled.contains("git")); //$NON-NLS-1$
         assertEquals(PreferenceConstants.TOOL_PREFS_MIGRATION_VERSION,
             store.getInt(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION));
     }
 
-    /**
-     * apply_quick_fix is a normal (default-ON) tool, unlike git - so the migration must not add it
-     * to every stored list, only to one that, once it gains apply_quick_fix, becomes EXACTLY a
-     * read-only preset's current shape: the signature of a store saved by a build that predates the
-     * tool, under Code Review or Analysis Only, before it existed to be excluded from them.
-     */
     @Test
-    public void testMigrationAddsApplyQuickFixToAPreExistingCodeReviewPreset()
+    public void testMigrationDoesNotTouchAStoreAlreadyAtCurrentVersion()
     {
-        PreferenceStore store = new PreferenceStore();
-        store.setDefault(PreferenceConstants.PREF_DISABLED_TOOLS,
-            PreferenceConstants.DEFAULT_DISABLED_TOOLS);
-        store.setDefault(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 0);
-        // What an installation running Code Review would have persisted BEFORE apply_quick_fix
-        // was added to the preset's definition.
-        Set<String> oldShape = new HashSet<>(ToolPreset.CODE_REVIEW.getDisabledTools());
-        oldShape.remove("apply_quick_fix");
-        store.setValue(PreferenceConstants.PREF_DISABLED_TOOLS,
-            ToolSettingsService.serializeDisabledTools(oldShape));
-
-        ToolSettingsService.ensureMigratedForTest(store);
-
-        Set<String> disabled = ToolSettingsService.parseDisabledTools(
-            store.getString(PreferenceConstants.PREF_DISABLED_TOOLS));
-        assertTrue("a stored Code Review preset must gain apply_quick_fix on migration: " + disabled,
-            disabled.contains("apply_quick_fix"));
-    }
-
-    @Test
-    public void testMigrationAddsApplyQuickFixToAPreExistingAnalysisOnlyPreset()
-    {
-        PreferenceStore store = new PreferenceStore();
-        store.setDefault(PreferenceConstants.PREF_DISABLED_TOOLS,
-            PreferenceConstants.DEFAULT_DISABLED_TOOLS);
-        store.setDefault(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 0);
-        Set<String> oldShape = new HashSet<>(ToolPreset.ANALYSIS_ONLY.getDisabledTools());
-        oldShape.remove("apply_quick_fix");
-        store.setValue(PreferenceConstants.PREF_DISABLED_TOOLS,
-            ToolSettingsService.serializeDisabledTools(oldShape));
-
-        ToolSettingsService.ensureMigratedForTest(store);
-
-        Set<String> disabled = ToolSettingsService.parseDisabledTools(
-            store.getString(PreferenceConstants.PREF_DISABLED_TOOLS));
-        assertTrue("a stored Analysis Only preset must gain apply_quick_fix on migration: " + disabled,
-            disabled.contains("apply_quick_fix"));
-    }
-
-    @Test
-    public void testMigrationDoesNotAddApplyQuickFixToACustomSelection()
-    {
-        PreferenceStore store = new PreferenceStore();
-        store.setDefault(PreferenceConstants.PREF_DISABLED_TOOLS,
-            PreferenceConstants.DEFAULT_DISABLED_TOOLS);
-        store.setDefault(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 0);
-        // A genuinely custom selection that merely OVERLAPS a preset in a couple of tools must not
-        // be mistaken for one: the migration asks whether the stored list CONTAINS a whole
-        // read-only preset, and two tools out of that preset is not that preset.
-        store.setValue(PreferenceConstants.PREF_DISABLED_TOOLS, "debug_launch,run_yaxunit_tests");
-
-        ToolSettingsService.ensureMigratedForTest(store);
-
-        Set<String> disabled = ToolSettingsService.parseDisabledTools(
-            store.getString(PreferenceConstants.PREF_DISABLED_TOOLS));
-        assertFalse("a custom selection must not gain apply_quick_fix: " + disabled,
-            disabled.contains("apply_quick_fix"));
-    }
-
-    @Test
-    public void testMigrationDoesNotFightAUserWhoAlreadyEnabledApplyQuickFix()
-    {
-        PreferenceStore store = new PreferenceStore();
-        store.setDefault(PreferenceConstants.PREF_DISABLED_TOOLS,
-            PreferenceConstants.DEFAULT_DISABLED_TOOLS);
-        store.setDefault(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 0);
-        // Already migrated once (version stored == current): a user who has since deliberately
-        // re-enabled apply_quick_fix under an otherwise Code-Review-shaped selection must be left
-        // alone by a later migration run.
-        Set<String> shape = new HashSet<>(ToolPreset.CODE_REVIEW.getDisabledTools());
-        shape.remove("apply_quick_fix");
-        store.setValue(PreferenceConstants.PREF_DISABLED_TOOLS,
-            ToolSettingsService.serializeDisabledTools(shape));
-        store.setValue(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION,
+        Set<String> selection = Set.of("debug_launch"); //$NON-NLS-1$
+        PreferenceStore store = storedDisabledTools(selection,
             PreferenceConstants.TOOL_PREFS_MIGRATION_VERSION);
 
         ToolSettingsService.ensureMigratedForTest(store);
 
-        Set<String> disabled = ToolSettingsService.parseDisabledTools(
-            store.getString(PreferenceConstants.PREF_DISABLED_TOOLS));
-        assertFalse("an already-migrated store must not be touched again: " + disabled,
-            disabled.contains("apply_quick_fix"));
+        assertEquals(selection, disabledTools(store));
     }
 
     @Test
-    public void testMigrationAddsApplyQuickFixToAReadOnlyPresetTheUserTightenedFurther()
+    public void testVersion2MigrationLeavesAnOverlappingCustomSelectionWithoutQuickFix()
     {
-        PreferenceStore store = new PreferenceStore();
-        store.setDefault(PreferenceConstants.PREF_DISABLED_TOOLS,
-            PreferenceConstants.DEFAULT_DISABLED_TOOLS);
-        store.setDefault(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 0);
-        // The ordinary upgrade path an EXACT-match migration missed: picked Code Review, then
-        // unticked one more tool. The stored list is a strict SUPERSET of the preset, so it is
-        // still a no-write profile - the write-capable quick-fix tool must not arrive enabled in it.
-        Set<String> tightened = new HashSet<>(ToolPreset.CODE_REVIEW.getDisabledTools());
-        tightened.remove("apply_quick_fix");
-        tightened.add("get_form_screenshot");
-        store.setValue(PreferenceConstants.PREF_DISABLED_TOOLS,
-            ToolSettingsService.serializeDisabledTools(tightened));
+        PreferenceStore store = storedDisabledTools(
+            Set.of("debug_launch", "run_yaxunit_tests"), 1); //$NON-NLS-1$ //$NON-NLS-2$
 
         ToolSettingsService.ensureMigratedForTest(store);
 
-        Set<String> disabled = ToolSettingsService.parseDisabledTools(
-            store.getString(PreferenceConstants.PREF_DISABLED_TOOLS));
-        assertTrue("a Code Review preset the user tightened further is still a no-write profile "
-            + "and must gain apply_quick_fix: " + disabled, disabled.contains("apply_quick_fix"));
-        assertTrue("the migration must not drop the user's own extra selection: " + disabled,
-            disabled.contains("get_form_screenshot"));
+        assertFalse("a partial overlap must not gain apply_quick_fix: " + disabledTools(store),
+            disabledTools(store).contains("apply_quick_fix")); //$NON-NLS-1$
     }
 
     @Test
-    public void testMigrationAddsApplyQuickFixToAnAnalysisOnlyPresetTheUserTightenedFurther()
+    public void testVersion2RecognizesFirstReleaseCodeReviewAtVersion1()
     {
-        PreferenceStore store = new PreferenceStore();
-        store.setDefault(PreferenceConstants.PREF_DISABLED_TOOLS,
-            PreferenceConstants.DEFAULT_DISABLED_TOOLS);
-        store.setDefault(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 0);
-        Set<String> tightened = new HashSet<>(ToolPreset.ANALYSIS_ONLY.getDisabledTools());
-        tightened.remove("apply_quick_fix");
-        tightened.add("get_markers");
-        store.setValue(PreferenceConstants.PREF_DISABLED_TOOLS,
-            ToolSettingsService.serializeDisabledTools(tightened));
-
-        ToolSettingsService.ensureMigratedForTest(store);
-
-        Set<String> disabled = ToolSettingsService.parseDisabledTools(
-            store.getString(PreferenceConstants.PREF_DISABLED_TOOLS));
-        assertTrue("an Analysis Only preset the user tightened further must gain apply_quick_fix: "
-            + disabled, disabled.contains("apply_quick_fix"));
-    }
-
-    @Test
-    public void testMigrationLeavesAPresetItIsMissingOneToolFromAlone()
-    {
-        PreferenceStore store = new PreferenceStore();
-        store.setDefault(PreferenceConstants.PREF_DISABLED_TOOLS,
-            PreferenceConstants.DEFAULT_DISABLED_TOOLS);
-        store.setDefault(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 0);
-        // The boundary on the other side: one tool SHORT of a read-only preset is not that preset,
-        // however close it looks. Migrating here would disable a tool in a profile that never
-        // expressed the no-write intent - so the superset test must be a real containment check,
-        // not "mostly overlaps".
-        Set<String> almost = new HashSet<>(ToolPreset.CODE_REVIEW.getDisabledTools());
-        almost.remove("apply_quick_fix");
-        almost.remove("write_module_source");
-        store.setValue(PreferenceConstants.PREF_DISABLED_TOOLS,
-            ToolSettingsService.serializeDisabledTools(almost));
-
-        ToolSettingsService.ensureMigratedForTest(store);
-
-        Set<String> disabled = ToolSettingsService.parseDisabledTools(
-            store.getString(PreferenceConstants.PREF_DISABLED_TOOLS));
-        assertFalse("a selection one tool short of the preset must not be migrated: " + disabled,
-            disabled.contains("apply_quick_fix"));
-    }
-
-    @Test
-    public void testVersion1HistoricalCodeReviewMigratesThroughVersions2And4()
-    {
-        Set<String> historicalShape = historicalPresetShapeAtVersion1(
-            ToolPreset.CODE_REVIEW, CODE_REVIEW_V4_ADDITIONS);
-        PreferenceStore store = storedDisabledTools(historicalShape, 1);
+        Set<String> afterVersion1 = new HashSet<>(FIRST_RELEASE_CODE_REVIEW_SHAPE);
+        afterVersion1.add("git"); //$NON-NLS-1$
+        PreferenceStore store = storedDisabledTools(afterVersion1, 1);
 
         ToolSettingsService.ensureMigratedForTest(store);
 
         Set<String> disabled = disabledTools(store);
         assertTrue("version 2 must add apply_quick_fix: " + disabled,
             disabled.contains("apply_quick_fix")); //$NON-NLS-1$
-        assertTrue("version 4 must add every Code Review addition: " + disabled,
-            disabled.containsAll(CODE_REVIEW_V4_ADDITIONS));
-        assertEquals(ToolPreset.CODE_REVIEW, ToolPreset.matchPreset(disabled));
+        assertTrue("version 2 must preserve git from version 1: " + disabled,
+            disabled.contains("git")); //$NON-NLS-1$
     }
 
     @Test
-    public void testVersion1HistoricalAnalysisOnlyMigratesThroughVersions2And4()
+    public void testVersion2RecognizesFirstReleaseAnalysisOnlyAtVersion1()
     {
-        Set<String> historicalShape = historicalPresetShapeAtVersion1(
-            ToolPreset.ANALYSIS_ONLY, ANALYSIS_ONLY_V4_ADDITIONS);
-        PreferenceStore store = storedDisabledTools(historicalShape, 1);
+        Set<String> afterVersion1 = new HashSet<>(FIRST_RELEASE_ANALYSIS_ONLY_SHAPE);
+        afterVersion1.add("git"); //$NON-NLS-1$
+        PreferenceStore store = storedDisabledTools(afterVersion1, 1);
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        assertTrue("version 2 must add apply_quick_fix to Analysis Only: "
+            + disabledTools(store), disabledTools(store).contains("apply_quick_fix")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testVersion2RecognizesCodeReviewTheUserTightenedFurther()
+    {
+        Set<String> tightened = new HashSet<>(FIRST_RELEASE_CODE_REVIEW_SHAPE);
+        tightened.add("get_form_screenshot"); //$NON-NLS-1$
+        PreferenceStore store = storedDisabledTools(tightened, 1);
 
         ToolSettingsService.ensureMigratedForTest(store);
 
         Set<String> disabled = disabledTools(store);
-        assertTrue("version 2 must add apply_quick_fix: " + disabled,
+        assertTrue("a tightened Code Review profile must gain apply_quick_fix: " + disabled,
             disabled.contains("apply_quick_fix")); //$NON-NLS-1$
-        assertTrue("version 4 must add every Analysis Only addition: " + disabled,
-            disabled.containsAll(ANALYSIS_ONLY_V4_ADDITIONS));
-        assertEquals(ToolPreset.ANALYSIS_ONLY, ToolPreset.matchPreset(disabled));
+        assertTrue("the user's extra disabled tool must survive: " + disabled,
+            disabled.contains("get_form_screenshot")); //$NON-NLS-1$
     }
 
     @Test
-    public void testVersion0HistoricalCodeReviewMigratesThroughEveryVersion()
+    public void testVersion2RecognizesAnalysisOnlyTheUserTightenedFurther()
     {
-        Set<String> historicalShape = historicalPresetShapeAtVersion1(
-            ToolPreset.CODE_REVIEW, CODE_REVIEW_V4_ADDITIONS);
-        historicalShape.remove("git"); //$NON-NLS-1$
-        PreferenceStore store = storedDisabledToolsWithoutMigrationKey(historicalShape);
+        Set<String> tightened = new HashSet<>(FIRST_RELEASE_ANALYSIS_ONLY_SHAPE);
+        tightened.add("get_markers"); //$NON-NLS-1$
+        PreferenceStore store = storedDisabledTools(tightened, 1);
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        Set<String> disabled = disabledTools(store);
+        assertTrue("a tightened Analysis Only profile must gain apply_quick_fix: " + disabled,
+            disabled.contains("apply_quick_fix")); //$NON-NLS-1$
+        assertTrue("the user's extra disabled tool must survive: " + disabled,
+            disabled.contains("get_markers")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testVersion2LeavesASelectionMissingOneRecognitionToolAlone()
+    {
+        Set<String> almostCodeReview = new HashSet<>(FIRST_RELEASE_CODE_REVIEW_SHAPE);
+        almostCodeReview.remove("wait_for_break"); //$NON-NLS-1$
+        PreferenceStore store = storedDisabledTools(almostCodeReview, 1);
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        assertFalse("a selection short of the frozen shape must not gain apply_quick_fix: "
+            + disabledTools(store), disabledTools(store).contains("apply_quick_fix")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testVersion4ChecksAnalysisOnlyBeforeCodeReview()
+    {
+        PreferenceStore store = storedDisabledTools(FIRST_RELEASE_ANALYSIS_ONLY_SHAPE, 3);
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        assertTrue("the most-specific match must add the Analysis Only-only addition",
+            disabledTools(store).contains("get_outgoing_structures")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMigrationRecognitionIgnoresStaleStoredNames()
+    {
+        Set<String> withStaleName = new HashSet<>(FIRST_RELEASE_CODE_REVIEW_SHAPE);
+        withStaleName.add("removed_historical_tool"); //$NON-NLS-1$
+        PreferenceStore store = storedDisabledTools(withStaleName, 1);
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        Set<String> disabled = disabledTools(store);
+        assertTrue("a stale name must not prevent recognition: " + disabled,
+            disabled.contains("apply_quick_fix")); //$NON-NLS-1$
+        assertTrue("migration must preserve stale stored names: " + disabled,
+            disabled.contains("removed_historical_tool")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFirstReleaseCodeReviewDisablesDangerousToolsAcrossEveryMigration()
+    {
+        PreferenceStore store = storedDisabledToolsWithoutMigrationKey(
+            FIRST_RELEASE_CODE_REVIEW_SHAPE);
         assertFalse(store.contains(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION));
 
         ToolSettingsService.ensureMigratedForTest(store);
@@ -538,93 +425,86 @@ public class ToolSettingsServiceTest
             disabled.contains("ask_workmate")); //$NON-NLS-1$
         assertTrue("version 4 must add every Code Review addition: " + disabled,
             disabled.containsAll(CODE_REVIEW_V4_ADDITIONS));
-        assertEquals(ToolPreset.CODE_REVIEW, ToolPreset.matchPreset(disabled));
+        // matchPreset is deliberately not asserted: migration is minimal and the live preset has
+        // grown, so this safely migrated first-release store is legitimately CUSTOM.
     }
 
     @Test
-    public void testVersion2PresetPredicatesStayFrozenAtTheirShippedShapes()
+    public void testFirstReleaseAnalysisOnlyDisablesDangerousToolsAcrossEveryMigration()
     {
-        Set<String> codeReviewShape =
-            ToolSettingsService.version2PresetShapeForTest(ToolPreset.CODE_REVIEW);
-        Set<String> analysisOnlyShape =
-            ToolSettingsService.version2PresetShapeForTest(ToolPreset.ANALYSIS_ONLY);
-
-        assertTrue("the version 2 Code Review predicate must not require version 4 additions",
-            Collections.disjoint(codeReviewShape, CODE_REVIEW_V4_ADDITIONS));
-        assertTrue("the version 2 Analysis Only predicate must not require version 4 additions",
-            Collections.disjoint(analysisOnlyShape, ANALYSIS_ONLY_V4_ADDITIONS));
-        // The shapes that shipped at version 2, frozen by NAME rather than by size. A size alone
-        // survives a net-zero edit (one tool added, another removed) and, when it does fail, says
-        // nothing about which tool moved; comparing the sorted names makes the assertion message
-        // itself the diff. Deriving either side from the live presets would defeat the ratchet:
-        // when a preset expands, production must extend PRESET_ADDITIONS_AFTER_V2 so these
-        // historical shapes stay exactly as they are.
-        assertEquals("extend PRESET_ADDITIONS_AFTER_V2 for later Code Review additions",
-            VERSION_2_CODE_REVIEW_SHAPE, sortedNames(codeReviewShape));
-        assertEquals("extend PRESET_ADDITIONS_AFTER_V2 for later Analysis Only additions",
-            VERSION_2_ANALYSIS_ONLY_SHAPE, sortedNames(analysisOnlyShape));
-    }
-
-    @Test
-    public void testMigrationToVersion4RestoresAnalysisOnlyPreset()
-    {
-        Set<String> oldShape = oldPresetShape(ToolPreset.ANALYSIS_ONLY,
-            ANALYSIS_ONLY_V4_ADDITIONS);
-        PreferenceStore store = storedDisabledTools(oldShape, 3);
+        PreferenceStore store = storedDisabledToolsWithoutMigrationKey(
+            FIRST_RELEASE_ANALYSIS_ONLY_SHAPE);
+        assertFalse(store.contains(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION));
 
         ToolSettingsService.ensureMigratedForTest(store);
 
         Set<String> disabled = disabledTools(store);
-        assertTrue(disabled.containsAll(ANALYSIS_ONLY_V4_ADDITIONS));
-        assertEquals(ToolPreset.ANALYSIS_ONLY, ToolPreset.matchPreset(disabled));
+        assertTrue("version 1 must add git: " + disabled, disabled.contains("git")); //$NON-NLS-1$
+        assertTrue("version 2 must add apply_quick_fix: " + disabled,
+            disabled.contains("apply_quick_fix")); //$NON-NLS-1$
+        assertTrue("version 3 must add ask_workmate: " + disabled,
+            disabled.contains("ask_workmate")); //$NON-NLS-1$
+        assertTrue("version 4 must add every Analysis Only addition: " + disabled,
+            disabled.containsAll(ANALYSIS_ONLY_V4_ADDITIONS));
+        // matchPreset is deliberately not asserted: migration is minimal and the live preset has
+        // grown, so this safely migrated first-release store is legitimately CUSTOM.
     }
 
     @Test
-    public void testMigrationToVersion4RestoresCodeReviewPreset()
+    public void testFirstReleaseDevelopmentDisablesDangerousToolsAcrossEveryMigration()
     {
-        Set<String> oldShape = oldPresetShape(ToolPreset.CODE_REVIEW,
-            CODE_REVIEW_V4_ADDITIONS);
-        PreferenceStore store = storedDisabledTools(oldShape, 3);
+        PreferenceStore store = storedDisabledToolsWithoutMigrationKey(
+            FIRST_RELEASE_DEVELOPMENT_SHAPE);
+        assertFalse(store.contains(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION));
 
         ToolSettingsService.ensureMigratedForTest(store);
 
         Set<String> disabled = disabledTools(store);
-        assertTrue(disabled.containsAll(CODE_REVIEW_V4_ADDITIONS));
-        assertEquals(ToolPreset.CODE_REVIEW, ToolPreset.matchPreset(disabled));
+        assertTrue("version 1 must add git: " + disabled, disabled.contains("git")); //$NON-NLS-1$
+        assertTrue("version 3 must add ask_workmate: " + disabled,
+            disabled.contains("ask_workmate")); //$NON-NLS-1$
+        assertTrue("version 4 must add every Development addition: " + disabled,
+            disabled.containsAll(DEVELOPMENT_V4_ADDITIONS));
+        assertFalse("Development is writable, so quick fixes stay enabled: " + disabled,
+            disabled.contains("apply_quick_fix")); //$NON-NLS-1$
+        // matchPreset is deliberately not asserted: migration is minimal and the live preset has
+        // grown, so this safely migrated first-release store is legitimately CUSTOM.
     }
 
     @Test
-    public void testMigrationToVersion4RestoresDevelopmentPreset()
+    public void testVersion4RecognizesCodeReviewStoreFromBeforeSetVariable()
     {
-        Set<String> oldShape = oldPresetShape(ToolPreset.DEVELOPMENT,
-            DEVELOPMENT_V4_ADDITIONS);
-        PreferenceStore store = storedDisabledTools(oldShape, 3);
+        assertFalse(FIRST_RELEASE_CODE_REVIEW_SHAPE.contains("set_variable")); //$NON-NLS-1$
+        PreferenceStore store = storedDisabledTools(FIRST_RELEASE_CODE_REVIEW_SHAPE, 3);
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        assertTrue("a pre-set_variable Code Review store must gain every version 4 addition",
+            disabledTools(store).containsAll(CODE_REVIEW_V4_ADDITIONS));
+    }
+
+    @Test
+    public void testVersion4RecognizesCodeReviewWhenUserReEnabledApplyQuickFix()
+    {
+        Set<String> beforeVersion4 = currentPresetBeforeVersion4(
+            ToolPreset.CODE_REVIEW, CODE_REVIEW_V4_ADDITIONS);
+        beforeVersion4.remove("apply_quick_fix"); //$NON-NLS-1$
+        PreferenceStore store = storedDisabledTools(beforeVersion4, 3);
 
         ToolSettingsService.ensureMigratedForTest(store);
 
         Set<String> disabled = disabledTools(store);
-        assertTrue(disabled.containsAll(DEVELOPMENT_V4_ADDITIONS));
-        assertEquals(ToolPreset.DEVELOPMENT, ToolPreset.matchPreset(disabled));
+        assertTrue("version 4 additions must still be applied: " + disabled,
+            disabled.containsAll(CODE_REVIEW_V4_ADDITIONS));
+        assertFalse("version 4 must not re-disable apply_quick_fix: " + disabled,
+            disabled.contains("apply_quick_fix")); //$NON-NLS-1$
     }
 
     @Test
-    public void testMigrationToVersion4ChecksAnalysisOnlyBeforeCodeReview()
+    public void testVersion4LeavesOverlappingSelectionWithoutAnyFrozenShapeUntouched()
     {
-        Set<String> oldShape = oldPresetShape(ToolPreset.ANALYSIS_ONLY,
-            ANALYSIS_ONLY_V4_ADDITIONS);
-        PreferenceStore store = storedDisabledTools(oldShape, 3);
-
-        ToolSettingsService.ensureMigratedForTest(store);
-
-        assertTrue(disabledTools(store).contains("get_outgoing_structures")); //$NON-NLS-1$
-    }
-
-    @Test
-    public void testMigrationToVersion4LeavesOverlappingCustomSelectionUntouched()
-    {
-        Set<String> overlap = Set.of(
-            "debug_launch", //$NON-NLS-1$
-            "write_module_source"); //$NON-NLS-1$
+        Set<String> overlap = new HashSet<>(FIRST_RELEASE_CODE_REVIEW_SHAPE);
+        overlap.remove("wait_for_break"); //$NON-NLS-1$
         PreferenceStore store = storedDisabledTools(overlap, 3);
 
         ToolSettingsService.ensureMigratedForTest(store);
@@ -633,82 +513,84 @@ public class ToolSettingsServiceTest
     }
 
     @Test
-    public void testMigrationDoesNotTouchAStoreAlreadyAtVersion4()
+    public void testVersion4RestoresCurrentAnalysisOnlyPreset()
     {
-        Set<String> oldShape = oldPresetShape(ToolPreset.ANALYSIS_ONLY,
-            ANALYSIS_ONLY_V4_ADDITIONS);
-        PreferenceStore store = storedDisabledTools(oldShape, 4);
-
-        ToolSettingsService.ensureMigratedForTest(store);
-
-        assertEquals(oldShape, disabledTools(store));
+        assertVersion4RestoresCurrentPreset(
+            ToolPreset.ANALYSIS_ONLY, ANALYSIS_ONLY_V4_ADDITIONS);
     }
 
     @Test
-    public void testMigrationToVersion4RecognizesCodeReviewWithGitEnabled()
+    public void testVersion4RestoresCurrentCodeReviewPreset()
     {
-        Set<String> oldShape = oldPresetShape(ToolPreset.CODE_REVIEW,
-            CODE_REVIEW_V4_ADDITIONS);
-        oldShape.remove("git"); //$NON-NLS-1$
-        PreferenceStore store = storedDisabledTools(oldShape, 3);
+        assertVersion4RestoresCurrentPreset(
+            ToolPreset.CODE_REVIEW, CODE_REVIEW_V4_ADDITIONS);
+    }
+
+    @Test
+    public void testVersion4RestoresCurrentDevelopmentPreset()
+    {
+        assertVersion4RestoresCurrentPreset(
+            ToolPreset.DEVELOPMENT, DEVELOPMENT_V4_ADDITIONS);
+    }
+
+    @Test
+    public void testVersion4RecognizesCodeReviewWithDefaultDisabledGitEnabled()
+    {
+        Set<String> beforeVersion4 = currentPresetBeforeVersion4(
+            ToolPreset.CODE_REVIEW, CODE_REVIEW_V4_ADDITIONS);
+        beforeVersion4.remove("git"); //$NON-NLS-1$
+        PreferenceStore store = storedDisabledTools(beforeVersion4, 3);
 
         ToolSettingsService.ensureMigratedForTest(store);
 
         Set<String> disabled = disabledTools(store);
         assertTrue(disabled.containsAll(CODE_REVIEW_V4_ADDITIONS));
-        assertFalse(disabled.contains("git")); //$NON-NLS-1$
+        assertFalse("the migration must preserve the user's enabled git choice: " + disabled,
+            disabled.contains("git")); //$NON-NLS-1$
     }
 
-    private static Set<String> oldPresetShape(ToolPreset preset, Set<String> additions)
+    @Test
+    public void testFrozenRecognitionShapesRemainSubsetsOfCurrentPresets()
     {
-        Set<String> oldShape = new HashSet<>(preset.getDisabledTools());
-        oldShape.removeAll(additions);
-        return oldShape;
+        assertRecognitionShapeStillDisabled(ToolPreset.ANALYSIS_ONLY,
+            ToolSettingsService.ANALYSIS_ONLY_RECOGNITION_SHAPE);
+        assertRecognitionShapeStillDisabled(ToolPreset.CODE_REVIEW,
+            ToolSettingsService.CODE_REVIEW_RECOGNITION_SHAPE);
+        assertRecognitionShapeStillDisabled(ToolPreset.DEVELOPMENT,
+            ToolSettingsService.DEVELOPMENT_RECOGNITION_SHAPE);
     }
 
-    /**
-     * The Code Review predicate exactly as version 2 shipped it. Frozen here so a preset change
-     * that leaks into an older migration names itself in the failure instead of moving a count.
-     */
-    private static final String VERSION_2_CODE_REVIEW_SHAPE =
-        "create_infobase, create_launch_config, create_metadata, debug_launch, debug_status"
-        + ", debug_yaxunit_tests, delete_infobase, delete_launch_config, delete_metadata"
-        + ", evaluate_expression, export_configuration_to_xml, generate_translation_strings"
-        + ", get_applications, get_profiling_results, get_translation_project_info, get_variables"
-        + ", import_configuration_from_xml, list_breakpoints, list_configurations, modify_metadata"
-        + ", remove_breakpoint, rename_metadata_object, resume, run_yaxunit_tests, set_breakpoint"
-        + ", set_variable, start_profiling, step, terminate_launch, translate_configuration"
-        + ", update_database, wait_for_break, write_module_source";
-
-    /** The Analysis Only predicate exactly as version 2 shipped it; see the field above. */
-    private static final String VERSION_2_ANALYSIS_ONLY_SHAPE =
-        "create_infobase, create_launch_config, create_metadata, debug_launch, debug_status"
-        + ", debug_yaxunit_tests, delete_infobase, delete_launch_config, delete_metadata"
-        + ", evaluate_expression, export_configuration_to_xml, generate_translation_strings"
-        + ", get_applications, get_form_layout_snapshot, get_form_screenshot, get_method_call_hierarchy"
-        + ", get_module_structure, get_profiling_results, get_symbol_info, get_template_screenshot"
-        + ", get_translation_project_info, get_variables, go_to_definition, import_configuration_from_xml"
-        + ", list_breakpoints, list_configurations, list_modules, modify_metadata, read_method_source"
-        + ", read_module_source, remove_breakpoint, rename_metadata_object, resume, run_yaxunit_tests"
-        + ", search_in_code, set_breakpoint, set_variable, start_profiling, step, terminate_launch"
-        + ", translate_configuration, update_database, validate_query, wait_for_break"
-        + ", write_module_source";
-
-    /** The set as a stable, sorted, comma-separated string, so a mismatch reads as a diff. */
-    private static String sortedNames(Set<String> names)
-    {
-        List<String> sorted = new ArrayList<>(names);
-        Collections.sort(sorted);
-        return String.join(", ", sorted);
-    }
-
-    private static Set<String> historicalPresetShapeAtVersion1(ToolPreset preset,
+    private static void assertVersion4RestoresCurrentPreset(ToolPreset preset,
         Set<String> version4Additions)
     {
-        Set<String> historicalShape = oldPresetShape(preset, version4Additions);
-        historicalShape.remove("apply_quick_fix"); //$NON-NLS-1$
-        historicalShape.remove("ask_workmate"); //$NON-NLS-1$
-        return historicalShape;
+        Set<String> beforeVersion4 = currentPresetBeforeVersion4(preset, version4Additions);
+        PreferenceStore store = storedDisabledTools(beforeVersion4, 3);
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        Set<String> disabled = disabledTools(store);
+        assertEquals("version 4 must restore the current disabled set for " + preset,
+            preset.getDisabledTools(), disabled);
+        assertEquals("the restored set must match " + preset,
+            preset, ToolPreset.matchPreset(disabled));
+    }
+
+    private static Set<String> currentPresetBeforeVersion4(ToolPreset preset,
+        Set<String> version4Additions)
+    {
+        Set<String> beforeVersion4 = new HashSet<>(preset.getDisabledTools());
+        beforeVersion4.removeAll(version4Additions);
+        return beforeVersion4;
+    }
+
+    private static void assertRecognitionShapeStillDisabled(ToolPreset preset,
+        Set<String> recognitionShape)
+    {
+        Set<String> offending = new TreeSet<>(recognitionShape);
+        offending.removeAll(preset.getDisabledTools());
+        assertTrue("frozen recognition shape for " + preset
+            + " contains tools the current preset no longer disables: " + offending,
+            offending.isEmpty());
     }
 
     private static PreferenceStore storedDisabledTools(Set<String> disabled, int migrationVersion)

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolSettingsServiceTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolSettingsServiceTest.java
@@ -8,8 +8,10 @@ package com.ditrix.edt.mcp.server.preferences;
 
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.eclipse.jface.preference.PreferenceStore;
@@ -484,6 +486,86 @@ public class ToolSettingsServiceTest
     }
 
     @Test
+    public void testVersion1HistoricalCodeReviewMigratesThroughVersions2And4()
+    {
+        Set<String> historicalShape = historicalPresetShapeAtVersion1(
+            ToolPreset.CODE_REVIEW, CODE_REVIEW_V4_ADDITIONS);
+        PreferenceStore store = storedDisabledTools(historicalShape, 1);
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        Set<String> disabled = disabledTools(store);
+        assertTrue("version 2 must add apply_quick_fix: " + disabled,
+            disabled.contains("apply_quick_fix")); //$NON-NLS-1$
+        assertTrue("version 4 must add every Code Review addition: " + disabled,
+            disabled.containsAll(CODE_REVIEW_V4_ADDITIONS));
+        assertEquals(ToolPreset.CODE_REVIEW, ToolPreset.matchPreset(disabled));
+    }
+
+    @Test
+    public void testVersion1HistoricalAnalysisOnlyMigratesThroughVersions2And4()
+    {
+        Set<String> historicalShape = historicalPresetShapeAtVersion1(
+            ToolPreset.ANALYSIS_ONLY, ANALYSIS_ONLY_V4_ADDITIONS);
+        PreferenceStore store = storedDisabledTools(historicalShape, 1);
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        Set<String> disabled = disabledTools(store);
+        assertTrue("version 2 must add apply_quick_fix: " + disabled,
+            disabled.contains("apply_quick_fix")); //$NON-NLS-1$
+        assertTrue("version 4 must add every Analysis Only addition: " + disabled,
+            disabled.containsAll(ANALYSIS_ONLY_V4_ADDITIONS));
+        assertEquals(ToolPreset.ANALYSIS_ONLY, ToolPreset.matchPreset(disabled));
+    }
+
+    @Test
+    public void testVersion0HistoricalCodeReviewMigratesThroughEveryVersion()
+    {
+        Set<String> historicalShape = historicalPresetShapeAtVersion1(
+            ToolPreset.CODE_REVIEW, CODE_REVIEW_V4_ADDITIONS);
+        historicalShape.remove("git"); //$NON-NLS-1$
+        PreferenceStore store = storedDisabledToolsWithoutMigrationKey(historicalShape);
+        assertFalse(store.contains(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION));
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        Set<String> disabled = disabledTools(store);
+        assertTrue("version 1 must add git: " + disabled, disabled.contains("git")); //$NON-NLS-1$
+        assertTrue("version 2 must add apply_quick_fix: " + disabled,
+            disabled.contains("apply_quick_fix")); //$NON-NLS-1$
+        assertTrue("version 3 must add ask_workmate: " + disabled,
+            disabled.contains("ask_workmate")); //$NON-NLS-1$
+        assertTrue("version 4 must add every Code Review addition: " + disabled,
+            disabled.containsAll(CODE_REVIEW_V4_ADDITIONS));
+        assertEquals(ToolPreset.CODE_REVIEW, ToolPreset.matchPreset(disabled));
+    }
+
+    @Test
+    public void testVersion2PresetPredicatesStayFrozenAtTheirShippedShapes()
+    {
+        Set<String> codeReviewShape =
+            ToolSettingsService.version2PresetShapeForTest(ToolPreset.CODE_REVIEW);
+        Set<String> analysisOnlyShape =
+            ToolSettingsService.version2PresetShapeForTest(ToolPreset.ANALYSIS_ONLY);
+
+        assertTrue("the version 2 Code Review predicate must not require version 4 additions",
+            Collections.disjoint(codeReviewShape, CODE_REVIEW_V4_ADDITIONS));
+        assertTrue("the version 2 Analysis Only predicate must not require version 4 additions",
+            Collections.disjoint(analysisOnlyShape, ANALYSIS_ONLY_V4_ADDITIONS));
+        // The shapes that shipped at version 2, frozen by NAME rather than by size. A size alone
+        // survives a net-zero edit (one tool added, another removed) and, when it does fail, says
+        // nothing about which tool moved; comparing the sorted names makes the assertion message
+        // itself the diff. Deriving either side from the live presets would defeat the ratchet:
+        // when a preset expands, production must extend PRESET_ADDITIONS_AFTER_V2 so these
+        // historical shapes stay exactly as they are.
+        assertEquals("extend PRESET_ADDITIONS_AFTER_V2 for later Code Review additions",
+            VERSION_2_CODE_REVIEW_SHAPE, sortedNames(codeReviewShape));
+        assertEquals("extend PRESET_ADDITIONS_AFTER_V2 for later Analysis Only additions",
+            VERSION_2_ANALYSIS_ONLY_SHAPE, sortedNames(analysisOnlyShape));
+    }
+
+    @Test
     public void testMigrationToVersion4RestoresAnalysisOnlyPreset()
     {
         Set<String> oldShape = oldPresetShape(ToolPreset.ANALYSIS_ONLY,
@@ -584,15 +666,65 @@ public class ToolSettingsServiceTest
         return oldShape;
     }
 
+    /**
+     * The Code Review predicate exactly as version 2 shipped it. Frozen here so a preset change
+     * that leaks into an older migration names itself in the failure instead of moving a count.
+     */
+    private static final String VERSION_2_CODE_REVIEW_SHAPE =
+        "create_infobase, create_launch_config, create_metadata, debug_launch, debug_status"
+        + ", debug_yaxunit_tests, delete_infobase, delete_launch_config, delete_metadata"
+        + ", evaluate_expression, export_configuration_to_xml, generate_translation_strings"
+        + ", get_applications, get_profiling_results, get_translation_project_info, get_variables"
+        + ", import_configuration_from_xml, list_breakpoints, list_configurations, modify_metadata"
+        + ", remove_breakpoint, rename_metadata_object, resume, run_yaxunit_tests, set_breakpoint"
+        + ", set_variable, start_profiling, step, terminate_launch, translate_configuration"
+        + ", update_database, wait_for_break, write_module_source";
+
+    /** The Analysis Only predicate exactly as version 2 shipped it; see the field above. */
+    private static final String VERSION_2_ANALYSIS_ONLY_SHAPE =
+        "create_infobase, create_launch_config, create_metadata, debug_launch, debug_status"
+        + ", debug_yaxunit_tests, delete_infobase, delete_launch_config, delete_metadata"
+        + ", evaluate_expression, export_configuration_to_xml, generate_translation_strings"
+        + ", get_applications, get_form_layout_snapshot, get_form_screenshot, get_method_call_hierarchy"
+        + ", get_module_structure, get_profiling_results, get_symbol_info, get_template_screenshot"
+        + ", get_translation_project_info, get_variables, go_to_definition, import_configuration_from_xml"
+        + ", list_breakpoints, list_configurations, list_modules, modify_metadata, read_method_source"
+        + ", read_module_source, remove_breakpoint, rename_metadata_object, resume, run_yaxunit_tests"
+        + ", search_in_code, set_breakpoint, set_variable, start_profiling, step, terminate_launch"
+        + ", translate_configuration, update_database, validate_query, wait_for_break"
+        + ", write_module_source";
+
+    /** The set as a stable, sorted, comma-separated string, so a mismatch reads as a diff. */
+    private static String sortedNames(Set<String> names)
+    {
+        List<String> sorted = new ArrayList<>(names);
+        Collections.sort(sorted);
+        return String.join(", ", sorted);
+    }
+
+    private static Set<String> historicalPresetShapeAtVersion1(ToolPreset preset,
+        Set<String> version4Additions)
+    {
+        Set<String> historicalShape = oldPresetShape(preset, version4Additions);
+        historicalShape.remove("apply_quick_fix"); //$NON-NLS-1$
+        historicalShape.remove("ask_workmate"); //$NON-NLS-1$
+        return historicalShape;
+    }
+
     private static PreferenceStore storedDisabledTools(Set<String> disabled, int migrationVersion)
+    {
+        PreferenceStore store = storedDisabledToolsWithoutMigrationKey(disabled);
+        store.setValue(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, migrationVersion);
+        return store;
+    }
+
+    private static PreferenceStore storedDisabledToolsWithoutMigrationKey(Set<String> disabled)
     {
         PreferenceStore store = new PreferenceStore();
         store.setDefault(PreferenceConstants.PREF_DISABLED_TOOLS,
             PreferenceConstants.DEFAULT_DISABLED_TOOLS);
-        store.setDefault(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 0);
         store.setValue(PreferenceConstants.PREF_DISABLED_TOOLS,
             ToolSettingsService.serializeDisabledTools(disabled));
-        store.setValue(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, migrationVersion);
         return store;
     }
 

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolSettingsServiceTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolSettingsServiceTest.java
@@ -21,6 +21,22 @@ import org.junit.Test;
  */
 public class ToolSettingsServiceTest
 {
+    private static final Set<String> ANALYSIS_ONLY_V4_ADDITIONS = Set.of(
+        "adopt_metadata_object", //$NON-NLS-1$
+        "build_external_objects", //$NON-NLS-1$
+        "set_infobase_credentials", //$NON-NLS-1$
+        "stop_profiling", //$NON-NLS-1$
+        "get_outgoing_structures"); //$NON-NLS-1$
+
+    private static final Set<String> CODE_REVIEW_V4_ADDITIONS = Set.of(
+        "adopt_metadata_object", //$NON-NLS-1$
+        "build_external_objects", //$NON-NLS-1$
+        "set_infobase_credentials", //$NON-NLS-1$
+        "stop_profiling"); //$NON-NLS-1$
+
+    private static final Set<String> DEVELOPMENT_V4_ADDITIONS = Set.of(
+        "stop_profiling"); //$NON-NLS-1$
+
     // === parseDisabledTools ===
 
     @Test
@@ -465,5 +481,124 @@ public class ToolSettingsServiceTest
             store.getString(PreferenceConstants.PREF_DISABLED_TOOLS));
         assertFalse("a selection one tool short of the preset must not be migrated: " + disabled,
             disabled.contains("apply_quick_fix"));
+    }
+
+    @Test
+    public void testMigrationToVersion4RestoresAnalysisOnlyPreset()
+    {
+        Set<String> oldShape = oldPresetShape(ToolPreset.ANALYSIS_ONLY,
+            ANALYSIS_ONLY_V4_ADDITIONS);
+        PreferenceStore store = storedDisabledTools(oldShape, 3);
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        Set<String> disabled = disabledTools(store);
+        assertTrue(disabled.containsAll(ANALYSIS_ONLY_V4_ADDITIONS));
+        assertEquals(ToolPreset.ANALYSIS_ONLY, ToolPreset.matchPreset(disabled));
+    }
+
+    @Test
+    public void testMigrationToVersion4RestoresCodeReviewPreset()
+    {
+        Set<String> oldShape = oldPresetShape(ToolPreset.CODE_REVIEW,
+            CODE_REVIEW_V4_ADDITIONS);
+        PreferenceStore store = storedDisabledTools(oldShape, 3);
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        Set<String> disabled = disabledTools(store);
+        assertTrue(disabled.containsAll(CODE_REVIEW_V4_ADDITIONS));
+        assertEquals(ToolPreset.CODE_REVIEW, ToolPreset.matchPreset(disabled));
+    }
+
+    @Test
+    public void testMigrationToVersion4RestoresDevelopmentPreset()
+    {
+        Set<String> oldShape = oldPresetShape(ToolPreset.DEVELOPMENT,
+            DEVELOPMENT_V4_ADDITIONS);
+        PreferenceStore store = storedDisabledTools(oldShape, 3);
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        Set<String> disabled = disabledTools(store);
+        assertTrue(disabled.containsAll(DEVELOPMENT_V4_ADDITIONS));
+        assertEquals(ToolPreset.DEVELOPMENT, ToolPreset.matchPreset(disabled));
+    }
+
+    @Test
+    public void testMigrationToVersion4ChecksAnalysisOnlyBeforeCodeReview()
+    {
+        Set<String> oldShape = oldPresetShape(ToolPreset.ANALYSIS_ONLY,
+            ANALYSIS_ONLY_V4_ADDITIONS);
+        PreferenceStore store = storedDisabledTools(oldShape, 3);
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        assertTrue(disabledTools(store).contains("get_outgoing_structures")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMigrationToVersion4LeavesOverlappingCustomSelectionUntouched()
+    {
+        Set<String> overlap = Set.of(
+            "debug_launch", //$NON-NLS-1$
+            "write_module_source"); //$NON-NLS-1$
+        PreferenceStore store = storedDisabledTools(overlap, 3);
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        assertEquals(overlap, disabledTools(store));
+    }
+
+    @Test
+    public void testMigrationDoesNotTouchAStoreAlreadyAtVersion4()
+    {
+        Set<String> oldShape = oldPresetShape(ToolPreset.ANALYSIS_ONLY,
+            ANALYSIS_ONLY_V4_ADDITIONS);
+        PreferenceStore store = storedDisabledTools(oldShape, 4);
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        assertEquals(oldShape, disabledTools(store));
+    }
+
+    @Test
+    public void testMigrationToVersion4RecognizesCodeReviewWithGitEnabled()
+    {
+        Set<String> oldShape = oldPresetShape(ToolPreset.CODE_REVIEW,
+            CODE_REVIEW_V4_ADDITIONS);
+        oldShape.remove("git"); //$NON-NLS-1$
+        PreferenceStore store = storedDisabledTools(oldShape, 3);
+
+        ToolSettingsService.ensureMigratedForTest(store);
+
+        Set<String> disabled = disabledTools(store);
+        assertTrue(disabled.containsAll(CODE_REVIEW_V4_ADDITIONS));
+        assertFalse(disabled.contains("git")); //$NON-NLS-1$
+    }
+
+    private static Set<String> oldPresetShape(ToolPreset preset, Set<String> additions)
+    {
+        Set<String> oldShape = new HashSet<>(preset.getDisabledTools());
+        oldShape.removeAll(additions);
+        return oldShape;
+    }
+
+    private static PreferenceStore storedDisabledTools(Set<String> disabled, int migrationVersion)
+    {
+        PreferenceStore store = new PreferenceStore();
+        store.setDefault(PreferenceConstants.PREF_DISABLED_TOOLS,
+            PreferenceConstants.DEFAULT_DISABLED_TOOLS);
+        store.setDefault(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, 0);
+        store.setValue(PreferenceConstants.PREF_DISABLED_TOOLS,
+            ToolSettingsService.serializeDisabledTools(disabled));
+        store.setValue(PreferenceConstants.PREF_TOOL_PREFS_MIGRATION, migrationVersion);
+        return store;
+    }
+
+    private static Set<String> disabledTools(PreferenceStore store)
+    {
+        return ToolSettingsService.parseDisabledTools(
+            store.getString(PreferenceConstants.PREF_DISABLED_TOOLS));
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GitGuideCoverageTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GitGuideCoverageTest.java
@@ -1,0 +1,59 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.impl;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.utils.GuideLoader;
+
+/** Keeps the git guide's exhaustive blocked-option list aligned with the parser guardrail. */
+public class GitGuideCoverageTest
+{
+    @Before
+    public void setUp()
+    {
+        GuideLoader.clearCache();
+    }
+
+    @After
+    public void tearDown()
+    {
+        GuideLoader.clearCache();
+    }
+
+    @Test
+    public void testGuideNamesEveryBlockedOption()
+    {
+        String guide = GuideLoader.load(GitTool.NAME);
+        List<String> missing = new ArrayList<>();
+        for (String flag : GitTool.BLOCKED_FLAGS)
+        {
+            // Whole-token match, not contains(): --config is a substring of --config-env and --exec
+            // of --exec-path, so a plain containment check would report a flag as documented because
+            // a DIFFERENT, longer flag happens to be - which is exactly the case this ratchet exists
+            // to catch. The lookahead rejects any character that could continue a flag name.
+            if (!Pattern.compile(Pattern.quote(flag) + "(?![A-Za-z0-9-])").matcher(guide).find()) //$NON-NLS-1$
+            {
+                missing.add(flag);
+            }
+        }
+        Collections.sort(missing);
+
+        assertTrue("The git guide is missing blocked options " + missing //$NON-NLS-1$
+            + ". Document every GitTool.BLOCKED_FLAGS entry in guides/git.md.", //$NON-NLS-1$
+            missing.isEmpty());
+    }
+}


### PR DESCRIPTION
Closes #419. Closes #420.

## The README count was a symptom, not the defect

`README.md` claimed 67 tools in prose and 87 in its generated index. Chasing that turned up the cause: **the Tools preference tab is built only from `ToolGroup`, and `ToolGroup` covered 73 of the 87 registered tools.**

`ToolsTab` does `treeViewer.setInput(ToolGroup.values())`, and its "uncheck all" iterates `ToolGroup.values()`. So a tool in no group is invisible in the UI **and stays enabled after the operator disables everything.** The 14 that were in no group:

`adopt_metadata_object`, `build_external_objects`, `enable_toolset`, `export_common_picture`, `get_event_log`, `get_mcp_history`, `get_outgoing_structures`, `get_server_status`, `get_tool_guide`, `list_common_pictures`, `list_toolsets`, `set_infobase_credentials`, `stop_profiling`, `validate_xdto_package`

`adopt_metadata_object` mutates an extension, and `stop_profiling` was ungrouped while `start_profiling` was not — you could disable the start and not the stop.

## What this changes

**Two ratchets**, so neither list can drift again:

- every registered tool belongs to **exactly one** `ToolGroup`, and no group names a tool that is not registered. Driven by the real production registration, with a populated-registry assertion so it cannot pass vacuously.
- the `git` guide names **every** `GitTool.BLOCKED_FLAGS` entry. Whole-token matching, not `contains` — `--config` is a substring of `--config-env` and `--exec` of `--exec-path`, so a plain containment check would report a flag as documented because a *different* flag is. That is precisely the case the ratchet exists to catch.

**The 14 tools placed** by meaning: CORE gets the server/guide/toolset/history tools, DEBUG gets `stop_profiling`, REFACTORING gets `adopt_metadata_object`, BSL_CODE gets `get_outgoing_structures`, CODE_INTELLIGENCE gets the common-picture pair, APPLICATIONS gets `build_external_objects` and `set_infobase_credentials`, PROBLEMS gets `validate_xdto_package`.

**Presets** (the one place where behaviour changes). `ToolPreset.matchPreset` filters out names unknown to any group, so these 14 were invisible to it and are now visible. The preset sets are built from group membership, so `adopt_metadata_object` is now disabled in both read-only presets automatically — by membership, not by a hand-listed name that could drift. `build_external_objects` and `set_infobase_credentials` likewise. `export_common_picture` stays enabled: despite the name it returns the PNG as base64 and never writes a file, so it is a pure model read.

**#420** — four blocked options were documented nowhere while the guide presented its list as exhaustive: `--ignore-revs-file`, `--exclude-from`, `--exclude-per-directory`, `--encoding`. Added to both `guides/git.md` and `docs/tools/git.md` with the reason each is refused.

**README** — the group table now matches `ToolGroup` exactly (verified mechanically: 10 groups, 87 tools), the Git group and the `git` toolset are listed, and the hard-coded tool count is **removed from the prose entirely**. A number restated by hand is what drifted in the first place; the generated `<!-- TOOLS-INDEX -->` block is now the only place that states one.

## Verification

Local build green: **5003 tests**, 0 failures, 0 errors, no `<<< FAILURE!` in the log.

Both ratchets were checked against a deliberate break, not just observed passing:

- removing `get_mcp_history` from its group → `Registered tools must belong to exactly one ToolGroup: [get_mcp_history (memberships=0)]`
- deleting `--encoding` from the guide → `The git guide is missing blocked options [--encoding]`

Both restored, build green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Deliberate behaviour on upgrade (not a defect)

The migrations recognise a stored profile by asking whether it **contains** a preset's frozen historical shape. That shape is deliberately the smallest one — what the preset has disabled throughout its history — because anything larger cannot be satisfied by a store saved before those tools existed.

A consequence, recorded here as **expected**: a hand-built profile can contain a preset's shape without ever having been saved under that preset, and will then receive that preset's additions. Concretely, a Development profile with `debug_launch`, `get_applications`, `rename_metadata_object`, `run_yaxunit_tests`, `update_database` and `write_module_source` additionally disabled contains the Code Review shape, so it also gets `adopt_metadata_object`, `build_external_objects` and `set_infobase_credentials` switched off.

That is the intended direction of error. Such a profile already excludes module writes, renames and database updates — it is a no-write profile in all but name, and the tools it gains are writes of the same kind. The opposite error is the one that matters: failing to recognise a profile leaves a metadata-mutating tool silently ENABLED in a configuration the operator believes is read-only. Over-matching costs three checkboxes; under-matching costs the invariant.

Exact backward compatibility for such hand-built profiles is explicitly **not** a goal, and era-keyed shapes were considered and rejected: they add a frozen shape per preset per version, and the stores most at risk carry no version at all, so there is no era to key on for precisely the profiles that need it most.
