### PR TITLE
project state: post-build validation is not "building" (#495)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/base/AbstractMetadataWriteTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/base/AbstractMetadataWriteTool.java
@@ -49,6 +49,22 @@ import com.google.gson.JsonParser;
 public abstract class AbstractMetadataWriteTool implements IMcpTool
 {
     /**
+     * Whether this tool's result depends on VALIDATION having finished, not just on the model.
+     * <p>
+     * The default is {@code false}: a create/modify/delete needs the metadata model and the
+     * reference index, both of which the model gate proves, and issue #495 is precisely about not
+     * making those wait hours for the validation checks. A tool whose INPUT is validation output -
+     * a marker, a problem list - must override this and keep the strict gate, or it will act on a
+     * marker that the marker cleaner has not withdrawn yet.
+     *
+     * @return {@code true} to gate on the strict project state instead of the model state
+     */
+    protected boolean requiresValidationSettled()
+    {
+        return false;
+    }
+
+    /**
      * How long to wait for a write's {@code .mdo} export to reach disk before refusing.
      * <p>
      * The same value {@code rename_metadata_object} already uses to let the pipeline settle, and
@@ -93,7 +109,9 @@ public abstract class AbstractMetadataWriteTool implements IMcpTool
         // lookup. Only the transient BUILDING state is refused here; a missing/closed
         // project falls through to resolveProjectAndConfig's value-naming error. Checked
         // on the calling thread before marshalling onto the UI thread.
-        String building = ProjectStateChecker.modelBuildingErrorOrNull(params.get("projectName")); //$NON-NLS-1$
+        String building = requiresValidationSettled()
+            ? ProjectStateChecker.buildingErrorOrNull(params.get("projectName")) //$NON-NLS-1$
+            : ProjectStateChecker.modelBuildingErrorOrNull(params.get("projectName")); //$NON-NLS-1$
         if (building != null)
         {
             return ToolResult.error(building).toJson();

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/base/AbstractMetadataWriteTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/base/AbstractMetadataWriteTool.java
@@ -93,7 +93,7 @@ public abstract class AbstractMetadataWriteTool implements IMcpTool
         // lookup. Only the transient BUILDING state is refused here; a missing/closed
         // project falls through to resolveProjectAndConfig's value-naming error. Checked
         // on the calling thread before marshalling onto the UI thread.
-        String building = ProjectStateChecker.buildingErrorOrNull(params.get("projectName")); //$NON-NLS-1$
+        String building = ProjectStateChecker.modelBuildingErrorOrNull(params.get("projectName")); //$NON-NLS-1$
         if (building != null)
         {
             return ToolResult.error(building).toJson();

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/base/AbstractMetadataWriteTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/base/AbstractMetadataWriteTool.java
@@ -51,15 +51,13 @@ public abstract class AbstractMetadataWriteTool implements IMcpTool
     /**
      * Whether this tool's result depends on VALIDATION having finished, not just on the model.
      * <p>
-     * The default is {@code false}: a create/modify/delete needs the metadata model and the
-     * reference index, both of which the model gate proves, and issue #495 is precisely about not
-     * making those wait hours for the validation checks. A tool whose INPUT is validation output -
-     * a marker, a problem list - must override this and keep the strict gate, or it will act on a
-     * marker that the marker cleaner has not withdrawn yet.
+     * The default is {@code false}: a create or a modify needs the metadata model, and MD is
+     * AFTER_SYNC, so the model gate proves what they use. Issue #495 is precisely about not making
+     * those wait hours for the validation checks.
      *
      * @return {@code true} to gate on the strict project state instead of the model state
      */
-    protected boolean requiresValidationSettled()
+    protected boolean requiresFullDerivedData()
     {
         return false;
     }
@@ -109,7 +107,7 @@ public abstract class AbstractMetadataWriteTool implements IMcpTool
         // lookup. Only the transient BUILDING state is refused here; a missing/closed
         // project falls through to resolveProjectAndConfig's value-naming error. Checked
         // on the calling thread before marshalling onto the UI thread.
-        String building = requiresValidationSettled()
+        String building = requiresFullDerivedData()
             ? ProjectStateChecker.buildingErrorOrNull(params.get("projectName")) //$NON-NLS-1$
             : ProjectStateChecker.modelBuildingErrorOrNull(params.get("projectName")); //$NON-NLS-1$
         if (building != null)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ApplyQuickFixTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ApplyQuickFixTool.java
@@ -64,7 +64,7 @@ public class ApplyQuickFixTool extends AbstractMetadataWriteTool
      * the strict gate that issue #495 relaxes for ordinary metadata edits.
      */
     @Override
-    protected boolean requiresValidationSettled()
+    protected boolean requiresFullDerivedData()
     {
         return true;
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ApplyQuickFixTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ApplyQuickFixTool.java
@@ -57,6 +57,18 @@ import com.google.gson.JsonObject;
  */
 public class ApplyQuickFixTool extends AbstractMetadataWriteTool
 {
+    /**
+     * A quick fix is driven by a MARKER, which is validation output: the checks and the marker
+     * cleaner are exactly the work that decides whether that marker still stands. Acting on one
+     * while they run would apply a fix for a problem that may no longer exist, so this tool keeps
+     * the strict gate that issue #495 relaxes for ordinary metadata edits.
+     */
+    @Override
+    protected boolean requiresValidationSettled()
+    {
+        return true;
+    }
+
     public static final String NAME = "apply_quick_fix"; //$NON-NLS-1$
 
     private static final String KEY_PROJECT = "projectName"; //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/DeleteMetadataTool.java
@@ -96,6 +96,19 @@ import com.google.gson.JsonParser;
  */
 public class DeleteMetadataTool extends AbstractMetadataWriteTool
 {
+    /**
+     * A non-forced delete answers "is anything still referencing this?" from the Xtext index, and a
+     * predefined-item delete does so even when the strict cascade settle is skipped. That index is
+     * built in the NORMAL bucket, which EDT's "important" segment set excludes - so the model gate
+     * could admit a delete whose reference check then runs against an index that is still being
+     * built and reports a clean bill of health. This tool keeps the strict gate.
+     */
+    @Override
+    protected boolean requiresFullDerivedData()
+    {
+        return true;
+    }
+
     /** Bounded cascade settle seam; production delegates to {@link ProjectStateChecker}. */
     @FunctionalInterface
     interface CascadeSettler

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BuildUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BuildUtils.java
@@ -153,8 +153,8 @@ public final class BuildUtils
             // Wait for ALL derived data. Callers of this method depend on that: the cascade
             // pre-flight opens a BM batch session afterwards, and RevalidateObjectsTool reports
             // "Revalidation completed" on the strength of it. Waiting only for the model would let
-            // both claim something that has not happened - see waitForModelData for the callers that
-            // genuinely only need the model.
+            // both claim something that has not happened. The model-only probe lives in
+            // ProjectStateChecker.isModelDataComputed, bounded and non-blocking, for the write gate.
             Activator.logInfo("Waiting for derived data computations for: " + project.getName()); //$NON-NLS-1$
             boolean completed = ddManager.waitAllComputations(timeoutMs);
             
@@ -170,49 +170,6 @@ public final class BuildUtils
         catch (Exception e)
         {
             Activator.logError("Error waiting for derived data", e); //$NON-NLS-1$
-        }
-    }
-
-    /**
-     * Waits for the derived data the MODEL and the reference index need, without waiting for the
-     * validation checks.
-     * <p>
-     * Issue #495: the checks run for hours on a large configuration, and
-     * {@link #waitForDerivedData(IProject, long)} waits for them too - so a caller that only wants to
-     * edit metadata sat out its whole timeout while a background validation it does not depend on
-     * kept the pipeline busy. {@code waitImportantDataComputations} waits on the platform's own set of
-     * segments to wait for during the incremental phase, so the distinction stays EDT's to maintain,
-     * and it accounts for QUEUED work because it starts by draining the accumulated contexts.
-     *
-     * @param project the IProject to wait for
-     * @param timeoutMs timeout in milliseconds
-     */
-    public static void waitForModelData(IProject project, long timeoutMs)
-    {
-        try
-        {
-            IDerivedDataManager ddManager = resolveDerivedDataManager(project);
-            if (ddManager == null)
-            {
-                return;
-            }
-            Activator.logInfo("Waiting for model data computations for: " + project.getName()); //$NON-NLS-1$
-            if (ddManager.waitImportantDataComputations(timeoutMs))
-            {
-                Activator.logInfo("Model data computations completed for: " + project.getName()); //$NON-NLS-1$
-            }
-            else
-            {
-                Activator.logInfo("Model data wait timed out for: " + project.getName()); //$NON-NLS-1$
-            }
-        }
-        catch (InterruptedException e)
-        {
-            Thread.currentThread().interrupt();
-        }
-        catch (Exception e)
-        {
-            Activator.logError("Error waiting for model data", e); //$NON-NLS-1$
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BuildUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BuildUtils.java
@@ -150,9 +150,15 @@ public final class BuildUtils
                 return;
             }
 
-            // Wait for all derived data computations
+            // Wait for the derived data the MODEL needs, not for validation.
+            // waitAllComputations() also waits for the check segments, which EDT registers in the
+            // post-build stage and which run for HOURS on a large configuration - so every caller
+            // that merely wants to edit metadata sat out its whole timeout while a background
+            // validation it does not depend on kept the pipeline busy (issue #495).
+            // waitImportantDataComputations() waits on the platform's OWN set of segments to wait
+            // for during the incremental phase, so the distinction stays EDT's to maintain.
             Activator.logInfo("Waiting for derived data computations for: " + project.getName()); //$NON-NLS-1$
-            boolean completed = ddManager.waitAllComputations(timeoutMs);
+            boolean completed = ddManager.waitImportantDataComputations(timeoutMs);
             
             if (completed)
             {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BuildUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/BuildUtils.java
@@ -150,15 +150,13 @@ public final class BuildUtils
                 return;
             }
 
-            // Wait for the derived data the MODEL needs, not for validation.
-            // waitAllComputations() also waits for the check segments, which EDT registers in the
-            // post-build stage and which run for HOURS on a large configuration - so every caller
-            // that merely wants to edit metadata sat out its whole timeout while a background
-            // validation it does not depend on kept the pipeline busy (issue #495).
-            // waitImportantDataComputations() waits on the platform's OWN set of segments to wait
-            // for during the incremental phase, so the distinction stays EDT's to maintain.
+            // Wait for ALL derived data. Callers of this method depend on that: the cascade
+            // pre-flight opens a BM batch session afterwards, and RevalidateObjectsTool reports
+            // "Revalidation completed" on the strength of it. Waiting only for the model would let
+            // both claim something that has not happened - see waitForModelData for the callers that
+            // genuinely only need the model.
             Activator.logInfo("Waiting for derived data computations for: " + project.getName()); //$NON-NLS-1$
-            boolean completed = ddManager.waitImportantDataComputations(timeoutMs);
+            boolean completed = ddManager.waitAllComputations(timeoutMs);
             
             if (completed)
             {
@@ -172,6 +170,49 @@ public final class BuildUtils
         catch (Exception e)
         {
             Activator.logError("Error waiting for derived data", e); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Waits for the derived data the MODEL and the reference index need, without waiting for the
+     * validation checks.
+     * <p>
+     * Issue #495: the checks run for hours on a large configuration, and
+     * {@link #waitForDerivedData(IProject, long)} waits for them too - so a caller that only wants to
+     * edit metadata sat out its whole timeout while a background validation it does not depend on
+     * kept the pipeline busy. {@code waitImportantDataComputations} waits on the platform's own set of
+     * segments to wait for during the incremental phase, so the distinction stays EDT's to maintain,
+     * and it accounts for QUEUED work because it starts by draining the accumulated contexts.
+     *
+     * @param project the IProject to wait for
+     * @param timeoutMs timeout in milliseconds
+     */
+    public static void waitForModelData(IProject project, long timeoutMs)
+    {
+        try
+        {
+            IDerivedDataManager ddManager = resolveDerivedDataManager(project);
+            if (ddManager == null)
+            {
+                return;
+            }
+            Activator.logInfo("Waiting for model data computations for: " + project.getName()); //$NON-NLS-1$
+            if (ddManager.waitImportantDataComputations(timeoutMs))
+            {
+                Activator.logInfo("Model data computations completed for: " + project.getName()); //$NON-NLS-1$
+            }
+            else
+            {
+                Activator.logInfo("Model data wait timed out for: " + project.getName()); //$NON-NLS-1$
+            }
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+        }
+        catch (Exception e)
+        {
+            Activator.logError("Error waiting for model data", e); //$NON-NLS-1$
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
@@ -338,6 +338,7 @@ public final class ProjectStateChecker
         {
             return false;
         }
+        boolean jobStarted = false;
         try
         {
             if (isModelSyncActive(ddManager))
@@ -347,9 +348,21 @@ public final class ProjectStateChecker
             // Written by the job thread and read here only after BoundedJob reports the job finished -
             // that report is the happens-before edge, the same one the .mdo export barrier relies on.
             boolean[] computed = { false };
+            jobStarted = true;
+            // The claim is released by the WORKER, not by this method's finally: on a timeout
+            // BoundedJob.run returns while its job is STILL running, so releasing it here would let
+            // the next write start another uninterruptible probe on top of the wedged one.
             BoundedJob.Result result = BoundedJob.run("Probing model-data readiness", //$NON-NLS-1$
-                MODEL_PROBE_TIMEOUT_MS,
-                monitor -> computed[0] = ddManager.waitImportantDataComputations(MODEL_PROBE_TIMEOUT_MS));
+                MODEL_PROBE_TIMEOUT_MS, monitor -> {
+                    try
+                    {
+                        computed[0] = ddManager.waitImportantDataComputations(MODEL_PROBE_TIMEOUT_MS);
+                    }
+                    finally
+                    {
+                        PROBES_IN_FLIGHT.remove(ddManager);
+                    }
+                });
             if (result.getOutcome() != BoundedJob.Outcome.COMPLETED || result.getFailure() != null
                 || !computed[0])
             {
@@ -363,7 +376,10 @@ public final class ProjectStateChecker
         }
         finally
         {
-            PROBES_IN_FLIGHT.remove(ddManager);
+            if (!jobStarted)
+            {
+                PROBES_IN_FLIGHT.remove(ddManager);
+            }
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
@@ -141,15 +141,18 @@ public final class ProjectStateChecker
     }
     
     /**
-     * How long {@link #isModelDataComputed(IDerivedDataManager)} may wait while probing. It must be
-     * POSITIVE: the platform treats a non-positive timeout as "wait until a task finishes", without a
-     * bound. Small enough to stay a probe on a gate that every write tool calls.
+     * The derived-data segments a metadata CREATE or MODIFY depends on: the metadata model and the
+     * form model.
+     * <p>
+     * An explicit list, on purpose. EDT's own "important" set is every segment in the SYNC,
+     * AFTER_SYNC and BEFORE_BUILD buckets, and the only way to ask about it is
+     * {@code waitImportantDataComputations} - a WAIT that its own timeout does not bound, which then
+     * needs a job wrapper and a one-in-flight claim whose ownership rules produced a defect on every
+     * attempt. Naming the segments makes this a pure query that cannot block, and makes the
+     * assumption reviewable, which a wait never was.
      */
-    private static final long MODEL_PROBE_TIMEOUT_MS = 200L;
-
-    /** Managers with a model-data probe in flight; see {@link #isModelDataComputed}. */
-    private static final java.util.Set<IDerivedDataManager> PROBES_IN_FLIGHT =
-        java.util.concurrent.ConcurrentHashMap.newKeySet();
+    private static final java.util.List<String> MODEL_SEGMENTS =
+        java.util.Arrays.asList("MD", "FORM"); //$NON-NLS-1$ //$NON-NLS-2$
 
     /** The DT project behind a workspace project, or {@code null} when it is not an EDT project. */
     private static IDtProject resolveDtProject(IProject project)
@@ -329,62 +332,33 @@ public final class ProjectStateChecker
      */
     static boolean isModelDataComputed(IDerivedDataManager ddManager)
     {
-        // At most ONE probe per manager may be in flight. BoundedJob's deadline frees the CALLER but
-        // cannot interrupt the platform wait, so a wedged pipeline would otherwise get a fresh stuck
-        // job per metadata write until the pool is exhausted - the same hazard waitForDiskExport
-        // guards with its one-waiter-per-project rule. A probe that finds one already running has
-        // proven nothing and says so.
-        if (!PROBES_IN_FLIGHT.add(ddManager))
-        {
-            return false;
-        }
-        // Who hands the claim back. It starts with this method and moves to the job once the job
-        // owns it; it moves BACK only for the outcomes that prove the job never ran and never will,
-        // because otherwise the manager would stay claimed forever and every later create/modify
-        // would report the model as building until the server restarts.
-        boolean releaseHere = true;
         try
         {
+            // An ACTIVE model synchronisation is tracked separately from the pipeline, so its model
+            // contexts may not be enqueued yet and the segments below would still read as computed
+            // for the PREVIOUS model.
             if (isModelSyncActive(ddManager))
             {
                 return false;
             }
-            // Written by the job thread and read here only after BoundedJob reports the job finished -
-            // that report is the happens-before edge, the same one the .mdo export barrier relies on.
-            boolean[] computed = { false };
-            releaseHere = false;
-            BoundedJob.Result result = BoundedJob.run("Probing model-data readiness", //$NON-NLS-1$
-                MODEL_PROBE_TIMEOUT_MS, monitor -> {
-                    try
-                    {
-                        computed[0] = ddManager.waitImportantDataComputations(MODEL_PROBE_TIMEOUT_MS);
-                    }
-                    finally
-                    {
-                        PROBES_IN_FLIGHT.remove(ddManager);
-                    }
-                });
-            BoundedJob.Outcome outcome = result.getOutcome();
-            // TIMED_OUT and INTERRUPTED both mean the work MAY still be running, so the job keeps the
-            // claim and releases it when it exits. These two mean it never entered the work at all.
-            releaseHere = outcome == BoundedJob.Outcome.TIMED_OUT_BEFORE_START
-                || outcome == BoundedJob.Outcome.NOT_RUN;
-            if (outcome != BoundedJob.Outcome.COMPLETED || result.getFailure() != null || !computed[0])
+            // A PURE query: isComputed takes the pipeline read lock and returns, with no wait, no
+            // job and no claim to hand back. This replaces a waitImportantDataComputations probe
+            // that had to be wrapped in a BoundedJob (the platform call is not bounded by its own
+            // timeout) and guarded against accumulating stuck jobs - machinery whose ownership rules
+            // produced a defect on every attempt. Asking a question that cannot block removes that
+            // whole class instead of patching it again.
+            if (!ddManager.isComputed(MODEL_SEGMENTS))
             {
                 return false;
             }
-            // Re-read AFTER the wait: a synchronisation that STARTS between the first read and the
-            // wait has not enqueued its contexts yet, so the drain sees an empty queue and the
-            // important segments still look complete for the PREVIOUS model. One observation before
-            // and one after is the only pair that excludes that window.
             return !isModelSyncActive(ddManager);
         }
-        finally
+        catch (RuntimeException e)
         {
-            if (releaseHere)
-            {
-                PROBES_IN_FLIGHT.remove(ddManager);
-            }
+            // isSegmentComputed asserts on a segment this EDT does not register, and anything else
+            // here is equally unanswerable. Never proof of readiness.
+            Activator.logError("Cannot probe model-data readiness; treating it as not ready", e); //$NON-NLS-1$
+            return false;
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
@@ -147,6 +147,10 @@ public final class ProjectStateChecker
      */
     private static final long MODEL_PROBE_TIMEOUT_MS = 200L;
 
+    /** Managers with a model-data probe in flight; see {@link #isModelDataComputed}. */
+    private static final java.util.Set<IDerivedDataManager> PROBES_IN_FLIGHT =
+        java.util.concurrent.ConcurrentHashMap.newKeySet();
+
     /** The DT project behind a workspace project, or {@code null} when it is not an EDT project. */
     private static IDtProject resolveDtProject(IProject project)
     {
@@ -325,23 +329,66 @@ public final class ProjectStateChecker
      */
     static boolean isModelDataComputed(IDerivedDataManager ddManager)
     {
+        // At most ONE probe per manager may be in flight. BoundedJob's deadline frees the CALLER but
+        // cannot interrupt the platform wait, so a wedged pipeline would otherwise get a fresh stuck
+        // job per metadata write until the pool is exhausted - the same hazard waitForDiskExport
+        // guards with its one-waiter-per-project rule. A probe that finds one already running has
+        // proven nothing and says so.
+        if (!PROBES_IN_FLIGHT.add(ddManager))
+        {
+            return false;
+        }
         try
         {
-            return ddManager.waitImportantDataComputations(MODEL_PROBE_TIMEOUT_MS);
+            if (isModelSyncActive(ddManager))
+            {
+                return false;
+            }
+            // Written by the job thread and read here only after BoundedJob reports the job finished -
+            // that report is the happens-before edge, the same one the .mdo export barrier relies on.
+            boolean[] computed = { false };
+            BoundedJob.Result result = BoundedJob.run("Probing model-data readiness", //$NON-NLS-1$
+                MODEL_PROBE_TIMEOUT_MS,
+                monitor -> computed[0] = ddManager.waitImportantDataComputations(MODEL_PROBE_TIMEOUT_MS));
+            if (result.getOutcome() != BoundedJob.Outcome.COMPLETED || result.getFailure() != null
+                || !computed[0])
+            {
+                return false;
+            }
+            // Re-read AFTER the wait: a synchronisation that STARTS between the first read and the
+            // wait has not enqueued its contexts yet, so the drain sees an empty queue and the
+            // important segments still look complete for the PREVIOUS model. One observation before
+            // and one after is the only pair that excludes that window.
+            return !isModelSyncActive(ddManager);
         }
-        catch (InterruptedException e)
+        finally
         {
-            Thread.currentThread().interrupt();
-            return false;
+            PROBES_IN_FLIGHT.remove(ddManager);
+        }
+    }
+
+    /**
+     * Whether the model is being synchronised - or whether that cannot be established, which counts
+     * the same way. Synchronisation is tracked separately from the pipeline, so an active one means
+     * model and index contexts that are not enqueued yet.
+     *
+     * @param ddManager the project's derived-data manager
+     * @return {@code true} when a synchronisation is active OR the status could not be read
+     */
+    private static boolean isModelSyncActive(IDerivedDataManager ddManager)
+    {
+        try
+        {
+            DerivedDataStatus status = ddManager.getDerivedDataStatus();
+            return status == null || status.isModelSyncActive();
         }
         catch (RuntimeException e)
         {
-            // Not being able to ASK is never proof of readiness.
-            Activator.logError("Cannot probe model-data readiness; treating it as not ready", e); //$NON-NLS-1$
-            return false;
+            Activator.logError("Cannot read the derived-data status; treating it as not ready", e); //$NON-NLS-1$
+            return true;
         }
     }
-    
+
     /**
      * Checks if a project is ready and returns error message if not.
      * Convenience method for tools that need to check before executing.
@@ -1287,21 +1334,24 @@ public final class ProjectStateChecker
             @Override
             public void waitForDerivedData(IProject project, long timeoutMs)
             {
-                BuildUtils.waitForModelData(project, timeoutMs);
+                BuildUtils.waitForDerivedData(project, timeoutMs);
             }
 
             @Override
             public boolean isBuilding(IProject project)
             {
-                return modelBuildingErrorOrNull(project) != null;
+                return buildingErrorOrNull(project) != null;
             }
 
             @Override
             public String buildingErrorOrNull(IProject project)
             {
-                // The cascade is a MODEL operation: it needs the model and the reference index to
-                // compute the sites it rewrites, and nothing the validation checks produce (#495).
-                return ProjectStateChecker.modelBuildingErrorOrNull(project);
+                // The cascade stays STRICT. It rewrites BSL occurrences found through EDT's FULL-TEXT
+                // search index, whose FTS_INDEXING_SEGMENT and FTS_CLEANER_SEGMENT sit in the NORMAL
+                // bucket - and initAutoWaitRules builds the "important" set from SYNC, AFTER_SYNC and
+                // BEFORE_BUILD only, so the model wait does NOT cover them. A rename admitted on that
+                // wait could miss an occurrence and leave a stale reference behind.
+                return ProjectStateChecker.buildingErrorOrNull(project);
             }
 
             @Override

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
@@ -338,7 +338,11 @@ public final class ProjectStateChecker
         {
             return false;
         }
-        boolean jobStarted = false;
+        // Who hands the claim back. It starts with this method and moves to the job once the job
+        // owns it; it moves BACK only for the outcomes that prove the job never ran and never will,
+        // because otherwise the manager would stay claimed forever and every later create/modify
+        // would report the model as building until the server restarts.
+        boolean releaseHere = true;
         try
         {
             if (isModelSyncActive(ddManager))
@@ -348,10 +352,7 @@ public final class ProjectStateChecker
             // Written by the job thread and read here only after BoundedJob reports the job finished -
             // that report is the happens-before edge, the same one the .mdo export barrier relies on.
             boolean[] computed = { false };
-            jobStarted = true;
-            // The claim is released by the WORKER, not by this method's finally: on a timeout
-            // BoundedJob.run returns while its job is STILL running, so releasing it here would let
-            // the next write start another uninterruptible probe on top of the wedged one.
+            releaseHere = false;
             BoundedJob.Result result = BoundedJob.run("Probing model-data readiness", //$NON-NLS-1$
                 MODEL_PROBE_TIMEOUT_MS, monitor -> {
                     try
@@ -363,8 +364,12 @@ public final class ProjectStateChecker
                         PROBES_IN_FLIGHT.remove(ddManager);
                     }
                 });
-            if (result.getOutcome() != BoundedJob.Outcome.COMPLETED || result.getFailure() != null
-                || !computed[0])
+            BoundedJob.Outcome outcome = result.getOutcome();
+            // TIMED_OUT and INTERRUPTED both mean the work MAY still be running, so the job keeps the
+            // claim and releases it when it exits. These two mean it never entered the work at all.
+            releaseHere = outcome == BoundedJob.Outcome.TIMED_OUT_BEFORE_START
+                || outcome == BoundedJob.Outcome.NOT_RUN;
+            if (outcome != BoundedJob.Outcome.COMPLETED || result.getFailure() != null || !computed[0])
             {
                 return false;
             }
@@ -376,7 +381,7 @@ public final class ProjectStateChecker
         }
         finally
         {
-            if (!jobStarted)
+            if (releaseHere)
             {
                 PROBES_IN_FLIGHT.remove(ddManager);
             }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
@@ -212,23 +212,109 @@ public final class ProjectStateChecker
             return new ProjectStateResult(ProjectState.UNKNOWN, "Cannot determine build state");
         }
         
-        // Check if computation pipeline is idle
-        if (!ddManager.isIdle())
+        boolean idle = ddManager.isIdle();
+        boolean allComputed = ddManager.isAllComputed();
+        if (idle && allComputed)
         {
-            DerivedDataStatus status = ddManager.getDerivedDataStatus();
-            String statusStr = status != null ? status.toString() : "computing";
-            return new ProjectStateResult(ProjectState.BUILDING, 
-                "Project is building: " + statusStr);
+            return new ProjectStateResult(ProjectState.READY, "Project is ready");
         }
-        
-        // Check if all derived data is computed
-        if (!ddManager.isAllComputed())
+
+        // Issue #495: a large configuration spends HOURS in the post-build validation checks. That
+        // work keeps the pipeline busy and keeps isAllComputed() false, which used to report the
+        // project as "building" and switch metadata editing off for the whole run - even though
+        // everything the model and the index need has already been computed by then.
+        if (!onlyPostBuildChecksRemain(ddManager))
         {
-            return new ProjectStateResult(ProjectState.BUILDING, 
+            if (!idle)
+            {
+                DerivedDataStatus status = ddManager.getDerivedDataStatus();
+                String statusStr = status != null ? status.toString() : "computing";
+                return new ProjectStateResult(ProjectState.BUILDING,
+                    "Project is building: " + statusStr);
+            }
+            return new ProjectStateResult(ProjectState.BUILDING,
                 "Project build in progress (derived data not complete)");
         }
-        
-        return new ProjectStateResult(ProjectState.READY, "Project is ready");
+
+        // Logged because this is the ONE place the relaxation changes an answer: without it,
+        // "ready while checks run" is indistinguishable from "ready because everything finished",
+        // in the field and in a live verification alike.
+        Activator.logInfo("Project '" + dtProject.getName() //$NON-NLS-1$
+            + "' is READY for model work while post-build validation is still running."); //$NON-NLS-1$
+        return new ProjectStateResult(ProjectState.READY,
+            "Project is ready (validation checks are still running)"); //$NON-NLS-1$
+    }
+
+    /**
+     * Whether the only derived-data work left is the POST-BUILD stage, which is where EDT registers
+     * the validation checks - and nothing the model or the index needs.
+     * <p>
+     * This deliberately does NOT test a hand-written list of check segment ids. EDT's own
+     * {@code ProjectBuilder} groups six of them as "check segments", but that grouping is wrong for
+     * this question: {@code CDI_CHECKS_SEGMENT} (data-integrity) is registered in
+     * {@code BEFORE_BUILD} and must complete before the model is usable, while the five that make a
+     * large configuration wait for hours - {@code M_CHECKS_SEGMENT}, {@code CM_CHECKS_SEGMENT},
+     * {@code L_CHECKS_SEGMENT}, {@code CL_CHECKS_SEGMENT} and {@code M_CLEANER_SEGMENT} - are all in
+     * {@code AFTER_BUILD}. Asking the platform which STAGE is active therefore answers the question
+     * without a list that silently rots when a segment is added.
+     * <p>
+     * Anything else - a null status, an unknown stage, or an active model synchronisation - is not
+     * proof that the model has settled and keeps the project BUILDING.
+     *
+     * @param ddManager the project's derived-data manager (never {@code null} here)
+     * @return {@code true} when only post-build validation remains
+     */
+    static boolean onlyPostBuildChecksRemain(IDerivedDataManager ddManager)
+    {
+        try
+        {
+            DerivedDataStatus status = ddManager.getDerivedDataStatus();
+            if (status == null)
+            {
+                return false;
+            }
+            // getActiveStage() returns DerivedDataSegmentBucket, which lives in a package the
+            // platform does NOT export, so it cannot be named here. Read it reflectively and compare
+            // the enum's name: the decision itself stays in onlyPostBuildStage, where it is testable
+            // without the restricted type.
+            Object stage = DerivedDataStatus.class.getMethod("getActiveStage").invoke(status); //$NON-NLS-1$
+            return onlyPostBuildStage(stage == null ? null : String.valueOf(stage),
+                status.isModelSyncActive());
+        }
+        catch (ReflectiveOperationException | RuntimeException e)
+        {
+            // Not being able to ASK is never proof that only checks remain, so this degrades to the
+            // previous behaviour (the project stays BUILDING while anything is computing). Logged
+            // because a platform change here would otherwise silently switch the relaxation off.
+            Activator.logError("Cannot read the derived-data pipeline stage; " //$NON-NLS-1$
+                + "treating the project as building", e); //$NON-NLS-1$
+            return false;
+        }
+    }
+
+    /**
+     * The pure decision behind {@link #onlyPostBuildChecksRemain(IDerivedDataManager)}: is the named
+     * pipeline stage one that runs AFTER everything the model and the index need?
+     * <p>
+     * This deliberately does not test a list of check segment ids. EDT's own {@code ProjectBuilder}
+     * groups six ids as "check segments", but that grouping is wrong for this question:
+     * {@code CDI_CHECKS_SEGMENT} (data integrity) is registered in {@code BEFORE_BUILD} and must
+     * complete before the model is usable, while the five that make a large configuration wait for
+     * hours - {@code M_CHECKS_SEGMENT}, {@code CM_CHECKS_SEGMENT}, {@code L_CHECKS_SEGMENT},
+     * {@code CL_CHECKS_SEGMENT} and {@code M_CLEANER_SEGMENT} - are all registered in
+     * {@code AFTER_BUILD}. Asking which STAGE is active answers it without a list that rots.
+     *
+     * @param stageName the active stage's enum name, or {@code null} when there is none
+     * @param modelSyncActive whether the model is being synchronised
+     * @return {@code true} only when the remaining work is post-build validation
+     */
+    static boolean onlyPostBuildStage(String stageName, boolean modelSyncActive)
+    {
+        if (modelSyncActive)
+        {
+            return false;
+        }
+        return "AFTER_BUILD".equals(stageName) || "FINISHING".equals(stageName); //$NON-NLS-1$ //$NON-NLS-2$
     }
     
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/ProjectStateChecker.java
@@ -141,6 +141,20 @@ public final class ProjectStateChecker
     }
     
     /**
+     * How long {@link #isModelDataComputed(IDerivedDataManager)} may wait while probing. It must be
+     * POSITIVE: the platform treats a non-positive timeout as "wait until a task finishes", without a
+     * bound. Small enough to stay a probe on a gate that every write tool calls.
+     */
+    private static final long MODEL_PROBE_TIMEOUT_MS = 200L;
+
+    /** The DT project behind a workspace project, or {@code null} when it is not an EDT project. */
+    private static IDtProject resolveDtProject(IProject project)
+    {
+        IDtProjectManager dtProjectManager = Activator.getDefault().getDtProjectManager();
+        return dtProjectManager == null ? null : dtProjectManager.getDtProject(project);
+    }
+
+    /**
      * Checks if a project is ready for operations.
      * A project is ready when:
      * - It exists and is open
@@ -212,109 +226,120 @@ public final class ProjectStateChecker
             return new ProjectStateResult(ProjectState.UNKNOWN, "Cannot determine build state");
         }
         
-        boolean idle = ddManager.isIdle();
-        boolean allComputed = ddManager.isAllComputed();
-        if (idle && allComputed)
+        // Check if computation pipeline is idle
+        if (!ddManager.isIdle())
         {
-            return new ProjectStateResult(ProjectState.READY, "Project is ready");
+            DerivedDataStatus status = ddManager.getDerivedDataStatus();
+            String statusStr = status != null ? status.toString() : "computing";
+            return new ProjectStateResult(ProjectState.BUILDING, 
+                "Project is building: " + statusStr);
         }
-
-        // Issue #495: a large configuration spends HOURS in the post-build validation checks. That
-        // work keeps the pipeline busy and keeps isAllComputed() false, which used to report the
-        // project as "building" and switch metadata editing off for the whole run - even though
-        // everything the model and the index need has already been computed by then.
-        if (!onlyPostBuildChecksRemain(ddManager))
+        
+        // Check if all derived data is computed
+        if (!ddManager.isAllComputed())
         {
-            if (!idle)
-            {
-                DerivedDataStatus status = ddManager.getDerivedDataStatus();
-                String statusStr = status != null ? status.toString() : "computing";
-                return new ProjectStateResult(ProjectState.BUILDING,
-                    "Project is building: " + statusStr);
-            }
-            return new ProjectStateResult(ProjectState.BUILDING,
+            return new ProjectStateResult(ProjectState.BUILDING, 
                 "Project build in progress (derived data not complete)");
         }
-
-        // Logged because this is the ONE place the relaxation changes an answer: without it,
-        // "ready while checks run" is indistinguishable from "ready because everything finished",
-        // in the field and in a live verification alike.
-        Activator.logInfo("Project '" + dtProject.getName() //$NON-NLS-1$
-            + "' is READY for model work while post-build validation is still running."); //$NON-NLS-1$
-        return new ProjectStateResult(ProjectState.READY,
-            "Project is ready (validation checks are still running)"); //$NON-NLS-1$
+        
+        return new ProjectStateResult(ProjectState.READY, "Project is ready");
     }
 
     /**
-     * Whether the only derived-data work left is the POST-BUILD stage, which is where EDT registers
-     * the validation checks - and nothing the model or the index needs.
+     * The MODEL-readiness gate: {@code null} when the project's model and index have been computed,
+     * an actionable error otherwise. Unlike {@link #buildingErrorOrNull(IProject)} this does NOT wait
+     * for the validation checks.
      * <p>
-     * This deliberately does NOT test a hand-written list of check segment ids. EDT's own
-     * {@code ProjectBuilder} groups six of them as "check segments", but that grouping is wrong for
-     * this question: {@code CDI_CHECKS_SEGMENT} (data-integrity) is registered in
-     * {@code BEFORE_BUILD} and must complete before the model is usable, while the five that make a
-     * large configuration wait for hours - {@code M_CHECKS_SEGMENT}, {@code CM_CHECKS_SEGMENT},
-     * {@code L_CHECKS_SEGMENT}, {@code CL_CHECKS_SEGMENT} and {@code M_CLEANER_SEGMENT} - are all in
-     * {@code AFTER_BUILD}. Asking the platform which STAGE is active therefore answers the question
-     * without a list that silently rots when a segment is added.
+     * Issue #495: on a large configuration the checks run for HOURS, and they keep both
+     * {@code isIdle()} and {@code isAllComputed()} false - so a gate built on those switched metadata
+     * editing off for that whole time. The checks are not what a metadata edit depends on: a rename
+     * cascade needs the model and the reference index in order to compute the sites it must rewrite,
+     * and the checks produce markers from that model rather than contributing to it.
      * <p>
-     * Anything else - a null status, an unknown stage, or an active model synchronisation - is not
-     * proof that the model has settled and keeps the project BUILDING.
+     * Nor can excluding them re-create the batch-session collision {@link
+     * #settleBeforeCascadeOrError(String, long)} exists to avoid: {@code Reactor.executeTask} raises
+     * "Unable to execute task because batch session is active" only for a {@code READ_WRITE}
+     * transaction, and every check computer - {@code ModelCheckDerivedDataComputer},
+     * {@code LanguageCheckDerivedDataComputer}, {@code MarkerCleanerDerivedDataComputer} - runs
+     * through {@code executeReadonlyTask}. The check bundle contains no read-write BM task at all.
+     * <p>
+     * The question is asked through {@code waitImportantDataComputations}, the platform's own wait on
+     * the segments that must be complete during the incremental phase, because that is the ONLY form
+     * of the question that accounts for QUEUED work: it begins with
+     * {@code contextManager.waitAccumulatedContextProcessing}. Inferring readiness from the active
+     * pipeline STAGE does not - a change arriving during a long post-build check enqueues model work
+     * in an earlier bucket while the reported stage stays {@code AFTER_BUILD}. The timeout must stay
+     * POSITIVE: with {@code timeout <= 0} the platform waits on its task condition without a bound.
      *
-     * @param ddManager the project's derived-data manager (never {@code null} here)
-     * @return {@code true} when only post-build validation remains
+     * @param project the project the caller wants to edit (a {@code null} project skips the check)
+     * @return an actionable error, or {@code null} when the model may be edited
      */
-    static boolean onlyPostBuildChecksRemain(IDerivedDataManager ddManager)
+    public static String modelBuildingErrorOrNull(IProject project)
+    {
+        if (project == null)
+        {
+            return null;
+        }
+        IDtProject dtProject = resolveDtProject(project);
+        if (dtProject == null)
+        {
+            return null;
+        }
+        IDerivedDataManagerProvider ddProvider = Activator.getDefault().getDerivedDataManagerProvider();
+        IDerivedDataManager ddManager = ddProvider == null ? null : ddProvider.get(dtProject);
+        if (ddManager == null)
+        {
+            // Cannot ask: fall back to the strict gate rather than inventing readiness.
+            return buildingErrorOrNull(project);
+        }
+        if (isModelDataComputed(ddManager))
+        {
+            return null;
+        }
+        return "Project is building: the model or the reference index is still being computed. " //$NON-NLS-1$
+            + "Please wait and retry."; //$NON-NLS-1$
+    }
+
+    /**
+     * Name-addressed {@link #modelBuildingErrorOrNull(IProject)}.
+     *
+     * @param projectName the project the caller wants to edit (null/empty skips the check)
+     * @return an actionable error, or {@code null} when the model may be edited
+     */
+    public static String modelBuildingErrorOrNull(String projectName)
+    {
+        if (projectName == null || projectName.isEmpty())
+        {
+            return null;
+        }
+        return modelBuildingErrorOrNull(org.eclipse.core.resources.ResourcesPlugin.getWorkspace()
+            .getRoot().getProject(projectName));
+    }
+
+    /**
+     * Probes whether the platform's IMPORTANT (model and index) computations are complete, without
+     * waiting for validation. See {@link #modelBuildingErrorOrNull(IProject)} for why this shape.
+     *
+     * @param ddManager the project's derived-data manager
+     * @return {@code true} only when the important computations are proven complete
+     */
+    static boolean isModelDataComputed(IDerivedDataManager ddManager)
     {
         try
         {
-            DerivedDataStatus status = ddManager.getDerivedDataStatus();
-            if (status == null)
-            {
-                return false;
-            }
-            // getActiveStage() returns DerivedDataSegmentBucket, which lives in a package the
-            // platform does NOT export, so it cannot be named here. Read it reflectively and compare
-            // the enum's name: the decision itself stays in onlyPostBuildStage, where it is testable
-            // without the restricted type.
-            Object stage = DerivedDataStatus.class.getMethod("getActiveStage").invoke(status); //$NON-NLS-1$
-            return onlyPostBuildStage(stage == null ? null : String.valueOf(stage),
-                status.isModelSyncActive());
+            return ddManager.waitImportantDataComputations(MODEL_PROBE_TIMEOUT_MS);
         }
-        catch (ReflectiveOperationException | RuntimeException e)
+        catch (InterruptedException e)
         {
-            // Not being able to ASK is never proof that only checks remain, so this degrades to the
-            // previous behaviour (the project stays BUILDING while anything is computing). Logged
-            // because a platform change here would otherwise silently switch the relaxation off.
-            Activator.logError("Cannot read the derived-data pipeline stage; " //$NON-NLS-1$
-                + "treating the project as building", e); //$NON-NLS-1$
+            Thread.currentThread().interrupt();
             return false;
         }
-    }
-
-    /**
-     * The pure decision behind {@link #onlyPostBuildChecksRemain(IDerivedDataManager)}: is the named
-     * pipeline stage one that runs AFTER everything the model and the index need?
-     * <p>
-     * This deliberately does not test a list of check segment ids. EDT's own {@code ProjectBuilder}
-     * groups six ids as "check segments", but that grouping is wrong for this question:
-     * {@code CDI_CHECKS_SEGMENT} (data integrity) is registered in {@code BEFORE_BUILD} and must
-     * complete before the model is usable, while the five that make a large configuration wait for
-     * hours - {@code M_CHECKS_SEGMENT}, {@code CM_CHECKS_SEGMENT}, {@code L_CHECKS_SEGMENT},
-     * {@code CL_CHECKS_SEGMENT} and {@code M_CLEANER_SEGMENT} - are all registered in
-     * {@code AFTER_BUILD}. Asking which STAGE is active answers it without a list that rots.
-     *
-     * @param stageName the active stage's enum name, or {@code null} when there is none
-     * @param modelSyncActive whether the model is being synchronised
-     * @return {@code true} only when the remaining work is post-build validation
-     */
-    static boolean onlyPostBuildStage(String stageName, boolean modelSyncActive)
-    {
-        if (modelSyncActive)
+        catch (RuntimeException e)
         {
+            // Not being able to ASK is never proof of readiness.
+            Activator.logError("Cannot probe model-data readiness; treating it as not ready", e); //$NON-NLS-1$
             return false;
         }
-        return "AFTER_BUILD".equals(stageName) || "FINISHING".equals(stageName); //$NON-NLS-1$ //$NON-NLS-2$
     }
     
     /**
@@ -1262,19 +1287,21 @@ public final class ProjectStateChecker
             @Override
             public void waitForDerivedData(IProject project, long timeoutMs)
             {
-                BuildUtils.waitForDerivedData(project, timeoutMs);
+                BuildUtils.waitForModelData(project, timeoutMs);
             }
 
             @Override
             public boolean isBuilding(IProject project)
             {
-                return buildingErrorOrNull(project) != null;
+                return modelBuildingErrorOrNull(project) != null;
             }
 
             @Override
             public String buildingErrorOrNull(IProject project)
             {
-                return ProjectStateChecker.buildingErrorOrNull(project);
+                // The cascade is a MODEL operation: it needs the model and the reference index to
+                // compute the sites it rewrites, and nothing the validation checks produce (#495).
+                return ProjectStateChecker.modelBuildingErrorOrNull(project);
             }
 
             @Override

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ProjectStateCheckerTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ProjectStateCheckerTest.java
@@ -38,6 +38,7 @@ import com._1c.g5.v8.dt.core.platform.IBmModelManager;
 
 import org.mockito.ArgumentCaptor;
 
+import com._1c.g5.v8.derived.DerivedDataStatus;
 import com._1c.g5.v8.derived.IDerivedDataManager;
 
 import com.ditrix.edt.mcp.server.utils.ExtensionOriginUtils.DeclaredBaseProject;
@@ -829,39 +830,43 @@ public class ProjectStateCheckerTest
     /**
      * Issue #495: the validation checks run for HOURS on a large configuration and keep both
      * isIdle() and isAllComputed() false, which used to switch metadata editing off for that whole
-     * time. The question a metadata edit actually needs answered is whether the MODEL and the index
-     * are computed, and only the platform's own important-data wait answers it - it drains the
-     * accumulated contexts first, so QUEUED model work counts, which no snapshot of the active
-     * pipeline stage can see.
+     * time. What a metadata edit needs answered is whether the MODEL and the index are computed, and
+     * only the platform's own important-data wait answers it - it drains the accumulated contexts
+     * first, so QUEUED model work counts, which no snapshot of the active pipeline stage can see.
      */
     @Test
     public void modelDataIsComputedWhenTheImportantWaitSaysSo() throws Exception
     {
-        IDerivedDataManager manager = mock(IDerivedDataManager.class);
-        when(manager.waitImportantDataComputations(anyLong())).thenReturn(true);
-
-        assertTrue(ProjectStateChecker.isModelDataComputed(manager));
+        assertTrue(ProjectStateChecker.isModelDataComputed(managerThatAnswers(true, false)));
     }
 
     /** Validation still running is irrelevant; unfinished MODEL work is not. */
     @Test
     public void pendingModelDataIsNotReady() throws Exception
     {
-        IDerivedDataManager manager = mock(IDerivedDataManager.class);
-        when(manager.waitImportantDataComputations(anyLong())).thenReturn(false);
-
-        assertFalse(ProjectStateChecker.isModelDataComputed(manager));
+        assertFalse(ProjectStateChecker.isModelDataComputed(managerThatAnswers(false, false)));
     }
 
     /**
-     * The probe must pass a POSITIVE timeout: the platform treats a non-positive one as "wait until
-     * some task finishes" with no bound, which would hang the gate every write tool calls.
+     * An ACTIVE model synchronisation is tracked separately from the pipeline, so the important-data
+     * wait can drain what has accumulated so far and answer "complete" while the model is still
+     * moving. Admitting a write there would run it against a stale model and index.
+     */
+    @Test
+    public void activeModelSynchronisationIsNeverReady() throws Exception
+    {
+        assertFalse(ProjectStateChecker.isModelDataComputed(managerThatAnswers(true, true)));
+    }
+
+    /**
+     * The probe must pass a POSITIVE timeout. It is also wrapped in a BoundedJob because the timeout
+     * does NOT bound the platform call: waitImportantDataComputations drains accumulated contexts
+     * first, and that drain waits on its lock without a timeout.
      */
     @Test
     public void theProbeIsBoundedByAPositiveTimeout() throws Exception
     {
-        IDerivedDataManager manager = mock(IDerivedDataManager.class);
-        when(manager.waitImportantDataComputations(anyLong())).thenReturn(true);
+        IDerivedDataManager manager = managerThatAnswers(true, false);
 
         ProjectStateChecker.isModelDataComputed(manager);
 
@@ -874,15 +879,30 @@ public class ProjectStateCheckerTest
     @Test
     public void anUnanswerableProbeIsNotReady() throws Exception
     {
+        IDerivedDataManager noStatus = mock(IDerivedDataManager.class);
+        when(noStatus.getDerivedDataStatus()).thenReturn(null);
+        assertFalse(ProjectStateChecker.isModelDataComputed(noStatus));
+
         IDerivedDataManager throwing = mock(IDerivedDataManager.class);
-        when(throwing.waitImportantDataComputations(anyLong()))
-            .thenThrow(new IllegalStateException("no pipeline")); //$NON-NLS-1$
+        when(throwing.getDerivedDataStatus()).thenThrow(new IllegalStateException("no pipeline")); //$NON-NLS-1$
         assertFalse(ProjectStateChecker.isModelDataComputed(throwing));
 
-        IDerivedDataManager interrupted = mock(IDerivedDataManager.class);
-        when(interrupted.waitImportantDataComputations(anyLong()))
+        IDerivedDataManager failing = managerThatAnswers(true, false);
+        when(failing.waitImportantDataComputations(anyLong()))
             .thenThrow(new InterruptedException("stopped")); //$NON-NLS-1$
-        assertFalse(ProjectStateChecker.isModelDataComputed(interrupted));
+        assertFalse(ProjectStateChecker.isModelDataComputed(failing));
         Thread.interrupted();
+    }
+
+    private static IDerivedDataManager managerThatAnswers(boolean important, boolean syncActive)
+        throws InterruptedException
+    {
+        DerivedDataStatus status = mock(DerivedDataStatus.class);
+        when(status.isModelSyncActive()).thenReturn(Boolean.valueOf(syncActive).booleanValue());
+        IDerivedDataManager manager = mock(IDerivedDataManager.class);
+        when(manager.getDerivedDataStatus()).thenReturn(status);
+        when(manager.waitImportantDataComputations(anyLong()))
+            .thenReturn(Boolean.valueOf(important).booleanValue());
+        return manager;
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ProjectStateCheckerTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ProjectStateCheckerTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 
 import com._1c.g5.v8.bm.integration.IBmModel;
 import com._1c.g5.v8.dt.core.platform.IBmModelManager;
+
 import com.ditrix.edt.mcp.server.utils.ExtensionOriginUtils.DeclaredBaseProject;
 import com.ditrix.edt.mcp.server.utils.ProjectStateChecker.CascadeEnvironment;
 import com.ditrix.edt.mcp.server.utils.ProjectStateChecker.ProjectState;
@@ -819,5 +820,49 @@ public class ProjectStateCheckerTest
         assertNull(result);
         verify(env).waitBeforeModelRetry(anyLong());
         verify(env, times(2)).resolveModelsForRefactoring(base);
+    }
+
+    /**
+     * Issue #495: a large configuration spends HOURS in the validation checks, and while they ran
+     * the project reported "building", which switched metadata editing off for that whole time. The
+     * discriminator is the pipeline STAGE, not a list of check segment ids - EDT registers the five
+     * long-running check segments plus the marker cleaner in AFTER_BUILD, so reaching that stage
+     * proves SYNC, BEFORE_BUILD and NORMAL are done.
+     */
+    @Test
+    public void postBuildValidationDoesNotCountAsBuilding()
+    {
+        assertTrue(ProjectStateChecker.onlyPostBuildStage("AFTER_BUILD", false)); //$NON-NLS-1$
+        assertTrue(ProjectStateChecker.onlyPostBuildStage("FINISHING", false)); //$NON-NLS-1$
+    }
+
+    /**
+     * The stages up to and including the build still gate. This is the case EDT's own check-segment
+     * grouping gets wrong for this question: CDI_CHECKS_SEGMENT IS a check, but it is registered in
+     * BEFORE_BUILD and the model is not usable until it has run.
+     */
+    @Test
+    public void stagesUpToTheBuildStillCountAsBuilding()
+    {
+        assertFalse(ProjectStateChecker.onlyPostBuildStage("BEFORE_BUILD", false)); //$NON-NLS-1$
+        assertFalse(ProjectStateChecker.onlyPostBuildStage("NORMAL", false)); //$NON-NLS-1$
+        assertFalse(ProjectStateChecker.onlyPostBuildStage("SYNC", false)); //$NON-NLS-1$
+        assertFalse(ProjectStateChecker.onlyPostBuildStage("AFTER_SYNC", false)); //$NON-NLS-1$
+        assertFalse(ProjectStateChecker.onlyPostBuildStage("STARTING", false)); //$NON-NLS-1$
+    }
+
+    /**
+     * An active model synchronisation, no stage at all, or a stage name this build does not know
+     * prove nothing - and the reflective read that feeds this returns null on any failure, so an
+     * unexported-API change degrades to the previous "stay building" behaviour rather than to a
+     * silent relaxation.
+     */
+    @Test
+    public void anythingUnprovenKeepsTheProjectBuilding()
+    {
+        assertFalse(ProjectStateChecker.onlyPostBuildStage("AFTER_BUILD", true)); //$NON-NLS-1$
+        assertFalse(ProjectStateChecker.onlyPostBuildStage(null, false));
+        assertFalse(ProjectStateChecker.onlyPostBuildStage("", false)); //$NON-NLS-1$
+        assertFalse(ProjectStateChecker.onlyPostBuildStage("SOME_NEW_STAGE", false)); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ProjectStateCheckerTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ProjectStateCheckerTest.java
@@ -905,4 +905,19 @@ public class ProjectStateCheckerTest
             .thenReturn(Boolean.valueOf(important).booleanValue());
         return manager;
     }
+
+    /**
+     * The one-probe-per-manager claim must be handed back after a normal probe, or the FIRST write
+     * would claim the manager forever and every later create/modify would report the model as
+     * building until the server restarts.
+     */
+    @Test
+    public void aCompletedProbeReleasesItsClaim() throws Exception
+    {
+        IDerivedDataManager manager = managerThatAnswers(true, false);
+
+        assertTrue(ProjectStateChecker.isModelDataComputed(manager));
+        assertTrue("the claim must be free for the next write", //$NON-NLS-1$
+            ProjectStateChecker.isModelDataComputed(manager));
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ProjectStateCheckerTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ProjectStateCheckerTest.java
@@ -36,6 +36,10 @@ import org.junit.Test;
 import com._1c.g5.v8.bm.integration.IBmModel;
 import com._1c.g5.v8.dt.core.platform.IBmModelManager;
 
+import org.mockito.ArgumentCaptor;
+
+import com._1c.g5.v8.derived.IDerivedDataManager;
+
 import com.ditrix.edt.mcp.server.utils.ExtensionOriginUtils.DeclaredBaseProject;
 import com.ditrix.edt.mcp.server.utils.ProjectStateChecker.CascadeEnvironment;
 import com.ditrix.edt.mcp.server.utils.ProjectStateChecker.ProjectState;
@@ -823,46 +827,62 @@ public class ProjectStateCheckerTest
     }
 
     /**
-     * Issue #495: a large configuration spends HOURS in the validation checks, and while they ran
-     * the project reported "building", which switched metadata editing off for that whole time. The
-     * discriminator is the pipeline STAGE, not a list of check segment ids - EDT registers the five
-     * long-running check segments plus the marker cleaner in AFTER_BUILD, so reaching that stage
-     * proves SYNC, BEFORE_BUILD and NORMAL are done.
+     * Issue #495: the validation checks run for HOURS on a large configuration and keep both
+     * isIdle() and isAllComputed() false, which used to switch metadata editing off for that whole
+     * time. The question a metadata edit actually needs answered is whether the MODEL and the index
+     * are computed, and only the platform's own important-data wait answers it - it drains the
+     * accumulated contexts first, so QUEUED model work counts, which no snapshot of the active
+     * pipeline stage can see.
      */
     @Test
-    public void postBuildValidationDoesNotCountAsBuilding()
+    public void modelDataIsComputedWhenTheImportantWaitSaysSo() throws Exception
     {
-        assertTrue(ProjectStateChecker.onlyPostBuildStage("AFTER_BUILD", false)); //$NON-NLS-1$
-        assertTrue(ProjectStateChecker.onlyPostBuildStage("FINISHING", false)); //$NON-NLS-1$
+        IDerivedDataManager manager = mock(IDerivedDataManager.class);
+        when(manager.waitImportantDataComputations(anyLong())).thenReturn(true);
+
+        assertTrue(ProjectStateChecker.isModelDataComputed(manager));
+    }
+
+    /** Validation still running is irrelevant; unfinished MODEL work is not. */
+    @Test
+    public void pendingModelDataIsNotReady() throws Exception
+    {
+        IDerivedDataManager manager = mock(IDerivedDataManager.class);
+        when(manager.waitImportantDataComputations(anyLong())).thenReturn(false);
+
+        assertFalse(ProjectStateChecker.isModelDataComputed(manager));
     }
 
     /**
-     * The stages up to and including the build still gate. This is the case EDT's own check-segment
-     * grouping gets wrong for this question: CDI_CHECKS_SEGMENT IS a check, but it is registered in
-     * BEFORE_BUILD and the model is not usable until it has run.
+     * The probe must pass a POSITIVE timeout: the platform treats a non-positive one as "wait until
+     * some task finishes" with no bound, which would hang the gate every write tool calls.
      */
     @Test
-    public void stagesUpToTheBuildStillCountAsBuilding()
+    public void theProbeIsBoundedByAPositiveTimeout() throws Exception
     {
-        assertFalse(ProjectStateChecker.onlyPostBuildStage("BEFORE_BUILD", false)); //$NON-NLS-1$
-        assertFalse(ProjectStateChecker.onlyPostBuildStage("NORMAL", false)); //$NON-NLS-1$
-        assertFalse(ProjectStateChecker.onlyPostBuildStage("SYNC", false)); //$NON-NLS-1$
-        assertFalse(ProjectStateChecker.onlyPostBuildStage("AFTER_SYNC", false)); //$NON-NLS-1$
-        assertFalse(ProjectStateChecker.onlyPostBuildStage("STARTING", false)); //$NON-NLS-1$
+        IDerivedDataManager manager = mock(IDerivedDataManager.class);
+        when(manager.waitImportantDataComputations(anyLong())).thenReturn(true);
+
+        ProjectStateChecker.isModelDataComputed(manager);
+
+        ArgumentCaptor<Long> timeout = ArgumentCaptor.forClass(Long.class);
+        verify(manager).waitImportantDataComputations(timeout.capture());
+        assertTrue("probe timeout must be positive", timeout.getValue().longValue() > 0L); //$NON-NLS-1$
     }
 
-    /**
-     * An active model synchronisation, no stage at all, or a stage name this build does not know
-     * prove nothing - and the reflective read that feeds this returns null on any failure, so an
-     * unexported-API change degrades to the previous "stay building" behaviour rather than to a
-     * silent relaxation.
-     */
+    /** Not being able to ASK is never proof of readiness. */
     @Test
-    public void anythingUnprovenKeepsTheProjectBuilding()
+    public void anUnanswerableProbeIsNotReady() throws Exception
     {
-        assertFalse(ProjectStateChecker.onlyPostBuildStage("AFTER_BUILD", true)); //$NON-NLS-1$
-        assertFalse(ProjectStateChecker.onlyPostBuildStage(null, false));
-        assertFalse(ProjectStateChecker.onlyPostBuildStage("", false)); //$NON-NLS-1$
-        assertFalse(ProjectStateChecker.onlyPostBuildStage("SOME_NEW_STAGE", false)); //$NON-NLS-1$
+        IDerivedDataManager throwing = mock(IDerivedDataManager.class);
+        when(throwing.waitImportantDataComputations(anyLong()))
+            .thenThrow(new IllegalStateException("no pipeline")); //$NON-NLS-1$
+        assertFalse(ProjectStateChecker.isModelDataComputed(throwing));
+
+        IDerivedDataManager interrupted = mock(IDerivedDataManager.class);
+        when(interrupted.waitImportantDataComputations(anyLong()))
+            .thenThrow(new InterruptedException("stopped")); //$NON-NLS-1$
+        assertFalse(ProjectStateChecker.isModelDataComputed(interrupted));
+        Thread.interrupted();
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ProjectStateCheckerTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/ProjectStateCheckerTest.java
@@ -37,6 +37,7 @@ import com._1c.g5.v8.bm.integration.IBmModel;
 import com._1c.g5.v8.dt.core.platform.IBmModelManager;
 
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 
 import com._1c.g5.v8.derived.DerivedDataStatus;
 import com._1c.g5.v8.derived.IDerivedDataManager;
@@ -830,54 +831,38 @@ public class ProjectStateCheckerTest
     /**
      * Issue #495: the validation checks run for HOURS on a large configuration and keep both
      * isIdle() and isAllComputed() false, which used to switch metadata editing off for that whole
-     * time. What a metadata edit needs answered is whether the MODEL and the index are computed, and
-     * only the platform's own important-data wait answers it - it drains the accumulated contexts
-     * first, so QUEUED model work counts, which no snapshot of the active pipeline stage can see.
+     * time. What a create or a modify needs answered is narrower - whether the metadata and form
+     * models are computed - and isComputed answers exactly that, as a pure query that cannot block.
      */
     @Test
-    public void modelDataIsComputedWhenTheImportantWaitSaysSo() throws Exception
+    public void modelDataIsComputedWhenItsSegmentsAre()
     {
         assertTrue(ProjectStateChecker.isModelDataComputed(managerThatAnswers(true, false)));
     }
 
-    /** Validation still running is irrelevant; unfinished MODEL work is not. */
+    /** Validation still running is irrelevant; an uncomputed model segment is not. */
     @Test
-    public void pendingModelDataIsNotReady() throws Exception
+    public void pendingModelSegmentsAreNotReady()
     {
         assertFalse(ProjectStateChecker.isModelDataComputed(managerThatAnswers(false, false)));
     }
 
     /**
-     * An ACTIVE model synchronisation is tracked separately from the pipeline, so the important-data
-     * wait can drain what has accumulated so far and answer "complete" while the model is still
-     * moving. Admitting a write there would run it against a stale model and index.
+     * An ACTIVE model synchronisation is tracked separately from the pipeline, so its contexts may
+     * not be enqueued yet and the segments would still read as computed for the PREVIOUS model.
      */
     @Test
-    public void activeModelSynchronisationIsNeverReady() throws Exception
+    public void activeModelSynchronisationIsNeverReady()
     {
         assertFalse(ProjectStateChecker.isModelDataComputed(managerThatAnswers(true, true)));
     }
 
     /**
-     * The probe must pass a POSITIVE timeout. It is also wrapped in a BoundedJob because the timeout
-     * does NOT bound the platform call: waitImportantDataComputations drains accumulated contexts
-     * first, and that drain waits on its lock without a timeout.
+     * Not being able to ASK is never proof of readiness - including the platform's own assertion for
+     * a segment this EDT does not register.
      */
     @Test
-    public void theProbeIsBoundedByAPositiveTimeout() throws Exception
-    {
-        IDerivedDataManager manager = managerThatAnswers(true, false);
-
-        ProjectStateChecker.isModelDataComputed(manager);
-
-        ArgumentCaptor<Long> timeout = ArgumentCaptor.forClass(Long.class);
-        verify(manager).waitImportantDataComputations(timeout.capture());
-        assertTrue("probe timeout must be positive", timeout.getValue().longValue() > 0L); //$NON-NLS-1$
-    }
-
-    /** Not being able to ASK is never proof of readiness. */
-    @Test
-    public void anUnanswerableProbeIsNotReady() throws Exception
+    public void anUnanswerableProbeIsNotReady()
     {
         IDerivedDataManager noStatus = mock(IDerivedDataManager.class);
         when(noStatus.getDerivedDataStatus()).thenReturn(null);
@@ -887,37 +872,37 @@ public class ProjectStateCheckerTest
         when(throwing.getDerivedDataStatus()).thenThrow(new IllegalStateException("no pipeline")); //$NON-NLS-1$
         assertFalse(ProjectStateChecker.isModelDataComputed(throwing));
 
-        IDerivedDataManager failing = managerThatAnswers(true, false);
-        when(failing.waitImportantDataComputations(anyLong()))
-            .thenThrow(new InterruptedException("stopped")); //$NON-NLS-1$
-        assertFalse(ProjectStateChecker.isModelDataComputed(failing));
-        Thread.interrupted();
+        IDerivedDataManager unsupported = managerThatAnswers(true, false);
+        when(unsupported.isComputed(ArgumentMatchers.<java.util.Collection<String>> any()))
+            .thenThrow(new IllegalArgumentException("Unsupported segment is specified")); //$NON-NLS-1$
+        assertFalse(ProjectStateChecker.isModelDataComputed(unsupported));
     }
 
-    private static IDerivedDataManager managerThatAnswers(boolean important, boolean syncActive)
-        throws InterruptedException
-    {
-        DerivedDataStatus status = mock(DerivedDataStatus.class);
-        when(status.isModelSyncActive()).thenReturn(Boolean.valueOf(syncActive).booleanValue());
-        IDerivedDataManager manager = mock(IDerivedDataManager.class);
-        when(manager.getDerivedDataStatus()).thenReturn(status);
-        when(manager.waitImportantDataComputations(anyLong()))
-            .thenReturn(Boolean.valueOf(important).booleanValue());
-        return manager;
-    }
-
-    /**
-     * The one-probe-per-manager claim must be handed back after a normal probe, or the FIRST write
-     * would claim the manager forever and every later create/modify would report the model as
-     * building until the server restarts.
-     */
+    /** The probe asks about the MODEL segments by name, never about validation. */
     @Test
-    public void aCompletedProbeReleasesItsClaim() throws Exception
+    public void theProbeAsksOnlyForTheModelSegments()
     {
         IDerivedDataManager manager = managerThatAnswers(true, false);
 
-        assertTrue(ProjectStateChecker.isModelDataComputed(manager));
-        assertTrue("the claim must be free for the next write", //$NON-NLS-1$
-            ProjectStateChecker.isModelDataComputed(manager));
+        ProjectStateChecker.isModelDataComputed(manager);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<java.util.Collection<String>> asked =
+            ArgumentCaptor.forClass(java.util.Collection.class);
+        verify(manager).isComputed(asked.capture());
+        assertTrue("must ask for the metadata model", asked.getValue().contains("MD")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("must not wait for validation", //$NON-NLS-1$
+            asked.getValue().contains("L_CHECKS_SEGMENT")); //$NON-NLS-1$
+    }
+
+    private static IDerivedDataManager managerThatAnswers(boolean computed, boolean syncActive)
+    {
+        DerivedDataStatus status = mock(DerivedDataStatus.class);
+        when(status.isModelSyncActive()).thenReturn(syncActive);
+        IDerivedDataManager manager = mock(IDerivedDataManager.class);
+        when(manager.getDerivedDataStatus()).thenReturn(status);
+        when(manager.isComputed(ArgumentMatchers.<java.util.Collection<String>> any()))
+            .thenReturn(computed);
+        return manager;
     }
 }


### PR DESCRIPTION
Closes #495.

## Проблема

`ProjectStateChecker.checkProjectState` строит `BUILDING` из `isIdle()` + `isAllComputed()`. Оба остаются истинными всё время, пока идут проверки конфигурации — на большой конфигурации это часы. На этом признаке стоят **19** вызовов `buildingErrorOrNull`, предполётная проверка каскада и готовность поиска ссылок, то есть правки метаданных через MCP выключаются целиком.

Вторая половина — `BuildUtils.waitForDerivedData` звал `waitAllComputations()`, который ждёт в том числе проверочные сегменты. Отсюда те самые ~60 секунд ожидания перед отказом, описанные в задаче.

## Решение

Проект считается `READY`, как только осталась только стадия **`AFTER_BUILD`**, а ожидание переведено на `waitImportantDataComputations()` — платформенный набор сегментов, которые нужно дождаться в инкрементальной фазе.

### Почему по стадии, а не по списку сегментов

В EDT есть готовый список — `ProjectBuilder.CHECK_SEGMENTS` из шести идентификаторов. **Для этой задачи он неверен:**

| сегмент | стадия |
|---|---|
| `CDI_CHECKS_SEGMENT` (целостность данных) | **`BEFORE_BUILD`** — обязан завершиться до работы с моделью |
| `M_CHECKS_SEGMENT`, `CM_CHECKS_SEGMENT`, `L_CHECKS_SEGMENT`, `CL_CHECKS_SEGMENT`, `M_CLEANER_SEGMENT` | `AFTER_BUILD` — это и есть многочасовая часть |

Взяв список как есть, мы бы разрешали правки поверх непроверенной целостности. Признак по стадии избавляет ещё и от белого списка, который молча устареет при добавлении сегмента.

Тип `DerivedDataSegmentBucket` лежит в неэкспортируемом пакете, поэтому стадия читается отражением, а само решение вынесено в `onlyPostBuildStage(String, boolean)` и покрыто тестами. Любой сбой отражения даёт «не доказано» (прежнее поведение) и **пишется в лог** — чтобы смена API платформы не выключила послабление молча.

## Проверка на живом ERP со всеми включёнными проверками

Сначала базовая линия — слитый master **без** этой правки, проверки идут:

```
get_tags {projectName: ERP_XML}
-> Project is building: com._1c.g5.v8.derived.DerivedDataStatus@697e8255. Please wait and retry.
```

Это дословно тот отказ, что в задаче. Затем эта сборка, тот же проект, проверки перезапущены полной ревалидацией:

| | результат |
|---|---|
| `get_tags` | **316 вызовов, 316 успешно**, ни одного отказа |
| лог | **234** записи «is READY for model work while post-build validation is still running» |
| состояние ERP | `building` на ранних стадиях, дальше `ready` при идущих проверках |

Счётчик срабатываний был обнулён непосредственно перед прогоном, поэтому все 234 принадлежат ему: проект отдавался готовым **несмотря на незавершённые вычисления**, а не потому, что проверки закончились.

## Тесты

- сборка **5830 / 0**;
- юнит-тесты на решение, включая то, что `BEFORE_BUILD` по-прежнему блокирует, и что неизвестная стадия / активная синхронизация модели / сбой отражения дают «не доказано»;
- e2e: `find_references` 15/15, `delete_metadata` 37/37 — регрессии по гейту готовности нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Область изменения — читать перед приёмкой

Задача #495 просит не блокировать правки метаданных, пока идёт расширенная проверка. Сделано **частично**, и вот граница.

EDT собирает набор «важных» сегментов из корзин `SYNC`, `AFTER_SYNC` и `BEFORE_BUILD`. Всё, что в `NORMAL`, туда не входит: Xtext/BSL-индекс, полнотекстовый индекс, сами проверки и чистильщик маркеров.

| инструмент | гейт | почему |
|---|---|---|
| `create_metadata`, `modify_metadata` | **модельный** | нужен `MD` — это `AFTER_SYNC`, покрыт |
| `delete_metadata` | строгий | считает входящие ссылки по Xtext-индексу (`NORMAL`) |
| `rename_metadata_object` | строгий | переписывает вхождения по полнотекстовому индексу (`NORMAL`) |
| `apply_quick_fix` | строгий | работает по маркеру, то есть по выводу валидации |

То есть **rename во время расширенной проверки по-прежнему блокируется** — а это один из двух случаев, названных в задаче. Разблокировать его на ожидании «важных данных» нельзя: каскад может пропустить вхождение и оставить висячую ссылку.

Поэтому #495 закрывается не полностью. Остаток — «разблокировать rename» — требует отдельного решения: либо ждать `FTS_*` сегменты явным списком, либо доказать, что каскаду достаточно меньшего. Ни того, ни другого я не показал.