### PR TITLE
PlatformFailures вместо getMessage() в соседних инструментах (#453)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DebugLaunchTool.java
@@ -38,6 +38,7 @@ import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils;
 import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils.ExistingClientSession;
 import com.ditrix.edt.mcp.server.utils.LaunchUpdateDialogAutoConfirmer;
 import com.ditrix.edt.mcp.server.utils.McpJobs;
+import com.ditrix.edt.mcp.server.utils.PlatformFailures;
 import com.ditrix.edt.mcp.server.utils.ProjectContext;
 import com.ditrix.edt.mcp.server.utils.ProjectStateChecker;
 import com.ditrix.edt.mcp.server.utils.StandaloneServerPortConflictPolicy;
@@ -407,7 +408,8 @@ public class DebugLaunchTool implements IMcpTool
         catch (Exception e)
         {
             Activator.logError("Unexpected error during debug launch by name", e); //$NON-NLS-1$
-            return ToolResult.error("Unexpected error: " + e.getMessage()).toJson(); //$NON-NLS-1$
+            return ToolResult.error(
+                "Unexpected error: " + PlatformFailures.describe(e)).toJson(); //$NON-NLS-1$
         }
     }
 
@@ -638,7 +640,8 @@ public class DebugLaunchTool implements IMcpTool
         catch (Exception e)
         {
             Activator.logError("Unexpected error during debug launch", e); //$NON-NLS-1$
-            return ToolResult.error("Unexpected error: " + e.getMessage()).toJson(); //$NON-NLS-1$
+            return ToolResult.error(
+                "Unexpected error: " + PlatformFailures.describe(e)).toJson(); //$NON-NLS-1$
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/RunYaxunitTestsTool.java
@@ -64,6 +64,7 @@ import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils.PrepInFlight;
 import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils.PreLaunchResult;
 import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
 import com.ditrix.edt.mcp.server.utils.McpJobs;
+import com.ditrix.edt.mcp.server.utils.PlatformFailures;
 import com.ditrix.edt.mcp.server.utils.ProjectContext;
 import com.ditrix.edt.mcp.server.utils.ProjectStateChecker;
 import com.ditrix.edt.mcp.server.utils.StandaloneServerPortConflictPolicy;
@@ -1040,7 +1041,8 @@ public class RunYaxunitTestsTool implements IMcpTool
         catch (CoreException e)
         {
             Activator.logError("Error running YAXUnit tests", e); //$NON-NLS-1$
-            return ToolResult.error("Launch failed: " + e.getMessage()).toJson(); //$NON-NLS-1$
+            return ToolResult.error(
+                "Launch failed: " + PlatformFailures.describe(e)).toJson(); //$NON-NLS-1$
         }
         catch (InterruptedException e)
         {
@@ -1050,7 +1052,7 @@ public class RunYaxunitTestsTool implements IMcpTool
         catch (Exception e)
         {
             Activator.logError("Unexpected error running YAXUnit tests", e); //$NON-NLS-1$
-            return ToolResult.error(e.getMessage()).toJson();
+            return ToolResult.error(PlatformFailures.describe(e)).toJson();
         }
     }
 
@@ -1649,7 +1651,7 @@ public class RunYaxunitTestsTool implements IMcpTool
                 // cause, not with the delegate's generic message.
                 String cancelled = declinedConflict(conflicts, launchPolicy);
                 return ToolResult.error(cancelled != null ? cancelled
-                    : "Launch failed: " + ex.getMessage()).toJson(); //$NON-NLS-1$
+                    : "Launch failed: " + PlatformFailures.describe(ex)).toJson(); //$NON-NLS-1$
             }
             finally
             {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/CliReflectionErrors.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/CliReflectionErrors.java
@@ -28,15 +28,16 @@ public final class CliReflectionErrors
     }
 
     /**
-     * Logs the failure and returns the matching error JSON, routing exactly as the
-     * tools used to do inline:
+     * Logs the failure and returns the matching error JSON, preserving the three-way
+     * routing the tools used to do inline:
      * <ul>
      *   <li>{@link InvocationTargetException} — the API itself threw; unwrap the real
-     *       cause and report {@code "<actionLabel> failed: <cause message>"}.</li>
+     *       cause and report {@code "<actionLabel> failed: <cause description>"}.</li>
      *   <li>{@link NoSuchMethodException} / {@link IllegalAccessException} — the CLI API
      *       shape differs from what the reflection expects; report
      *       {@code "<apiLabel> API mismatch: <message>"}.</li>
-     *   <li>anything else — unexpected; report the raw {@code e.getMessage()}.</li>
+     *   <li>anything else — unexpected; report the most informative platform-failure
+     *       description available.</li>
      * </ul>
      *
      * @param e the exception caught around the reflective CLI-API call
@@ -52,7 +53,8 @@ public final class CliReflectionErrors
         {
             Throwable cause = e.getCause() != null ? e.getCause() : e;
             Activator.logError(actionLabel + " failed", cause); //$NON-NLS-1$
-            return ToolResult.error(actionLabel + " failed: " + cause.getMessage()).toJson(); //$NON-NLS-1$
+            return ToolResult.error(actionLabel + " failed: " //$NON-NLS-1$
+                + PlatformFailures.describe(cause)).toJson();
         }
         if (e instanceof NoSuchMethodException || e instanceof IllegalAccessException)
         {
@@ -60,6 +62,6 @@ public final class CliReflectionErrors
             return ToolResult.error(apiLabel + " API mismatch: " + e.getMessage()).toJson(); //$NON-NLS-1$
         }
         Activator.logError("Unexpected error: " + actionLabel, e); //$NON-NLS-1$
-        return ToolResult.error(e.getMessage()).toJson();
+        return ToolResult.error(PlatformFailures.describe(e)).toJson();
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/CliReflectionErrorsTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/CliReflectionErrorsTest.java
@@ -19,7 +19,7 @@ import com.google.gson.JsonParser;
 /**
  * Tests {@link CliReflectionErrors#toErrorJson} — the shared error mapper used by the
  * reflection-wrapped CLI/LanguageTool tools. Verifies the three dispatch branches
- * produce the exact actionable message each tool used to build inline, so the shared
+ * produce actionable messages and preserve the API-mismatch contract, so the shared
  * helper cannot silently drift the wire-visible error text.
  */
 public class CliReflectionErrorsTest
@@ -31,7 +31,7 @@ public class CliReflectionErrorsTest
         return obj.get("error").getAsString(); //$NON-NLS-1$
     }
 
-    /** InvocationTargetException → "<actionLabel> failed: <cause message>" (the API itself threw). */
+    /** InvocationTargetException → "<actionLabel> failed: <cause description>". */
     @Test
     public void invocationTargetUnwrapsCauseUnderActionLabel()
     {
@@ -46,7 +46,22 @@ public class CliReflectionErrorsTest
     {
         String msg = error(CliReflectionErrors.toErrorJson(
             new InvocationTargetException(null), "Translate configuration", "LanguageTool")); //$NON-NLS-1$ //$NON-NLS-2$
-        assertEquals("Translate configuration failed: null", msg); //$NON-NLS-1$
+        assertEquals("Translate configuration failed: InvocationTargetException " //$NON-NLS-1$
+            + "(the platform reported no message)", msg); //$NON-NLS-1$
+    }
+
+    /** A textless target failure is described instead of rendering a literal null message. */
+    @Test
+    public void invocationTargetWithTextlessCauseNamesTheCause()
+    {
+        Exception e = new InvocationTargetException(new IllegalStateException());
+        String msg = error(
+            CliReflectionErrors.toErrorJson(e, "Export", "CLI")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertFalse("the unwrapped target must not render a null message", //$NON-NLS-1$
+            msg.contains("null")); //$NON-NLS-1$
+        assertEquals("Export failed: IllegalStateException " //$NON-NLS-1$
+            + "(the platform reported no message)", msg); //$NON-NLS-1$
     }
 
     /** NoSuchMethodException → "<apiLabel> API mismatch: <message>" (CLI shape differs). */
@@ -67,7 +82,7 @@ public class CliReflectionErrorsTest
                 new IllegalAccessException("denied"), "Generate translation strings", "LanguageTool"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
     }
 
-    /** Any other exception → the raw message, unprefixed. */
+    /** An ordinary unexpected exception keeps its nonblank message, unprefixed. */
     @Test
     public void unexpectedExceptionReturnsRawMessage()
     {


### PR DESCRIPTION
Продолжение #474 по тому же issue #453.

## Что произошло

Мы с #474 делали #453 параллельно и пришли к одному и тому же решению для `update_database`. **#474 сделан лучше на пересечении**, и я перебазировался на него, выбросив свою половину:

- их сообщение действеннее — оно называет следующий шаг («update may have applied partially, so do not retry blindly: check `get_applications` (updateState) and the EDT Error Log»), что для необратимого инструмента важнее самой диагностики;
- их тесты строже: 14 против моих 3, по одному литералу на тест, и они пинят **отсутствие** ключей при `false`, а не только присутствие;
- они поправили устаревший `references/launch/update_database.md`, который обещал старую форму ответа.

Этот PR — только то, чего в #474 нет.

## Что осталось

Тот же скопированный шаблон `getMessage()` живёт ещё в трёх файлах, и issue #453 прямо просил посмотреть соседей.

Дефект тот же и шире заявленного `null`: в эти `catch` попадает `CoreException`, у которого `getMessage()` — общий заголовок, а причина лежит в дочернем `IStatus` (EDT собирает `MultiStatus`). То есть терялся диагноз не только на безтекстовых исключениях, а на каждом платформенном отказе этого класса.

- **`DebugLaunchTool`** — обе ветки `catch (Exception)` вокруг запуска.
- **`RunYaxunitTestsTool`** — три места, включая **обе** ветки `CoreException`.
- **`CliReflectionErrors`** — ветка `InvocationTargetException` и финальный fallback.

## Что намеренно НЕ тронуто

- Ветка `NoSuchMethodException`/`IllegalAccessException` в `CliReflectionErrors`: там сообщение — сигнатура рефлексии, оно никогда не null и не является платформенным отказом.
- Ветка `declinedConflict` в YAXUnit: она намеренно сообщает собственную причину отмены вместо сообщения делегата, и комментарий над ней это фиксирует.
- Остальные ~90 мест с `getMessage()`: issue просит чинить соседей только если это дёшево, а диф на 60 файлов нечитаем при ревью.
- **`project`/`applicationId` в payload `buildUnexpectedErrorResult`.** В моей первой версии они были — issue жалуется, что ответ не даёт «ни объекта». После перехода на хелпер из #474 добавление потребовало бы менять его сигнатуру и 14 свежих тестовых вызовов, а выигрыш мал: вызывающий и так знает, какие `project`/`applicationId` он передал, ценность только в симметрии с соседней веткой. Churn по свежему покрытому коду того не стоит. Если решишь, что симметрия важнее — сделаю отдельно, правка на пару строк.

## Проверено

- **Сборка + юнит:** BUILD SUCCESS, 5418 тестов, 0 падений (включая 14 новых из #474).
- **Живой стенд** (на версии до ребейза, но затронутые этим PR файлы те же): `run_yaxunit_tests` 12/12, `translate_configuration` 7/7 — это путь через `CliReflectionErrors`, `debug_launch` зелёный в составе шардов.
- **Conformance:** exit 0, «Baseline check passed: all failures are expected».

`tools/list` не меняется — golden не трогался.

## По находке ревьюера из прошлой итерации

P1 про расцепление матчера transient-гонки в `test_export_configuration_to_xml.py` проверен по исходникам платформы и отклонён: обе сигнатуры, на которые опирается матчер, приезжают обычными `RuntimeException` без `IStatus` — `AssertionFailedException extends RuntimeException` (`Assert.isTrue` формирует `"assertion failed: " + message`) и `IllegalStateException` из `ProjectOrchestrator.createWrongPhaseMessage`. `PlatformFailures.statusOf` отдаёт статус только для `CoreException`/`ApplicationException`, значит для обеих ветка с детьми не выполняется вовсе и `describe` возвращает `getMessage()` дословно. Изменение в `CliReflectionErrors` в этом PR сохранено без правок именно поэтому.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
