### PR TITLE
Автономный сервер: перенос портов разрешает только свой сервер (#437)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
@@ -1298,14 +1298,14 @@ public class DebugLaunchTool implements IMcpTool
         // port-conflict matcher is armed and can refuse the launch - without a window that refusal
         // reached nobody. "policy != null" is the non-Attach signal (the caller passes null for an
         // Attach, which attaches to a running server and never starts one).
+        // Resolved ONCE, before anything uses it: the window, the arm and its release must all
+        // carry the SAME name. Read twice, a rebound configuration (or one best-effort lookup
+        // that momentarily fails) would address the window to one server and the arm to another,
+        // and the arm would never be released by the value it was taken with.
+        String launchServer = launchServerName(config);
         LaunchUpdateDialogAutoConfirmer.ConflictWatch conflicts = policy == null
             ? null
-            : LaunchUpdateDialogAutoConfirmer.beginConflictWatch(launchInfobase,
-                launchServerName(config));
-        // Resolved ONCE and reused for the disarm: reading it again later could return a
-        // different server if the configuration was rebound meanwhile, and the arm would then
-        // never be released by the value it was taken with.
-        String launchServer = launchServerName(config);
+            : LaunchUpdateDialogAutoConfirmer.beginConflictWatch(launchInfobase, launchServer);
         LaunchUpdateDialogAutoConfirmer.arm(autoConfirmUpdateDialog, true, autoConfirmUpdateDialog,
             launchPolicy, launchInfobase, launchPortPolicy, launchServer);
         // Keep the infobase auth-dialog suppression active for the WHOLE async launch

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
@@ -1038,7 +1038,13 @@ public class DebugLaunchTool implements IMcpTool
         try
         {
             String projectName = config.getAttribute(LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
-            String applicationId = LaunchConfigUtils.getApplicationIdFor(config);
+            // The DELEGATE id, the same one standaloneServerPortPolicy resolves: a runtime
+            // configuration without a stored ATTR_APPLICATION_ID launches the default application
+            // application, while getApplicationIdFor yields a synthetic "launch:<name>" that no
+            // IApplicationManager knows - so attribution came back null and the arm, though
+            // created, could never authorise the re-address the caller asked for.
+            String applicationId = LaunchLifecycleUtils.resolveDelegateApplicationId(config,
+                projectName);
             ProjectContext ctx = ProjectContext.of(projectName);
             if (!ctx.isOpen())
             {
@@ -1065,7 +1071,13 @@ public class DebugLaunchTool implements IMcpTool
         try
         {
             String projectName = config.getAttribute(LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
-            String applicationId = LaunchConfigUtils.getApplicationIdFor(config);
+            // The DELEGATE id, the same one standaloneServerPortPolicy resolves: a runtime
+            // configuration without a stored ATTR_APPLICATION_ID launches the default application
+            // application, while getApplicationIdFor yields a synthetic "launch:<name>" that no
+            // IApplicationManager knows - so attribution came back null and the arm, though
+            // created, could never authorise the re-address the caller asked for.
+            String applicationId = LaunchLifecycleUtils.resolveDelegateApplicationId(config,
+                projectName);
             ProjectContext ctx = ProjectContext.of(projectName);
             if (!ctx.isOpen())
             {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
@@ -1054,6 +1054,33 @@ public class DebugLaunchTool implements IMcpTool
     }
 
     /**
+     * The WST server name behind a launch configuration - what the port-conflict dialog quotes.
+     * Best-effort: {@code null} simply refuses the writing answer.
+     *
+     * @param config the launch configuration
+     * @return the server name, or {@code null}
+     */
+    private static String launchServerName(ILaunchConfiguration config)
+    {
+        try
+        {
+            String projectName = config.getAttribute(LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+            String applicationId = LaunchConfigUtils.getApplicationIdFor(config);
+            ProjectContext ctx = ProjectContext.of(projectName);
+            if (!ctx.isOpen())
+            {
+                return null;
+            }
+            return LaunchLifecycleUtils.attributionServerName(
+                Activator.getDefault().getApplicationManager(), ctx.project(), applicationId);
+        }
+        catch (Exception e) // NOSONAR a best-effort hint must never break the launch
+        {
+            return null;
+        }
+    }
+
+    /**
      * Launches the given configuration in debug mode, asynchronously.
      *
      * <p>Uses a direct {@code config.launch(DEBUG_MODE, monitor)} — not
@@ -1180,7 +1207,7 @@ public class DebugLaunchTool implements IMcpTool
         StandaloneServerPortConflictPolicy launchPortPolicy = standaloneServerPortPolicy(config,
             portPolicy);
         LaunchUpdateDialogAutoConfirmer.arm(autoConfirmUpdateDialog, true, autoConfirmUpdateDialog,
-            launchPolicy, launchInfobase, launchPortPolicy);
+            launchPolicy, launchInfobase, launchPortPolicy, launchServerName(config));
         InfobaseAuthDialogSuppressor.markActivityStart();
         try
         {
@@ -1270,7 +1297,7 @@ public class DebugLaunchTool implements IMcpTool
             ? null
             : LaunchUpdateDialogAutoConfirmer.beginConflictWatch(launchInfobase);
         LaunchUpdateDialogAutoConfirmer.arm(autoConfirmUpdateDialog, true, autoConfirmUpdateDialog,
-            launchPolicy, launchInfobase, launchPortPolicy);
+            launchPolicy, launchInfobase, launchPortPolicy, launchServerName(config));
         // Keep the infobase auth-dialog suppression active for the WHOLE async launch
         // (#230). This launch is fire-and-forget: tool.execute() has already returned and
         // stamped lastActivityEndMillis, and with updateBeforeLaunch=false there is no

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
@@ -1206,8 +1206,12 @@ public class DebugLaunchTool implements IMcpTool
         ExternalInfobaseChangesPolicy launchPolicy = autoConfirmUpdateDialog ? policy : null;
         StandaloneServerPortConflictPolicy launchPortPolicy = standaloneServerPortPolicy(config,
             portPolicy);
+        // Resolved ONCE and reused for the disarm: reading it again later could return a
+        // different server if the configuration was rebound meanwhile, and the arm would then
+        // never be released by the value it was taken with.
+        String launchServer = launchServerName(config);
         LaunchUpdateDialogAutoConfirmer.arm(autoConfirmUpdateDialog, true, autoConfirmUpdateDialog,
-            launchPolicy, launchInfobase, launchPortPolicy, launchServerName(config));
+            launchPolicy, launchInfobase, launchPortPolicy, launchServer);
         InfobaseAuthDialogSuppressor.markActivityStart();
         try
         {
@@ -1224,7 +1228,8 @@ public class DebugLaunchTool implements IMcpTool
         {
             InfobaseAuthDialogSuppressor.markActivityEnd();
             LaunchUpdateDialogAutoConfirmer.disarm(autoConfirmUpdateDialog, true,
-                autoConfirmUpdateDialog, launchPolicy, launchInfobase, launchPortPolicy);
+                autoConfirmUpdateDialog, launchPolicy, launchInfobase, launchPortPolicy,
+                launchServer);
         }
     }
 
@@ -1295,9 +1300,14 @@ public class DebugLaunchTool implements IMcpTool
         // Attach, which attaches to a running server and never starts one).
         LaunchUpdateDialogAutoConfirmer.ConflictWatch conflicts = policy == null
             ? null
-            : LaunchUpdateDialogAutoConfirmer.beginConflictWatch(launchInfobase);
+            : LaunchUpdateDialogAutoConfirmer.beginConflictWatch(launchInfobase,
+                launchServerName(config));
+        // Resolved ONCE and reused for the disarm: reading it again later could return a
+        // different server if the configuration was rebound meanwhile, and the arm would then
+        // never be released by the value it was taken with.
+        String launchServer = launchServerName(config);
         LaunchUpdateDialogAutoConfirmer.arm(autoConfirmUpdateDialog, true, autoConfirmUpdateDialog,
-            launchPolicy, launchInfobase, launchPortPolicy, launchServerName(config));
+            launchPolicy, launchInfobase, launchPortPolicy, launchServer);
         // Keep the infobase auth-dialog suppression active for the WHOLE async launch
         // (#230). This launch is fire-and-forget: tool.execute() has already returned and
         // stamped lastActivityEndMillis, and with updateBeforeLaunch=false there is no
@@ -1355,7 +1365,8 @@ public class DebugLaunchTool implements IMcpTool
         {
             InfobaseAuthDialogSuppressor.markActivityEnd();
             LaunchUpdateDialogAutoConfirmer.disarm(autoConfirmUpdateDialog, true,
-                autoConfirmUpdateDialog, launchPolicy, launchInfobase, launchPortPolicy);
+                autoConfirmUpdateDialog, launchPolicy, launchInfobase, launchPortPolicy,
+                launchServer);
             if (conflicts != null)
             {
                 conflicts.close();

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
@@ -1134,6 +1134,12 @@ public class RunYaxunitTestsTool implements IMcpTool
         String launchInfobase = LaunchLifecycleUtils.attributionInfobaseName(
             Activator.getDefault().getApplicationManager(),
             launchCtx.isOpen() ? launchCtx.project() : null, applicationId);
+        // The server's OWN name, which is what the port-conflict dialog quotes: the infobase
+        // name inside it is not enough to tell "Base" from "My Base", and the answer rewrites
+        // whichever server the dialog belongs to.
+        String launchServer = LaunchLifecycleUtils.attributionServerName(
+            Activator.getDefault().getApplicationManager(),
+            launchCtx.isOpen() ? launchCtx.project() : null, applicationId);
         // Armed even without a resolved name: the confirmer degrades such an arm to 'cancel', so
         // the modal is answered (no hang) but nothing is written on an unattributable dialog.
         ExternalInfobaseChangesPolicy launchPolicy = armFlags[0] ? req.externalChanges : null;
@@ -1156,7 +1162,7 @@ public class RunYaxunitTestsTool implements IMcpTool
                 ? null
                 : LaunchUpdateDialogAutoConfirmer.beginConflictWatch(launchInfobase);
         LaunchUpdateDialogAutoConfirmer.arm(armFlags[0], armFlags[1], armFlags[0], launchPolicy,
-            launchInfobase, launchPortPolicy);
+            launchInfobase, launchPortPolicy, launchServer);
         ILaunch launch;
         try
         {
@@ -1597,6 +1603,8 @@ public class RunYaxunitTestsTool implements IMcpTool
             // around a standalone-server application's delegate-performed update.
             String launchInfobase = LaunchLifecycleUtils.attributionInfobaseName(appManager, project,
                 applicationId);
+            String launchServer = LaunchLifecycleUtils.attributionServerName(appManager,
+                project, applicationId);
             ExternalInfobaseChangesPolicy launchPolicy = armFlags[0] ? req.externalChanges : null;
             // The port matcher is armed only for a STANDALONE-SERVER target: a file or client-server
             // application cannot raise that modal, and an arm held for the whole run would claim a
@@ -1613,7 +1621,7 @@ public class RunYaxunitTestsTool implements IMcpTool
                     ? null
                     : LaunchUpdateDialogAutoConfirmer.beginConflictWatch(launchInfobase);
             LaunchUpdateDialogAutoConfirmer.arm(armFlags[0], armFlags[1], armFlags[0], launchPolicy,
-                launchInfobase, launchPortPolicy);
+                launchInfobase, launchPortPolicy, launchServer);
             ILaunch[] spawned = new ILaunch[1];
             try
             {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
@@ -1160,7 +1160,8 @@ public class RunYaxunitTestsTool implements IMcpTool
         LaunchUpdateDialogAutoConfirmer.ConflictWatch conflicts =
             launchPolicy == null && launchPortPolicy == null
                 ? null
-                : LaunchUpdateDialogAutoConfirmer.beginConflictWatch(launchInfobase);
+                : LaunchUpdateDialogAutoConfirmer.beginConflictWatch(launchInfobase,
+                    launchServer);
         LaunchUpdateDialogAutoConfirmer.arm(armFlags[0], armFlags[1], armFlags[0], launchPolicy,
             launchInfobase, launchPortPolicy, launchServer);
         ILaunch launch;
@@ -1191,7 +1192,7 @@ public class RunYaxunitTestsTool implements IMcpTool
         finally
         {
             LaunchUpdateDialogAutoConfirmer.disarm(armFlags[0], armFlags[1], armFlags[0], launchPolicy,
-                launchInfobase, launchPortPolicy);
+                launchInfobase, launchPortPolicy, launchServer);
             // Closed HERE, not after the check below: a launch() that throws must not leave the
             // window registered in the confirmer for the rest of the session.
             closeQuietly(conflicts);
@@ -1619,7 +1620,8 @@ public class RunYaxunitTestsTool implements IMcpTool
             LaunchUpdateDialogAutoConfirmer.ConflictWatch conflicts =
                 launchPolicy == null && launchPortPolicy == null
                     ? null
-                    : LaunchUpdateDialogAutoConfirmer.beginConflictWatch(launchInfobase);
+                    : LaunchUpdateDialogAutoConfirmer.beginConflictWatch(launchInfobase,
+                        launchServer);
             LaunchUpdateDialogAutoConfirmer.arm(armFlags[0], armFlags[1], armFlags[0], launchPolicy,
                 launchInfobase, launchPortPolicy, launchServer);
             ILaunch[] spawned = new ILaunch[1];
@@ -1650,7 +1652,7 @@ public class RunYaxunitTestsTool implements IMcpTool
             finally
             {
                 LaunchUpdateDialogAutoConfirmer.disarm(armFlags[0], armFlags[1], armFlags[0],
-                    launchPolicy, launchInfobase, launchPortPolicy);
+                    launchPolicy, launchInfobase, launchPortPolicy, launchServer);
                 closeQuietly(conflicts);
             }
             String declined = declinedConflict(conflicts, launchPolicy);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
@@ -744,8 +744,13 @@ public class UpdateDatabaseTool implements IMcpTool
                 // from the application's display name — resolving the wrong one would leave every
                 // dialog unattributable and silently degrade override/import to cancel.
                 String infobaseName = LaunchLifecycleUtils.conflictAttributionName(application);
+                // Resolved once, for the window AND the arm below: a port-conflict event is routed
+                // by this name, so the window must know it or it records a concurrent server's
+                // failure as its own.
+                String armedServerName = LaunchLifecycleUtils.attributionServerName(appManager,
+                    project, applicationId);
                 try (LaunchUpdateDialogAutoConfirmer.ConflictWatch watch =
-                    LaunchUpdateDialogAutoConfirmer.beginConflictWatch(infobaseName))
+                    LaunchUpdateDialogAutoConfirmer.beginConflictWatch(infobaseName, armedServerName))
                 {
                     // The port matcher is armed ONLY for a standalone-server target: a file or
                     // client-server application cannot raise that modal, and an arm held for the
@@ -755,9 +760,7 @@ public class UpdateDatabaseTool implements IMcpTool
                         DebugServerTargetSupport.isServerApplicationId(applicationId)
                             ? portPolicy : null;
                     LaunchUpdateDialogAutoConfirmer.arm(false, false, true, externalChanges,
-                        infobaseName, armedPortPolicy,
-                        LaunchLifecycleUtils.attributionServerName(appManager, project,
-                            applicationId));
+                        infobaseName, armedPortPolicy, armedServerName);
                     try
                     {
                         stateAfter = StandaloneServerStateRecovery.updateWithRecovery(appManager,
@@ -792,7 +795,7 @@ public class UpdateDatabaseTool implements IMcpTool
                         // rewritten, and a RuntimeException on the way out must not swallow that.
                         portsReassigned = watch.portsReassigned();
                         LaunchUpdateDialogAutoConfirmer.disarm(false, false, true, externalChanges,
-                            infobaseName, armedPortPolicy);
+                            infobaseName, armedPortPolicy, armedServerName);
                     }
                     // Same reasoning as the catch above, for the path where the cancelled server
                     // start lets update() return a (cached, therefore meaningless) state instead

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
@@ -755,7 +755,9 @@ public class UpdateDatabaseTool implements IMcpTool
                         DebugServerTargetSupport.isServerApplicationId(applicationId)
                             ? portPolicy : null;
                     LaunchUpdateDialogAutoConfirmer.arm(false, false, true, externalChanges,
-                        infobaseName, armedPortPolicy);
+                        infobaseName, armedPortPolicy,
+                        LaunchLifecycleUtils.attributionServerName(appManager, project,
+                            applicationId));
                     try
                     {
                         stateAfter = StandaloneServerStateRecovery.updateWithRecovery(appManager,

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
@@ -1669,6 +1669,76 @@ public final class LaunchLifecycleUtils
     }
 
     /**
+     * Resolves the WST server's own name for {@code applicationId} — the string EDT quotes in its
+     * standalone-server port-conflict modal.
+     *
+     * <p>Read from the server, never parsed out of the dialog. EDT builds that title as
+     * {@code "<localized prefix> <infobase>"}, so recognising it by the infobase alone accepts a
+     * DIFFERENT server whose name merely ends the same way ("Base" matches "… for My Base") - and
+     * the answer this name authorises REWRITES the named server's configuration.
+     *
+     * @param appManager the EDT application manager (may be {@code null})
+     * @param project the project the application belongs to (may be {@code null})
+     * @param applicationId the application id (may be {@code null})
+     * @return the server name, or {@code null} when it cannot be resolved
+     */
+    public static String attributionServerName(IApplicationManager appManager, IProject project,
+        String applicationId)
+    {
+        if (appManager == null || project == null || applicationId == null || applicationId.isEmpty())
+        {
+            return null;
+        }
+        try
+        {
+            return appManager.getApplication(project, applicationId)
+                .map(LaunchLifecycleUtils::serverNameOf)
+                .orElse(null);
+        }
+        catch (Exception e) // NOSONAR a best-effort hint must never break a launch
+        {
+            return null;
+        }
+    }
+
+    /**
+     * Reflective {@code IServerApplication.getServer().getName()}. Reflective because the WST
+     * server types are not on this bundle's classpath, and best-effort because a name that will
+     * not resolve must degrade to "cannot attribute", never to a failed launch.
+     *
+     * @param application the application (may be {@code null})
+     * @return the backing server's name, or {@code null}
+     */
+    private static String serverNameOf(IApplication application)
+    {
+        if (application == null)
+        {
+            return null;
+        }
+        try
+        {
+            Object server = application.getClass().getMethod("getServer").invoke(application); //$NON-NLS-1$
+            if (server == null)
+            {
+                return null;
+            }
+            Object name = server.getClass().getMethod("getName").invoke(server); //$NON-NLS-1$
+            return name == null ? null : trimToNullName(name.toString());
+        }
+        catch (Exception | LinkageError e) // NOSONAR not a server application, or an older API
+        {
+            return null;
+        }
+    }
+
+    /** {@code null} for a blank name, the trimmed value otherwise. */
+    private static String trimToNullName(String value)
+    {
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    /**
      * Resolves the name EDT interpolates into its "Infobase \"<name>\" configuration was
      * changed…" conflict modal: the bound {@link com._1c.g5.v8.dt.platform.services.model
      * .InfobaseReference}'s name, since an application's own (localized) name can differ from

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
@@ -2749,32 +2749,6 @@ public final class LaunchUpdateDialogAutoConfirmer
         return segments;
     }
 
-    /**
-     * Whether some OTHER window covering {@code infobaseName} resolved a server name and that name
-     * is what this dialog quotes.
-     *
-     * <p>This is what tells two look-alike situations apart. Two windows over the SAME server, one
-     * of whose lookups failed: the named one matches exactly, so the unnamed one is demonstrably
-     * about the same server and must hear the event too. A window over {@code Base} while
-     * {@code My Base} raises the dialog: nothing corroborates it, and the suffix alone must not be
-     * allowed to claim a foreign conflict.
-     *
-     * @param detail the dialog text
-     * @param infobaseName the unnamed window's infobase
-     * @return {@code true} when a named sibling claims this dialog
-     */
-    private static boolean corroboratedByNamedSibling(String detail, String infobaseName)
-    {
-        for (ConflictWatch other : CONFLICT_WATCHES)
-        {
-            if (other.serverName != null && Objects.equals(other.infobaseName, infobaseName)
-                && namesThisServerExactly(detail, other.serverName))
-            {
-                return true;
-            }
-        }
-        return false;
-    }
 
     /**
      * Whether NO open window could resolve a server name at all — the older-EDT / everything-failed
@@ -2815,14 +2789,17 @@ public final class LaunchUpdateDialogAutoConfirmer
             else if (watch.infobaseName != null)
             {
                 // No server name resolved, so the infobase is all it has - and by itself that is
-                // the very test this change removed: "…for My Base" ends with " Base" too. It is
-                // trusted only when CORROBORATED, i.e. when another window for the SAME infobase
-                // did resolve a server name and that name is what this dialog quotes. Then the
-                // dialog is demonstrably about this infobase's server, and both windows - the
-                // same operation, one of whose lookups happened to fail - hear it.
-                if (corroboratedByNamedSibling(detail, watch.infobaseName)
-                    || (noWindowNamedAServer() && detail != null
-                        && namesThisServer(detail, watch.infobaseName)))
+                // the very test this change removed: "…for My Base" ends with " Base" too.
+                //
+                // It is therefore trusted ONLY when nobody could name a server at all (an older
+                // EDT, or a lookup that fails for everyone): then this matcher is the only
+                // evidence in the room, and refusing it would blind every window at once. When
+                // some other window DID resolve a name, this one stays silent — it cannot prove
+                // the dialog is its own, and recording a foreign conflict would make a call that
+                // succeeded report someone else's failure. Losing detail is the lesser harm: the
+                // launch that really failed still fails, just with less explanation.
+                if (noWindowNamedAServer() && detail != null
+                    && namesThisServer(detail, watch.infobaseName))
                 {
                     targets.add(watch);
                 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
@@ -2326,7 +2326,10 @@ public final class LaunchUpdateDialogAutoConfirmer
                 {
                     // Told apart: a caller that asked to move the server but was outvoted by a
                     // concurrent one gets different advice from a caller whose own policy refused.
-                    refusalReason = portArmsFor(detail).isEmpty() ? PORT_REASON_NOT_ATTRIBUTED
+                    // Told apart by the SAME attribution the press uses. On the loose matcher a
+                    // dialog of "My Base" was reported as "vetoed" because an arm for "Base"
+                    // had asked for a re-address — advice about someone else's call.
+                    refusalReason = portArmsForServer(detail).isEmpty() ? PORT_REASON_NOT_ATTRIBUTED
                         : (reassignAskedFor(detail) ? PORT_REASON_VETOED : PORT_REASON_POLICY);
                 }
             }
@@ -2354,25 +2357,6 @@ public final class LaunchUpdateDialogAutoConfirmer
         }
     }
 
-    /**
-     * The outstanding arms this dialog is demonstrably about: those whose infobase the dialog text
-     * names ({@link #namesThisServer}). Must be called with {@code LOCK} held.
-     *
-     * <p>An arm that could not name its own infobase never matches: the writing answer requires
-     * PROOF that the dialog is this caller's, not the absence of proof that it is someone else's.
-     */
-    private static List<PortConflictArm> portArmsFor(String detail)
-    {
-        List<PortConflictArm> attributed = new ArrayList<>();
-        for (PortConflictArm arm : PORT_CONFLICT_ARMS)
-        {
-            if (namesThisServer(detail, arm.infobaseName))
-            {
-                attributed.add(arm);
-            }
-        }
-        return attributed;
-    }
 
     /**
      * The arms whose SERVER this dialog quotes verbatim — the attribution the WRITING answer uses.
@@ -2413,7 +2397,7 @@ public final class LaunchUpdateDialogAutoConfirmer
     {
         synchronized (LOCK)
         {
-            for (PortConflictArm arm : portArmsFor(detail))
+            for (PortConflictArm arm : portArmsForServer(detail))
             {
                 if (arm.policy == StandaloneServerPortConflictPolicy.REASSIGN)
                 {
@@ -2737,68 +2721,40 @@ public final class LaunchUpdateDialogAutoConfirmer
 
     private static List<ConflictWatch> portConflictTargets(String detail)
     {
-        // The SERVER name first, compared exactly: it is the only test that tells this window's
-        // server from another whose name merely ends the same way. A window that resolved one
-        // and does not match is demonstrably not this dialog's owner.
-        List<ConflictWatch> byServer = new ArrayList<>();
-        boolean anyServerNamed = false;
+        // Each window is judged by the BEST evidence it has, and only a window that demonstrably
+        // names a DIFFERENT server is excluded. Judging them together — "did anyone match by
+        // server?" — silenced two windows that had every right to hear the event: one covering the
+        // same server whose own lookup happened to fail, and one that could name nothing at all.
+        List<ConflictWatch> targets = new ArrayList<>();
         for (ConflictWatch watch : CONFLICT_WATCHES)
         {
             if (watch.serverName != null)
             {
-                anyServerNamed = true;
+                // Named its server: exactly this dialog's server, or not its business.
                 if (namesThisServerExactly(detail, watch.serverName))
                 {
-                    byServer.add(watch);
+                    targets.add(watch);
                 }
             }
-        }
-        if (!byServer.isEmpty())
-        {
-            return byServer;
-        }
-        // No window named the server this dialog is about. Fall back to the infobase matcher for
-        // the windows that could not name a server at all - dropping their diagnosis is the
-        // failure this accounting exists to prevent - but never for one that named a DIFFERENT
-        // server, which the exact test above has already ruled out.
-        List<ConflictWatch> named = new ArrayList<>();
-        if (detail != null)
-        {
-            for (ConflictWatch watch : CONFLICT_WATCHES)
+            else if (watch.infobaseName != null)
             {
-                if (watch.serverName == null && namesThisServer(detail, watch.infobaseName))
+                // No server name resolved: the infobase is the best evidence it has. Loose, but
+                // this window has already proved it cannot do better, and losing its diagnosis is
+                // the failure this accounting exists to prevent.
+                if (detail != null && namesThisServer(detail, watch.infobaseName))
                 {
-                    named.add(watch);
+                    targets.add(watch);
                 }
             }
-        }
-        if (!named.isEmpty())
-        {
-            return named;
-        }
-        if (anyServerNamed && detail != null)
-        {
-            // Every window that could name its server named a different one: this dialog belongs
-            // to none of them, and recording it would make a call that succeeded report someone
-            // else's port conflict.
-            return new ArrayList<>();
-        }
-        // Nothing matched by name. A window that could not name its own infobase still has to hear
-        // about it — the dialog may well be its own, and losing the busy-port diagnosis there is the
-        // failure this whole change exists to remove. Windows that DID name themselves and did not
-        // match are excluded: the dialog demonstrably belongs to another server, and marking them
-        // would make an operation that completed normally report someone else's failure.
-        List<ConflictWatch> unresolved = new ArrayList<>();
-        for (ConflictWatch watch : CONFLICT_WATCHES)
-        {
-            if (watch.infobaseName == null)
+            else
             {
-                unresolved.add(watch);
+                // Named nothing: it may well be this dialog's owner, so it always hears.
+                targets.add(watch);
             }
         }
-        if (!unresolved.isEmpty())
+        if (!targets.isEmpty())
         {
-            return unresolved;
+            return targets;
         }
         // Every window named itself and none matched: only an unreadable dialog (or one quoting no
         // server at all) is still unattributable, and then everyone hears it rather than nobody.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
@@ -2326,11 +2326,7 @@ public final class LaunchUpdateDialogAutoConfirmer
                 {
                     // Told apart: a caller that asked to move the server but was outvoted by a
                     // concurrent one gets different advice from a caller whose own policy refused.
-                    // Told apart by the SAME attribution the press uses. On the loose matcher a
-                    // dialog of "My Base" was reported as "vetoed" because an arm for "Base"
-                    // had asked for a re-address — advice about someone else's call.
-                    refusalReason = portArmsForServer(detail).isEmpty() ? PORT_REASON_NOT_ATTRIBUTED
-                        : (reassignAskedFor(detail) ? PORT_REASON_VETOED : PORT_REASON_POLICY);
+                    refusalReason = refusalReasonFor(detail);
                 }
             }
             notePortConflict(detail, refusalReason);
@@ -2371,6 +2367,40 @@ public final class LaunchUpdateDialogAutoConfirmer
      * @param detail the dialog text
      * @return the arms demonstrably about this server
      */
+    /**
+     * WHY the writing answer was refused, told apart so the caller gets advice about its OWN call.
+     *
+     * <p>Attribution by server name comes first, matching the press itself. When no arm named this
+     * server, one that could not resolve a name may still be the caller's own — and if ITS policy
+     * declined the re-address, the honest reason is {@code POLICY} with the
+     * {@code standaloneServerPortConflict='reassign'} hint, not {@code NOT_ATTRIBUTED}. A nameless
+     * arm that DID ask for the re-address gets {@code NOT_ATTRIBUTED}, because "we could not tell
+     * whose dialog this is" is exactly why it was refused.
+     *
+     * @param detail the dialog text
+     * @return one of the {@code PORT_REASON_*} constants
+     */
+    private static String refusalReasonFor(String detail)
+    {
+        synchronized (LOCK)
+        {
+            if (!portArmsForServer(detail).isEmpty())
+            {
+                return reassignAskedFor(detail) ? PORT_REASON_VETOED : PORT_REASON_POLICY;
+            }
+            for (PortConflictArm arm : PORT_CONFLICT_ARMS)
+            {
+                if (arm.serverName == null && arm.infobaseName != null
+                    && arm.policy != StandaloneServerPortConflictPolicy.REASSIGN
+                    && namesThisServer(detail, arm.infobaseName))
+                {
+                    return PORT_REASON_POLICY;
+                }
+            }
+            return PORT_REASON_NOT_ATTRIBUTED;
+        }
+    }
+
     private static List<PortConflictArm> portArmsForServer(String detail)
     {
         List<PortConflictArm> attributed = new ArrayList<>();
@@ -2719,6 +2749,52 @@ public final class LaunchUpdateDialogAutoConfirmer
         return segments;
     }
 
+    /**
+     * Whether some OTHER window covering {@code infobaseName} resolved a server name and that name
+     * is what this dialog quotes.
+     *
+     * <p>This is what tells two look-alike situations apart. Two windows over the SAME server, one
+     * of whose lookups failed: the named one matches exactly, so the unnamed one is demonstrably
+     * about the same server and must hear the event too. A window over {@code Base} while
+     * {@code My Base} raises the dialog: nothing corroborates it, and the suffix alone must not be
+     * allowed to claim a foreign conflict.
+     *
+     * @param detail the dialog text
+     * @param infobaseName the unnamed window's infobase
+     * @return {@code true} when a named sibling claims this dialog
+     */
+    private static boolean corroboratedByNamedSibling(String detail, String infobaseName)
+    {
+        for (ConflictWatch other : CONFLICT_WATCHES)
+        {
+            if (other.serverName != null && Objects.equals(other.infobaseName, infobaseName)
+                && namesThisServerExactly(detail, other.serverName))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Whether NO open window could resolve a server name at all — the older-EDT / everything-failed
+     * case, where the infobase matcher is the only evidence anyone has and refusing it would blind
+     * every window at once.
+     *
+     * @return {@code true} when no window carries a server name
+     */
+    private static boolean noWindowNamedAServer()
+    {
+        for (ConflictWatch watch : CONFLICT_WATCHES)
+        {
+            if (watch.serverName != null)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private static List<ConflictWatch> portConflictTargets(String detail)
     {
         // Each window is judged by the BEST evidence it has, and only a window that demonstrably
@@ -2738,10 +2814,15 @@ public final class LaunchUpdateDialogAutoConfirmer
             }
             else if (watch.infobaseName != null)
             {
-                // No server name resolved: the infobase is the best evidence it has. Loose, but
-                // this window has already proved it cannot do better, and losing its diagnosis is
-                // the failure this accounting exists to prevent.
-                if (detail != null && namesThisServer(detail, watch.infobaseName))
+                // No server name resolved, so the infobase is all it has - and by itself that is
+                // the very test this change removed: "…for My Base" ends with " Base" too. It is
+                // trusted only when CORROBORATED, i.e. when another window for the SAME infobase
+                // did resolve a server name and that name is what this dialog quotes. Then the
+                // dialog is demonstrably about this infobase's server, and both windows - the
+                // same operation, one of whose lookups happened to fail - hear it.
+                if (corroboratedByNamedSibling(detail, watch.infobaseName)
+                    || (noWindowNamedAServer() && detail != null
+                        && namesThisServer(detail, watch.infobaseName)))
                 {
                     targets.add(watch);
                 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
@@ -459,10 +459,20 @@ public final class LaunchUpdateDialogAutoConfirmer
         final StandaloneServerPortConflictPolicy policy;
         final String infobaseName;
 
-        PortConflictArm(StandaloneServerPortConflictPolicy policy, String infobaseName)
+        /**
+         * The WST server's OWN name, resolved from the application rather than parsed out of
+         * the dialog. The writing answer requires this to match exactly - see
+         * {@link LaunchUpdateDialogAutoConfirmer#reassignAskedFor}. {@code null} when it could
+         * not be resolved, which refuses the write rather than guessing.
+         */
+        final String serverName;
+
+        PortConflictArm(StandaloneServerPortConflictPolicy policy, String infobaseName,
+            String serverName)
         {
             this.policy = policy;
             this.infobaseName = infobaseName;
+            this.serverName = serverName;
         }
     }
 
@@ -1068,9 +1078,33 @@ public final class LaunchUpdateDialogAutoConfirmer
      *            reassign answer requires UNANIMITY across the outstanding arms — see
      *            {@link #PORT_CONFLICT_ARMS}
      */
-    public static void arm(boolean updateDialog, boolean sessionDialog, boolean restructureDialog, // NOSONAR mirrors the existing arm-flag list; a parameter object would move the arity, not remove it
+    public static void arm(boolean updateDialog, boolean sessionDialog, boolean restructureDialog,
         ExternalInfobaseChangesPolicy conflictPolicy, String infobaseName,
         StandaloneServerPortConflictPolicy portPolicy)
+    {
+        // No server name: a reassign armed this way can answer nothing, by design. Callers that
+        // can start a standalone server resolve the name and use the overload below.
+        arm(updateDialog, sessionDialog, restructureDialog, conflictPolicy, infobaseName,
+            portPolicy, null);
+    }
+
+    /**
+     * Arms the matchers, naming the standalone server this call may start.
+     *
+     * @param updateDialog arm the "Update database configuration" TITLE matcher
+     * @param sessionDialog arm the code-1003 "Debug session already exists" BODY matcher
+     * @param restructureDialog arm the DB-restructure TITLE matcher (press "Accept")
+     * @param conflictPolicy the button to press on the external-changes conflict modal, or
+     *            {@code null} to leave that modal alone
+     * @param infobaseName the infobase this call targets, as EDT names it (may be {@code null})
+     * @param portPolicy how to answer the port-conflict modal; {@code null} leaves it alone
+     * @param serverName the WST server's own name, resolved from the application. The
+     *            {@code REASSIGN} answer is pressed only on a dialog quoting exactly this name;
+     *            {@code null} means the write is refused rather than aimed by guesswork
+     */
+    public static void arm(boolean updateDialog, boolean sessionDialog, boolean restructureDialog, // NOSONAR mirrors the existing arm-flag list; a parameter object would move the arity, not remove it
+        ExternalInfobaseChangesPolicy conflictPolicy, String infobaseName,
+        StandaloneServerPortConflictPolicy portPolicy, String serverName)
     {
         // The port-conflict matcher counts as "something to arm": with all the other flags off —
         // run_yaxunit_tests(updateBeforeLaunch=false) reaches exactly that — the old condition
@@ -1106,7 +1140,8 @@ public final class LaunchUpdateDialogAutoConfirmer
             // anyway would let that window answer another operation's dialog.
             if (portPolicy != null)
             {
-                PORT_CONFLICT_ARMS.add(new PortConflictArm(portPolicy, trimToNull(infobaseName)));
+                PORT_CONFLICT_ARMS.add(new PortConflictArm(portPolicy, trimToNull(infobaseName),
+                    trimToNull(serverName)));
             }
             if (conflictPolicy != null)
             {
@@ -2310,7 +2345,41 @@ public final class LaunchUpdateDialogAutoConfirmer
         return attributed;
     }
 
-    /** Whether any arm this dialog is attributable to asked for {@code reassign}. */
+    /**
+     * The arms whose SERVER this dialog quotes verbatim — the attribution the WRITING answer uses.
+     * Must be called with {@code LOCK} held.
+     *
+     * <p>By the server's own name, compared exactly, and never by the infobase name inside it: EDT
+     * titles the server {@code "<localized prefix> <infobase>"}, so an infobase test accepts a
+     * different server whose name merely ends the same way — an arm for {@code Base} would
+     * authorise the dialog of {@code My Base}, and the press rewrites whichever server the dialog
+     * belongs to (#437).
+     *
+     * @param detail the dialog text
+     * @return the arms demonstrably about this server
+     */
+    private static List<PortConflictArm> portArmsForServer(String detail)
+    {
+        List<PortConflictArm> attributed = new ArrayList<>();
+        for (PortConflictArm arm : PORT_CONFLICT_ARMS)
+        {
+            if (namesThisServerExactly(detail, arm.serverName))
+            {
+                attributed.add(arm);
+            }
+        }
+        return attributed;
+    }
+
+    /**
+     * Whether any arm this dialog is attributable to asked for {@code reassign}. This decides the
+     * WORDING of a refusal — "you asked and were outvoted" versus "your own policy declined" — so
+     * it stays on the infobase matcher; the press itself is gated by {@link #reassignRequested},
+     * which is stricter.
+     *
+     * @param detail the dialog text
+     * @return {@code true} when some attributable arm asked for the re-address
+     */
     private static boolean reassignAskedFor(String detail)
     {
         synchronized (LOCK)
@@ -2324,6 +2393,29 @@ public final class LaunchUpdateDialogAutoConfirmer
             }
             return false;
         }
+    }
+
+    /**
+     * Whether {@code detail} quotes {@code serverName} verbatim.
+     *
+     * @param detail the dialog text (may be {@code null})
+     * @param serverName the arm's resolved server name (may be {@code null})
+     * @return {@code true} when some quoted segment IS that name
+     */
+    static boolean namesThisServerExactly(String detail, String serverName)
+    {
+        if (detail == null || serverName == null || serverName.isEmpty())
+        {
+            return false;
+        }
+        for (String quoted : quotedSegments(detail))
+        {
+            if (quoted.equals(serverName))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** Best-effort close of a still-open dialog shell; never throws. */
@@ -2403,12 +2495,15 @@ public final class LaunchUpdateDialogAutoConfirmer
             // one that asked for it.
             for (PortConflictArm arm : PORT_CONFLICT_ARMS)
             {
-                if (arm.infobaseName == null)
+                // Its infobase OR its server: both names are best-effort, and an arm missing
+                // either may be the one starting THIS server. Dropping it from the vote would let
+                // a caller that declined the re-address be overruled by one that asked for it.
+                if (arm.infobaseName == null || arm.serverName == null)
                 {
                     return false;
                 }
             }
-            List<PortConflictArm> attributed = portArmsFor(detail);
+            List<PortConflictArm> attributed = portArmsForServer(detail);
             if (attributed.isEmpty())
             {
                 // Not attributable to any armed call: never perform the WRITING answer on a dialog
@@ -2763,12 +2858,27 @@ public final class LaunchUpdateDialogAutoConfirmer
      *
      * @param policy the answer this arm chose (may be {@code null} = default)
      */
-    static void armPortConflictForTest(StandaloneServerPortConflictPolicy policy, String infobaseName)
+    static void armPortConflictForTest(StandaloneServerPortConflictPolicy policy,
+        String infobaseName)
+    {
+        armPortConflictForTest(policy, infobaseName, null);
+    }
+
+    /**
+     * Test seam: takes one port-conflict arm that also names its server.
+     *
+     * @param policy the answer this arm chose (may be {@code null} = default)
+     * @param infobaseName the infobase the arm covers
+     * @param serverName the WST server name the writing answer must match exactly
+     */
+    static void armPortConflictForTest(StandaloneServerPortConflictPolicy policy,
+        String infobaseName, String serverName)
     {
         synchronized (LOCK)
         {
             PORT_CONFLICT_ARMS.add(new PortConflictArm(
-                policy == null ? StandaloneServerPortConflictPolicy.DEFAULT : policy, infobaseName));
+                policy == null ? StandaloneServerPortConflictPolicy.DEFAULT : policy, infobaseName,
+                serverName));
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
@@ -2546,10 +2546,13 @@ public final class LaunchUpdateDialogAutoConfirmer
             // one that asked for it.
             for (PortConflictArm arm : PORT_CONFLICT_ARMS)
             {
-                // Its infobase OR its server: both names are best-effort, and an arm missing
-                // either may be the one starting THIS server. Dropping it from the vote would let
-                // a caller that declined the re-address be overruled by one that asked for it.
-                if (arm.infobaseName == null || arm.serverName == null)
+                // Only the SERVER name. An arm that could not resolve one may be starting this
+                // very server, and dropping it from the vote would let a caller that declined the
+                // re-address be overruled by one that asked for it. The infobase name does not
+                // enter this: an arm whose server name matches the dialog exactly has already
+                // PROVED the dialog is its own, and vetoing it because a second, weaker lookup
+                // happened to fail would cancel a re-address the caller explicitly asked for.
+                if (arm.serverName == null)
                 {
                     return false;
                 }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmer.java
@@ -1233,9 +1233,37 @@ public final class LaunchUpdateDialogAutoConfirmer
      * @param infobaseName the name passed to {@code arm} (may be {@code null})
      * @param portPolicy the port-conflict policy passed to {@code arm} (may be {@code null})
      */
-    public static void disarm(boolean updateDialog, boolean sessionDialog, boolean restructureDialog, // NOSONAR mirrors arm(...)
+    public static void disarm(boolean updateDialog, boolean sessionDialog, boolean restructureDialog,
         ExternalInfobaseChangesPolicy conflictPolicy, String infobaseName,
         StandaloneServerPortConflictPolicy portPolicy)
+    {
+        disarm(updateDialog, sessionDialog, restructureDialog, conflictPolicy, infobaseName,
+            portPolicy, null);
+    }
+
+    /**
+     * Disarms an arm made with the seven-argument
+     * {@link #arm(boolean, boolean, boolean, ExternalInfobaseChangesPolicy, String,
+     * StandaloneServerPortConflictPolicy, String)} — pass the SAME values, INCLUDING the server
+     * name.
+     *
+     * <p>The server name is part of the arm's identity, not decoration: two concurrent launches of
+     * same-named infobases in different projects differ only by it, and releasing "the first arm
+     * with this policy and infobase" would then take the other call's arm and leave its own behind
+     * — refusing the re-address the surviving call asked for, and authorising it for a server that
+     * has already finished (#437).
+     *
+     * @param updateDialog release one update-matcher arm
+     * @param sessionDialog release one session-matcher arm
+     * @param restructureDialog release one restructure-matcher arm
+     * @param conflictPolicy release one conflict-matcher arm of THIS policy, or {@code null}
+     * @param infobaseName the name passed to {@code arm} (may be {@code null})
+     * @param portPolicy the port-conflict policy passed to {@code arm} (may be {@code null})
+     * @param serverName the server name passed to {@code arm} (may be {@code null})
+     */
+    public static void disarm(boolean updateDialog, boolean sessionDialog, boolean restructureDialog, // NOSONAR mirrors arm(...)
+        ExternalInfobaseChangesPolicy conflictPolicy, String infobaseName,
+        StandaloneServerPortConflictPolicy portPolicy, String serverName)
     {
         // The port-conflict matcher counts as "something to arm": with all the other flags off —
         // run_yaxunit_tests(updateBeforeLaunch=false) reaches exactly that — the old condition
@@ -1265,7 +1293,8 @@ public final class LaunchUpdateDialogAutoConfirmer
             // Mirrors the add in arm(...): only an arm that took a port policy releases one.
             if (portPolicy != null)
             {
-                releasePortConflictArm(portPolicy, trimToNull(infobaseName));
+                releasePortConflictArm(portPolicy, trimToNull(infobaseName),
+                    trimToNull(serverName));
             }
             if (conflictPolicy != null)
             {
@@ -2444,8 +2473,16 @@ public final class LaunchUpdateDialogAutoConfirmer
      * {@code LOCK} held.
      */
     private static void releasePortConflictArm(StandaloneServerPortConflictPolicy portPolicy,
-        String infobaseName)
+        String infobaseName, String serverName)
     {
+        // The exact triple first: the server name is what tells two same-named infobases apart,
+        // and releasing by the pair alone would take the OTHER call's arm.
+        if (removeFirstPortArm(a -> a.policy == portPolicy
+            && Objects.equals(a.infobaseName, infobaseName)
+            && Objects.equals(a.serverName, serverName)))
+        {
+            return;
+        }
         if (removeFirstPortArm(a -> a.policy == portPolicy
             && Objects.equals(a.infobaseName, infobaseName)))
         {
@@ -2700,12 +2737,36 @@ public final class LaunchUpdateDialogAutoConfirmer
 
     private static List<ConflictWatch> portConflictTargets(String detail)
     {
+        // The SERVER name first, compared exactly: it is the only test that tells this window's
+        // server from another whose name merely ends the same way. A window that resolved one
+        // and does not match is demonstrably not this dialog's owner.
+        List<ConflictWatch> byServer = new ArrayList<>();
+        boolean anyServerNamed = false;
+        for (ConflictWatch watch : CONFLICT_WATCHES)
+        {
+            if (watch.serverName != null)
+            {
+                anyServerNamed = true;
+                if (namesThisServerExactly(detail, watch.serverName))
+                {
+                    byServer.add(watch);
+                }
+            }
+        }
+        if (!byServer.isEmpty())
+        {
+            return byServer;
+        }
+        // No window named the server this dialog is about. Fall back to the infobase matcher for
+        // the windows that could not name a server at all - dropping their diagnosis is the
+        // failure this accounting exists to prevent - but never for one that named a DIFFERENT
+        // server, which the exact test above has already ruled out.
         List<ConflictWatch> named = new ArrayList<>();
         if (detail != null)
         {
             for (ConflictWatch watch : CONFLICT_WATCHES)
             {
-                if (namesThisServer(detail, watch.infobaseName))
+                if (watch.serverName == null && namesThisServer(detail, watch.infobaseName))
                 {
                     named.add(watch);
                 }
@@ -2714,6 +2775,13 @@ public final class LaunchUpdateDialogAutoConfirmer
         if (!named.isEmpty())
         {
             return named;
+        }
+        if (anyServerNamed && detail != null)
+        {
+            // Every window that could name its server named a different one: this dialog belongs
+            // to none of them, and recording it would make a call that succeeded report someone
+            // else's port conflict.
+            return new ArrayList<>();
         }
         // Nothing matched by name. A window that could not name its own infobase still has to hear
         // about it — the dialog may well be its own, and losing the busy-port diagnosis there is the
@@ -2887,12 +2955,41 @@ public final class LaunchUpdateDialogAutoConfirmer
      *
      * @param policy the policy the matching {@code arm} was taken with (may be {@code null})
      */
-    static void disarmPortConflictForTest(StandaloneServerPortConflictPolicy policy, String infobaseName)
+    static void disarmPortConflictForTest(StandaloneServerPortConflictPolicy policy,
+        String infobaseName)
+    {
+        disarmPortConflictForTest(policy, infobaseName, null);
+    }
+
+    /**
+     * Test seam: releases one port-conflict arm by its full identity, exactly as {@code disarm}
+     * does.
+     *
+     * @param policy the policy the matching {@code arm} was taken with (may be {@code null})
+     * @param infobaseName the infobase the matching {@code arm} named
+     * @param serverName the server the matching {@code arm} named
+     */
+    static void disarmPortConflictForTest(StandaloneServerPortConflictPolicy policy,
+        String infobaseName, String serverName)
     {
         synchronized (LOCK)
         {
-            releasePortConflictArm(policy, infobaseName);
+            releasePortConflictArm(policy, infobaseName, serverName);
         }
+    }
+
+    /**
+     * Test seam: routes one port-conflict event exactly as the dialog handler does.
+     *
+     * <p>Needed because the handler itself runs off an SWT dialog, which a headless test cannot
+     * raise — and the ROUTING is the part that decides whose operation reports a failure.
+     *
+     * @param detail the dialog text
+     * @param reason why the dialog was refused
+     */
+    static void notePortConflictForTest(String detail, String reason)
+    {
+        notePortConflict(detail, reason);
     }
 
     /** Test seam: how many port-conflict arms are outstanding. */
@@ -2928,7 +3025,24 @@ public final class LaunchUpdateDialogAutoConfirmer
      */
     public static ConflictWatch beginConflictWatch(String infobaseName)
     {
-        ConflictWatch watch = new ConflictWatch(trimToNull(infobaseName));
+        return beginConflictWatch(infobaseName, null);
+    }
+
+    /**
+     * Opens a window that also knows the standalone server it covers.
+     *
+     * <p>The server name is what routes a port-conflict event correctly: EDT titles the server
+     * after the infobase, so recognising the dialog by the infobase alone records a CONCURRENT
+     * launch of a same-suffixed server into this window - and the operation then reports a
+     * failure that belongs to someone else (#437).
+     *
+     * @param infobaseName the infobase being worked on (may be {@code null})
+     * @param serverName the WST server name this call may start (may be {@code null})
+     * @return the open window, never {@code null}
+     */
+    public static ConflictWatch beginConflictWatch(String infobaseName, String serverName)
+    {
+        ConflictWatch watch = new ConflictWatch(trimToNull(infobaseName), trimToNull(serverName));
         synchronized (LOCK)
         {
             CONFLICT_WATCHES.add(watch);
@@ -2973,6 +3087,9 @@ public final class LaunchUpdateDialogAutoConfirmer
     public static final class ConflictWatch implements AutoCloseable
     {
         private final String infobaseName;
+
+        /** The server this window covers, when the caller could resolve it. */
+        private final String serverName;
         private int cancels;
         private String reason;
         private boolean portConflict;
@@ -2983,7 +3100,13 @@ public final class LaunchUpdateDialogAutoConfirmer
 
         ConflictWatch(String infobaseName)
         {
+            this(infobaseName, null);
+        }
+
+        ConflictWatch(String infobaseName, String serverName)
+        {
             this.infobaseName = infobaseName;
+            this.serverName = serverName;
         }
 
         void record(String cancelReason)

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmerTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmerTest.java
@@ -812,6 +812,59 @@ public class LaunchUpdateDialogAutoConfirmerTest
     }
 
     @Test
+    public void testAForeignPortConflictIsNotRecordedIntoThisWindow() throws Exception
+    {
+        // Review of #445: the press was already refused for a foreign dialog, but the ACCOUNTING
+        // still routed by the infobase suffix - so a concurrent launch of "My Base" was recorded
+        // into the window of "Base", and that operation reported a failure it never had.
+        try (LaunchUpdateDialogAutoConfirmer.ConflictWatch mine =
+            LaunchUpdateDialogAutoConfirmer.beginConflictWatch("Base",
+                "Standalone server for Base"))
+        {
+            LaunchUpdateDialogAutoConfirmer.notePortConflictForTest(
+                "Standalone server " + QUOTE + "Standalone server for My Base" + QUOTE
+                    + " cannot use port 8080.",
+                LaunchUpdateDialogAutoConfirmer.PORT_REASON_POLICY);
+            assertFalse("another server's conflict must not fail this operation",
+                mine.portConflicted());
+
+            LaunchUpdateDialogAutoConfirmer.notePortConflictForTest(
+                "Standalone server " + QUOTE + "Standalone server for Base" + QUOTE
+                    + " cannot use port 8080.",
+                LaunchUpdateDialogAutoConfirmer.PORT_REASON_POLICY);
+            assertTrue("its own conflict still lands", mine.portConflicted());
+        }
+    }
+
+    @Test
+    public void testTwoSameNamedInfobasesReleaseTheirOwnArm()
+    {
+        // Review of #445: the server name is part of the identity, so a release that matched
+        // only (policy, infobase) took the OTHER call arm - leaving one call unable to get
+        // the re-address it asked for, and an arm outstanding for a server already finished.
+        String serverA = "Standalone server for Base";
+        String serverB = "Other server for Base";
+        LaunchUpdateDialogAutoConfirmer.armPortConflictForTest(
+            StandaloneServerPortConflictPolicy.REASSIGN, "Base", serverA);
+        LaunchUpdateDialogAutoConfirmer.armPortConflictForTest(
+            StandaloneServerPortConflictPolicy.REASSIGN, "Base", serverB);
+
+        LaunchUpdateDialogAutoConfirmer.disarmPortConflictForTest(
+            StandaloneServerPortConflictPolicy.REASSIGN, "Base", serverB);
+
+        String dialogA = "Standalone server " + QUOTE + serverA + QUOTE + " cannot use port.";
+        assertTrue("the arm that stayed is the one that was not released",
+            LaunchUpdateDialogAutoConfirmer.reassignAllowedForTest(dialogA));
+        String dialogB = "Standalone server " + QUOTE + serverB + QUOTE + " cannot use port.";
+        assertFalse("and the released one no longer authorises anything",
+            LaunchUpdateDialogAutoConfirmer.reassignAllowedForTest(dialogB));
+
+        LaunchUpdateDialogAutoConfirmer.disarmPortConflictForTest(
+            StandaloneServerPortConflictPolicy.REASSIGN, "Base", serverA);
+        assertEquals(0, LaunchUpdateDialogAutoConfirmer.portConflictArmsForTest());
+    }
+
+    @Test
     public void testAnArmForBaseDoesNotAuthoriseTheDialogOfMyBase()
     {
         // THE #437 hole: EDT titles the server "<localized prefix> <infobase>", so matching by

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmerTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmerTest.java
@@ -757,6 +757,8 @@ public class LaunchUpdateDialogAutoConfirmerTest
     // === "Find free port" needs unanimity, and the bookkeeping must not drift (review of #435) ===
 
     /** A dialog text naming the server of infobase "TestConfiguration #1". */
+    private static final String QUOTE = String.valueOf((char)34);
+
     private static final String PORT_DETAIL =
         "Standalone server \"Standalone server for TestConfiguration #1\" conflicts ...";
 
@@ -782,7 +784,8 @@ public class LaunchUpdateDialogAutoConfirmerTest
         // THIS server. Dropping it from the vote would let a caller that declined the re-address be
         // overruled by one that asked for it.
         LaunchUpdateDialogAutoConfirmer.armPortConflictForTest(
-            StandaloneServerPortConflictPolicy.REASSIGN, "TestConfiguration #1");
+            StandaloneServerPortConflictPolicy.REASSIGN, "TestConfiguration #1",
+            "Standalone server for TestConfiguration #1");
         assertTrue("alone, the attributed reassign arm may press",
             LaunchUpdateDialogAutoConfirmer.reassignAllowedForTest(PORT_DETAIL));
         LaunchUpdateDialogAutoConfirmer.armPortConflictForTest(
@@ -809,12 +812,55 @@ public class LaunchUpdateDialogAutoConfirmerTest
     }
 
     @Test
+    public void testAnArmForBaseDoesNotAuthoriseTheDialogOfMyBase()
+    {
+        // THE #437 hole: EDT titles the server "<localized prefix> <infobase>", so matching by
+        // the infobase alone accepted a server whose name merely ENDS with it. An arm for
+        // "Base" would then press "Find free port" on the dialog of "My Base" and rewrite a
+        // DIFFERENT server. Attribution is by the server name, compared exactly.
+        String myBaseDialog =
+            "Standalone server " + QUOTE + "Standalone server for My Base" + QUOTE
+                + " cannot use port 8080.";
+        LaunchUpdateDialogAutoConfirmer.armPortConflictForTest(
+            StandaloneServerPortConflictPolicy.REASSIGN, "Base",
+            "Standalone server for Base");
+
+        assertFalse("an arm for Base must not authorise the dialog of My Base",
+            LaunchUpdateDialogAutoConfirmer.reassignAllowedForTest(myBaseDialog));
+
+        String baseDialog = "Standalone server " + QUOTE + "Standalone server for Base" + QUOTE
+            + " cannot use port 8080.";
+        assertTrue("its own dialog is still answered",
+            LaunchUpdateDialogAutoConfirmer.reassignAllowedForTest(baseDialog));
+
+        LaunchUpdateDialogAutoConfirmer.disarmPortConflictForTest(
+            StandaloneServerPortConflictPolicy.REASSIGN, "Base");
+        assertEquals(0, LaunchUpdateDialogAutoConfirmer.portConflictArmsForTest());
+    }
+
+    @Test
+    public void testAnArmWithoutAResolvedServerNameNeverPresses()
+    {
+        // The writing answer requires PROOF that the dialog belongs to this server. A name that
+        // could not be resolved is not proof - it refuses, and (per the unanimity rule) it also
+        // vetoes a concurrent arm that did resolve one.
+        LaunchUpdateDialogAutoConfirmer.armPortConflictForTest(
+            StandaloneServerPortConflictPolicy.REASSIGN, "TestConfiguration #1", null);
+        assertFalse("no server name, no press",
+            LaunchUpdateDialogAutoConfirmer.reassignAllowedForTest(PORT_DETAIL));
+        LaunchUpdateDialogAutoConfirmer.disarmPortConflictForTest(
+            StandaloneServerPortConflictPolicy.REASSIGN, "TestConfiguration #1");
+        assertEquals(0, LaunchUpdateDialogAutoConfirmer.portConflictArmsForTest());
+    }
+
+    @Test
     public void testLoneReassignArmIsAllowedAndBalancedArmsLeaveNothingBehind()
     {
         assertEquals("the suite must start from no outstanding arms", 0,
             LaunchUpdateDialogAutoConfirmer.portConflictArmsForTest());
         LaunchUpdateDialogAutoConfirmer.armPortConflictForTest(
-            StandaloneServerPortConflictPolicy.REASSIGN, "TestConfiguration #1");
+            StandaloneServerPortConflictPolicy.REASSIGN, "TestConfiguration #1",
+            "Standalone server for TestConfiguration #1");
         assertTrue("a lone reassign arm may move the server",
             LaunchUpdateDialogAutoConfirmer.reassignAllowedForTest(PORT_DETAIL));
         LaunchUpdateDialogAutoConfirmer.disarmPortConflictForTest(
@@ -831,9 +877,11 @@ public class LaunchUpdateDialogAutoConfirmerTest
         // The press rewrites the server configuration for everyone using that server, so a
         // concurrent call that did not ask for it must be able to veto.
         LaunchUpdateDialogAutoConfirmer.armPortConflictForTest(
-            StandaloneServerPortConflictPolicy.REASSIGN, "TestConfiguration #1");
+            StandaloneServerPortConflictPolicy.REASSIGN, "TestConfiguration #1",
+            "Standalone server for TestConfiguration #1");
         LaunchUpdateDialogAutoConfirmer.armPortConflictForTest(
-            StandaloneServerPortConflictPolicy.CANCEL, "TestConfiguration #1");
+            StandaloneServerPortConflictPolicy.CANCEL, "TestConfiguration #1",
+            "Standalone server for TestConfiguration #1");
         assertFalse("a single cancelling arm must veto the move",
             LaunchUpdateDialogAutoConfirmer.reassignAllowedForTest(PORT_DETAIL));
         LaunchUpdateDialogAutoConfirmer.disarmPortConflictForTest(
@@ -852,14 +900,16 @@ public class LaunchUpdateDialogAutoConfirmerTest
         // widest overload and releasing through a narrower one (which passes the default) must not
         // leave a "reassign" behind for the next, unrelated caller to be answered with.
         LaunchUpdateDialogAutoConfirmer.armPortConflictForTest(
-            StandaloneServerPortConflictPolicy.REASSIGN, "TestConfiguration #1");
+            StandaloneServerPortConflictPolicy.REASSIGN, "TestConfiguration #1",
+            "Standalone server for TestConfiguration #1");
         LaunchUpdateDialogAutoConfirmer.disarmPortConflictForTest(
             StandaloneServerPortConflictPolicy.CANCEL, "TestConfiguration #1");
         assertEquals("the arm must be gone, not merely re-labelled", 0,
             LaunchUpdateDialogAutoConfirmer.portConflictArmsForTest());
 
         LaunchUpdateDialogAutoConfirmer.armPortConflictForTest(
-            StandaloneServerPortConflictPolicy.CANCEL, "TestConfiguration #1");
+            StandaloneServerPortConflictPolicy.CANCEL, "TestConfiguration #1",
+            "Standalone server for TestConfiguration #1");
         assertFalse("a later cancelling caller must NOT inherit the earlier reassign",
             LaunchUpdateDialogAutoConfirmer.reassignAllowedForTest(PORT_DETAIL));
         LaunchUpdateDialogAutoConfirmer.disarmPortConflictForTest(

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmerTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/LaunchUpdateDialogAutoConfirmerTest.java
@@ -837,6 +837,23 @@ public class LaunchUpdateDialogAutoConfirmerTest
     }
 
     @Test
+    public void testAnExactServerMatchStandsWithoutTheInfobaseName()
+    {
+        // Review of #445: the two lookups are independent, and the weaker one failing must not
+        // cancel a re-address the caller asked for. An exact server match already proves the
+        // dialog belongs to this arm; only a missing SERVER name still vetoes.
+        LaunchUpdateDialogAutoConfirmer.armPortConflictForTest(
+            StandaloneServerPortConflictPolicy.REASSIGN, null,
+            "Standalone server for TestConfiguration #1");
+        assertTrue("an exact server match authorises the press on its own",
+            LaunchUpdateDialogAutoConfirmer.reassignAllowedForTest(PORT_DETAIL));
+        LaunchUpdateDialogAutoConfirmer.disarmPortConflictForTest(
+            StandaloneServerPortConflictPolicy.REASSIGN, null,
+            "Standalone server for TestConfiguration #1");
+        assertEquals(0, LaunchUpdateDialogAutoConfirmer.portConflictArmsForTest());
+    }
+
+    @Test
     public void testTwoSameNamedInfobasesReleaseTheirOwnArm()
     {
         // Review of #445: the server name is part of the identity, so a release that matched


### PR DESCRIPTION
Закрывает #437 — P1 из ревью PR #435, тред там оставлен открытым осознанно.

## Дыра

Диалог «Конфликт портов автономного сервера» адресовался к вызову по имени ИНФОБАЗЫ, найденному суффиксом в кавычечном имени сервера (`namesThisServer`). Против префиксного пересечения этого хватает (`Base` против `Base Copy`), против суффиксного — нет: для инфобаз `Base` и `My Base` строка `"Standalone server for My Base"` проходит проверку для арма, взведённого на `Base`.

Последствие: активный арм с `standaloneServerPortConflict=reassign` для `Base` нажимал «Найти свободный порт» на диалоге, принадлежащем `My Base` (параллельный запуск или ручной старт из UI), — и EDT переписывал конфигурацию **чужого** сервера.

Разбор имени тут не годится: `Standalone server for <инфобаза>` строит мастер EDT, локализованный вариант шаблона неизвестен и в декомпилированных исходниках платформы отсутствует.

## Решение — имя носит арм, а не диалог

1. `LaunchLifecycleUtils.attributionServerName(...)` читает имя WST-сервера там, где оно точно известно: `IServerApplication.getServer().getName()`. Рефлексией (типы WST не на classpath бандла) и best-effort: не резолвится — `null`.
2. `PortConflictArm` носит это имя; добавлена перегрузка `arm(...)` с ним, прежняя делегирует с `null`.
3. `reassignRequested` атрибутирует диалог **строгим равенством** с этим именем среди кавычечных сегментов. Нерезолвнутое имя сервера — как и нерезолвнутая инфобаза — ветирует запись, правило единогласия сохранено.
4. Имя протянуто во все три пути: `update_database`, `debug_launch` (оба арма), `run_yaxunit_tests` (оба пути).

Матчер по инфобазе (`namesThisServer`) остался там, где он ничего не пишет: формулировка отказа (`VETOED` против `POLICY`) и учёт окон.

## Проверка

- `testAnArmForBaseDoesNotAuthoriseTheDialogOfMyBase` — арм для `Base` не нажимает на диалоге `My Base`, свой диалог по-прежнему обслуживает;
- `testAnArmWithoutAResolvedServerNameNeverPresses` — без имени сервера записи нет;
- шесть существующих армов в наборе теперь называют свой сервер.

Обратная проверка: со старой адресацией оба новых теста падают ровно своими сообщениями (`an arm for Base must not authorise the dialog of My Base`, `no server name, no press`).

Сборка: 5313 тестов, зелено.