### PR TITLE
ask_workmate: прямой вызов инструмента укладывается в обещанный бюджет (#442)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -1419,20 +1419,16 @@ public class WorkmateGateway
      * @param future the tool's future
      * @param deadlineNanos when the caller's budget expires
      * @param cancelled the flag behind the token handed to Workmate
+     * @param finishedAtNanos when the future completed, armed at dispatch
      * @return the tool's result
      * @throws TimeoutException when the budget runs out first
      * @throws InterruptedException if the wait is interrupted
      * @throws ExecutionException if the tool failed
      */
     private static Object awaitToolResult(CompletableFuture<?> future, long deadlineNanos,
-        AtomicBoolean cancelled) throws TimeoutException, InterruptedException, ExecutionException
+        AtomicBoolean cancelled, AtomicLong finishedAtNanos)
+        throws TimeoutException, InterruptedException, ExecutionException
     {
-        // WHEN the future finished, not when this thread noticed. Everything below arbitrates
-        // against this stamp: a descheduled waiter must not turn a failure that beat the clock
-        // into a timeout, nor a timeout into a tool failure.
-        AtomicLong finishedAtNanos = new AtomicLong(Long.MIN_VALUE);
-        future.whenComplete(
-            (result, failure) -> finishedAtNanos.compareAndSet(Long.MIN_VALUE, System.nanoTime()));
         while (true)
         {
             // Expiry is decided in NANOSECONDS: remainingMillis truncates, so a remainder under
@@ -1683,6 +1679,12 @@ public class WorkmateGateway
                     + " instead of CompletableFuture"); //$NON-NLS-1$
             }
             CompletableFuture<?> future = (CompletableFuture<?>)futureValue;
+            // Armed HERE, the instant the future exists: a stamp taken later would record when
+            // the waiter got round to looking, so a tool that failed early while this thread was
+            // descheduled past the deadline would be reported as our timeout.
+            AtomicLong finishedAtNanos = new AtomicLong(Long.MIN_VALUE);
+            future.whenComplete((toolResult, toolFailure) -> finishedAtNanos
+                .compareAndSet(Long.MIN_VALUE, System.nanoTime()));
 
             Object result;
             try
@@ -1691,7 +1693,7 @@ public class WorkmateGateway
                 // wait computed here would start late if this thread is descheduled, and then
                 // run its full length PAST the deadline. callTools also does synchronous work
                 // of its own, which the pre-invoke measurement cannot include.
-                result = awaitToolResult(future, deadlineNanos, cancelled);
+                result = awaitToolResult(future, deadlineNanos, cancelled, finishedAtNanos);
                 finished.set(true);
             }
             catch (TimeoutException e)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -1456,6 +1456,20 @@ public class WorkmateGateway
                 // Deliberately swallowed: only the absolute deadline above ends this wait.
                 continue;
             }
+            catch (ExecutionException failed)
+            {
+                // The token handed to Workmate reports "cancelled" the moment the budget is spent,
+                // and Workmate answers that by completing the future EXCEPTIONALLY - waking this
+                // blocking get with a failure that is really our own timeout in disguise.
+                // Re-arbitrated against the clock, so the caller gets the timeout diagnosis and
+                // its "raise timeoutSeconds" advice instead of "the tool failed".
+                if (budgetSpent(deadlineNanos))
+                {
+                    cancelled.set(true);
+                    throw new TimeoutException("the tool's budget ran out"); //$NON-NLS-1$
+                }
+                throw failed;
+            }
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
 import com.ditrix.edt.mcp.server.bridge.BridgeActivity;
@@ -151,6 +152,12 @@ public class WorkmateGateway
 
     /** How often the wait wakes up to see whether the turn is still doing anything. */
     static final long DEFAULT_IDLE_POLL_MS = 5_000L;
+
+    /**
+     * How often a directly invoked tool's wait re-reads the clock. Short, because its only
+     * job is to keep a descheduled thread from waking up past the deadline it was given.
+     */
+    private static final long TOOL_WAIT_POLL_MS = 1_000L;
 
     /** Mutable only so a test can shrink the window; production never changes them. */
     private static volatile long idleTurnTimeoutMs = DEFAULT_IDLE_TURN_TIMEOUT_MS;
@@ -1402,6 +1409,45 @@ public class WorkmateGateway
     }
 
     /**
+     * Waits for a directly invoked Workmate tool, bounded by an ABSOLUTE deadline.
+     *
+     * <p>Every wake re-reads the clock instead of trusting one relative measurement: a thread
+     * descheduled after computing "how long is left" would otherwise begin that full wait
+     * whenever it resumes, and overrun the budget by however long it was away. The token is
+     * marked as soon as the deadline passes, so the tool learns it too.
+     *
+     * @param future the tool's future
+     * @param deadlineNanos when the caller's budget expires
+     * @param cancelled the flag behind the token handed to Workmate
+     * @return the tool's result
+     * @throws TimeoutException when the budget runs out first
+     * @throws InterruptedException if the wait is interrupted
+     * @throws ExecutionException if the tool failed
+     */
+    private static Object awaitToolResult(CompletableFuture<?> future, long deadlineNanos,
+        AtomicBoolean cancelled) throws TimeoutException, InterruptedException, ExecutionException
+    {
+        while (true)
+        {
+            long leftMs = remainingMillis(deadlineNanos);
+            if (leftMs <= 0)
+            {
+                cancelled.set(true);
+                throw new TimeoutException("the tool's budget ran out"); //$NON-NLS-1$
+            }
+            try
+            {
+                return future.get(Math.min(leftMs, TOOL_WAIT_POLL_MS), TimeUnit.MILLISECONDS);
+            }
+            catch (TimeoutException stillRunning)
+            {
+                // Deliberately swallowed: only the absolute deadline above ends this wait.
+                continue;
+            }
+        }
+    }
+
+    /**
      * Milliseconds left of a total budget, never negative.
      *
      * @param deadlineNanos the {@link System#nanoTime()} value the budget expires at
@@ -1519,7 +1565,8 @@ public class WorkmateGateway
             }
             Class<?> cancellationTokenClass = requireClass(aiBundle, CANCELLATION_TOKEN);
             AtomicBoolean cancelled = new AtomicBoolean(false);
-            Object token = createCancellationToken(cancellationTokenClass, cancelled);
+            Object token = createCancellationToken(cancellationTokenClass, cancelled,
+                () -> remainingMillis(deadlineNanos) <= 0);
             Method callTools = requireMethod(toolsClass, "callTools", callsClass, //$NON-NLS-1$
                 cancellationTokenClass);
             progress.onProgress("Invoking Workmate tool '" + toolName + "' directly."); //$NON-NLS-1$ //$NON-NLS-2$
@@ -1560,21 +1607,14 @@ public class WorkmateGateway
             }
             CompletableFuture<?> future = (CompletableFuture<?>)futureValue;
 
-            // Recomputed AFTER the invoke returned: callTools does synchronous work of its own
-            // (it looks the tool up and starts it), and waiting on the budget measured before it
-            // would add that duration back on top of the absolute deadline.
-            long waitMillis = remainingMillis(deadlineNanos);
-            if (waitMillis <= 0)
-            {
-                // The tool is already running, so this is never the retryable kind of timeout.
-                cancelled.set(true);
-                future.cancel(true);
-                throw GatewayException.timedOutAfterDispatch();
-            }
             Object result;
             try
             {
-                result = future.get(waitMillis, TimeUnit.MILLISECONDS);
+                // Driven by the ABSOLUTE deadline, re-read on every wake: a single relative
+                // wait computed here would start late if this thread is descheduled, and then
+                // run its full length PAST the deadline. callTools also does synchronous work
+                // of its own, which the pre-invoke measurement cannot include.
+                result = awaitToolResult(future, deadlineNanos, cancelled);
             }
             catch (TimeoutException e)
             {
@@ -2363,11 +2403,31 @@ public class WorkmateGateway
 
     private static Object createCancellationToken(Class<?> tokenClass, AtomicBoolean cancelled)
     {
+        return createCancellationToken(tokenClass, cancelled, () -> false);
+    }
+
+    /**
+     * A cancellation token that is ALSO cancelled once {@code expired} says the budget is gone.
+     *
+     * <p>A check placed before the dispatch can only ever be check-then-act: the thread may be
+     * preempted between the two, and no placement fixes that. What does is making the token
+     * itself deadline-aware - Workmate polls it inside its own loop, so a tool entered late,
+     * or still running when the budget ends, sees the cancellation at its next check instead of
+     * depending on this side of the call at all.
+     *
+     * @param tokenClass Workmate's cancellation-token interface
+     * @param cancelled set when this side gives up waiting
+     * @param expired reports whether the caller's budget is spent
+     * @return the proxy to hand to Workmate
+     */
+    private static Object createCancellationToken(Class<?> tokenClass, AtomicBoolean cancelled,
+        BooleanSupplier expired)
+    {
         return Proxy.newProxyInstance(tokenClass.getClassLoader(), new Class<?>[] {tokenClass},
             (proxy, method, args) -> {
                 if ("isCanceled".equals(method.getName())) //$NON-NLS-1$
                 {
-                    return cancelled.get();
+                    return cancelled.get() || expired.getAsBoolean();
                 }
                 if ("toString".equals(method.getName())) //$NON-NLS-1$
                 {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
@@ -1426,6 +1427,12 @@ public class WorkmateGateway
     private static Object awaitToolResult(CompletableFuture<?> future, long deadlineNanos,
         AtomicBoolean cancelled) throws TimeoutException, InterruptedException, ExecutionException
     {
+        // WHEN the future finished, not when this thread noticed. Everything below arbitrates
+        // against this stamp: a descheduled waiter must not turn a failure that beat the clock
+        // into a timeout, nor a timeout into a tool failure.
+        AtomicLong finishedAtNanos = new AtomicLong(Long.MIN_VALUE);
+        future.whenComplete(
+            (result, failure) -> finishedAtNanos.compareAndSet(Long.MIN_VALUE, System.nanoTime()));
         while (true)
         {
             // Expiry is decided in NANOSECONDS: remainingMillis truncates, so a remainder under
@@ -1433,11 +1440,12 @@ public class WorkmateGateway
             // given - cancelling a tool that was about to finish inside it.
             if (budgetSpent(deadlineNanos))
             {
-                // A RESULT beats the clock - but only a real one. If this thread was descheduled
-                // at the boundary while the tool finished, the work is done and its answer is in hand: reporting a
-                // timeout would throw away a real result and, worse, tell the caller its tool may
-                // still be running when it demonstrably is not.
-                if (future.isDone() && !future.isCompletedExceptionally())
+                // An OUTCOME that beat the clock wins, whichever kind it is. A result would
+                // otherwise be thrown away, and a genuine tool failure would be reported as
+                // "may still be running" when it demonstrably finished - both of them because
+                // this thread happened to wake up late.
+                if (future.isDone() && (!future.isCompletedExceptionally()
+                    || finishedBeforeDeadline(finishedAtNanos, deadlineNanos)))
                 {
                     return future.get();
                 }
@@ -1463,7 +1471,8 @@ public class WorkmateGateway
                 // blocking get with a failure that is really our own timeout in disguise.
                 // Re-arbitrated against the clock, so the caller gets the timeout diagnosis and
                 // its "raise timeoutSeconds" advice instead of "the tool failed".
-                if (budgetSpent(deadlineNanos))
+                if (budgetSpent(deadlineNanos)
+                    && !finishedBeforeDeadline(finishedAtNanos, deadlineNanos))
                 {
                     cancelled.set(true);
                     throw new TimeoutException("the tool's budget ran out"); //$NON-NLS-1$
@@ -1488,6 +1497,24 @@ public class WorkmateGateway
     private static boolean budgetSpent(long deadlineNanos)
     {
         return System.nanoTime() - deadlineNanos >= 0;
+    }
+
+    /**
+     * Whether the future finished BEFORE the deadline, by the stamp taken when it completed.
+     *
+     * <p>The stamp is what separates "the tool failed on its own" from "our own cancellation
+     * came back as a failure": the token only reports cancelled once the budget is spent, so a
+     * completion recorded before that instant cannot be ours - however late this thread wakes
+     * up to see it.
+     *
+     * @param finishedAtNanos the completion stamp, or {@code Long.MIN_VALUE} if not finished
+     * @param deadlineNanos when the budget expires
+     * @return {@code true} when the outcome predates the deadline
+     */
+    private static boolean finishedBeforeDeadline(AtomicLong finishedAtNanos, long deadlineNanos)
+    {
+        long finishedAt = finishedAtNanos.get();
+        return finishedAt != Long.MIN_VALUE && finishedAt - deadlineNanos < 0;
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -20,7 +20,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
@@ -159,16 +158,6 @@ public class WorkmateGateway
      * job is to keep a descheduled thread from waking up past the deadline it was given.
      */
     private static final long TOOL_WAIT_POLL_MS = 1_000L;
-
-    /** Completion stamp: the future has not finished yet. */
-    private static final long NOT_FINISHED = Long.MIN_VALUE;
-
-    /**
-     * Completion stamp: the future was ALREADY complete when this adapter received it, and
-     * {@code CompletableFuture} exposes no completion time to recover. Arbitration then reports
-     * that outcome as it stands rather than guessing whose deadline caused it.
-     */
-    private static final long UNDATABLE = Long.MAX_VALUE;
 
     /** Mutable only so a test can shrink the window; production never changes them. */
     private static volatile long idleTurnTimeoutMs = DEFAULT_IDLE_TURN_TIMEOUT_MS;
@@ -1429,15 +1418,13 @@ public class WorkmateGateway
      * @param future the tool's future
      * @param deadlineNanos when the caller's budget expires
      * @param cancelled the flag behind the token handed to Workmate
-     * @param finishedAtNanos when the future completed, armed at dispatch
      * @return the tool's result
      * @throws TimeoutException when the budget runs out first
      * @throws InterruptedException if the wait is interrupted
      * @throws ExecutionException if the tool failed
      */
-    private static Object awaitToolResult(CompletableFuture<?> source, CompletableFuture<?> observed, // NOSONAR arbitration needs the source, the wait needs the stamped stage, both need the clock
-        long deadlineNanos, AtomicBoolean cancelled, AtomicLong finishedAtNanos)
-        throws TimeoutException, InterruptedException, ExecutionException
+    private static Object awaitToolResult(CompletableFuture<?> future, long deadlineNanos,
+        AtomicBoolean cancelled) throws TimeoutException, InterruptedException, ExecutionException
     {
         while (true)
         {
@@ -1446,13 +1433,15 @@ public class WorkmateGateway
             // given - cancelling a tool that was about to finish inside it.
             if (budgetSpent(deadlineNanos))
             {
-                // Decided on the SOURCE, never on the stamped stage: the thread completing the
-                // source can be preempted before the stamping action runs, and judging by the
-                // stage would then cancel a tool that had already finished and throw its result
-                // away.
-                if (source.isDone() && reportAsItStands(source, finishedAtNanos, deadlineNanos))
+                // THE rule, and the only one this side can prove: a timeout is a budget that ran
+                // out while the tool had NOT finished. Once the future is terminal its outcome is
+                // handed over as it stands - result or failure alike - because nothing here can
+                // establish whether our cancellation caused it. Review of #444 walked that to the
+                // end: a completion stamp records when a dependent action RAN, never when the
+                // source completed, and the producer side belongs to Workmate.
+                if (future.isDone())
                 {
-                    return source.get();
+                    return future.get();
                 }
                 cancelled.set(true);
                 throw new TimeoutException("the tool's budget ran out"); //$NON-NLS-1$
@@ -1462,7 +1451,7 @@ public class WorkmateGateway
             long leftMs = Math.max(1L, remainingMillis(deadlineNanos));
             try
             {
-                return observed.get(Math.min(leftMs, TOOL_WAIT_POLL_MS), TimeUnit.MILLISECONDS);
+                return future.get(Math.min(leftMs, TOOL_WAIT_POLL_MS), TimeUnit.MILLISECONDS);
             }
             catch (TimeoutException stillRunning)
             {
@@ -1471,17 +1460,9 @@ public class WorkmateGateway
             }
             catch (ExecutionException failed)
             {
-                // The token handed to Workmate reports "cancelled" the moment the budget is spent,
-                // and Workmate answers that by completing the future EXCEPTIONALLY - waking this
-                // blocking get with a failure that is really our own timeout in disguise.
-                // Re-arbitrated against the clock, so the caller gets the timeout diagnosis and
-                // its "raise timeoutSeconds" advice instead of "the tool failed".
-                if (budgetSpent(deadlineNanos)
-                    && !reportAsItStands(source, finishedAtNanos, deadlineNanos))
-                {
-                    cancelled.set(true);
-                    throw new TimeoutException("the tool's budget ran out"); //$NON-NLS-1$
-                }
+                // Terminal is terminal: the tool answered, and its own answer - a failure
+                // included - carries more for the caller than a timeout label this side cannot
+                // justify. Relabelling it would hide the cause behind "the budget ran out".
                 throw failed;
             }
         }
@@ -1505,35 +1486,15 @@ public class WorkmateGateway
     }
 
     /**
-     * Whether the future finished BEFORE the deadline, by the stamp taken when it completed.
+     * Whether the directly invoked tool has reached a terminal state.
      *
-     * <p>The stamp is what separates "the tool failed on its own" from "our own cancellation
-     * came back as a failure": the token only reports cancelled once the budget is spent, so a
-     * completion recorded before that instant cannot be ours - however late this thread wakes
-     * up to see it.
-     *
-     * <p>Three states, because the middle one is real: {@link #NOT_FINISHED} (the wait goes on,
-     * and an expiry there IS ours), a dated stamp (compared with the deadline), and
-     * {@link #UNDATABLE} — a future already complete when it reached this adapter, which
-     * {@code CompletableFuture} gives no way to date. An undatable outcome is reported AS IT
-     * STANDS: turning a real tool failure into "the budget ran out" destroys the diagnosis, while
-     * the reverse only loses the "raise timeoutSeconds" hint from a message that already tells the
-     * caller to inspect before repeating. Losing a hint beats losing a cause.
-     *
-     * @param finishedAtNanos the completion stamp
-     * @param deadlineNanos when the budget expires
-     * @return {@code true} when the outcome must be reported as it stands
+     * @param toolFuture holder filled when {@code callTools} hands its future over
+     * @return {@code true} once that future is done; {@code false} while it is absent or running
      */
-    private static boolean reportAsItStands(CompletableFuture<?> source, AtomicLong finishedAtNanos,
-        long deadlineNanos)
+    private static boolean toolFinished(AtomicReference<CompletableFuture<?>> toolFuture)
     {
-        if (!source.isCompletedExceptionally())
-        {
-            return true;
-        }
-        long finishedAt = finishedAtNanos.get();
-        return finishedAt == UNDATABLE || finishedAt == NOT_FINISHED
-            || finishedAt - deadlineNanos < 0;
+        CompletableFuture<?> future = toolFuture.get();
+        return future != null && future.isDone();
     }
 
     /**
@@ -1654,15 +1615,20 @@ public class WorkmateGateway
             }
             Class<?> cancellationTokenClass = requireClass(aiBundle, CANCELLATION_TOKEN);
             AtomicBoolean cancelled = new AtomicBoolean(false);
-            // Workmate may keep the token and poll it after the call is over. Without this,
-            // the deadline half of the predicate would eventually report a CANCELLED call that
-            // in fact finished in time, purely because the clock moved on.
-            AtomicBoolean finished = new AtomicBoolean(false);
+            // The future the deadline half of the token judges. Filled in the moment callTools
+            // hands it over; until then there is nothing running that could be cancelled.
+            AtomicReference<CompletableFuture<?>> toolFuture = new AtomicReference<>();
+            // Two halves. Our own give-up, and the budget - but the budget stops mattering the
+            // instant the future is TERMINAL: Workmate may keep polling this token during its
+            // cleanup, and a call that finished in time must not be told it was cancelled just
+            // because the clock moved on afterwards. Judged by the future's own state rather than
+            // by a flag this side sets after the fact, which scheduler delay could postpone.
+            //
             // Nanoseconds, not remainingMillis(): that helper truncates a sub-millisecond
             // remainder to zero, which would report the budget spent up to a millisecond early
             // and abort a tool that was about to finish inside it.
             Object token = createCancellationToken(cancellationTokenClass, cancelled,
-                () -> !finished.get() && budgetSpent(deadlineNanos));
+                () -> !toolFinished(toolFuture) && budgetSpent(deadlineNanos));
             Method callTools = requireMethod(toolsClass, "callTools", callsClass, //$NON-NLS-1$
                 cancellationTokenClass);
             progress.onProgress("Invoking Workmate tool '" + toolName + "' directly."); //$NON-NLS-1$ //$NON-NLS-2$
@@ -1702,29 +1668,7 @@ public class WorkmateGateway
                     + " instead of CompletableFuture"); //$NON-NLS-1$
             }
             CompletableFuture<?> future = (CompletableFuture<?>)futureValue;
-            // Armed HERE, the instant the future exists: a stamp taken later would record when
-            // the waiter got round to looking, so a tool that failed early while this thread was
-            // descheduled past the deadline would be reported as our timeout.
-            AtomicLong finishedAtNanos = new AtomicLong(NOT_FINISHED);
-            // What the WAIT observes. Not the raw future: whenComplete is a DEPENDENT stage, run
-            // after the outcome is published, so a waiter watching the raw future can see it
-            // finished while the stamp is still unwritten - and then read "not finished" as "our
-            // deadline won". Waiting on the dependent stage orders the two: it cannot complete
-            // before its own action has stamped.
-            CompletableFuture<?> observed;
-            if (future.isDone())
-            {
-                // Already complete before this adapter ever saw it, and CompletableFuture keeps no
-                // completion time to recover: stamping "now" would record when WE looked, which
-                // can fall past the deadline and turn a genuine early failure into our timeout.
-                finishedAtNanos.set(UNDATABLE);
-                observed = future;
-            }
-            else
-            {
-                observed = future.whenComplete((toolResult, toolFailure) -> finishedAtNanos
-                    .compareAndSet(NOT_FINISHED, System.nanoTime()));
-            }
+            toolFuture.set(future);
 
             Object result;
             try
@@ -1733,10 +1677,7 @@ public class WorkmateGateway
                 // wait computed here would start late if this thread is descheduled, and then
                 // run its full length PAST the deadline. callTools also does synchronous work
                 // of its own, which the pre-invoke measurement cannot include.
-                // The dependent stage is what is WAITED on; cancellation below still goes to
-                // the original future, since cancelling a derived stage would not stop the tool.
-                result = awaitToolResult(future, observed, deadlineNanos, cancelled, finishedAtNanos);
-                finished.set(true);
+                result = awaitToolResult(future, deadlineNanos, cancelled);
             }
             catch (TimeoutException e)
             {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -1435,8 +1435,8 @@ public class WorkmateGateway
      * @throws InterruptedException if the wait is interrupted
      * @throws ExecutionException if the tool failed
      */
-    private static Object awaitToolResult(CompletableFuture<?> future, long deadlineNanos,
-        AtomicBoolean cancelled, AtomicLong finishedAtNanos)
+    private static Object awaitToolResult(CompletableFuture<?> source, CompletableFuture<?> observed, // NOSONAR arbitration needs the source, the wait needs the stamped stage, both need the clock
+        long deadlineNanos, AtomicBoolean cancelled, AtomicLong finishedAtNanos)
         throws TimeoutException, InterruptedException, ExecutionException
     {
         while (true)
@@ -1446,14 +1446,13 @@ public class WorkmateGateway
             // given - cancelling a tool that was about to finish inside it.
             if (budgetSpent(deadlineNanos))
             {
-                // An OUTCOME that beat the clock wins, whichever kind it is. A result would
-                // otherwise be thrown away, and a genuine tool failure would be reported as
-                // "may still be running" when it demonstrably finished - both of them because
-                // this thread happened to wake up late.
-                if (future.isDone() && (!future.isCompletedExceptionally()
-                    || finishedBeforeDeadline(finishedAtNanos, deadlineNanos)))
+                // Decided on the SOURCE, never on the stamped stage: the thread completing the
+                // source can be preempted before the stamping action runs, and judging by the
+                // stage would then cancel a tool that had already finished and throw its result
+                // away.
+                if (source.isDone() && reportAsItStands(source, finishedAtNanos, deadlineNanos))
                 {
-                    return future.get();
+                    return source.get();
                 }
                 cancelled.set(true);
                 throw new TimeoutException("the tool's budget ran out"); //$NON-NLS-1$
@@ -1463,7 +1462,7 @@ public class WorkmateGateway
             long leftMs = Math.max(1L, remainingMillis(deadlineNanos));
             try
             {
-                return future.get(Math.min(leftMs, TOOL_WAIT_POLL_MS), TimeUnit.MILLISECONDS);
+                return observed.get(Math.min(leftMs, TOOL_WAIT_POLL_MS), TimeUnit.MILLISECONDS);
             }
             catch (TimeoutException stillRunning)
             {
@@ -1478,7 +1477,7 @@ public class WorkmateGateway
                 // Re-arbitrated against the clock, so the caller gets the timeout diagnosis and
                 // its "raise timeoutSeconds" advice instead of "the tool failed".
                 if (budgetSpent(deadlineNanos)
-                    && !finishedBeforeDeadline(finishedAtNanos, deadlineNanos))
+                    && !reportAsItStands(source, finishedAtNanos, deadlineNanos))
                 {
                     cancelled.set(true);
                     throw new TimeoutException("the tool's budget ran out"); //$NON-NLS-1$
@@ -1525,14 +1524,16 @@ public class WorkmateGateway
      * @param deadlineNanos when the budget expires
      * @return {@code true} when the outcome must be reported as it stands
      */
-    private static boolean finishedBeforeDeadline(AtomicLong finishedAtNanos, long deadlineNanos)
+    private static boolean reportAsItStands(CompletableFuture<?> source, AtomicLong finishedAtNanos,
+        long deadlineNanos)
     {
-        long finishedAt = finishedAtNanos.get();
-        if (finishedAt == UNDATABLE)
+        if (!source.isCompletedExceptionally())
         {
             return true;
         }
-        return finishedAt != NOT_FINISHED && finishedAt - deadlineNanos < 0;
+        long finishedAt = finishedAtNanos.get();
+        return finishedAt == UNDATABLE || finishedAt == NOT_FINISHED
+            || finishedAt - deadlineNanos < 0;
     }
 
     /**
@@ -1734,7 +1735,7 @@ public class WorkmateGateway
                 // of its own, which the pre-invoke measurement cannot include.
                 // The dependent stage is what is WAITED on; cancellation below still goes to
                 // the original future, since cancelling a derived stage would not stop the tool.
-                result = awaitToolResult(observed, deadlineNanos, cancelled, finishedAtNanos);
+                result = awaitToolResult(future, observed, deadlineNanos, cancelled, finishedAtNanos);
                 finished.set(true);
             }
             catch (TimeoutException e)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -1539,6 +1539,15 @@ public class WorkmateGateway
                 throw GatewayException.callFailed("the job was already reported as finished " //$NON-NLS-1$
                     + "before tool '" + toolName + "' could be invoked, so it was not invoked"); //$NON-NLS-1$ //$NON-NLS-2$
             }
+            // Again, after the handshake and not only before it: onTryCommit takes the job
+            // record's lock and can wait there, so the budget may run out between the two. The
+            // conversation path re-checks in the same place for the same reason. Still the
+            // retryable kind - the commit stops the registry from killing the job, but no tool
+            // has been entered, so nothing was left half-done.
+            if (remainingMillis(deadlineNanos) <= 0)
+            {
+                throw GatewayException.timedOut();
+            }
             Object futureValue = invoke(callTools, tools, calls, token);
             // The tool is RUNNING from here on - JShell executes arbitrary code, and other
             // Workmate tools change this project - so nothing below may advise a retry.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -1433,11 +1433,11 @@ public class WorkmateGateway
             // given - cancelling a tool that was about to finish inside it.
             if (budgetSpent(deadlineNanos))
             {
-                // A RESULT beats the clock. If this thread was descheduled at the boundary while
-                // the tool finished, the work is done and its answer is in hand: reporting a
+                // A RESULT beats the clock - but only a real one. If this thread was descheduled
+                // at the boundary while the tool finished, the work is done and its answer is in hand: reporting a
                 // timeout would throw away a real result and, worse, tell the caller its tool may
                 // still be running when it demonstrably is not.
-                if (future.isDone() && !future.isCancelled())
+                if (future.isDone() && !future.isCompletedExceptionally())
                 {
                     return future.get();
                 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -1513,14 +1513,26 @@ public class WorkmateGateway
      * completion recorded before that instant cannot be ours - however late this thread wakes
      * up to see it.
      *
-     * @param finishedAtNanos the completion stamp, or {@code Long.MIN_VALUE} if not finished
+     * <p>Three states, because the middle one is real: {@link #NOT_FINISHED} (the wait goes on,
+     * and an expiry there IS ours), a dated stamp (compared with the deadline), and
+     * {@link #UNDATABLE} — a future already complete when it reached this adapter, which
+     * {@code CompletableFuture} gives no way to date. An undatable outcome is reported AS IT
+     * STANDS: turning a real tool failure into "the budget ran out" destroys the diagnosis, while
+     * the reverse only loses the "raise timeoutSeconds" hint from a message that already tells the
+     * caller to inspect before repeating. Losing a hint beats losing a cause.
+     *
+     * @param finishedAtNanos the completion stamp
      * @param deadlineNanos when the budget expires
-     * @return {@code true} when the outcome predates the deadline
+     * @return {@code true} when the outcome must be reported as it stands
      */
     private static boolean finishedBeforeDeadline(AtomicLong finishedAtNanos, long deadlineNanos)
     {
         long finishedAt = finishedAtNanos.get();
-        return finishedAt != Long.MIN_VALUE && finishedAt - deadlineNanos < 0;
+        if (finishedAt == UNDATABLE)
+        {
+            return true;
+        }
+        return finishedAt != NOT_FINISHED && finishedAt - deadlineNanos < 0;
     }
 
     /**
@@ -1692,9 +1704,19 @@ public class WorkmateGateway
             // Armed HERE, the instant the future exists: a stamp taken later would record when
             // the waiter got round to looking, so a tool that failed early while this thread was
             // descheduled past the deadline would be reported as our timeout.
-            AtomicLong finishedAtNanos = new AtomicLong(Long.MIN_VALUE);
-            future.whenComplete((toolResult, toolFailure) -> finishedAtNanos
-                .compareAndSet(Long.MIN_VALUE, System.nanoTime()));
+            AtomicLong finishedAtNanos = new AtomicLong(NOT_FINISHED);
+            if (future.isDone())
+            {
+                // Already complete before this adapter ever saw it, and CompletableFuture keeps no
+                // completion time to recover: stamping "now" would record when WE looked, which
+                // can fall past the deadline and turn a genuine early failure into our timeout.
+                finishedAtNanos.set(UNDATABLE);
+            }
+            else
+            {
+                future.whenComplete((toolResult, toolFailure) -> finishedAtNanos
+                    .compareAndSet(NOT_FINISHED, System.nanoTime()));
+            }
 
             Object result;
             try

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -1565,8 +1565,15 @@ public class WorkmateGateway
             }
             Class<?> cancellationTokenClass = requireClass(aiBundle, CANCELLATION_TOKEN);
             AtomicBoolean cancelled = new AtomicBoolean(false);
+            // Workmate may keep the token and poll it after the call is over. Without this,
+            // the deadline half of the predicate would eventually report a CANCELLED call that
+            // in fact finished in time, purely because the clock moved on.
+            AtomicBoolean finished = new AtomicBoolean(false);
+            // Nanoseconds, not remainingMillis(): that helper truncates a sub-millisecond
+            // remainder to zero, which would report the budget spent up to a millisecond early
+            // and abort a tool that was about to finish inside it.
             Object token = createCancellationToken(cancellationTokenClass, cancelled,
-                () -> remainingMillis(deadlineNanos) <= 0);
+                () -> !finished.get() && System.nanoTime() - deadlineNanos >= 0);
             Method callTools = requireMethod(toolsClass, "callTools", callsClass, //$NON-NLS-1$
                 cancellationTokenClass);
             progress.onProgress("Invoking Workmate tool '" + toolName + "' directly."); //$NON-NLS-1$ //$NON-NLS-2$
@@ -1615,6 +1622,7 @@ public class WorkmateGateway
                 // run its full length PAST the deadline. callTools also does synchronous work
                 // of its own, which the pre-invoke measurement cannot include.
                 result = awaitToolResult(future, deadlineNanos, cancelled);
+                finished.set(true);
             }
             catch (TimeoutException e)
             {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -1433,6 +1433,14 @@ public class WorkmateGateway
             // given - cancelling a tool that was about to finish inside it.
             if (budgetSpent(deadlineNanos))
             {
+                // A RESULT beats the clock. If this thread was descheduled at the boundary while
+                // the tool finished, the work is done and its answer is in hand: reporting a
+                // timeout would throw away a real result and, worse, tell the caller its tool may
+                // still be running when it demonstrably is not.
+                if (future.isDone() && !future.isCancelled())
+                {
+                    return future.get();
+                }
                 cancelled.set(true);
                 throw new TimeoutException("the tool's budget ran out"); //$NON-NLS-1$
             }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -1460,6 +1460,11 @@ public class WorkmateGateway
     public String callWorkmateTool(String toolName, String argsJson, long timeoutMillis,
         ProgressListener progress) throws GatewayException
     {
+        // Taken BEFORE the reflective setup, not after it: bundle lookup, injector resolution,
+        // the authorization probe and building the call all spend the caller's budget, and a
+        // wait measured afterwards would hand the tool a fresh full budget on top of what setup
+        // already used - so the job could outlive the timeoutSeconds it advertised (#442).
+        long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
         // Outside the try, because the catch at the bottom classifies by it: a tool that has
         // started may already have run code, and "retry" would run it twice.
         AtomicBoolean invoked = new AtomicBoolean(false);
@@ -1519,6 +1524,14 @@ public class WorkmateGateway
                 cancellationTokenClass);
             progress.onProgress("Invoking Workmate tool '" + toolName + "' directly."); //$NON-NLS-1$ //$NON-NLS-2$
 
+            // Checked immediately before the invoke, because invoking is what has consequences:
+            // a Workmate tool can run arbitrary code (JShell) or change this configuration, and a
+            // call let out after the advertised budget spends time the caller was never promised.
+            // Nothing has been dispatched yet, so this is the ordinary retryable timeout.
+            if (remainingMillis(deadlineNanos) <= 0)
+            {
+                throw GatewayException.timedOut();
+            }
             // Same reason as the facade above: a Workmate tool can run arbitrary code (JShell)
             // or change the configuration, and cancelling the wait does not undo that.
             if (!progress.onTryCommit())
@@ -1537,10 +1550,22 @@ public class WorkmateGateway
                     + " instead of CompletableFuture"); //$NON-NLS-1$
             }
             CompletableFuture<?> future = (CompletableFuture<?>)futureValue;
+
+            // Recomputed AFTER the invoke returned: callTools does synchronous work of its own
+            // (it looks the tool up and starts it), and waiting on the budget measured before it
+            // would add that duration back on top of the absolute deadline.
+            long waitMillis = remainingMillis(deadlineNanos);
+            if (waitMillis <= 0)
+            {
+                // The tool is already running, so this is never the retryable kind of timeout.
+                cancelled.set(true);
+                future.cancel(true);
+                throw GatewayException.timedOutAfterDispatch();
+            }
             Object result;
             try
             {
-                result = future.get(timeoutMillis, TimeUnit.MILLISECONDS);
+                result = future.get(waitMillis, TimeUnit.MILLISECONDS);
             }
             catch (TimeoutException e)
             {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -1429,12 +1429,17 @@ public class WorkmateGateway
     {
         while (true)
         {
-            long leftMs = remainingMillis(deadlineNanos);
-            if (leftMs <= 0)
+            // Expiry is decided in NANOSECONDS: remainingMillis truncates, so a remainder under
+            // one millisecond would read as zero and end the wait before the deadline it was
+            // given - cancelling a tool that was about to finish inside it.
+            if (System.nanoTime() - deadlineNanos >= 0)
             {
                 cancelled.set(true);
                 throw new TimeoutException("the tool's budget ran out"); //$NON-NLS-1$
             }
+            // ... while the WAIT length may round, as long as it never rounds down to zero (which
+            // would spin) - it only decides how soon the deadline is looked at again.
+            long leftMs = Math.max(1L, remainingMillis(deadlineNanos));
             try
             {
                 return future.get(Math.min(leftMs, TOOL_WAIT_POLL_MS), TimeUnit.MILLISECONDS);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -160,6 +160,16 @@ public class WorkmateGateway
      */
     private static final long TOOL_WAIT_POLL_MS = 1_000L;
 
+    /** Completion stamp: the future has not finished yet. */
+    private static final long NOT_FINISHED = Long.MIN_VALUE;
+
+    /**
+     * Completion stamp: the future was ALREADY complete when this adapter received it, and
+     * {@code CompletableFuture} exposes no completion time to recover. Arbitration then reports
+     * that outcome as it stands rather than guessing whose deadline caused it.
+     */
+    private static final long UNDATABLE = Long.MAX_VALUE;
+
     /** Mutable only so a test can shrink the window; production never changes them. */
     private static volatile long idleTurnTimeoutMs = DEFAULT_IDLE_TURN_TIMEOUT_MS;
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -646,7 +646,7 @@ public class WorkmateGateway
                 // Checked BEFORE the commit handshake, not only inside the send: a request that
                 // has not gone out yet leaves nothing behind, so an expired budget here is an
                 // ordinary retryable timeout rather than the "already dispatched" kind.
-                if (session == null && remainingMillis(deadlineNanos) <= 0)
+                if (session == null && budgetSpent(deadlineNanos))
                 {
                     throw GatewayException.timedOut();
                 }
@@ -690,7 +690,7 @@ public class WorkmateGateway
                     lastAnnouncement = stripped;
                 }
                 if (isAnswer || turn.session == null || continuations >= MAX_CONTINUATIONS
-                    || remainingMillis(deadlineNanos) <= 0)
+                    || budgetSpent(deadlineNanos))
                 {
                     break;
                 }
@@ -1075,8 +1075,7 @@ public class WorkmateGateway
         // Immediately before the send, because dispatching is what has consequences: Workmate's
         // tool loop can change this configuration, and a request let out after the advertised
         // budget spends time the caller was never promised. A later wait-timeout does not undo it.
-        long remainingMillis = remainingMillis(deadlineNanos);
-        if (remainingMillis <= 0)
+        if (budgetSpent(deadlineNanos))
         {
             throw firstTurn ? GatewayException.timedOut() : GatewayException.timedOutAfterDispatch();
         }
@@ -1108,8 +1107,7 @@ public class WorkmateGateway
         // Recomputed AFTER the dispatch returned: sendAsync does synchronous work of its own
         // (it creates the conversation), and waiting on the budget measured before it would add
         // that duration back on top of the absolute deadline, once per turn.
-        long waitMillis = remainingMillis(deadlineNanos);
-        if (waitMillis <= 0)
+        if (budgetSpent(deadlineNanos))
         {
             // The request is already out, so this is never the retryable kind of timeout.
             cancelled.set(true);
@@ -1124,7 +1122,8 @@ public class WorkmateGateway
             // Milliseconds, not floored seconds: rounding down cancelled a turn up to a second
             // before the advertised budget ran out, and a floor of one second let an already
             // spent budget overshoot by one more.
-            sendResult = awaitTurn(future, waitMillis);
+            // The length may round; only "is there still time" must not (budgetSpent above).
+            sendResult = awaitTurn(future, Math.max(1L, remainingMillis(deadlineNanos)));
         }
         catch (TimeoutException e)
         {
@@ -1432,7 +1431,7 @@ public class WorkmateGateway
             // Expiry is decided in NANOSECONDS: remainingMillis truncates, so a remainder under
             // one millisecond would read as zero and end the wait before the deadline it was
             // given - cancelling a tool that was about to finish inside it.
-            if (System.nanoTime() - deadlineNanos >= 0)
+            if (budgetSpent(deadlineNanos))
             {
                 cancelled.set(true);
                 throw new TimeoutException("the tool's budget ran out"); //$NON-NLS-1$
@@ -1450,6 +1449,23 @@ public class WorkmateGateway
                 continue;
             }
         }
+    }
+
+    /**
+     * Whether a budget is spent.
+     *
+     * <p>The ONE place this question is answered, and it is answered in nanoseconds:
+     * {@link #remainingMillis} truncates, so a remainder under a millisecond reads as zero and
+     * a caller asking "<= 0" would declare the budget gone up to a millisecond early - early
+     * enough to refuse a dispatch, or cancel a tool, that still had time. Milliseconds are for
+     * how LONG to wait; nanoseconds decide WHETHER there is still time.
+     *
+     * @param deadlineNanos the {@link System#nanoTime()} value the budget expires at
+     * @return {@code true} once the deadline has been reached
+     */
+    private static boolean budgetSpent(long deadlineNanos)
+    {
+        return System.nanoTime() - deadlineNanos >= 0;
     }
 
     /**
@@ -1578,7 +1594,7 @@ public class WorkmateGateway
             // remainder to zero, which would report the budget spent up to a millisecond early
             // and abort a tool that was about to finish inside it.
             Object token = createCancellationToken(cancellationTokenClass, cancelled,
-                () -> !finished.get() && System.nanoTime() - deadlineNanos >= 0);
+                () -> !finished.get() && budgetSpent(deadlineNanos));
             Method callTools = requireMethod(toolsClass, "callTools", callsClass, //$NON-NLS-1$
                 cancellationTokenClass);
             progress.onProgress("Invoking Workmate tool '" + toolName + "' directly."); //$NON-NLS-1$ //$NON-NLS-2$
@@ -1587,7 +1603,7 @@ public class WorkmateGateway
             // a Workmate tool can run arbitrary code (JShell) or change this configuration, and a
             // call let out after the advertised budget spends time the caller was never promised.
             // Nothing has been dispatched yet, so this is the ordinary retryable timeout.
-            if (remainingMillis(deadlineNanos) <= 0)
+            if (budgetSpent(deadlineNanos))
             {
                 throw GatewayException.timedOut();
             }
@@ -1603,7 +1619,7 @@ public class WorkmateGateway
             // conversation path re-checks in the same place for the same reason. Still the
             // retryable kind - the commit stops the registry from killing the job, but no tool
             // has been entered, so nothing was left half-done.
-            if (remainingMillis(deadlineNanos) <= 0)
+            if (budgetSpent(deadlineNanos))
             {
                 throw GatewayException.timedOut();
             }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -1705,16 +1705,23 @@ public class WorkmateGateway
             // the waiter got round to looking, so a tool that failed early while this thread was
             // descheduled past the deadline would be reported as our timeout.
             AtomicLong finishedAtNanos = new AtomicLong(NOT_FINISHED);
+            // What the WAIT observes. Not the raw future: whenComplete is a DEPENDENT stage, run
+            // after the outcome is published, so a waiter watching the raw future can see it
+            // finished while the stamp is still unwritten - and then read "not finished" as "our
+            // deadline won". Waiting on the dependent stage orders the two: it cannot complete
+            // before its own action has stamped.
+            CompletableFuture<?> observed;
             if (future.isDone())
             {
                 // Already complete before this adapter ever saw it, and CompletableFuture keeps no
                 // completion time to recover: stamping "now" would record when WE looked, which
                 // can fall past the deadline and turn a genuine early failure into our timeout.
                 finishedAtNanos.set(UNDATABLE);
+                observed = future;
             }
             else
             {
-                future.whenComplete((toolResult, toolFailure) -> finishedAtNanos
+                observed = future.whenComplete((toolResult, toolFailure) -> finishedAtNanos
                     .compareAndSet(NOT_FINISHED, System.nanoTime()));
             }
 
@@ -1725,7 +1732,9 @@ public class WorkmateGateway
                 // wait computed here would start late if this thread is descheduled, and then
                 // run its full length PAST the deadline. callTools also does synchronous work
                 // of its own, which the pre-invoke measurement cannot include.
-                result = awaitToolResult(future, deadlineNanos, cancelled, finishedAtNanos);
+                // The dependent stage is what is WAITED on; cancellation below still goes to
+                // the original future, since cancelling a derived stage would not stop the tool.
+                result = awaitToolResult(observed, deadlineNanos, cancelled, finishedAtNanos);
                 finished.set(true);
             }
             catch (TimeoutException e)


### PR DESCRIPTION
Закрывает #442 — отложенный тред ревью #440 (путь прямого вызова инструмента к #427 отношения не имел).

## Что было

`WorkmateGateway.callWorkmateTool(...)` брал бюджет на входе и ждал future ЦЕЛИКОМ по этому замеру. Между замером и ожиданием успевали отработать рефлексивная подготовка и синхронная часть `callTools`, поэтому фактическое время = подготовка + весь бюджет. Реестр заданий намеренно не убивает уже зафиксированную работу по своему дедлайну — значит обещанный вызывающему `timeoutSeconds` мог быть превышен.

## Что стало

То же, что уже сделано для разговорного пути в #440:

1. **Абсолютный дедлайн на входе**, до всякой рефлексии.
2. **Проверка непосредственно перед `invoke(callTools, ...)`** — после дедлайна инструмент не запускается вовсе. Это обычный retryable `TIMED_OUT`: ничего не отправлено, повтор безопасен.
3. **Пересчёт остатка после возврата `callTools`**, ожидание по нему; исчерпание в этот момент — `TIMED_OUT_AFTER_DISPATCH` с отменой future, потому что инструмент уже работает и может исполнять произвольный код (JShell).

## Проверка

Юнит-тестов на рефлексивный шов нет (как и раньше), поэтому — живой стенд, EDT 2026.2.0.289:

| Вызов | Ожидание | Факт |
|---|---|---|
| `workmateTool=JShellSession, timeoutSeconds=1` | падение около 1 с, текст пост-отправочный | `failed`, **elapsed 1.003 s**, «request had already been sent … Do NOT simply retry» |
| `workmateTool=JShellSession, timeoutSeconds=300` | штатная работа | `done`, **elapsed 70.97 s**, сессия возвращена |

Сборка: 5311 тестов, зелено.