### PR TITLE
Пишущий инструмент сам сообщает, куда он записал, и барьер ждёт ровно это (#408)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/base/AbstractMetadataWriteTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/base/AbstractMetadataWriteTool.java
@@ -19,11 +19,13 @@ import org.eclipse.ui.PlatformUI;
 import com._1c.g5.v8.dt.core.platform.IConfigurationProvider;
 import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
 import com.ditrix.edt.mcp.server.Activator;
+import com.ditrix.edt.mcp.server.protocol.GsonProvider;
 import com.ditrix.edt.mcp.server.protocol.McpKeys;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
 import com.ditrix.edt.mcp.server.utils.BuildUtils;
 import com.ditrix.edt.mcp.server.utils.ProjectStateChecker;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -55,8 +57,19 @@ public abstract class AbstractMetadataWriteTool implements IMcpTool
      */
     private static final long EXPORT_DEADLINE_MS = 60_000L;
 
+    /**
+     * The smallest slice of the shared budget still worth spending on a wait.
+     * <p>
+     * Not a tuning knob: below this a wait cannot plausibly observe a pipeline drain, while it still
+     * starts an un-cancellable platform wait and takes out a per-project claim that lapses after
+     * {@code 3x} its own timeout - i.e. it buys nothing and spends the only guard against a second
+     * un-cancellable wait for the same project.
+     */
+    private static final long MIN_USEFUL_WAIT_MS = 1_000L;
+
     /** The result member every tool sets to say whether it succeeded. */
     private static final String KEY_SUCCESS = "success"; //$NON-NLS-1$
+
 
     @Override
     public ResponseType getResponseType()
@@ -86,8 +99,12 @@ public abstract class AbstractMetadataWriteTool implements IMcpTool
         }
 
         AtomicReference<String> resultRef = new AtomicReference<>();
+        WriteScope scope = new WriteScope();
         Display display = PlatformUI.getWorkbench().getDisplay();
-        display.syncExec(() -> {
+        display.syncExec(() -> WriteScope.runWithScope(scope, () -> {
+            // Bound around the tool's own work so that submitting an export IS declaring one: the
+            // single place this plugin hands save tasks to the platform records into whatever scope
+            // is bound.
             try
             {
                 resultRef.set(executeOnUiThread(params));
@@ -97,12 +114,12 @@ public abstract class AbstractMetadataWriteTool implements IMcpTool
                 Activator.logError("Error in " + getName(), e); //$NON-NLS-1$
                 resultRef.set(ToolResult.error(e.getMessage()).toJson());
             }
-        });
+        }));
 
         // Deliberately AFTER syncExec returns, i.e. off the UI thread: the export runs on EDT's
         // derived-data pipeline, and waiting for it while holding the UI thread is how a headless
         // MCP call turns into a hung workbench.
-        return awaitDiskExport(params, resultRef.get());
+        return awaitDiskExport(params, resultRef.get(), scope);
     }
 
     /**
@@ -123,12 +140,13 @@ public abstract class AbstractMetadataWriteTool implements IMcpTool
      *
      * @param params the tool parameters
      * @param result the JSON the tool produced
+     * @param scope what the call itself said about where it wrote
      * @return {@code result} unchanged, or an actionable error when the export is still pending
      */
     // Protected, not package-visible: a subclass's own test drives the barrier through this entry
     // to pin that its post-barrier work is ordered AFTER the drain, and that ordering is not
     // observable from anywhere else.
-    protected String awaitDiskExport(Map<String, String> params, String result)
+    protected String awaitDiskExport(Map<String, String> params, String result, WriteScope scope)
     {
         // Parsed once, and only a SUCCESS is parsed at all: an error is a well-formed JSON object
         // too, and treating one as a write would make a rejected argument wait out the whole
@@ -138,42 +156,138 @@ public abstract class AbstractMetadataWriteTool implements IMcpTool
         {
             return result;
         }
-        Collection<String> projects = exportProjectsToAwait(params, success);
-        if (projects == null || projects.isEmpty())
+        WriteScope.Verdict verdict = scope.verdict(defaultProjectsToAwait(params));
+        if (verdict.written().isEmpty() && verdict.cascaded().isEmpty())
         {
             // Nothing to WAIT for, but the post-wait step still runs: a tool may have work that
             // must not start until the barrier is behind it, and skipping it here would silently
             // drop that work for exactly the calls that queued nothing. Reported as established:
             // this call put nothing in the queue, so there is nothing about it left unfinished.
-            return refreshAfterExportAwait(params, result, true);
+            return publish(verdict, refreshAfterExportAwait(params, result, true));
         }
         // ONE budget for the whole set, not one per project: a cascade that touches the base and
         // three extensions must not be able to take four deadlines to answer.
-        long deadlineAtMs = System.currentTimeMillis() + EXPORT_DEADLINE_MS;
+        long deadlineAtMs = System.currentTimeMillis() + exportDeadlineMs();
         // Tracked, because DRAINED and UNOBSERVABLE are not the same news for a tool whose next
         // step reads the disk: only the first says the export finished. Passing them on as one
         // would be the "wider than the code" mistake this PR keeps finding.
         boolean drainEstablished = true;
-        for (String projectName : projects)
+        // Written first, so the projects a stall can be blamed on get the budget rather than the
+        // ones it cannot.
+        for (String projectName : verdict.written())
         {
-            if (projectName == null || projectName.isEmpty())
-            {
-                // A named-but-unusable entry is not a project we established anything about, so it
-                // must not leave the verdict at its optimistic initial value: skipping the wait is
-                // not the same as the wait having succeeded.
-                drainEstablished = false;
-                continue;
-            }
-            long remainingMs = Math.max(1L, deadlineAtMs - System.currentTimeMillis());
-            BuildUtils.DiskExportState state =
-                exportEnvironment().waitForDiskExport(projectName, remainingMs);
+            BuildUtils.DiskExportState state = waitWithin(deadlineAtMs, projectName);
             if (state == BuildUtils.DiskExportState.PENDING)
             {
                 return exportNotConfirmed(projectName);
             }
             drainEstablished &= state == BuildUtils.DiskExportState.DRAINED;
         }
-        return refreshAfterExportAwait(params, result, drainEstablished);
+        for (String projectName : verdict.cascaded())
+        {
+            // A stall here can never refuse: this call never went near that project's export path,
+            // so a queue that will not drain there is not evidence about this call. Awaiting it is
+            // still worth doing - it is the difference between answering over a half-written
+            // extension and not - which is why the outcome only clears the "established" flag.
+            drainEstablished &= waitWithin(deadlineAtMs, projectName) == BuildUtils.DiskExportState.DRAINED;
+        }
+        return publish(verdict, refreshAfterExportAwait(params, result, drainEstablished));
+    }
+
+    /**
+     * @return the shared budget for the whole awaited set; overridden only by tests, so the
+     *     "a slice too small to be worth starting" guard can be reached without a 60-second test
+     */
+    protected long exportDeadlineMs()
+    {
+        return EXPORT_DEADLINE_MS;
+    }
+
+    /**
+     * Runs one bounded wait inside the shared budget, or declines to start it.
+     * <p>
+     * A slice too small to drain anything is not a cheap wait, it is a harmful one: the platform
+     * wait it starts cannot be cancelled, while the per-project claim that keeps a second
+     * un-cancellable wait from being scheduled lapses after {@code 3x} the timeout - so a 1ms slice
+     * buys nothing and gives up the one guard there is.
+     * <p>
+     * Declining is reported as UNOBSERVABLE, which is the truth - nothing was observed about that
+     * project - and which for a project this call WROTE in means a success that establishes nothing
+     * about it rather than a refusal. That is deliberate: a refusal has to rest on an observation,
+     * and there was none. It is reachable only for the second and later entries of a set, i.e. only
+     * since a call could name more than one project.
+     *
+     * @param deadlineAtMs when the shared budget runs out
+     * @param projectName the project to wait for
+     * @return how the wait ended, or {@link BuildUtils.DiskExportState#UNOBSERVABLE} when it was not
+     *     worth starting
+     */
+    private BuildUtils.DiskExportState waitWithin(long deadlineAtMs, String projectName)
+    {
+        if (projectName == null || projectName.isEmpty())
+        {
+            // A named-but-unusable entry is not a project we established anything about, so it must
+            // not leave the verdict at its optimistic initial value: skipping the wait is not the
+            // same as the wait having succeeded.
+            return BuildUtils.DiskExportState.UNOBSERVABLE;
+        }
+        long remainingMs = deadlineAtMs - System.currentTimeMillis();
+        if (remainingMs < MIN_USEFUL_WAIT_MS)
+        {
+            return BuildUtils.DiskExportState.UNOBSERVABLE;
+        }
+        return exportEnvironment().waitForDiskExport(projectName, remainingMs);
+    }
+
+    /**
+     * Adds the call's own account of where it wrote to the response it is about to return.
+     * <p>
+     * Done in ONE place, from the very value the barrier waited on, so what the caller is told and
+     * what the tool waited for cannot drift apart. Left out entirely - rather than published as an
+     * empty list - when the call did not state its scope: an empty list is a finding ("this call
+     * wrote in no project of its own"), and showing it for a call that merely could not tell would
+     * be the same over-claim this whole path exists to remove.
+     *
+     * @param verdict the barrier's reading of the call
+     * @param result the JSON about to be returned
+     * @return the JSON to return
+     */
+    private static String publish(WriteScope.Verdict verdict, String result)
+    {
+        Collection<String> projects = verdict.publishable();
+        if (projects == null)
+        {
+            return result;
+        }
+        JsonObject success = successObject(result);
+        if (success == null)
+        {
+            // The post-wait hook may have turned the success into a refusal; a refusal has no write
+            // scope to report.
+            return result;
+        }
+        JsonArray array = new JsonArray();
+        for (String project : projects)
+        {
+            array.add(project);
+        }
+        success.add(WriteScope.RESULT_MEMBER, array);
+        return GsonProvider.toJson(success);
+    }
+
+    /**
+     * What to wait for when the call said nothing about where it wrote: the project it was asked
+     * about. Kept so a tool that declares nothing behaves exactly as it did before #408 rather than
+     * silently starting to wait for everything or for nothing.
+     *
+     * @param params the tool parameters
+     * @return the default wait set
+     */
+    private static Collection<String> defaultProjectsToAwait(Map<String, String> params)
+    {
+        String projectName = params.get(McpKeys.PROJECT_NAME);
+        return projectName == null || projectName.isEmpty() ? Collections.emptyList()
+            : Collections.singletonList(projectName);
     }
 
     /**
@@ -201,48 +315,6 @@ public abstract class AbstractMetadataWriteTool implements IMcpTool
     }
 
     /**
-     * Which export queues this call asks to see drained before it answers - the projects it
-     * CLAIMS to have written. An empty collection means "await nothing".
-     * <p>
-     * Deliberately a claim rather than a guarantee: a tool may knowingly under-claim, and
-     * {@code delete_metadata} does for the cascade case. The barrier is only ever as complete as
-     * the answer it is given.
-     * <p>
-     * The single question the barrier asks. It is deliberately asked of the RESULT and returns a
-     * SET rather than a yes/no, because both halves of "wait for what" vary per call and neither
-     * can be read off the arguments or off the class:
-     * <ul>
-     * <li>{@code apply_quick_fix} rewrites BSL source and queues no {@code .mdo} export at all, so
-     * waiting could only let unrelated work in the same project refuse a healthy edit;</li>
-     * <li>{@code adopt_metadata_object} is called with the BASE configuration by contract and
-     * writes into the EXTENSION;</li>
-     * <li>a confirmed {@code delete_metadata} cascade also cleans references in the dependent
-     * extensions, whose exports this hook does NOT currently claim - see the reason and the cost
-     * at that tool's override;</li>
-     * <li>an adoption of an already-adopted object, a resync of an in-sync project and a delete
-     * PREVIEW are successes that queued nothing.</li>
-     * </ul>
-     * Asking "did it write?" and "whose project?" separately is what produced those as four
-     * separate defects; asking which exports THIS call queued puts them all to one question, so a
-     * tool added later answers it in one place instead of becoming a fifth. It does not follow that
-     * every answer is complete - a tool can still under-claim, and {@code delete_metadata} knowingly
-     * does for the cascade case.
-     * <p>
-     * The default is the project named in {@code projectName}: a tool that says nothing is assumed
-     * to have written where it was asked to.
-     *
-     * @param params the tool parameters
-     * @param result the tool's own result, already known to be a success
-     * @return the projects to await; empty to skip the wait entirely
-     */
-    protected Collection<String> exportProjectsToAwait(Map<String, String> params, JsonObject result)
-    {
-        String projectName = params.get(McpKeys.PROJECT_NAME);
-        return projectName == null || projectName.isEmpty() ? Collections.emptyList()
-            : Collections.singletonList(projectName);
-    }
-
-    /**
      * Lets a tool restate anything in its result that the export wait has just made out of date.
      * <p>
      * A tool that reports on DISK state samples it inside {@code executeOnUiThread}, which is
@@ -265,7 +337,7 @@ public abstract class AbstractMetadataWriteTool implements IMcpTool
     }
 
     /**
-     * Reads a string member of a result, for a subclass deciding {@link #exportProjectsToAwait}.
+     * Reads a string member of a result, for a subclass restating part of its own answer.
      *
      * @param result the tool's own result
      * @param member the member to read

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/base/WriteScope.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/base/WriteScope.java
@@ -1,0 +1,466 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.base;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.core.resources.IProject;
+
+/**
+ * What a single write call says about WHERE it wrote - stated by the call itself, while it runs.
+ * <p>
+ * The export barrier used to ask this question AFTERWARDS, of the tool's arguments and of the JSON
+ * it had already produced, and every tool answered it with a different indirect signal: the
+ * extension name read back out of its own result, the position of the marker it fixed, its own
+ * report counters, the {@code confirm} argument. None of those is a statement about a write; each
+ * new writing tool was a fresh chance to guess wrong in either direction - waiting for a project
+ * nothing was queued in refuses a healthy call, and not waiting for the one that was answers "done"
+ * over an unfinished disk. Issue #408.
+ * <p>
+ * <b>The statement is a by-product of doing the write, not a second thing to remember.</b> Every
+ * export this plugin submits goes through one call -
+ * {@code BmTransactions.forceExportToDisk} - and that call records the project here. A tool that
+ * submits an export therefore declares by submitting. The explicit methods exist only for what that
+ * choke point cannot see: a branch that wrote but had no FQN to submit, the platform's own cascade,
+ * a success that queued nothing, and a write whose reach the platform will not report.
+ * <p>
+ * <b>What the choke point cannot see</b>, stated so the guarantee is not read wider than it is: the
+ * exports the PLATFORM schedules for itself - the BM reactor after a write transaction commits,
+ * EDT's md-refactoring inside a delete or a rename, the adoption service's own BM task - never pass
+ * through our helper. They are unobservable from here, which is why {@link #cascadedInto(IProject)}
+ * exists and why it is graded differently from a write we performed ourselves.
+ * <p>
+ * <b>Two grades, and the grade decides whether a stalled queue may REFUSE the call.</b>
+ * <ul>
+ * <li>a project this call WROTE in (a submitted export, or {@link #wrote(IProject)} when the write
+ * queued no export of its own) is waited for and a queue that will not drain refuses - the same
+ * verdict the barrier has always reached, now for the right project;</li>
+ * <li>a project the platform's cascade MAY have written in ({@link #cascadedInto(IProject)}) is
+ * waited for but can never refuse: we never went near that project's export path, so a stall there
+ * is somebody else's news. This is what lets a delete cascade be awaited at all without
+ * reintroducing the false refusal that awaiting the scanned-but-untouched set would cause.</li>
+ * </ul>
+ * <p>
+ * <b>"Nothing" and "unknown" are different, at every layer.</b> {@link #queuedNothing()} is a
+ * finding - this call put nothing in the queue. Saying nothing at all is an absence of knowledge, and
+ * {@link #undeterminable(String, Collection)} is a third thing again: a decision that the platform
+ * does not report what was touched. They must never collapse into one value, because the barrier owes
+ * a different answer to each and because publishing "I wrote nowhere" for a call that simply could
+ * not tell is the over-claim this whole issue is about.
+ * <p>
+ * Order of statements does not matter, and the precedence is
+ * record &gt; {@link #undeterminable(String, Collection)} &gt; {@link #queuedNothing()} &gt; silence.
+ * A record wins because it is the hardest fact available; between the other two the safe reading is
+ * the one that waits more and claims less, so a call that contradicted itself by stating both is
+ * read as "I cannot tell". That is what makes a tool safe to write in
+ * the obvious way - {@code resync_to_disk} may report "nothing to export" and only then have its
+ * dangling-reference cleanup export {@code Configuration.mdo}; the later record simply wins.
+ * <p>
+ * Instances are confined to one call. The base class binds one to the thread that runs
+ * {@code executeOnUiThread} and restores the previous binding afterwards, so a nested tool call -
+ * reachable, because the consent dialog and {@code resync_to_disk} both pump nested SWT event loops
+ * in which another request's UI runnable can run - records into its own scope and gives the outer one
+ * back.
+ */
+public final class WriteScope
+{
+    /**
+     * The scope of the call currently running on this thread, if any.
+     * <p>
+     * Thread-bound rather than passed as a parameter because the recording point is
+     * {@code BmTransactions.forceExportToDisk}, which is reached from ~20 call sites across three
+     * tools AND from the shared writers ({@code FormElementWriter}, {@code RoleRightsWriter}). A
+     * parameter would have to be threaded through all of them and could still be dropped on one
+     * branch; the choke point cannot be bypassed while still queuing an export.
+     */
+    private static final ThreadLocal<WriteScope> BOUND = new ThreadLocal<>();
+
+    /** The result member the barrier publishes this scope into. */
+    public static final String RESULT_MEMBER = "writtenProjects"; //$NON-NLS-1$
+
+    /**
+     * The one wording for the published member, so five output schemas cannot describe the same
+     * field differently. The wire strips output-schema descriptions, so its length is paid by
+     * maintainers reading the source, not by every session's {@code tools/list}.
+     */
+    public static final String OUTPUT_SCHEMA_DESCRIPTION =
+        "The projects this call wrote in. Their export queue is what the tool waits for before " //$NON-NLS-1$
+            + "answering - a wait it cannot always observe (no derived-data service, or the shared " //$NON-NLS-1$
+            + "budget already spent), so this names what was waited FOR, not a guarantee that the " //$NON-NLS-1$
+            + "bytes have landed. An empty array means the call wrote in no project of its own: a " //$NON-NLS-1$
+            + "finding, not a silence. The member is ABSENT when the tool could not determine where " //$NON-NLS-1$
+            + "it wrote. A " //$NON-NLS-1$
+            + "project the platform's own cascade may have touched is awaited but not listed here, " //$NON-NLS-1$
+            + "because 'may have' must not be published as 'wrote'."; //$NON-NLS-1$
+
+    /** Projects this call wrote in. Insertion-ordered so the wait order is reproducible. */
+    private final Set<String> written = new LinkedHashSet<>();
+
+    /** Projects the platform's cascade may have written in. */
+    private final Set<String> cascadedInto = new LinkedHashSet<>();
+
+    private boolean queuedNothing;
+
+    private String undeterminableReason;
+
+    private List<String> undeterminableFallback;
+
+    /**
+     * Runs {@code work} with {@code scope} bound to the current thread, and gives the previous
+     * binding back afterwards.
+     * <p>
+     * The only way to bind one, so the restore cannot be forgotten and cannot be skipped by an
+     * {@link Error}: leaving the UI thread bound to a finished call would charge every later export
+     * to it. Saving and restoring rather than clearing, because a NESTED call is reachable - the
+     * consent dialog and {@code resync_to_disk} both pump nested SWT event loops, in which another
+     * request's UI runnable can run - and the inner call must not swallow the outer one's scope.
+     * <p>
+     * Public so a tool's own test can observe what its declarations do; production code reaches it
+     * only from {@code AbstractMetadataWriteTool.execute}.
+     *
+     * @param scope the scope to bind; must not be {@code null}
+     * @param work the work to run under it
+     */
+    public static void runWithScope(WriteScope scope, Runnable work)
+    {
+        WriteScope previous = BOUND.get();
+        BOUND.set(scope);
+        try
+        {
+            work.run();
+        }
+        finally
+        {
+            if (previous == null)
+            {
+                BOUND.remove();
+            }
+            else
+            {
+                BOUND.set(previous);
+            }
+        }
+    }
+
+    /**
+     * Records that an export was submitted for {@code project}. Called from the single place this
+     * plugin hands save tasks to the platform, so that submitting IS declaring.
+     * <p>
+     * Called whatever the platform answered. A refused submission is not evidence that this call did
+     * not write - the model change stands, and for a list submission that threw part way through, it
+     * is not even evidence that nothing was queued. The project identity is knowledge we have either
+     * way, and dropping it is how the barrier used to end up waiting for the wrong project.
+     *
+     * @param project the project whose export was submitted; ignored when {@code null}
+     */
+    public static void recordExportSubmission(IProject project)
+    {
+        WriteScope scope = BOUND.get();
+        if (scope != null)
+        {
+            scope.wrote(project);
+        }
+    }
+
+    /**
+     * Static face of {@link #wrote(IProject)}, for a tool that wrote without submitting an export.
+     * <p>
+     * The explicit methods are reached statically for the same reason the choke point is: the
+     * statement belongs at the line that knows it, and that line is often deep inside a private
+     * helper that has no business taking a scope parameter. A no-op outside a write tool's call, so
+     * a helper shared with a read tool stays correct.
+     *
+     * @param project the project written in; ignored when {@code null}
+     */
+    public static void recordWrite(IProject project)
+    {
+        WriteScope scope = BOUND.get();
+        if (scope != null)
+        {
+            scope.wrote(project);
+        }
+    }
+
+    /**
+     * Static face of {@link #wrote(String)}.
+     *
+     * @param projectName the project written in; ignored when {@code null} or empty
+     */
+    public static void recordWrite(String projectName)
+    {
+        WriteScope scope = BOUND.get();
+        if (scope != null)
+        {
+            scope.wrote(projectName);
+        }
+    }
+
+    /**
+     * Static face of {@link #cascadedInto(IProject)}.
+     *
+     * @param project the cascade participant; ignored when {@code null}
+     */
+    public static void recordCascade(IProject project)
+    {
+        WriteScope scope = BOUND.get();
+        if (scope != null)
+        {
+            scope.cascadedInto(project);
+        }
+    }
+
+    /**
+     * Static face of {@link #cascadedInto(String)}.
+     *
+     * @param projectName the cascade participant; ignored when {@code null} or empty
+     */
+    public static void recordCascade(String projectName)
+    {
+        WriteScope scope = BOUND.get();
+        if (scope != null)
+        {
+            scope.cascadedInto(projectName);
+        }
+    }
+
+    /** Static face of {@link #queuedNothing()}. */
+    public static void recordNothingQueued()
+    {
+        WriteScope scope = BOUND.get();
+        if (scope != null)
+        {
+            scope.queuedNothing();
+        }
+    }
+
+    /**
+     * Static face of {@link #undeterminable(String, Collection)}.
+     *
+     * @param reason why the write scope cannot be determined
+     * @param fallbackProjects the projects to wait for instead
+     */
+    public static void recordUndeterminable(String reason, Collection<String> fallbackProjects)
+    {
+        WriteScope scope = BOUND.get();
+        if (scope != null)
+        {
+            scope.undeterminable(reason, fallbackProjects);
+        }
+    }
+
+    /**
+     * States that this call wrote in {@code project}.
+     * <p>
+     * Needed only where a write queued no export of its own - the platform had already scheduled the
+     * save (a refactoring), or there was no top-object FQN to name. Where the tool submits an export,
+     * the choke point has already recorded it and calling this again is harmless.
+     *
+     * @param project the project written in; ignored when {@code null}
+     */
+    public void wrote(IProject project)
+    {
+        if (project != null)
+        {
+            wrote(project.getName());
+        }
+    }
+
+    /**
+     * Name-taking form of {@link #wrote(IProject)}, so the decision can be exercised without a live
+     * workspace - the barrier waits by name anyway.
+     *
+     * @param projectName the project written in; ignored when {@code null} or empty
+     */
+    public void wrote(String projectName)
+    {
+        if (projectName != null && !projectName.isEmpty())
+        {
+            written.add(projectName);
+        }
+    }
+
+    /**
+     * States that the PLATFORM's cascade may have written in {@code project} - this call authorized
+     * the work but did not perform it and cannot see what it touched.
+     * <p>
+     * Waited for, never able to refuse, and deliberately NOT published as a project this call wrote
+     * in: the honest set is "every open extension of the target", which is what EDT SCANS, not what it
+     * writes.
+     *
+     * @param project the cascade participant; ignored when {@code null}
+     */
+    public void cascadedInto(IProject project)
+    {
+        if (project != null)
+        {
+            cascadedInto(project.getName());
+        }
+    }
+
+    /**
+     * Name-taking form of {@link #cascadedInto(IProject)}.
+     *
+     * @param projectName the cascade participant; ignored when {@code null} or empty
+     */
+    public void cascadedInto(String projectName)
+    {
+        if (projectName != null && !projectName.isEmpty())
+        {
+            cascadedInto.add(projectName);
+        }
+    }
+
+    /**
+     * States that this call put nothing in any export queue - a finding, not a silence. Overridden by
+     * any later record, so it is safe to state as soon as it is known.
+     */
+    public void queuedNothing()
+    {
+        queuedNothing = true;
+    }
+
+    /**
+     * States that what was written cannot be determined here, and names what to wait for instead.
+     * <p>
+     * For the one case the platform keeps to itself: {@code apply_quick_fix} hands the work to EDT's
+     * fix extension point, which reports nothing about what it touched. The classification stays -
+     * it is the best signal available - but it is now a decision recorded at the call whose opacity
+     * is the reason, rather than a guess re-derived from the response afterwards, and it publishes
+     * nothing, because "I could not tell" must not be shown to a caller as "I wrote nowhere".
+     *
+     * @param reason why the write scope cannot be determined; kept for diagnostics
+     * @param fallbackProjects the projects to wait for instead; may be empty, never {@code null}
+     */
+    public void undeterminable(String reason, Collection<String> fallbackProjects)
+    {
+        this.undeterminableReason = reason;
+        this.undeterminableFallback = new ArrayList<>(fallbackProjects);
+    }
+
+    /**
+     * @return the projects declared as written in, in the order they were declared - the same set
+     *     the barrier waits for strictly and publishes to the caller
+     */
+    public List<String> writtenProjects()
+    {
+        return new ArrayList<>(written);
+    }
+
+    /**
+     * @return the projects declared as ones the platform's cascade may have written in - waited for,
+     *     never able to refuse, never published
+     */
+    public List<String> cascadeProjects()
+    {
+        return new ArrayList<>(cascadedInto);
+    }
+
+    /** @return whether the call stated that it queued nothing */
+    public boolean statedNothingQueued()
+    {
+        return queuedNothing;
+    }
+
+    /** @return why the scope could not be determined, or {@code null} */
+    String undeterminableReason()
+    {
+        return undeterminableReason;
+    }
+
+    /**
+     * What the barrier does with this call.
+     *
+     * @param defaultProjects what to wait for when the call said nothing at all - today's default,
+     *            kept so a tool that declares nothing behaves exactly as it does now
+     * @return the verdict; never {@code null}
+     */
+    Verdict verdict(Collection<String> defaultProjects)
+    {
+        if (!written.isEmpty() || !cascadedInto.isEmpty())
+        {
+            // A record beats every statement, whatever order they arrived in: it is the hardest
+            // fact available - something really was written or authorized.
+            return new Verdict(new ArrayList<>(written), removeAll(cascadedInto, written), true);
+        }
+        if (undeterminableFallback != null)
+        {
+            // Ahead of queuedNothing() on purpose. A call that states BOTH has contradicted itself,
+            // and of the two the safe reading is the one that waits more and claims less: publishing
+            // "[] - I queued nothing" while a fallback was named would drop that wait AND assert a
+            // finding the same call has just said it cannot make. No tool states both today.
+            return new Verdict(new ArrayList<>(undeterminableFallback), Collections.emptyList(), false);
+        }
+        if (queuedNothing)
+        {
+            return new Verdict(new ArrayList<>(), Collections.emptyList(), true);
+        }
+        return new Verdict(new ArrayList<>(defaultProjects), Collections.emptyList(), false);
+    }
+
+    /**
+     * A project written in AND named as a cascade participant is one project, and the stronger grade
+     * wins: it must be able to refuse.
+     */
+    private static List<String> removeAll(Set<String> from, Set<String> remove)
+    {
+        List<String> result = new ArrayList<>(from);
+        result.removeAll(remove);
+        return result;
+    }
+
+    /** The barrier's reading of one call: what to wait for, how hard, and what to publish. */
+    static final class Verdict
+    {
+        /** Projects this call wrote in: waited for, and a stall refuses. */
+        private final List<String> written;
+
+        /** Projects the platform's cascade may have touched: waited for, a stall never refuses. */
+        private final List<String> cascaded;
+
+        /** Whether the call actually stated its scope, i.e. whether it may be published. */
+        private final boolean declared;
+
+        Verdict(List<String> written, List<String> cascaded, boolean declared)
+        {
+            this.written = written;
+            this.cascaded = cascaded;
+            this.declared = declared;
+        }
+
+        List<String> written()
+        {
+            return written;
+        }
+
+        List<String> cascaded()
+        {
+            return cascaded;
+        }
+
+        boolean declared()
+        {
+            return declared;
+        }
+
+        /**
+         * @return the projects to publish to the caller, sorted for a stable response; {@code null}
+         *     when the call did not state its scope - and {@code null} means the member is left out
+         *     entirely, which is how "unknown" stays distinguishable from the empty list that means
+         *     "this call queued nothing"
+         */
+        Collection<String> publishable()
+        {
+            return declared ? new TreeSet<>(written) : null;
+        }
+    }
+}

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/AdoptMetadataObjectTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/AdoptMetadataObjectTool.java
@@ -30,6 +30,7 @@ import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.protocol.McpKeys;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.base.AbstractMetadataWriteTool;
+import com.ditrix.edt.mcp.server.tools.base.WriteScope;
 import com.ditrix.edt.mcp.server.utils.BmTransactions;
 import com.ditrix.edt.mcp.server.utils.FormStructureReader;
 import com.ditrix.edt.mcp.server.utils.MetadataNodeResolver;
@@ -111,23 +112,8 @@ public class AdoptMetadataObjectTool extends AbstractMetadataWriteTool
                     + "means the write has already run - but that establishes the queue is empty, not that " //$NON-NLS-1$
                     + "the bytes are correct (a platform-side write failure is logged inside EDT), and the " //$NON-NLS-1$
                     + "wait is skipped where the export state cannot be observed", false) //$NON-NLS-1$
+            .stringArrayProperty(WriteScope.RESULT_MEMBER, WriteScope.OUTPUT_SCHEMA_DESCRIPTION)
             .build();
-    }
-
-    @Override
-    protected Collection<String> exportProjectsToAwait(Map<String, String> params, JsonObject result)
-    {
-        // "already adopted" is a SUCCESS that never called adoptAndAttach and never queued an
-        // export, so there is nothing of ours to wait for.
-        if ("alreadyAdopted".equals(resultString(result, McpKeys.ACTION))) //$NON-NLS-1$
-        {
-            return Collections.emptyList();
-        }
-        // projectName is the BASE configuration by contract, but adoption writes into the
-        // EXTENSION - so the export to wait for is the one the tool reports, not the one it was
-        // asked about.
-        String extension = resultString(result, KEY_EXTENSION_PROJECT);
-        return extension == null ? Collections.emptyList() : Collections.singletonList(extension);
     }
 
     @Override
@@ -217,6 +203,10 @@ public class AdoptMetadataObjectTool extends AbstractMetadataWriteTool
 
         if (adopter.isAdopted(source, target))
         {
+            // A SUCCESS that changes nothing: adoptAndAttach is never called, so no export is
+            // queued anywhere. Stated rather than left silent, because "queued nothing" and "did
+            // not say" owe the barrier different answers.
+            WriteScope.recordNothingQueued();
             // The adopted FQN equals the source FQN (adoption is by-UUID, the Name is preserved).
             // Do NOT call bmGetFqn() on the adopted object - for a MEMBER (form/attribute) it is not
             // a top object and bmGetFqn() throws ("may be called on top objects only").
@@ -232,6 +222,12 @@ public class AdoptMetadataObjectTool extends AbstractMetadataWriteTool
 
         // The service runs its own BM write task on the extension's model.
         EObject adopted = adopter.adoptAndAttach(source, target, new NullProgressMonitor());
+
+        // projectName is the BASE configuration by contract; the write lands in the EXTENSION.
+        // Stated here rather than left to the export submission below, because that submission is
+        // skipped when nothing came back dirty - and a write with no export of its own is still a
+        // write in this project, not a call that wrote nowhere.
+        WriteScope.recordWrite(target.getProject());
 
         // The adopted FQN equals the source FQN (adoption is by-UUID; the Name is preserved). Do NOT
         // call bmGetFqn() on the adopted object - for a MEMBER (form/attribute) it is not a top object

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ApplyQuickFixTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ApplyQuickFixTool.java
@@ -29,6 +29,7 @@ import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
 import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.base.AbstractMetadataWriteTool;
+import com.ditrix.edt.mcp.server.tools.base.WriteScope;
 import com.ditrix.edt.mcp.server.tools.impl.GetProjectErrorsTool.ErrorInfo;
 import com.ditrix.edt.mcp.server.utils.BmTransactions;
 import com.e1c.g5.v8.dt.check.qfix.FixProcessHandle;
@@ -128,43 +129,24 @@ public class ApplyQuickFixTool extends AbstractMetadataWriteTool
             .build();
     }
 
-    @Override
-    protected Collection<String> exportProjectsToAwait(Map<String, String> params, JsonObject result)
+    /**
+     * What to await for a fix whose reach the platform will not report.
+     * <p>
+     * Package-visible so both branches can be pinned directly: the classification is the whole of
+     * this tool's answer to "where did I write", and a test that could only reach it through a live
+     * EDT fix run would not pin it at all.
+     *
+     * @param modulePath the module position of the marker that was fixed, empty/{@code null} when it
+     *     had none
+     * @param projectName the project the call named
+     * @return the projects to await
+     */
+    static Collection<String> undeterminableFallback(String modulePath, String projectName)
     {
-        // Two kinds of marker, two answers - and the tool knows which it fixed, so this is
-        // classified rather than assumed in either direction.
-        //
-        // A MODULE marker is fixed by editing that module, which TYPICALLY queues nothing for
-        // .mdo export; waiting anyway would let unrelated metadata work in the same project refuse
-        // a successful edit - a false refusal on a healthy input.
-        //
-        // A marker with NO module position is usually an object-level one raised on the model - and
-        // then its fix is overwhelmingly likely to queue the same export every metadata write
-        // queues. It can also just be a marker whose locator did not resolve, which is why this
-        // branch is the CONSERVATIVE one rather than the confident one: waiting costs a pause,
-        // not answering early costs a half-written tree. Skipping the wait there lets the caller commit a tree the fix has not finished
-        // writing. Neither half is a law - see the known limit below - but the two point opposite
-        // ways often enough that one answer for both is wrong either way round.
-        //
-        // Answering "empty" for both was the first shape of this defect and answering "the project"
-        // for both is its mirror; the discriminator is the marker's own module position, which this
-        // class already relies on to tell the two apart when it reports and orders candidates.
-        //
-        // KNOWN LIMIT, stated because it is a real one: the module position describes where the
-        // PROBLEM was, not everything the chosen fix touched. EDT's fix extension point does not
-        // forbid a variant on a module-positioned diagnostic from also changing the model, and
-        // nothing here can see that. Such a fix is waited for too little.
-        //
-        // The direction is deliberate rather than accidental: that residual is a MISSED check,
-        // which for this tool is exactly the pre-#406 behaviour, whereas guessing the other way
-        // would refuse work that succeeded. See issue #408 - the durable answer is for the tool to
-        // report what it wrote, instead of having it inferred from where the marker sat.
-        String modulePath = resultString(result, KEY_MODULE_PATH);
         if (modulePath != null && !modulePath.isEmpty())
         {
             return Collections.emptyList();
         }
-        String projectName = params.get(KEY_PROJECT);
         return projectName == null || projectName.isEmpty() ? Collections.<String> emptyList()
             : Collections.singletonList(projectName);
     }
@@ -264,7 +246,7 @@ public class ApplyQuickFixTool extends AbstractMetadataWriteTool
         }
         MarkerMatch chosen = matches.get(chosenIdx);
 
-        return applyFix(fixManager, dtProject, chosen, variant);
+        return applyFix(fixManager, dtProject, chosen, variant, projectName);
     }
 
     /**
@@ -447,7 +429,7 @@ public class ApplyQuickFixTool extends AbstractMetadataWriteTool
      * returns where no change was applied.
      */
     private static String applyFix(IFixManager fixManager, IDtProject dtProject, MarkerMatch chosen,
-        int variant)
+        int variant, String projectName)
     {
         FixProcessHandle handle = fixManager.prepareFix(chosen.marker, dtProject);
         if (handle == null)
@@ -507,6 +489,25 @@ public class ApplyQuickFixTool extends AbstractMetadataWriteTool
                     + "via write_module_source / modify_metadata.").toJson(); //$NON-NLS-1$
             }
             fixManager.executeFix(handle, new NullProgressMonitor());
+
+            // The one write in this plugin whose scope cannot be stated: EDT's fix extension point
+            // reports NOTHING about what the variant touched, and the point does not forbid a fix on
+            // a module-positioned diagnostic from changing the model as well. So this stays a
+            // classification - but it is recorded here, at the call whose opacity is the reason,
+            // rather than re-derived afterwards from the response, and it publishes no write scope
+            // at all, because "I could not tell" must never reach the caller as "I wrote nowhere".
+            //
+            // The classification itself is unchanged and deliberately asymmetric. A MODULE marker is
+            // fixed by editing that module, which typically queues no .mdo export; waiting anyway
+            // would let unrelated metadata work in the same project refuse a successful edit. A
+            // marker with NO module position is usually an object-level one raised on the model, and
+            // its fix is overwhelmingly likely to queue the same export every metadata write queues -
+            // and it can also be a marker whose locator simply did not resolve, which is why that
+            // branch is the conservative one: waiting costs a pause, answering early costs a
+            // half-written tree. One answer for both was this defect's first shape, and its mirror.
+            WriteScope.recordUndeterminable(
+                "EDT's quick-fix extension point does not report what the fix touched", //$NON-NLS-1$
+                undeterminableFallback(chosen.modulePath, projectName));
 
             return ToolResult.success()
                 .put("success", true) //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
@@ -48,6 +48,7 @@ import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.protocol.McpKeys;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.base.AbstractMetadataWriteTool;
+import com.ditrix.edt.mcp.server.tools.base.WriteScope;
 import com.ditrix.edt.mcp.server.utils.BmTransactions;
 import com.ditrix.edt.mcp.server.utils.ExtensionOriginUtils;
 import com.ditrix.edt.mcp.server.utils.FormElementWriter;
@@ -317,6 +318,7 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
                 "Extension event call type written (Before/After/Instead), when an extension event " //$NON-NLS-1$
                 + "handler (form:EventHandlerExtension) was created") //$NON-NLS-1$
             .stringProperty(McpKeys.MESSAGE, "Human-readable confirmation message") //$NON-NLS-1$
+            .stringArrayProperty(WriteScope.RESULT_MEMBER, WriteScope.OUTPUT_SCHEMA_DESCRIPTION)
             .build();
     }
 
@@ -1887,6 +1889,9 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         // Persist BOTH the content form's own Form.form (its FQN, generated inside the tx) and the owner
         // .mdo (which registers the new form in its <forms> and, when setAsDefault, the default-form ref).
         List<String> dirty = formObjectDirtyFqns(contentFormFqn, ownerFqn);
+        // Nothing dirty means no submission, and a skipped submission is not a call that wrote
+        // nowhere - the form was created. Stated so the scope is the project, not silence (#408).
+        WriteScope.recordWrite(project);
         boolean persisted = !dirty.isEmpty() && BmTransactions.forceExportToDisk(project, dirty);
 
         // The form is NEW, so its synonym map carries exactly the locale just written (issue #298).

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
@@ -52,6 +52,7 @@ import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.protocol.McpKeys;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.base.AbstractMetadataWriteTool;
+import com.ditrix.edt.mcp.server.tools.base.WriteScope;
 import com.ditrix.edt.mcp.server.tools.reference.MetadataReferenceService;
 import com.ditrix.edt.mcp.server.utils.BmModelResolver;
 import com.ditrix.edt.mcp.server.utils.BmTransactions;
@@ -125,9 +126,26 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         DestructiveConsentGate.ConsentDecision request(String toolName, ConsentPreview preview);
     }
 
+    /**
+     * Reads which projects take part in a cascade rooted at the target. A package-private SEAM: the
+     * production default is {@link ProjectStateChecker#cascadeParticipants(IProject)}, which needs a
+     * live workspace, while a unit test substitutes a fixed set so what a confirmed delete DECLARES
+     * can be observed headlessly.
+     */
+    @FunctionalInterface
+    interface CascadeParticipants
+    {
+        /**
+         * @param base the project the cascade mutates
+         * @return the other projects taking part; never {@code null}
+         */
+        List<IProject> of(IProject base);
+    }
+
     private final ConsentRequester consentRequester;
     private final CascadeSettler cascadeSettler;
     private final ExportSubmitter exportSubmitter;
+    private final CascadeParticipants cascadeParticipants;
 
     /** Production instance: consent goes to the real gate. */
     public DeleteMetadataTool()
@@ -135,7 +153,7 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         this((tool, preview) -> DestructiveConsentGate.getInstance().requireConsent(tool, preview),
             (projectName, timeoutMs) -> ProjectStateChecker.settleBeforeCascadeOrError(projectName,
                 timeoutMs, NAME, "Nothing was deleted."), //$NON-NLS-1$
-            BmTransactions::forceExportToDisk);
+            BmTransactions::forceExportToDisk, ProjectStateChecker::cascadeParticipants);
     }
 
     /**
@@ -148,22 +166,31 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         this(consentRequester,
             (projectName, timeoutMs) -> ProjectStateChecker.settleBeforeCascadeOrError(projectName,
                 timeoutMs, NAME, "Nothing was deleted."), //$NON-NLS-1$
-            BmTransactions::forceExportToDisk);
+            BmTransactions::forceExportToDisk, ProjectStateChecker::cascadeParticipants);
     }
 
     /** Test seam for the caller-thread cascade settle. */
     DeleteMetadataTool(ConsentRequester consentRequester, CascadeSettler cascadeSettler)
     {
-        this(consentRequester, cascadeSettler, BmTransactions::forceExportToDisk);
+        this(consentRequester, cascadeSettler, BmTransactions::forceExportToDisk,
+            ProjectStateChecker::cascadeParticipants);
     }
 
     /** Test seam for the cascade settle AND the post-refactoring export submission. */
     DeleteMetadataTool(ConsentRequester consentRequester, CascadeSettler cascadeSettler,
         ExportSubmitter exportSubmitter)
     {
+        this(consentRequester, cascadeSettler, exportSubmitter, ProjectStateChecker::cascadeParticipants);
+    }
+
+    /** Test seam for everything above PLUS the cascade participant set the write scope declares. */
+    DeleteMetadataTool(ConsentRequester consentRequester, CascadeSettler cascadeSettler,
+        ExportSubmitter exportSubmitter, CascadeParticipants cascadeParticipants)
+    {
         this.consentRequester = consentRequester;
         this.cascadeSettler = cascadeSettler;
         this.exportSubmitter = exportSubmitter;
+        this.cascadeParticipants = cascadeParticipants;
     }
 
     /**
@@ -305,45 +332,8 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
                 + "(the same count), kept for one release for wire compatibility") //$NON-NLS-1$
             .booleanProperty("forced", "Whether the delete was forced past blocking references") //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty(McpKeys.MESSAGE, "Human-readable description of the result") //$NON-NLS-1$
+            .stringArrayProperty(WriteScope.RESULT_MEMBER, WriteScope.OUTPUT_SCHEMA_DESCRIPTION)
             .build();
-    }
-
-    @Override
-    protected Collection<String> exportProjectsToAwait(Map<String, String> params, JsonObject result)
-    {
-        // A preview writes nothing, so it queued no export and must not be exposed to refusal by
-        // unrelated background work.
-        if (!JsonUtils.extractBooleanArgument(params, "confirm", false)) //$NON-NLS-1$
-        {
-            return Collections.emptyList();
-        }
-        // Scope is the TARGET project only, deliberately.
-        //
-        // And in the target project the wait is normally ordered with a real export: the generic
-        // mdclass branch ASKS for the container's .mdo export itself (see submitContainerExport)
-        // before this barrier runs, so waiting here is a wait for work this call queued rather than
-        // a probe that can find the segment quiet before the refactoring has queued anything. When
-        // that request is refused the ordering is gone again - which is why the refusal is reported
-        // in the result instead of only logged.
-        //
-        // A confirmed mdclass delete does cascade: EDT's md-refactoring also cleans the references
-        // held by dependent extensions, and their .mdo files are exported too - so in that branch
-        // the honest set is larger than this. It is not added here, because the set EDT exposes
-        // (IDependentProject.getDependent, the same selection #405's pre-flight uses) is the set of
-        // models it SCANS, not the set it WRITES, and awaiting a scanned-but-untouched extension
-        // reintroduces exactly the false refusal this same review round removed from
-        // apply_quick_fix: an unrelated wedged export in that extension would fail a healthy
-        // delete. The specialized branches make it worse - form-member, form-object, XDTO-member
-        // and predefined-item deletes bypass the refactoring entirely and touch only this project.
-        //
-        // Awaiting only the target is therefore a KNOWN NARROW WAIT, and its cost is bounded and
-        // named: a cascade that also dirtied an extension can answer while that extension's export
-        // is still queued - the pre-#406 behaviour for that file, not a regression. Closing it
-        // properly needs the tool to report what it actually wrote rather than have it re-derived
-        // afterwards, which is a change to how tools describe their own writes.
-        String projectName = params.get(McpKeys.PROJECT_NAME);
-        return projectName == null || projectName.isEmpty() ? Collections.<String> emptyList()
-            : Collections.singletonList(projectName);
     }
 
     @Override
@@ -386,6 +376,12 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         String projectName = JsonUtils.extractStringArgument(params, McpKeys.PROJECT_NAME);
         String fqn = JsonUtils.extractStringArgument(params, "fqn"); //$NON-NLS-1$
         boolean confirm = JsonUtils.extractBooleanArgument(params, "confirm", false); //$NON-NLS-1$
+        if (!confirm)
+        {
+            // A preview writes nothing, on every branch - the flag IS the gate. Said once, here,
+            // and safe against being wrong: an actual write record always beats it.
+            WriteScope.recordNothingQueued();
+        }
         boolean force = JsonUtils.extractBooleanArgument(params, "force", false); //$NON-NLS-1$
 
         ProjectContext ctx = resolveProjectAndConfig(projectName);
@@ -661,6 +657,22 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
         try
         {
             refactoring.perform();
+            // This project was written in, whatever the container export below manages to queue:
+            // stating it here rather than leaving it to that submission keeps the wait honest when
+            // the container could not be named at all.
+            WriteScope.recordWrite(project);
+            // The cascade also cleans the references held by dependent extensions - EDT's
+            // refactoring writes them, we do not, and it does not report which of them it touched.
+            // So they are declared as projects this call MAY have written in: awaited, so a caller
+            // that reads the disk next no longer sees the extension half-written, but never able to
+            // refuse, because a stalled queue in a project we never submitted to is not evidence
+            // about this call. That grading is what makes awaiting them safe at all - the set is
+            // "every open extension of the target", i.e. what EDT SCANS, and awaiting a
+            // scanned-but-untouched extension under the strict grade would fail a healthy delete.
+            for (IProject participant : cascadeParticipants.of(project))
+            {
+                WriteScope.recordCascade(participant);
+            }
             // Said out loud in the answer, not only in the log: when this call could not queue the
             // container's export, the barrier behind it is back to reporting only what the
             // refactoring queued on its own - which is exactly the state that let a delete answer
@@ -1400,6 +1412,9 @@ public class DeleteMetadataTool extends AbstractMetadataWriteTool
             return ToolResult.error("Failed to delete form: " + unwrapCauseMessage(e)).toJson(); //$NON-NLS-1$
         }
 
+        // The form is out of the model at this point; an owner FQN we could not name only costs
+        // the submission, not the fact that this project was written in (#408).
+        WriteScope.recordWrite(project);
         boolean persisted = ownerFqn != null && !ownerFqn.isEmpty()
             && BmTransactions.forceExportToDisk(project, ownerFqn);
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -68,6 +68,7 @@ import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.protocol.McpKeys;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.base.AbstractMetadataWriteTool;
+import com.ditrix.edt.mcp.server.tools.base.WriteScope;
 import com.ditrix.edt.mcp.server.utils.BmTransactions;
 import com.ditrix.edt.mcp.server.utils.CommonAttributeContentWriter;
 import com.ditrix.edt.mcp.server.utils.ConsentPreview;
@@ -426,6 +427,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 "Where a moved form item ended up (when 'parent'/'position' moved a form item), e.g. " //$NON-NLS-1$
                 + "\"group 'Main' at index 1\"") //$NON-NLS-1$
             .stringProperty(McpKeys.MESSAGE, "Human-readable confirmation message") //$NON-NLS-1$
+            .stringArrayProperty(WriteScope.RESULT_MEMBER, WriteScope.OUTPUT_SCHEMA_DESCRIPTION)
             .build();
     }
 
@@ -2193,6 +2195,8 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         {
             exportFqns.add(contentFqn);
         }
+        // The settings were written whether or not an FQN could be collected to export (#408).
+        WriteScope.recordWrite(ctx.project);
         boolean persisted =
             !exportFqns.isEmpty() && BmTransactions.forceExportToDisk(ctx.project, exportFqns);
         return buildDcsResult(normFqn, result, persisted, localeUnused);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskTool.java
@@ -43,6 +43,7 @@ import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.protocol.McpKeys;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.base.AbstractMetadataWriteTool;
+import com.ditrix.edt.mcp.server.tools.base.WriteScope;
 import com.ditrix.edt.mcp.server.utils.BmTransactions;
 import com.ditrix.edt.mcp.server.utils.MetadataPathResolver;
 import com.google.gson.JsonElement;
@@ -223,22 +224,8 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
             .booleanProperty(KEY_REVALIDATE, "Whether a post-export revalidation was requested") //$NON-NLS-1$
             .stringProperty("revalidateWarning", "Set when the optional post-export revalidation failed") //$NON-NLS-1$ //$NON-NLS-2$
             .stringProperty(McpKeys.MESSAGE, "Human-readable summary of the outcome") //$NON-NLS-1$
+            .stringArrayProperty(WriteScope.RESULT_MEMBER, WriteScope.OUTPUT_SCHEMA_DESCRIPTION)
             .build();
-    }
-
-    @Override
-    protected Collection<String> exportProjectsToAwait(Map<String, String> params, JsonObject result)
-    {
-        // A project that is already in sync exports nothing and reports objectsExported=0. That is
-        // a genuine no-op success, so there is no export of ours to confirm; waiting would only
-        // expose a healthy call to refusal by unrelated background export work. Dangling-reference
-        // cleanup DOES re-export Configuration, and it reports its own non-zero count, so the two
-        // are asked together rather than assuming the export list is the only writer.
-        boolean queued = !"0".equals(resultString(result, "objectsExported")) //$NON-NLS-1$ //$NON-NLS-2$
-            || !"0".equals(resultString(result, "danglingRemovedCount")); //$NON-NLS-1$ //$NON-NLS-2$
-        String projectName = params.get(McpKeys.PROJECT_NAME);
-        return queued && projectName != null && !projectName.isEmpty()
-            ? Collections.singletonList(projectName) : Collections.<String> emptyList();
     }
 
     /**
@@ -483,6 +470,14 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
         List<String> exportFqns = selectExportFqns(fullExport, allFqns, missingBefore);
         // An empty export list (already in sync, no full export requested) is a genuine
         // no-op: nothing to write, trivially successful.
+        if (exportFqns.isEmpty())
+        {
+            // A genuine no-op: already in sync, nothing handed to the export queue. Stated, because
+            // the barrier owes a different answer to "queued nothing" than to "said nothing" - and
+            // it is safe to state this early: the dangling cleanup below may still export, and an
+            // actual record always wins over this.
+            WriteScope.recordNothingQueued();
+        }
         boolean exported = exportFqns.isEmpty() || BmTransactions.forceExportToDisk(ctx.project, exportFqns);
 
         // Step 4: re-check on disk. After a successful export the missing-before set
@@ -856,6 +851,10 @@ public class ResyncToDiskTool extends AbstractMetadataWriteTool
         // registers the removed proxies. Only needed when something was removed.
         if (result.removedFromModel && result.found > 0)
         {
+            // The model changed here whatever happens next, and the re-export below is skipped when
+            // the FQN cannot be named. Stated separately so a cleanup that could not name its file
+            // is still a write in this project rather than the "queued nothing" reported above.
+            WriteScope.recordWrite(project);
             String configFqn = ((IBmObject)config).bmGetFqn();
             if (configFqn != null && !configFqn.isEmpty())
             {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BmTransactions.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BmTransactions.java
@@ -19,6 +19,7 @@ import com._1c.g5.v8.dt.core.platform.IBmModelManager;
 import com._1c.g5.v8.dt.core.platform.IDtProject;
 import com._1c.g5.v8.dt.core.platform.IDtProjectManager;
 import com.ditrix.edt.mcp.server.Activator;
+import com.ditrix.edt.mcp.server.tools.base.WriteScope;
 
 /**
  * Runs work against the 1C BM (business model) inside an explicit read or write
@@ -206,6 +207,13 @@ public final class BmTransactions
      */
     public static boolean forceExportToDisk(IProject project, List<String> topObjectFqns)
     {
+        // The single place this plugin hands save tasks to the platform, and therefore the single
+        // place a write tool's own account of WHERE it wrote can be taken without the tool having to
+        // remember to give one (issue #408). Recorded before the attempt, not after a successful
+        // one: a refused submission is not evidence that this call did not write - the model change
+        // stands - and for a list submission that threw part way through it is not even evidence
+        // that nothing was queued. No-op outside a write tool's call.
+        WriteScope.recordExportSubmission(project);
         try
         {
             IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -55,6 +55,7 @@ import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
 import com._1c.g5.v8.dt.platform.IEObjectProvider;
 import com._1c.g5.v8.dt.platform.version.Version;
 import com.ditrix.edt.mcp.server.Activator;
+import com.ditrix.edt.mcp.server.tools.base.WriteScope;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 
 /**
@@ -1143,6 +1144,12 @@ public final class FormElementWriter
             // The content Form is a separate top object serialized to Form.form - export ITS fqn.
             return (formModel instanceof IBmObject) ? ((IBmObject)formModel).bmGetFqn() : null;
         });
+        // The write is committed at this point whether or not an export can be submitted below, and
+        // the export IS skipped when the content form has no FQN to name. Stating the project here
+        // is what keeps that branch a write with a known scope instead of a call that says nothing
+        // (issue #408); where the submission does happen it records the same project again, which
+        // is one entry either way.
+        WriteScope.recordWrite(ctx.project);
         boolean exported = contentFormFqn != null && !contentFormFqn.isEmpty()
             && BmTransactions.forceExportToDisk(ctx.project, contentFormFqn);
         if (exported)
@@ -1187,6 +1194,11 @@ public final class FormElementWriter
             work.run(mdFormInTx(ctx, tx), tx);
             return null;
         });
+        // AFTER the transaction, not before it: a rollback leaves nothing written, and a scope that
+        // had already claimed the project would make the barrier wait for an export of a change
+        // that never happened. Stated at all because this writer submits no export of its own - the
+        // caller exports the owning .mdo - so the choke point never sees this project (#408).
+        WriteScope.recordWrite(ctx.project);
     }
 
     /** Re-fetches the MD-form inside the transaction, failing clearly when it has gone. */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
@@ -592,6 +592,41 @@ public final class ProjectStateChecker
         return unsettledParticipants;
     }
 
+    /**
+     * The projects a cascade rooted at {@code base} takes part in, besides {@code base} itself.
+     * <p>
+     * The SAME selection the cascade pre-flight settles on, exposed so the post-flight export wait
+     * cannot drift away from it: two independent readings of "who takes part" is how a cascade ends
+     * up settling one set and awaiting another. It is a fresh reading, not a snapshot of the
+     * pre-flight one - a project can be closed in between, and the set that matters to the wait is
+     * the one in force when the write happened.
+     * <p>
+     * It answers "who COULD take part", not "who was written": EDT's refactoring does not report
+     * what it touched, which is exactly why a caller must grade these projects as ones it may have
+     * written in rather than ones it did.
+     *
+     * @param base the project the cascade mutates; {@code null} yields an empty list
+     * @return the participating projects, never {@code null}
+     */
+    public static List<IProject> cascadeParticipants(IProject base)
+    {
+        if (base == null)
+        {
+            return new ArrayList<>();
+        }
+        try
+        {
+            return findParticipants(base, CascadeEnvironment.DEFAULT);
+        }
+        catch (RuntimeException e)
+        {
+            // This reading only ever WIDENS a wait. Failing to read it must therefore never fail the
+            // operation that already happened - the caller falls back to awaiting what it can name
+            // itself, which is what it did before the participants were awaited at all.
+            return new ArrayList<>();
+        }
+    }
+
     private static List<IProject> findParticipants(IProject base, CascadeEnvironment env)
     {
         List<IProject> participants = new ArrayList<>();

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/WriteScopeInventoryTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/WriteScopeInventoryTest.java
@@ -1,0 +1,127 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.tools.base.AbstractMetadataWriteTool;
+
+/**
+ * Ratchet: every tool that inherits the post-write export barrier must have had its write scope
+ * thought about (issue #408).
+ * <p>
+ * The barrier waits for what the call says it wrote. A tool that says nothing keeps the pre-#408
+ * behaviour - wait for the project it was asked about - which is safe but is a GUESS, and the whole
+ * point of #408 is that guessing produced five different wrong answers in five tools. This test
+ * cannot check that a tool declares correctly; what it can check is that no writing tool arrives
+ * without anybody deciding, which is the failure mode that actually happened.
+ * <p>
+ * Deliberately a registry sweep rather than a source scan. This repository already has source
+ * scanners, and they document what they cannot see - a token in a comment, a dead branch, an
+ * indirect superclass. A ratchet that a comment can satisfy proves nothing; a table that a new
+ * subclass is missing from cannot be satisfied by accident.
+ * <p>
+ * <b>What it does NOT catch</b>, so nobody reads it as more than it is: it cannot tell whether an
+ * entry declares CORRECTLY - only that somebody decided - and it sees only tools that inherit the
+ * barrier. A tool that implements {@code IMcpTool} directly and writes anyway is invisible to it,
+ * and one such tool already exists ({@code build_external_objects}); those tools have no export
+ * barrier at all, which is a separate gap and not one this table can close.
+ */
+public class WriteScopeInventoryTest
+{
+    /**
+     * How each tool inheriting the barrier answers "where did I write", by fully qualified class
+     * name. Every entry is a decision somebody made, and adding a subclass without adding it here
+     * fails the build.
+     */
+    private static final Set<String> CLASSIFIED = new HashSet<>(Arrays.asList(
+        // DECLARES by exporting: every export goes through BmTransactions.forceExportToDisk, which
+        // records the project - so these declare simply by doing the write.
+        "com.ditrix.edt.mcp.server.tools.impl.CreateMetadataTool", //$NON-NLS-1$
+        "com.ditrix.edt.mcp.server.tools.impl.ModifyMetadataTool", //$NON-NLS-1$
+        // DECLARES by exporting, plus an explicit statement for the branches that write without
+        // submitting an export of their own, or that succeed while queuing nothing at all.
+        "com.ditrix.edt.mcp.server.tools.impl.AdoptMetadataObjectTool", //$NON-NLS-1$
+        "com.ditrix.edt.mcp.server.tools.impl.ResyncToDiskTool", //$NON-NLS-1$
+        "com.ditrix.edt.mcp.server.tools.impl.DeleteMetadataTool", //$NON-NLS-1$
+        // CANNOT DECLARE: EDT's quick-fix extension point reports nothing about what the fix
+        // touched, so this one states that outright and names what to wait for instead. It is the
+        // only member of this class, and a second one should be argued for, not assumed.
+        "com.ditrix.edt.mcp.server.tools.impl.ApplyQuickFixTool")); //$NON-NLS-1$
+
+    @After
+    public void tearDown()
+    {
+        McpToolRegistry.getInstance().clear();
+    }
+
+    @Test
+    public void everyToolThatInheritsTheExportBarrierIsClassified()
+    {
+        McpToolRegistry registry = McpToolRegistry.getInstance();
+        BuiltInToolRegistrar.registerAll(registry);
+
+        List<String> unclassified = new ArrayList<>();
+        List<String> inheritors = new ArrayList<>();
+        for (IMcpTool tool : registry.getAllTools())
+        {
+            if (!AbstractMetadataWriteTool.class.isAssignableFrom(tool.getClass()))
+            {
+                continue;
+            }
+            // By FULLY QUALIFIED name: a later subclass that happens to share a simple name with
+            // a classified one would otherwise be counted as decided about, which is the one way
+            // this table could be satisfied by accident.
+            String className = tool.getClass().getName();
+            inheritors.add(className);
+            if (!CLASSIFIED.contains(className))
+            {
+                unclassified.add(className);
+            }
+        }
+
+        assertTrue("the sweep found no write tools at all, so it would pass vacuously", //$NON-NLS-1$
+            inheritors.size() >= 6);
+        assertTrue("Tools inheriting the export barrier with no decision about their write scope: " //$NON-NLS-1$
+            + unclassified + ". Decide what the tool tells the barrier - it declares by calling " //$NON-NLS-1$
+            + "BmTransactions.forceExportToDisk, or explicitly via WriteScope (queuedNothing / " //$NON-NLS-1$
+            + "wrote / cascadedInto / undeterminable) - then add it to CLASSIFIED with the reason.", //$NON-NLS-1$
+            unclassified.isEmpty());
+    }
+
+    @Test
+    public void theClassificationTableNamesOnlyRealWriteTools()
+    {
+        // The other direction, so the table cannot rot into a list of tools that no longer exist:
+        // a stale entry would silently keep the ratchet from firing if the name were reused.
+        McpToolRegistry registry = McpToolRegistry.getInstance();
+        BuiltInToolRegistrar.registerAll(registry);
+
+        Set<String> registered = new HashSet<>();
+        for (IMcpTool tool : registry.getAllTools())
+        {
+            if (AbstractMetadataWriteTool.class.isAssignableFrom(tool.getClass()))
+            {
+                registered.add(tool.getClass().getName());
+            }
+        }
+
+        List<String> stale = new ArrayList<>(CLASSIFIED);
+        stale.removeAll(registered);
+        assertTrue("Classified names that are not registered write tools any more: " + stale, //$NON-NLS-1$
+            stale.isEmpty());
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/base/AbstractMetadataWriteToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/base/AbstractMetadataWriteToolTest.java
@@ -12,41 +12,48 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Collection;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.function.BiFunction;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.utils.BuildUtils.DiskExportState;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 /**
- * Tests for the post-write disk-export barrier in {@link AbstractMetadataWriteTool} (issue #406).
+ * Tests for the post-write disk-export barrier in {@link AbstractMetadataWriteTool} (issues #406 and
+ * #408).
  * <p>
  * The behaviour under test is the DECISION: a metadata write whose {@code .mdo} export has not
  * reached disk must not answer "done", because the two files a top-object change touches are
- * exported as independent tasks, so the working tree passes through a state where the
- * configuration references an object whose file is already gone.
+ * exported as independent tasks, so the working tree passes through a state where the configuration
+ * references an object whose file is already gone.
  * <p>
- * These tests drive {@link AbstractMetadataWriteTool#awaitDiskExport} directly rather than
- * {@code execute}: the latter marshals onto the SWT UI thread, which no headless test has. The
- * export environment is stubbed through the package-visible seam, which is also what lets the
- * false-refusal cases be asserted at all - "the wait could not observe anything" has to be
- * distinguishable from "the wait observed a pending export".
+ * Since #408 the barrier no longer re-derives WHERE the write went from the response; the call
+ * states it through a {@link WriteScope} while it runs. These tests therefore drive
+ * {@link AbstractMetadataWriteTool#awaitDiskExport} with an explicit scope - {@code execute} would
+ * marshal onto the SWT UI thread, which no headless test has. The export environment is stubbed
+ * through the package-visible seam, which is also what lets the false-refusal cases be asserted at
+ * all: "the wait could not observe anything" has to be distinguishable from "the wait observed a
+ * pending export".
  */
 public class AbstractMetadataWriteToolTest
 {
     private static final String PROJECT = "TestConfiguration"; //$NON-NLS-1$
     private static final String EXTENSION = "TestConfiguration.tests"; //$NON-NLS-1$
 
-    /** Records what the barrier asked about, so a wait on the WRONG project is visible. */
+    /** Records what the barrier asked about, in order, so a wait on the WRONG project is visible. */
     private static final class RecordingEnvironment implements AbstractMetadataWriteTool.IExportEnvironment
     {
         private final DiskExportState answer;
+        final List<String> asked = new ArrayList<>();
         String askedFor;
         long deadlineMs;
         int calls;
@@ -59,6 +66,7 @@ public class AbstractMetadataWriteToolTest
         @Override
         public DiskExportState waitForDiskExport(String projectName, long timeoutMs)
         {
+            asked.add(projectName);
             askedFor = projectName;
             deadlineMs = timeoutMs;
             calls++;
@@ -70,18 +78,12 @@ public class AbstractMetadataWriteToolTest
     private static class StubTool extends AbstractMetadataWriteTool
     {
         private final RecordingEnvironment environment;
-        private final BiFunction<Map<String, String>, JsonObject, Collection<String>> scope;
+
+        Boolean sawDrainEstablished;
 
         StubTool(RecordingEnvironment environment)
         {
-            this(environment, null);
-        }
-
-        StubTool(RecordingEnvironment environment,
-            BiFunction<Map<String, String>, JsonObject, Collection<String>> scope)
-        {
             this.environment = environment;
-            this.scope = scope;
         }
 
         @Override
@@ -91,9 +93,11 @@ public class AbstractMetadataWriteToolTest
         }
 
         @Override
-        protected Collection<String> exportProjectsToAwait(Map<String, String> params, JsonObject result)
+        protected String refreshAfterExportAwait(Map<String, String> params, String result,
+            boolean drainEstablished)
         {
-            return scope == null ? super.exportProjectsToAwait(params, result) : scope.apply(params, result);
+            sawDrainEstablished = Boolean.valueOf(drainEstablished);
+            return result;
         }
 
         @Override
@@ -133,11 +137,45 @@ public class AbstractMetadataWriteToolTest
         return ToolResult.success().put("action", "executed").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
+    /** A scope that said nothing at all - the compatibility case. */
+    private static WriteScope silent()
+    {
+        return new WriteScope();
+    }
+
+    private static WriteScope wroteIn(String... projectNames)
+    {
+        WriteScope scope = new WriteScope();
+        for (String projectName : projectNames)
+        {
+            scope.wrote(projectName);
+        }
+        return scope;
+    }
+
+    /** @return the {@code writtenProjects} member, or {@code null} when it is absent */
+    private static List<String> publishedProjects(String json)
+    {
+        JsonObject object = JsonParser.parseString(json).getAsJsonObject();
+        if (!object.has(WriteScope.RESULT_MEMBER))
+        {
+            return null;
+        }
+        List<String> projects = new ArrayList<>();
+        JsonArray array = object.getAsJsonArray(WriteScope.RESULT_MEMBER);
+        for (int i = 0; i < array.size(); i++)
+        {
+            projects.add(array.get(i).getAsString());
+        }
+        return projects;
+    }
+
     @Test
     public void testPendingExportTurnsASuccessIntoAnActionableRefusal()
     {
         RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.PENDING);
-        String answer = new StubTool(environment).awaitDiskExport(params(PROJECT), successJson());
+        String answer =
+            new StubTool(environment).awaitDiskExport(params(PROJECT), successJson(), wroteIn(PROJECT));
 
         assertTrue("a pending export must not be reported as success", //$NON-NLS-1$
             answer.contains("\"success\":false")); //$NON-NLS-1$
@@ -153,13 +191,16 @@ public class AbstractMetadataWriteToolTest
     }
 
     @Test
-    public void testDrainedExportReturnsTheToolsOwnResultUntouched()
+    public void testDrainedExportReturnsTheToolsOwnPayloadPlusItsWriteScope()
     {
         RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.DRAINED);
         String result = successJson();
 
-        assertSame("a drained export must not rewrite the tool's answer", result, //$NON-NLS-1$
-            new StubTool(environment).awaitDiskExport(params(PROJECT), result));
+        String answer = new StubTool(environment).awaitDiskExport(params(PROJECT), result, wroteIn(PROJECT));
+
+        assertTrue("a drained export must not rewrite the tool's own members: " + answer, //$NON-NLS-1$
+            answer.contains("\"action\":\"executed\"") && answer.contains("\"success\":true")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(Collections.singletonList(PROJECT), publishedProjects(answer));
         assertEquals(1, environment.calls);
     }
 
@@ -170,7 +211,8 @@ public class AbstractMetadataWriteToolTest
         // waits for must be the number its refusal names - a message quoting a deadline the code
         // does not use is how an operator gets sent to look in the wrong place.
         RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.PENDING);
-        String answer = new StubTool(environment).awaitDiskExport(params(PROJECT), successJson());
+        String answer =
+            new StubTool(environment).awaitDiskExport(params(PROJECT), successJson(), wroteIn(PROJECT));
 
         // Close to the declared 60s, not merely "finite": an unbounded or wildly large deadline
         // would pass a `> 0` check while defeating the unattended-safety reason the bound exists.
@@ -189,10 +231,11 @@ public class AbstractMetadataWriteToolTest
         // evidence that anything is pending, and refusing on it would break healthy callers. This
         // is why the seam is tri-state and not a boolean.
         RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.UNOBSERVABLE);
-        String result = successJson();
 
-        assertSame("an unobservable export state must not produce a refusal", result, //$NON-NLS-1$
-            new StubTool(environment).awaitDiskExport(params(PROJECT), result));
+        String answer = new StubTool(environment).awaitDiskExport(params(PROJECT), successJson(), wroteIn(PROJECT));
+
+        assertTrue("an unobservable export state must not produce a refusal: " + answer, //$NON-NLS-1$
+            answer.contains("\"success\":true")); //$NON-NLS-1$
     }
 
     @Test
@@ -203,48 +246,61 @@ public class AbstractMetadataWriteToolTest
         RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.PENDING);
         String result = ToolResult.error("Node not found: Catalog.Nope").toJson(); //$NON-NLS-1$
 
-        assertSame(result, new StubTool(environment).awaitDiskExport(params(PROJECT), result));
+        assertSame(result, new StubTool(environment).awaitDiskExport(params(PROJECT), result, wroteIn(PROJECT)));
         assertEquals("an error result must not reach the export wait", 0, environment.calls); //$NON-NLS-1$
     }
 
     @Test
-    public void testANonMutatingCallIsNeverWaitedOn()
+    public void testACallThatStatesItQueuedNothingIsNeverWaitedOn()
     {
         // A preview has no export of its own; making it wait would only let unrelated background
         // export work refuse it.
         RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.PENDING);
-        String result = successJson();
+        WriteScope scope = new WriteScope();
+        scope.queuedNothing();
 
-        assertSame(result,
-            new StubTool(environment, (p, r) -> Collections.emptyList())
-                .awaitDiskExport(params(PROJECT), result));
+        StubTool tool = new StubTool(environment);
+        String answer = tool.awaitDiskExport(params(PROJECT), successJson(), scope);
+
         assertEquals("a preview must not reach the export wait", 0, environment.calls); //$NON-NLS-1$
+        // "Nothing was queued" is ESTABLISHED, not unknown: the post-wait step is entitled to run
+        // work that only makes sense once the queue is behind it.
+        assertEquals(Boolean.TRUE, tool.sawDrainEstablished);
+        // ... and the caller is told so with an empty list, which is a finding.
+        assertEquals(Collections.emptyList(), publishedProjects(answer));
     }
 
     @Test
-    public void testTheSameToolWaitsOrNotDependingOnWhatTheRESULTSays()
+    public void testSayingNothingAtAllIsNotTheSameAsSayingNothingWasQueued()
     {
-        // The no-op exemption has to discriminate on the RESULT, not on the tool or the arguments.
-        // adopt_metadata_object is the real case: "alreadyAdopted" is a SUCCESS that queued no
-        // export, while "adopted" on the very same tool, with the very same arguments, did. A hook
-        // that only saw the parameters could not tell these two apart, so it would either wait on
-        // a no-op (and let unrelated background work refuse a healthy call) or skip a real write.
-        BiFunction<Map<String, String>, JsonObject, Collection<String>> scope =
-            (p, r) -> "alreadyAdopted".equals(AbstractMetadataWriteTool.resultString(r, "action")) //$NON-NLS-1$ //$NON-NLS-2$
-                ? Collections.emptyList() : Collections.singletonList(p.get("projectName")); //$NON-NLS-1$
+        // The distinction the whole contract turns on. A tool that never states its scope is
+        // UNKNOWN, and unknown keeps the pre-#408 behaviour - wait for the project it was asked
+        // about - because assuming either extreme silently changes what a tool does.
+        RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.DRAINED);
 
-        RecordingEnvironment onNoOp = new RecordingEnvironment(DiskExportState.PENDING);
-        String noOp = ToolResult.success().put("action", "alreadyAdopted").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
-        assertSame("a successful no-op must not be refused over somebody else's pending export", //$NON-NLS-1$
-            noOp, new StubTool(onNoOp, scope).awaitDiskExport(params(PROJECT), noOp));
-        assertEquals("a no-op must not even reach the export wait", 0, onNoOp.calls); //$NON-NLS-1$
+        String answer = new StubTool(environment).awaitDiskExport(params(PROJECT), successJson(), silent());
 
-        RecordingEnvironment onRealWrite = new RecordingEnvironment(DiskExportState.PENDING);
-        String wrote = ToolResult.success().put("action", "adopted").toJson(); //$NON-NLS-1$ //$NON-NLS-2$
-        String answer = new StubTool(onRealWrite, scope).awaitDiskExport(params(PROJECT), wrote);
-        assertEquals("a real write MUST still be waited on", 1, onRealWrite.calls); //$NON-NLS-1$
-        assertTrue("and a real write with a pending export must still be refused: " + answer, //$NON-NLS-1$
-            answer.contains("\"success\":false")); //$NON-NLS-1$
+        assertEquals("a silent call must still be waited for, as before #408", 1, environment.calls); //$NON-NLS-1$
+        assertEquals(PROJECT, environment.askedFor);
+        assertNull("an unknown scope must publish NOTHING - an empty list would claim a finding " //$NON-NLS-1$
+            + "the tool never made: " + answer, publishedProjects(answer)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testAnActualWriteBeatsAnEarlierStatementThatNothingWasQueued()
+    {
+        // resync_to_disk really is written this way: it reports "already in sync, nothing to
+        // export" and only THEN has its dangling-reference cleanup re-export Configuration.mdo. If
+        // the first statement won, that export would never be waited for.
+        RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.DRAINED);
+        WriteScope scope = new WriteScope();
+        scope.queuedNothing();
+        scope.wrote(PROJECT);
+
+        String answer = new StubTool(environment).awaitDiskExport(params(PROJECT), successJson(), scope);
+
+        assertEquals(1, environment.calls);
+        assertEquals(Collections.singletonList(PROJECT), publishedProjects(answer));
     }
 
     @Test
@@ -252,28 +308,108 @@ public class AbstractMetadataWriteToolTest
     {
         // adopt_metadata_object takes the BASE configuration by contract and writes into the
         // EXTENSION. A barrier keyed on projectName would wait for a project with nothing queued
-        // and pass while the real target is still exporting - so it must follow the result.
+        // and pass while the real target is still exporting.
         RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.DRAINED);
-        String result = ToolResult.success().put("extensionProject", EXTENSION).toJson(); //$NON-NLS-1$
 
-        new StubTool(environment,
-            (p, r) -> Collections.singletonList(AbstractMetadataWriteTool.resultString(r, "extensionProject"))) //$NON-NLS-1$
-                .awaitDiskExport(params(PROJECT), result);
+        String answer =
+            new StubTool(environment).awaitDiskExport(params(PROJECT), successJson(), wroteIn(EXTENSION));
 
         assertEquals("the barrier must wait for the project that was written, not the one asked for", //$NON-NLS-1$
             EXTENSION, environment.askedFor);
+        assertEquals(Collections.singletonList(EXTENSION), publishedProjects(answer));
     }
 
     @Test
-    public void testTheWaitFallsBackToProjectNameWhenTheDeclaredKeyIsAbsent()
+    public void testACascadeParticipantIsWaitedForButCanNeverRefuse()
     {
+        // The delete cascade: EDT's refactoring cleans the references held by dependent extensions,
+        // we never submitted anything there, and the set is "every open extension of the target" -
+        // what EDT SCANS. Awaiting it under the strict grade would let an unrelated wedged export in
+        // an untouched extension fail a healthy delete, which is why the grade exists.
+        RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.PENDING);
+        WriteScope scope = new WriteScope();
+        scope.cascadedInto(EXTENSION);
+
+        StubTool tool = new StubTool(environment);
+        String answer = tool.awaitDiskExport(params(PROJECT), successJson(), scope);
+
+        assertEquals("the participant must still be waited for", 1, environment.calls); //$NON-NLS-1$
+        assertEquals(EXTENSION, environment.askedFor);
+        assertTrue("a stall in a project we never submitted to must not refuse the call: " + answer, //$NON-NLS-1$
+            answer.contains("\"success\":true")); //$NON-NLS-1$
+        assertEquals("but it must not be reported as established either", Boolean.FALSE, //$NON-NLS-1$
+            tool.sawDrainEstablished);
+        // "The platform MAY have written here" must not be published under a name that says "wrote".
+        assertEquals(Collections.emptyList(), publishedProjects(answer));
+    }
+
+    @Test
+    public void testWrittenProjectsAreWaitedForBeforeCascadeParticipants()
+    {
+        // One budget covers the whole set, so the order decides who gets it: the projects a stall
+        // can actually be blamed on must be settled before the ones it cannot.
         RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.DRAINED);
-        // Declared key, but this particular branch did not report it.
-        String result = successJson();
+        WriteScope scope = new WriteScope();
+        scope.cascadedInto(EXTENSION);
+        scope.wrote(PROJECT);
 
-        new StubTool(environment).awaitDiskExport(params(PROJECT), result);
+        new StubTool(environment).awaitDiskExport(params(PROJECT), successJson(), scope);
 
-        assertEquals(PROJECT, environment.askedFor);
+        assertEquals(Arrays.asList(PROJECT, EXTENSION), environment.asked);
+    }
+
+    @Test
+    public void testAProjectBothWrittenAndCascadedIntoIsWaitedForOnceUnderTheStrongerGrade()
+    {
+        RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.PENDING);
+        WriteScope scope = new WriteScope();
+        scope.wrote(PROJECT);
+        scope.cascadedInto(PROJECT);
+
+        String answer = new StubTool(environment).awaitDiskExport(params(PROJECT), successJson(), scope);
+
+        assertEquals("one project, one wait", 1, environment.calls); //$NON-NLS-1$
+        assertTrue("and the grade that can refuse must win: " + answer, //$NON-NLS-1$
+            answer.contains("\"success\":false")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testAWaitIsNotStartedOnASliceTooSmallToBeWorthIt()
+    {
+        // A slice too small to drain anything is not a cheap wait but a harmful one: the platform
+        // wait it starts cannot be cancelled, while the per-project claim that keeps a SECOND
+        // un-cancellable wait from being scheduled lapses after 3x its own timeout. So a leftover
+        // fraction of the shared budget must buy nothing rather than buy that. Before #408 the loop
+        // clamped the remainder to 1ms and started the wait anyway.
+        RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.PENDING);
+        StubTool tool = new StubTool(environment)
+        {
+            @Override
+            protected long exportDeadlineMs()
+            {
+                return 900L;
+            }
+        };
+
+        String answer = tool.awaitDiskExport(params(PROJECT), successJson(), wroteIn(PROJECT));
+
+        assertEquals("a slice below the floor must not start a wait at all", 0, environment.calls); //$NON-NLS-1$
+        assertTrue("and not starting a wait is not a refusal: " + answer, //$NON-NLS-1$
+            answer.contains("\"success\":true")); //$NON-NLS-1$
+        assertEquals("but nothing was established about that project either", Boolean.FALSE, //$NON-NLS-1$
+            tool.sawDrainEstablished);
+    }
+
+    @Test
+    public void testTheFloorDoesNotFireOnAFullBudget()
+    {
+        // The other half of the guard: with the real budget every declared project is still asked,
+        // so the floor cannot quietly turn the barrier off.
+        RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.DRAINED);
+
+        new StubTool(environment).awaitDiskExport(params(PROJECT), successJson(), wroteIn(PROJECT, EXTENSION));
+
+        assertEquals(Arrays.asList(PROJECT, EXTENSION), environment.asked);
     }
 
     @Test
@@ -284,7 +420,7 @@ public class AbstractMetadataWriteToolTest
         RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.PENDING);
         String result = "not json at all"; //$NON-NLS-1$
 
-        assertSame(result, new StubTool(environment).awaitDiskExport(params(PROJECT), result));
+        assertSame(result, new StubTool(environment).awaitDiskExport(params(PROJECT), result, wroteIn(PROJECT)));
         assertEquals(0, environment.calls);
         assertNull(environment.askedFor);
     }
@@ -295,8 +431,63 @@ public class AbstractMetadataWriteToolTest
         RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.PENDING);
         String result = successJson();
 
-        assertSame(result, new StubTool(environment).awaitDiskExport(new HashMap<>(), result));
+        assertSame(result, new StubTool(environment).awaitDiskExport(new HashMap<>(), result, silent()));
         assertEquals(0, environment.calls);
+    }
+
+    @Test
+    public void testAnUndeterminableScopeWaitsItsFallbackAndPublishesNothing()
+    {
+        // apply_quick_fix: EDT's fix extension point reports nothing about what the fix touched, so
+        // the classification stays - but it must not reach the caller as a claim about writes.
+        RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.DRAINED);
+        WriteScope scope = new WriteScope();
+        scope.undeterminable("the platform does not say", Collections.singletonList(PROJECT)); //$NON-NLS-1$
+
+        String answer = new StubTool(environment).awaitDiskExport(params(PROJECT), successJson(), scope);
+
+        assertEquals(1, environment.calls);
+        assertEquals(PROJECT, environment.askedFor);
+        assertNull("'I could not tell' must not be published as 'I wrote nowhere': " + answer, //$NON-NLS-1$
+            publishedProjects(answer));
+    }
+
+    @Test
+    public void testAnUndeterminableScopeWithAnEmptyFallbackSkipsTheWait()
+    {
+        RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.PENDING);
+        WriteScope scope = new WriteScope();
+        scope.undeterminable("a module fix queues no .mdo export", Collections.<String> emptyList()); //$NON-NLS-1$
+
+        String answer = new StubTool(environment).awaitDiskExport(params(PROJECT), successJson(), scope);
+
+        assertEquals("the classification must be honoured, not the projectName default", 0, //$NON-NLS-1$
+            environment.calls);
+        assertNull(publishedProjects(answer));
+    }
+
+    @Test
+    public void testThePublishedListIsSortedAndDeduplicated()
+    {
+        RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.DRAINED);
+
+        String answer = new StubTool(environment)
+            .awaitDiskExport(params(PROJECT), successJson(), wroteIn(EXTENSION, PROJECT, EXTENSION));
+
+        assertEquals(Arrays.asList(PROJECT, EXTENSION), publishedProjects(answer));
+    }
+
+    @Test
+    public void testARefusalCarriesNoWriteScope()
+    {
+        // The member describes a successful call's writes; a refusal is not one, and bolting the
+        // list onto it would suggest the refusal is a report about those projects.
+        RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.PENDING);
+
+        String answer =
+            new StubTool(environment).awaitDiskExport(params(PROJECT), successJson(), wroteIn(PROJECT));
+
+        assertNull(publishedProjects(answer));
     }
 
     /** Overrides ONLY what the base class leaves abstract, plus the seam - nothing else. */
@@ -344,12 +535,13 @@ public class AbstractMetadataWriteToolTest
     public void testAWriteToolThatOverridesNothingStillGetsTheBarrier()
     {
         // The reason the barrier lives in the base class rather than at the ~34 export call sites:
-        // a tool added later inherits it without doing anything. This pins the two defaults that
-        // make that true - "this call mutates" and "wait for projectName".
+        // a tool added later inherits it without doing anything. This pins the default that makes
+        // that true - a call that states nothing is still waited for, on the project it was asked
+        // about, exactly as before #408.
         RecordingEnvironment environment = new RecordingEnvironment(DiskExportState.PENDING);
         InheritedDefaultsTool plain = new InheritedDefaultsTool(environment);
 
-        String answer = plain.awaitDiskExport(params(PROJECT), successJson());
+        String answer = plain.awaitDiskExport(params(PROJECT), successJson(), silent());
 
         assertFalse("a tool that overrides nothing must still refuse on a pending export", //$NON-NLS-1$
             answer.contains("\"success\":true")); //$NON-NLS-1$

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/base/WriteScopeTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/base/WriteScopeTest.java
@@ -1,0 +1,247 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.tools.base;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+/**
+ * Tests for the statement a write call makes about where it wrote (issue #408).
+ * <p>
+ * The three answers a call can give - "here", "nowhere", "I cannot tell" - and the fourth it gives
+ * by saying nothing at all are what the barrier branches on, so what is pinned here is that they
+ * stay four distinct things. Collapsing any two is the defect this type exists to prevent: it is how
+ * "the tool queued nothing" and "the tool never said" ended up sharing one empty collection, and how
+ * a scanned-but-untouched extension would end up refusing a healthy delete.
+ */
+public class WriteScopeTest
+{
+    private static final String PROJECT = "TestConfiguration"; //$NON-NLS-1$
+    private static final String EXTENSION = "TestConfiguration.tests"; //$NON-NLS-1$
+
+    @Test
+    public void testAnActualWriteBeatsAStatementThatNothingWasQueuedWhicheverCameFirst()
+    {
+        // Order-independence is what makes a tool safe to write in the obvious way: resync_to_disk
+        // states "already in sync" and only THEN has its dangling cleanup re-export
+        // Configuration.mdo. If the earlier statement won, that export would never be waited for.
+        WriteScope nothingFirst = new WriteScope();
+        nothingFirst.queuedNothing();
+        nothingFirst.wrote(PROJECT);
+
+        WriteScope writeFirst = new WriteScope();
+        writeFirst.wrote(PROJECT);
+        writeFirst.queuedNothing();
+
+        assertEquals(Collections.singletonList(PROJECT), nothingFirst.writtenProjects());
+        assertEquals(Collections.singletonList(PROJECT), writeFirst.writtenProjects());
+        assertEquals(nothingFirst.verdict(Collections.<String> emptyList()).written(),
+            writeFirst.verdict(Collections.<String> emptyList()).written());
+    }
+
+    @Test
+    public void testSayingNothingIsNotADeclarationAndFallsBackToTheDefault()
+    {
+        WriteScope scope = new WriteScope();
+
+        WriteScope.Verdict verdict = scope.verdict(Collections.singletonList(PROJECT));
+
+        assertEquals("a silent call keeps the pre-#408 wait", Collections.singletonList(PROJECT), //$NON-NLS-1$
+            verdict.written());
+        assertFalse("but it is not a declaration, so nothing may be published", verdict.declared()); //$NON-NLS-1$
+        assertNull(verdict.publishable());
+    }
+
+    @Test
+    public void testStatingThatNothingWasQueuedIsADeclarationOfTheEmptySet()
+    {
+        // The pair that must never merge: this call KNOWS it queued nothing, so it waits for
+        // nothing AND says so, whereas the silent call above waits for the default and says nothing.
+        WriteScope scope = new WriteScope();
+        scope.queuedNothing();
+
+        WriteScope.Verdict verdict = scope.verdict(Collections.singletonList(PROJECT));
+
+        assertTrue("a stated no-op must not inherit the default wait", verdict.written().isEmpty()); //$NON-NLS-1$
+        assertTrue(verdict.declared());
+        assertEquals(Collections.emptyList(), new java.util.ArrayList<>(verdict.publishable()));
+    }
+
+    @Test
+    public void testAnUndeterminableScopeWaitsItsFallbackWithoutPublishingAnything()
+    {
+        WriteScope scope = new WriteScope();
+        scope.undeterminable("the platform does not report it", Collections.singletonList(PROJECT)); //$NON-NLS-1$
+
+        WriteScope.Verdict verdict = scope.verdict(Collections.singletonList(EXTENSION));
+
+        assertEquals("the stated fallback wins over the default", Collections.singletonList(PROJECT), //$NON-NLS-1$
+            verdict.written());
+        assertNull("'I could not tell' is not 'I wrote nowhere'", verdict.publishable()); //$NON-NLS-1$
+        assertEquals("the platform does not report it", scope.undeterminableReason()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testARecordOverridesAnUndeterminableStatement()
+    {
+        // If a tool that could not classify its write turns out to have submitted an export after
+        // all, the export is the harder fact and must be waited for.
+        WriteScope scope = new WriteScope();
+        scope.undeterminable("opaque", Collections.<String> emptyList()); //$NON-NLS-1$
+        scope.wrote(PROJECT);
+
+        WriteScope.Verdict verdict = scope.verdict(Collections.<String> emptyList());
+
+        assertEquals(Collections.singletonList(PROJECT), verdict.written());
+        assertEquals(Collections.singletonList(PROJECT),
+            new java.util.ArrayList<>(verdict.publishable()));
+    }
+
+    @Test
+    public void testACallThatSaysBothThingsIsReadAsTheOneThatWaitsMoreAndClaimsLess()
+    {
+        // "I queued nothing" and "I cannot tell where I wrote" contradict each other, and the two
+        // owe opposite answers: one skips the wait and publishes a finding, the other waits a
+        // named fallback and publishes nothing. Reading such a call as the confident one would
+        // drop the wait AND assert a finding the same call has just said it cannot make.
+        WriteScope scope = new WriteScope();
+        scope.queuedNothing();
+        scope.undeterminable("opaque", Collections.singletonList(PROJECT)); //$NON-NLS-1$
+
+        WriteScope.Verdict verdict = scope.verdict(Collections.<String> emptyList());
+
+        assertEquals(Collections.singletonList(PROJECT), verdict.written());
+        assertNull(verdict.publishable());
+    }
+
+    @Test
+    public void testACascadeParticipantIsDeclaredButNeverPublishedAsWritten()
+    {
+        WriteScope scope = new WriteScope();
+        scope.cascadedInto(EXTENSION);
+
+        WriteScope.Verdict verdict = scope.verdict(Collections.singletonList(PROJECT));
+
+        assertEquals(Collections.singletonList(EXTENSION), verdict.cascaded());
+        assertTrue("a cascade participant is not a project we wrote in", verdict.written().isEmpty()); //$NON-NLS-1$
+        assertEquals("and it must not be published under a name that says 'wrote'", //$NON-NLS-1$
+            Collections.emptyList(), new java.util.ArrayList<>(verdict.publishable()));
+        assertTrue("declaring only participants is still a declaration", verdict.declared()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testAProjectBothWrittenAndCascadedIntoKeepsOnlyTheStrongerGrade()
+    {
+        // Otherwise it would be waited for twice, and the second wait would be under the grade that
+        // cannot refuse - quietly weakening the first.
+        WriteScope scope = new WriteScope();
+        scope.cascadedInto(PROJECT);
+        scope.wrote(PROJECT);
+
+        WriteScope.Verdict verdict = scope.verdict(Collections.<String> emptyList());
+
+        assertEquals(Collections.singletonList(PROJECT), verdict.written());
+        assertTrue(verdict.cascaded().isEmpty());
+    }
+
+    @Test
+    public void testTheStaticFacesRecordIntoTheBoundScopeAndNowhereElse()
+    {
+        // The choke point in BmTransactions reaches the scope this way, from ~20 call sites and
+        // from helpers shared with read tools - so recording outside a write call must be a no-op
+        // rather than an error, and must not leak into the next call.
+        WriteScope scope = new WriteScope();
+        WriteScope.runWithScope(scope, () -> {
+            WriteScope.recordWrite(PROJECT);
+            WriteScope.recordCascade(EXTENSION);
+        });
+
+        assertEquals(Collections.singletonList(PROJECT), scope.writtenProjects());
+        assertEquals(Collections.singletonList(EXTENSION), scope.cascadeProjects());
+
+        // Outside any call: no scope, no crash, nothing recorded anywhere.
+        WriteScope.recordWrite("SomeOtherProject"); //$NON-NLS-1$
+        assertEquals(Collections.singletonList(PROJECT), scope.writtenProjects());
+    }
+
+    @Test
+    public void testANestedCallRecordsIntoItsOwnScopeAndGivesTheOuterOneBack()
+    {
+        // Reachable: the consent dialog and resync_to_disk both pump nested SWT event loops, in
+        // which another request's UI runnable can run on the same thread. Clearing the binding
+        // instead of restoring it would leave the outer call recording nothing for the rest of its
+        // work - the failure mode being prevented is silent under-claiming, not a crash.
+        WriteScope outer = new WriteScope();
+        WriteScope inner = new WriteScope();
+
+        WriteScope.runWithScope(outer, () -> {
+            WriteScope.recordWrite(PROJECT);
+            WriteScope.runWithScope(inner, () -> WriteScope.recordWrite(EXTENSION));
+            WriteScope.recordCascade("AfterTheNestedCall"); //$NON-NLS-1$
+        });
+
+        assertEquals(Collections.singletonList(PROJECT), outer.writtenProjects());
+        assertEquals(Collections.singletonList("AfterTheNestedCall"), outer.cascadeProjects()); //$NON-NLS-1$
+        assertEquals(Collections.singletonList(EXTENSION), inner.writtenProjects());
+    }
+
+    @Test
+    public void testTheBindingIsGivenBackEvenWhenTheCallThrowsAnError()
+    {
+        // An Error escaping a tool is not caught by the base class's catch(Exception), so a binding
+        // that is only cleared on the normal path would leave the UI thread bound to a finished
+        // call - and every later export on that thread would be charged to it.
+        WriteScope leaked = new WriteScope();
+        try
+        {
+            WriteScope.runWithScope(leaked, () -> {
+                throw new StackOverflowError("simulated"); //$NON-NLS-1$
+            });
+        }
+        catch (StackOverflowError expected)
+        {
+            // The point is what the binding looks like afterwards.
+        }
+
+        WriteScope.recordWrite(PROJECT);
+        assertTrue("the finished call must not still be collecting records", //$NON-NLS-1$
+            leaked.writtenProjects().isEmpty());
+    }
+
+    @Test
+    public void testThePublishedListIsSortedAndDeduplicated()
+    {
+        WriteScope scope = new WriteScope();
+        scope.wrote(EXTENSION);
+        scope.wrote(PROJECT);
+        scope.wrote(EXTENSION);
+
+        assertEquals(Arrays.asList(PROJECT, EXTENSION),
+            new java.util.ArrayList<>(scope.verdict(Collections.<String> emptyList()).publishable()));
+    }
+
+    @Test
+    public void testUnusableNamesAreIgnoredRatherThanRecordedAsProjects()
+    {
+        WriteScope scope = new WriteScope();
+        scope.wrote((String)null);
+        scope.wrote(""); //$NON-NLS-1$
+        scope.cascadedInto((String)null);
+
+        assertTrue(scope.writtenProjects().isEmpty());
+        assertTrue(scope.cascadeProjects().isEmpty());
+        assertFalse("and an ignored name must not count as a declaration", //$NON-NLS-1$
+            scope.verdict(Collections.singletonList(PROJECT)).declared());
+    }
+}

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/AdoptMetadataObjectToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/AdoptMetadataObjectToolTest.java
@@ -88,27 +88,4 @@ public class AdoptMetadataObjectToolTest
         assertTrue(schema.contains("\"persisted\"")); //$NON-NLS-1$
     }
 
-    @Test
-    public void testTheExportScopeIsTheExtensionAndOnlyForARealAdoption()
-    {
-        // Pinned against the REAL tool, not a stub carrying a copy of the rule: both the key and
-        // the value have to match what this tool actually emits, and a stub stays green through a
-        // typo in either (#406).
-        AdoptMetadataObjectTool tool = new AdoptMetadataObjectTool();
-        Map<String, String> params = Collections.singletonMap("projectName", "TestConfiguration"); //$NON-NLS-1$ //$NON-NLS-2$
-
-        JsonObject noOp = new JsonObject();
-        noOp.addProperty("action", "alreadyAdopted"); //$NON-NLS-1$ //$NON-NLS-2$
-        noOp.addProperty("extensionProject", "TestConfiguration.tests"); //$NON-NLS-1$ //$NON-NLS-2$
-        assertTrue("'alreadyAdopted' queued no export, so nothing must be awaited", //$NON-NLS-1$
-            tool.exportProjectsToAwait(params, noOp).isEmpty());
-
-        JsonObject adopted = new JsonObject();
-        adopted.addProperty("action", "adopted"); //$NON-NLS-1$ //$NON-NLS-2$
-        adopted.addProperty("extensionProject", "TestConfiguration.tests"); //$NON-NLS-1$ //$NON-NLS-2$
-        // projectName is the BASE configuration by contract; the write goes to the EXTENSION.
-        assertEquals("a real adoption must await the EXTENSION, not the project it was called with", //$NON-NLS-1$
-            Collections.singletonList("TestConfiguration.tests"), //$NON-NLS-1$
-            new ArrayList<>(tool.exportProjectsToAwait(params, adopted)));
-    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ApplyQuickFixToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ApplyQuickFixToolTest.java
@@ -486,18 +486,13 @@ public class ApplyQuickFixToolTest
     public void testASuccessfulSourceFixIsNeverRefusedOverSomebodyElsesMetadataExport()
     {
         // The false-refusal guard (#406). A MODULE marker is fixed by editing that module, which
-        // typically queues no .mdo export - so it must await nothing. Awaiting the project here would let an
-        // unrelated metadata export still draining in that project turn a SUCCESSFUL edit into a
-        // 60s "export not confirmed" error: a refusal of work that actually happened, which is the
-        // most expensive mistake this barrier can make.
-        JsonObject moduleFix = new JsonObject();
-        moduleFix.addProperty("success", true); //$NON-NLS-1$
-        moduleFix.addProperty("modulePath", "CommonModules/Calc/Module.bsl"); //$NON-NLS-1$ //$NON-NLS-2$
-
+        // typically queues no .mdo export - so it must await nothing. Awaiting the project here
+        // would let an unrelated metadata export still draining in that project turn a SUCCESSFUL
+        // edit into a 60s "export not confirmed" error: a refusal of work that actually happened,
+        // which is the most expensive mistake this barrier can make.
         assertTrue("a module-positioned fix must await no export at all", //$NON-NLS-1$
-            new ApplyQuickFixTool()
-                .exportProjectsToAwait(Collections.singletonMap("projectName", "TestConfiguration"), //$NON-NLS-1$ //$NON-NLS-2$
-                    moduleFix)
+            ApplyQuickFixTool
+                .undeterminableFallback("CommonModules/Calc/Module.bsl", "TestConfiguration") //$NON-NLS-1$ //$NON-NLS-2$
                 .isEmpty());
     }
 
@@ -506,23 +501,18 @@ public class ApplyQuickFixToolTest
     {
         // The mirror, and the reason the answer above is not simply "never wait". An OBJECT-level
         // marker has no module position because it is raised on the MODEL, so its fix is
-        // overwhelmingly likely to queue the same .mdo export every metadata write queues. Answering "empty" for it too - which is
-        // what the first version of this override did - lets the caller commit a tree the fix has
-        // not finished writing.
-        JsonObject objectFix = new JsonObject();
-        objectFix.addProperty("success", true); //$NON-NLS-1$
-        objectFix.addProperty("modulePath", ""); //$NON-NLS-1$ //$NON-NLS-2$
-
+        // overwhelmingly likely to queue the same .mdo export every metadata write queues.
+        // Answering "empty" for it too - which is what the first version of this rule did - lets the
+        // caller commit a tree the fix has not finished writing.
         assertEquals("with no module position the conservative answer is to await the export", //$NON-NLS-1$
             Collections.singletonList("TestConfiguration"), //$NON-NLS-1$
-            new ArrayList<>(new ApplyQuickFixTool().exportProjectsToAwait(
-                Collections.singletonMap("projectName", "TestConfiguration"), objectFix))); //$NON-NLS-1$ //$NON-NLS-2$
+            new ArrayList<>(ApplyQuickFixTool.undeterminableFallback("", "TestConfiguration"))); //$NON-NLS-1$ //$NON-NLS-2$
 
-        // A result that does not report the discriminator at all is treated as object-level too:
-        // the safe direction is to wait, because the alternative is answering early about a write.
-        assertEquals("a result without the discriminator must be awaited, not skipped", //$NON-NLS-1$
+        // No discriminator at all is treated as object-level too: the safe direction is to wait,
+        // because the alternative is answering early about a write.
+        assertEquals("a fix with no reported position must be awaited, not skipped", //$NON-NLS-1$
             Collections.singletonList("TestConfiguration"), //$NON-NLS-1$
-            new ArrayList<>(new ApplyQuickFixTool().exportProjectsToAwait(
-                Collections.singletonMap("projectName", "TestConfiguration"), new JsonObject()))); //$NON-NLS-1$ //$NON-NLS-2$
+            new ArrayList<>(ApplyQuickFixTool.undeterminableFallback(null, "TestConfiguration"))); //$NON-NLS-1$
     }
+
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataToolTest.java
@@ -8,6 +8,7 @@ package com.ditrix.edt.mcp.server.tools.impl;
 
 import com.ditrix.edt.mcp.server.utils.ConsentPreview;
 import com.ditrix.edt.mcp.server.utils.DestructiveConsentGate;
+import com.ditrix.edt.mcp.server.tools.base.WriteScope;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1578,30 +1579,6 @@ public class DeleteMetadataToolTest
         assertEquals("the prompt counts the member plus its contained elements", 4, seen[0]); //$NON-NLS-1$
     }
 
-    @Test
-    public void testAPreviewAwaitsNothingAndAConfirmAwaitsExactlyTheTargetProject()
-    {
-        // The scope question (#406): which exports did THIS call queue?
-        DeleteMetadataTool tool = new DeleteMetadataTool();
-        JsonObject result = new JsonObject();
-
-        Map<String, String> preview = new HashMap<>();
-        preview.put("projectName", "TestConfiguration"); //$NON-NLS-1$ //$NON-NLS-2$
-        assertTrue("a preview mutates nothing, so it queued no export and must await none", //$NON-NLS-1$
-            tool.exportProjectsToAwait(preview, result).isEmpty());
-
-        Map<String, String> confirm = new HashMap<>(preview);
-        confirm.put("confirm", "true"); //$NON-NLS-1$ //$NON-NLS-2$
-        // EXACT equality, not "contains": the scope is the target and nothing else. A wait that
-        // also covered the dependent extensions was tried and rejected in review - the set EDT
-        // exposes is what it SCANS, not what it WRITES, so awaiting a scanned-but-untouched
-        // extension would fail a healthy delete on somebody else's wedged export. A `contains`
-        // assertion would let that come back unnoticed.
-        assertEquals("a confirmed delete awaits the target project and nothing else", //$NON-NLS-1$
-            Collections.singletonList("TestConfiguration"), //$NON-NLS-1$
-            new ArrayList<>(tool.exportProjectsToAwait(confirm, result)));
-    }
-
     // ─────────────────────────────────────────────────────────────────────────────────────────
     // The generic delete SUBMITS its container export, and submits it after performing (#408)
     //
@@ -1667,7 +1644,8 @@ public class DeleteMetadataToolTest
         fixture.refactoringService = refactoringService;
         fixture.resolution = BmModelResolver.resolve(project, modelManager);
         fixture.tool = new DeleteMetadataTool((name, preview) -> decision,
-            (projectName, timeoutMs) -> null, recorder.submitter());
+            (projectName, timeoutMs) -> null, recorder.submitter(),
+            base -> fixture.participants);
         return fixture;
     }
 
@@ -1678,12 +1656,79 @@ public class DeleteMetadataToolTest
         IProject project;
         IMdRefactoringService refactoringService;
         BmModelResolver.Resolution resolution;
+        List<IProject> participants = new ArrayList<>();
 
         String run(String containerFqn, boolean confirm)
         {
             return tool.prepareMdClassDelete(project, "CommonModule.Calc", mock(MdObject.class), //$NON-NLS-1$
                 containerFqn, confirm, false, refactoringService, resolution);
         }
+    }
+
+    @Test
+    public void testAConfirmedDeleteDeclaresTheTargetItWroteAndTheExtensionsTheCascadeReaches()
+    {
+        // #408: the barrier used to re-derive the wait from the `confirm` ARGUMENT, which says the
+        // caller authorized a destructive path - not that anything was written, and not where. Now
+        // the call states it, and states the two kinds apart.
+        ExportOrderRecorder recorder = new ExportOrderRecorder();
+        GenericDeleteFixture fixture =
+            genericDelete(recorder, DestructiveConsentGate.ConsentDecision.ALLOW, null);
+        IProject extension = mock(IProject.class);
+        when(extension.getName()).thenReturn("TestConfiguration.tests"); //$NON-NLS-1$
+        fixture.participants.add(extension);
+
+        WriteScope scope = new WriteScope();
+        WriteScope.runWithScope(scope, () -> fixture.run("Configuration", true)); //$NON-NLS-1$
+
+        assertEquals("the target is a project this call WROTE in", //$NON-NLS-1$
+            Collections.singletonList("TestConfiguration"), scope.writtenProjects()); //$NON-NLS-1$
+        // Not written, awaited: EDT's refactoring cleans the references held by dependent
+        // extensions and reports nothing about which of them it touched, and the set we can name is
+        // "every open extension of the target" - what EDT SCANS. Declaring these as WRITTEN would
+        // let an unrelated wedged export in an untouched extension refuse a healthy delete, which
+        // is exactly why the earlier attempt to widen this wait was rejected.
+        assertEquals("the cascade participants are awaited, not claimed as written", //$NON-NLS-1$
+            Collections.singletonList("TestConfiguration.tests"), scope.cascadeProjects()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testADeleteStillDeclaresTheTargetWhenItsContainerExportCannotBeQueued()
+    {
+        // The gap the container submission alone leaves: when the container cannot be named, no
+        // export is submitted, so nothing is recorded at the choke point - and the delete has
+        // still happened. Without the explicit statement the call would fall back to "said
+        // nothing", and a cascade declaration would make it look declared while dropping the
+        // target from the strict wait entirely.
+        ExportOrderRecorder recorder = new ExportOrderRecorder();
+        GenericDeleteFixture fixture =
+            genericDelete(recorder, DestructiveConsentGate.ConsentDecision.ALLOW, null);
+
+        WriteScope scope = new WriteScope();
+        WriteScope.runWithScope(scope, () -> fixture.run("", true)); //$NON-NLS-1$
+
+        assertTrue("no container FQN means no submission at all: " + recorder.calls, //$NON-NLS-1$
+            recorder.calls.stream().noneMatch(call -> call.startsWith("submit"))); //$NON-NLS-1$
+        assertEquals("the delete happened, so the project it happened in must still be declared", //$NON-NLS-1$
+            Collections.singletonList("TestConfiguration"), scope.writtenProjects()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testARefusedDeleteDeclaresNoWriteAtAll()
+    {
+        // Consent REJECT: nothing ran, so there is nothing to declare - and in particular the
+        // participants must not be declared off the back of an authorization that never happened.
+        ExportOrderRecorder recorder = new ExportOrderRecorder();
+        GenericDeleteFixture fixture =
+            genericDelete(recorder, DestructiveConsentGate.ConsentDecision.REJECT, null);
+        IProject extension = mock(IProject.class);
+        fixture.participants.add(extension);
+
+        WriteScope scope = new WriteScope();
+        WriteScope.runWithScope(scope, () -> fixture.run("Configuration", true)); //$NON-NLS-1$
+
+        assertTrue("a refused delete wrote nowhere", scope.writtenProjects().isEmpty()); //$NON-NLS-1$
+        assertTrue("and reached no cascade", scope.cascadeProjects().isEmpty()); //$NON-NLS-1$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ResyncToDiskToolTest.java
@@ -27,6 +27,7 @@ import java.util.function.UnaryOperator;
 import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+import com.ditrix.edt.mcp.server.tools.base.WriteScope;
 
 /**
  * Lightweight contract tests for {@link ResyncToDiskTool}: tool metadata, the bundled
@@ -705,39 +706,6 @@ public class ResyncToDiskToolTest
     }
 
     @Test
-    public void testTheExportScopeIsEmptyOnlyWhenNothingWasWrittenAtAll()
-    {
-        // Pinned against the REAL tool so the key names have to match what it emits (#406).
-        ResyncToDiskTool tool = new ResyncToDiskTool();
-        Map<String, String> params = Collections.singletonMap("projectName", "TestConfiguration"); //$NON-NLS-1$ //$NON-NLS-2$
-
-        JsonObject noOp = new JsonObject();
-        noOp.addProperty("objectsExported", 0); //$NON-NLS-1$
-        noOp.addProperty("danglingRemovedCount", 0); //$NON-NLS-1$
-        assertTrue("an in-sync project exports nothing, so there is nothing of ours to await", //$NON-NLS-1$
-            tool.exportProjectsToAwait(params, noOp).isEmpty());
-
-        JsonObject exported = new JsonObject();
-        exported.addProperty("objectsExported", 3); //$NON-NLS-1$
-        exported.addProperty("danglingRemovedCount", 0); //$NON-NLS-1$
-        assertEquals("a real export must be awaited", Collections.singletonList("TestConfiguration"), //$NON-NLS-1$ //$NON-NLS-2$
-            new ArrayList<>(tool.exportProjectsToAwait(params, exported)));
-
-        // The dangling cleanup re-exports Configuration on its own, so it counts as a write even
-        // when the missing-subset export list was empty.
-        JsonObject cleaned = new JsonObject();
-        cleaned.addProperty("objectsExported", 0); //$NON-NLS-1$
-        cleaned.addProperty("danglingRemovedCount", 2); //$NON-NLS-1$
-        assertEquals("removing dangling references rewrites Configuration.mdo and must be awaited", //$NON-NLS-1$
-            Collections.singletonList("TestConfiguration"), //$NON-NLS-1$
-            new ArrayList<>(tool.exportProjectsToAwait(params, cleaned)));
-
-        assertEquals("a result missing the counters must be awaited, not silently skipped", //$NON-NLS-1$
-            Collections.singletonList("TestConfiguration"), //$NON-NLS-1$
-            new ArrayList<>(tool.exportProjectsToAwait(params, new JsonObject())));
-    }
-
-    @Test
     public void testATruncatedDiskReportIsLabelledAndItsWholeProjectCountsAreLeftAlone()
     {
         // missingBefore is capped at MAX_LISTED_FQNS while missingBeforeCount stays the true
@@ -797,7 +765,18 @@ public class ResyncToDiskToolTest
 
         String drive(Map<String, String> params, String result)
         {
-            return awaitDiskExport(params, result);
+            // The real tool records an export at the choke point, so the barrier is entered with
+            // the project declared; these tests drive the barrier directly, so they say it here.
+            WriteScope scope = new WriteScope();
+            scope.wrote(params.get("projectName")); //$NON-NLS-1$
+            return awaitDiskExport(params, result, scope);
+        }
+
+        String driveWithNothingQueued(Map<String, String> params, String result)
+        {
+            WriteScope scope = new WriteScope();
+            scope.queuedNothing();
+            return awaitDiskExport(params, result, scope);
         }
 
         @Override
@@ -916,7 +895,7 @@ public class ResyncToDiskToolTest
         params.put("projectName", "TestConfiguration"); //$NON-NLS-1$ //$NON-NLS-2$
         params.put("revalidate", "true"); //$NON-NLS-1$ //$NON-NLS-2$
 
-        tool.drive(params, json.toString());
+        tool.driveWithNothingQueued(params, json.toString());
 
         assertEquals("a no-op must still revalidate, and must not wait for anything", //$NON-NLS-1$
             Collections.singletonList("revalidated"), order); //$NON-NLS-1$

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/BmTransactionsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/BmTransactionsTest.java
@@ -81,4 +81,43 @@ public class BmTransactionsTest
         verify(model).execute(any());
         verify(model, never()).executeReadonlyTask(any());
     }
+
+    @Test
+    public void testForceExportToDiskRecordsTheProjectIntoTheCallsWriteScope()
+    {
+        // The #408 mechanism, pinned at the point that makes it a mechanism rather than a
+        // convention: this is the ONE place the plugin hands save tasks to the platform, reached
+        // from ~20 call sites across three tools and from the shared form/rights writers. Because
+        // the record is taken here, a tool declares where it wrote by DOING the write - a new tool
+        // cannot forget a step it never has to take.
+        org.eclipse.core.resources.IProject project =
+            mock(org.eclipse.core.resources.IProject.class);
+        when(project.getName()).thenReturn("TestConfiguration"); //$NON-NLS-1$
+
+        com.ditrix.edt.mcp.server.tools.base.WriteScope scope =
+            new com.ditrix.edt.mcp.server.tools.base.WriteScope();
+        com.ditrix.edt.mcp.server.tools.base.WriteScope.runWithScope(scope,
+            () -> BmTransactions.forceExportToDisk(project, "Catalog.Products")); //$NON-NLS-1$
+
+        // Headless there are no EDT services, so the submission itself cannot succeed - and that is
+        // the case worth pinning: the record is taken for the ATTEMPT. A refused submission is not
+        // evidence that the call did not write (the model change stands, and a list submission that
+        // threw part way through is not even evidence that nothing was queued), so dropping the
+        // project there is how the barrier used to end up waiting for the wrong one.
+        assertEquals(java.util.Collections.singletonList("TestConfiguration"), //$NON-NLS-1$
+            scope.writtenProjects());
+    }
+
+    @Test
+    public void testForceExportToDiskOutsideAWriteCallRecordsNothingAndDoesNotThrow()
+    {
+        // The same helper is reachable from paths that are not a write tool's call at all
+        // (build_external_objects runs in a Job). Recording must simply not happen there.
+        org.eclipse.core.resources.IProject project =
+            mock(org.eclipse.core.resources.IProject.class);
+        when(project.getName()).thenReturn("TestConfiguration"); //$NON-NLS-1$
+
+        assertTrue("no services headless, so no submission - and no exception either", //$NON-NLS-1$
+            !BmTransactions.forceExportToDisk(project, "Catalog.Products")); //$NON-NLS-1$
+    }
 }

--- a/tests/e2e/tools/test_adopt_metadata_object.py
+++ b/tests/e2e/tools/test_adopt_metadata_object.py
@@ -71,6 +71,14 @@ def test_already_adopted_object_is_benign_not_readopted():
     if s.get("extensionProject") != TESTS_PROJECT:
         raise AssertionError("expected extensionProject=%s; got %r" % (TESTS_PROJECT, s.get("extensionProject")))
 
+    # #408: "queued nothing" is a FINDING and is published as an empty list. The distinction
+    # that matters is against ABSENT, which means "the tool could not tell" - collapsing the two
+    # is what let a no-op success and an unknown scope share one value in the old barrier.
+    if s.get("writtenProjects") != []:
+        raise AssertionError(
+            "a success that queued nothing must publish an EMPTY writtenProjects, got %r"
+            % (s.get("writtenProjects"),))
+
     assert_no_diff("adopt of an already-adopted object must not touch the base project")
 
 

--- a/tests/e2e/tools/test_apply_quick_fix.py
+++ b/tests/e2e/tools/test_apply_quick_fix.py
@@ -288,6 +288,21 @@ def test_never_reports_success_without_actually_changing_anything():
                 continue
 
             # Acceptable outcome 2: claimed applied -> the effect must be real.
+            # #408: this is the ONE tool that cannot say where it wrote - EDT's fix extension
+            # point reports nothing about what the variant touched - so it must publish NO write
+            # scope at all. An empty list here would be a claim ("I wrote nowhere") the tool is
+            # in no position to make.
+            # SCOPE OF THIS ASSERTION, stated so it is not read as more: it pins that the member
+            # never appears, which an UNDECLARED scope would also satisfy - so it does not
+            # distinguish "declared undeterminable" from "declared nothing at all". The
+            # classification itself is pinned in ApplyQuickFixToolTest; the wiring between it and
+            # the barrier is not observable from outside, because the two differ only in what is
+            # WAITED for.
+            structured = r.structured if isinstance(r.structured, dict) else {}
+            if "writtenProjects" in structured:
+                raise AssertionError(
+                    "apply_quick_fix cannot know what the fix touched, so it must publish no "
+                    "write scope at all; got %r" % (structured.get("writtenProjects"),))
             wait_for_project_ready()
             after = _count_markers(TESTS_PROJECT, c["checkId"], c["modulePath"])
             if after >= before:

--- a/tests/e2e/tools/test_create_metadata.py
+++ b/tests/e2e/tools/test_create_metadata.py
@@ -122,6 +122,24 @@ def test_create_top_level_catalog_appears_in_readback():
 
 
 @e2e_test(tool="create_metadata", kind="write-metadata")
+def test_create_reports_the_project_it_wrote_in():
+    """#408: the call states WHERE it wrote instead of having it inferred for it.
+
+    The export barrier used to derive its wait set from the arguments and from the response;
+    now the write itself records the project, and the same value is published. Mutation
+    thinking: a tool that stopped recording would publish nothing (member absent) and a tool
+    that published the ARGUMENT rather than the recorded write would still pass a
+    "projectName is in there" check - so this asserts the exact list."""
+    name = "E2EWriteScopeCatalog"
+    r = call("create_metadata", {"projectName": PROJECT, "fqn": "Catalog." + name})
+    assert_ok(r, "create Catalog.%s" % name)
+
+    s = r.structured
+    assert s is not None, "JSON tool must return structuredContent"
+    assert s.get("writtenProjects") == [PROJECT],         "a real write must publish exactly the project it wrote in: %r" % (s.get("writtenProjects"),)
+
+
+@e2e_test(tool="create_metadata", kind="write-metadata")
 def test_create_document_with_synonym_echoes_language_code():
     name = "E2EUnifiedDoc"
     r = call("create_metadata", {

--- a/tests/e2e/tools/test_delete_metadata.py
+++ b/tests/e2e/tools/test_delete_metadata.py
@@ -148,6 +148,12 @@ def test_confirm_deletes_member_attribute():
     })
     assert_ok(r, "delete the seeded attribute")
     assert r.structured.get("action") == "executed", "member delete must execute: %r" % (r.structured,)
+    # #408: a confirmed delete states the project it wrote in, so the barrier waits for the export
+    # of THAT project rather than for whatever the arguments named. The cascade participants are
+    # awaited too but deliberately NOT listed here - "the platform may have written there" must not
+    # be published under a name that says "wrote".
+    assert r.structured.get("writtenProjects") == [PROJECT],         "a confirmed delete must publish the project it wrote in: %r" % (
+            r.structured.get("writtenProjects"),)
     # The member half of #408, and it must come BEFORE any other MCP round trip: a member's
     # container IS its owning top object, so the owner .mdo is the file this call queued the export
     # of, and it has to be correct the moment the call returned. An intervening call is time an
@@ -266,6 +272,11 @@ def test_preview_without_confirm_lists_changepoints_and_does_not_mutate():
     assert "blockingReferencesCount" in r.structured, "preview must report the blocking-reference count"
     assert_contains(r.structured.get("message", ""), "confirm=true",
                     "preview message must instruct re-calling with confirm=true")
+
+    # #408: the preview states that it queued nothing, instead of the barrier inferring it from
+    # the `confirm` ARGUMENT - which says the caller authorized a destructive path, not that
+    # anything was written.
+    assert r.structured.get("writtenProjects") == [],         "a preview writes nowhere and must say so: %r" % (r.structured.get("writtenProjects"),)
 
     assert_contains(_list_commonmodules(), "Calc", "preview must NOT delete CommonModule.Calc")
     assert_no_diff("a preview must not touch the project on disk")

--- a/tests/e2e/tools/test_resync_to_disk.py
+++ b/tests/e2e/tools/test_resync_to_disk.py
@@ -170,6 +170,14 @@ def test_resync_in_sync_fixture_is_a_noop_and_does_not_mutate():
     if not isinstance(total, int) or total <= 0:
         raise AssertionError("totalTopObjects must be a positive int: %r" % total)
 
+    # #408: the tool STATES that it queued nothing, instead of the barrier rebuilding that
+    # boolean out of these report counters afterwards. An empty list is the finding; the member
+    # would be ABSENT if the tool could not tell, and those two must never look the same.
+    if sc.get("writtenProjects") != []:
+        raise AssertionError(
+            "an in-sync resync queued nothing and must publish an EMPTY writtenProjects: %r"
+            % (sc.get("writtenProjects"),))
+
     # Ground truth: a default run on an in-sync project writes nothing at all, so the
     # committed tree must be unchanged.
     assert_no_diff("default resync of an in-sync project must not change any tracked file")

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -46,6 +46,12 @@
         },
         "success": {
           "type": "boolean"
+        },
+        "writtenProjects": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [
@@ -648,6 +654,12 @@
         },
         "targetNamespace": {
           "type": "string"
+        },
+        "writtenProjects": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [
@@ -1182,6 +1194,12 @@
         },
         "success": {
           "type": "boolean"
+        },
+        "writtenProjects": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [
@@ -3204,6 +3222,12 @@
         },
         "template": {
           "type": "object"
+        },
+        "writtenProjects": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [
@@ -3511,6 +3535,12 @@
         },
         "totalTopObjects": {
           "type": "integer"
+        },
+        "writtenProjects": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [


### PR DESCRIPTION
Closes #408 (первая половина; вторую — «подал ли экспорт вообще» — закрыл #421).

## Что было

Послеполётный барьер экспорта спрашивал у инструмента `exportProjectsToAwait(params, result)` — то
есть **выводил область записи задним числом**, из аргументов вызова и из уже построенного им JSON.
Пять инструментов — пять разных косвенных признаков: имя расширения, вычитанное обратно из
собственного ответа; позиция маркера, который правил quick fix; собственные счётчики отчёта; входной
флаг `confirm`; и — сознательно неиспользованный — набор участников рефакторинга. Ни один из них не
является утверждением о записи, и каждый новый пишущий инструмент был новым шансом ошибиться **в обе
стороны**: ждать проект, в котором ничего не поставлено в очередь, — значит отказать здоровому
вызову; не ждать тот, в котором поставлено, — значит ответить «готово» поверх недописанного диска.
`apply_quick_fix` успел дать и то, и другое, в соседних раундах.

Ваше решение (16.08): **меняем контракт.**

## Что стало

Вызов сам заявляет область записи — **по ходу выполнения, а не после**.

**Заявление — побочный эффект самой записи, а не второе действие, которое надо не забыть.** Все
экспорты этого плагина подаются в одном месте — `BmTransactions.forceExportToDisk`, — и это место
записывает проект в `WriteScope` текущего вызова. Инструмент, подавший экспорт, тем самым уже
заявил, куда писал; забыть шаг, которого не нужно делать, нельзя. Явные методы остались ровно для
того, чего эта точка не видит.

**Границу называю сразу, чтобы её не прочитали шире:** экспорты, которые планирует сама платформа —
BM-реактор после коммита транзакции, md-рефакторинг внутри delete/rename, собственная BM-задача
сервиса заимствования — через наш helper не проходят и отсюда ненаблюдаемы. Именно поэтому нужен
мягкий класс (`cascadedInto`) и совместимый fallback.

**Четыре состояния, и никакие два не выражаются одним значением:**

| состояние | смысл | как возникает |
|---|---|---|
| DECLARED, непустое | «писал вот сюда» | запись в точке подачи или `wrote(...)` |
| DECLARED, пустое | «ничего не поставил в очередь» — **находка** | `queuedNothing()` |
| UNDETERMINABLE | «платформа мне этого не сообщает» — **решение** | `undeterminable(reason, fallback)` |
| UNDECLARED | неизвестно | вызов не сказал ничего |

Приоритет строгий и не зависит от порядка: запись > `undeterminable` > `queuedNothing` > молчание.
Независимость от порядка — это то, что позволяет писать инструмент естественно: `resync_to_disk`
сообщает «уже синхронизирован» и только потом его чистка висячих ссылок переэкспортирует
`Configuration.mdo` — более поздняя запись просто побеждает.

**Два класса, и класс решает, может ли зависшая очередь ОТКАЗАТЬ вызову.** Проект, в который вызов
писал, ждётся строго: не дренировалось — отказ (прежний текст, прежняя семантика, теперь про верный
проект). Проект, в который мог написать каскад платформы, ждётся, но отказать не может: мы не
подходили к его очереди экспорта, значит зависание там — не свидетельство об этом вызове. Это
обобщение правила из #421: **отказ требует, чтобы экспорт подал сам этот вызов.**

## Каскад в зависимых расширениях — названная цена бездействия

Закрыт настолько, насколько позволяет платформа. Подтверждённое удаление объявляет участников
каскада мягко; набор — тот же, который уже вычисляет пред-полётный settle (открытые расширения,
чей родитель — цель), выведенный одним новым публичным аксессором, чтобы два чтения «кто участвует»
не разъехались.

Прежнее возражение — «ожидание просканированного, но не тронутого расширения вернёт ложный отказ» —
снято **конструкцией**: мягкая запись отказать не может в принципе. Зависший экспорт в нетронутом
расширении стоит теперь задержки внутри общего 60-секундного бюджета и снимает флаг «установлено»,
но здоровое удаление не роняет.

Остаточные ограничения названы и в теле PR, и в javadoc:
- у мягкого ожидания нет отношения «подал → жду»: подать за расширение мы не можем, потому что не
  знаем, какие его объекты тронул каскад (EDT не сообщает свой changed set), поэтому в узком окне
  проба может застать очередь тихой до того, как рефакторинг в неё положит. Это строго больше, чем
  сегодняшний ноль ожидания, и то же окно, которое #421 описал для целевого проекта;
- `BoundedJob` перебрасывает `Error`, так что «мягкая запись никогда не ломает вызов» — утверждение
  про отказы, а не про ошибки JVM.

## Проволочная поверхность

В успешный payload добавлен один член — `writtenProjects`, массив, отсортированный и без повторов.
`[]` — «вызов не писал ни в один свой проект» (находка), **отсутствие члена** — «инструмент не смог
определить». Эти два никогда не совпадают. Каскадные участники в поле не попадают: «платформа могла
туда написать» нельзя публиковать под именем, которое говорит «писал».

Поле добавляется **ровно в одном месте** — в базовом классе, из того самого значения, по которому
барьер ждал, — так что опубликованное и ожидаемое разъехаться не могут.

Перегенерирован `tests/e2e/tools_list.golden.json` (+30 строк: пять outputSchema). `docs/tools/*.md`
не трогал намеренно: рендерер гайдов читает описание, inputSchema и guide, но не outputSchema, — и
прозу в гайды не добавлял, потому что после #430 тратить payload `tools/list` на пересказ схемы было
бы движением назад (описания outputSchema на провод и так не уходят).

## Совместимость

- Инструмент, который ничего не заявил, ждёт ровно то же, что и до #408 (`projectName`). Ни в одну
  сторону поведение молча не меняется.
- `structuredContent` только пополняется; ничего не переименовано и не удалено.
- `refreshAfterExportAwait`, `exportEnvironment()`, `beforeUiThreadOrError` не изменены.
- Побочно исправлен дефект самого цикла ожидания: исчерпав общий бюджет, он всё равно запускал
  ожидания с `Math.max(1L, …)` = 1 мс, а такая проба ничего не даёт и при этом занимает
  per-project claim на `3 × timeout` = 3 мс, то есть тратит единственную защиту от второй
  неостанавливаемой платформенной ожидалки. Теперь слишком маленький остаток не тратится вовсе, а
  проект отмечается как «не установлено». Для позднего строгого проекта это успех без установления,
  а не отказ: отказ обязан опираться на наблюдение, а наблюдения не было.

## Ратчет

`WriteScopeInventoryTest` — прогон по реестру: каждый зарегистрированный наследник барьера обязан
быть в явной таблице классификации (по ПОЛНОМУ имени класса). Новый пишущий инструмент валит сборку,
пока кто-нибудь не решит, что он сообщает барьеру. Сознательно не source-скан: в репозитории уже есть
такие сканеры, и они сами документируют, чего не видят (токен в комментарии, мёртвая ветка,
косвенное наследование); ратчет, который удовлетворяется комментарием, не доказывает ничего.

Чего он НЕ ловит — сказано в его же javadoc: правильность заявления он проверить не может, и видит
только наследников барьера; инструмент, реализующий `IMcpTool` напрямую и пишущий модель, ему
невидим (такой уже есть — `build_external_objects`), но у таких инструментов барьера нет вообще, и
это отдельный пробел.

## Проверка

- сборка: `BUILD SUCCESS`, **5147** юнит-тестов;
- **11 мутаций по одной, все пойманы** (файл восстанавливался, sha256 сверялся):
  приоритет `queuedNothing` над записями · «молчание» объявлено декларацией · каскад как строгий
  класс · возврат к ожиданию на 1 мс · снятие заявления цели у delete · снятие участников каскада ·
  отключение записи в точке подачи · публикация без сортировки · очистка привязки вместо
  восстановления · отключение публикации · перестановка `undeterminable`/`queuedNothing`;
- стенд EDT 2026.2 (:8766) перевыложен, anti-stale снят ДО выкладки: маркер `writtenProjects`
  0 → 1 при живом положительном контроле, классов `WriteScope` 0 → 2; рантайм-проба живого сервера:
  87 инструментов, `writtenProjects` в outputSchema пяти и отсутствует у `apply_quick_fix`;
- e2e против живого сервера: `create_metadata` 119/119, `delete_metadata` 36/36, `resync_to_disk`
  10/10, `adopt_metadata_object` 4/4, `apply_quick_fix` 3/3 (+2 skip — на этой фикстуре нет ни
  одного «Fix registered»), `tools_list` 2/2 — все с чистой фикстурой;
- codex-проход по дифу до push, два раунда; находки второго раунда — про код первого — учтены
  (заявление после транзакции, а не до неё; формулировка схемы; приоритет; ратчет по FQN).

## Что осознанно НЕ закрыто

- **Пишущие инструменты, у которых барьера нет вообще**: `rename_metadata_object`,
  `write_module_source`, `build_external_objects`, `create_project`,
  `import_configuration_from_xml`, перевод, git, инфобазы, launch. Они не питают этот барьер — это
  другой пробел, и он больше этого PR.
- `apply_quick_fix` остаётся выводом, потому что точка расширения EDT не сообщает о правке ничего.
  Изменилось то, что это теперь **явное решение в одном месте**, рядом с непрозрачным вызовом, а не
  догадка, восстановленная из ответа. Классификация закреплена юнит-тестом; **проводка между ней и
  барьером снаружи ненаблюдаема** — оба варианта отличаются только тем, чего ждут, — и e2e-утверждение
  там пинит лишь то, что поле не публикуется никогда.
- Заявления на ветках, где запись есть, а подача экспорта пропущена (пустой dirty у form-object,
  пустой FQN содержимого формы, DCS), — защитные: на текущей фикстуре эти ветки не достижимы, и
  отдельного e2e-пина у них нет.
- Ошибочный результат по-прежнему не ждёт ничего, даже если экспорт уже подан.
- Строгий `PENDING` не доказывает, что в очереди осталась именно НАША задача: сервер держит до
  восьми параллельных запросов на общий per-project сегмент экспорта. Текст отказа и так говорит
  «не подтверждено», а не «ваш экспорт упал».
