### PR TITLE
get_metadata_details: состав общего реквизита рендерится с именами владельцев (#505)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatter.java
@@ -17,6 +17,7 @@ import com._1c.g5.v8.dt.metadata.mdclass.BasicFeature;
 import com._1c.g5.v8.dt.metadata.mdclass.BasicForm;
 import com._1c.g5.v8.dt.metadata.mdclass.BasicTabularSection;
 import com._1c.g5.v8.dt.metadata.mdclass.CharacteristicsDescription;
+import com._1c.g5.v8.dt.metadata.mdclass.CommonAttributeContentItem;
 import com._1c.g5.v8.dt.metadata.mdclass.DbObjectAttribute;
 import com._1c.g5.v8.dt.mcore.ColorValue;
 import com._1c.g5.v8.dt.mcore.FontValue;
@@ -48,6 +49,9 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter // NOS
 
     /** Table column label for an origin cell. */
     private static final String ORIGIN_TOKEN = "Origin"; //$NON-NLS-1$
+
+    /** Explicit marker for a common-attribute content item whose owner no longer resolves. */
+    private static final String UNRESOLVED_METADATA = "[unresolved metadata]"; //$NON-NLS-1$
 
     /**
      * Gets the singleton instance.
@@ -247,6 +251,10 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter // NOS
             // Handle EMap collections like Synonym, ObjectPresentation
             formatMapEntryCollection(sb, collectionName, collection);
         }
+        else if (firstItem instanceof CommonAttributeContentItem)
+        {
+            formatCommonAttributeContentCollection(sb, collectionName, collection);
+        }
         else if (firstItem instanceof MdObject)
         {
             formatMdObjectCollection(sb, collectionName, collection, full, language);
@@ -254,6 +262,29 @@ public class UniversalMetadataFormatter extends AbstractMetadataFormatter // NOS
         else if (firstItem instanceof EObject)
         {
             formatEObjectCollection(sb, collectionName, collection);
+        }
+    }
+
+    /**
+     * Formats the owners and per-owner use values of a common attribute. Owner FQNs use the same
+     * {@code Type.Name} representation accepted by {@code modify_metadata}'s {@code content}
+     * payload. A missing owner is rendered explicitly because an empty cell would make a dangling
+     * content entry look valid.
+     */
+    private void formatCommonAttributeContentCollection(StringBuilder sb, String name, Collection<?> items)
+    {
+        addSectionHeader(sb, name);
+        startTable(sb, "Metadata", "Use"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        for (Object item : items)
+        {
+            if (item instanceof CommonAttributeContentItem)
+            {
+                CommonAttributeContentItem contentItem = (CommonAttributeContentItem)item;
+                MdObject metadata = contentItem.getMetadata();
+                String metadataFqn = metadata == null ? UNRESOLVED_METADATA : formatEObjectReference(metadata);
+                addTableRow(sb, metadataFqn, formatEnum(contentItem.getUse()));
+            }
         }
     }
     

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/metadata/UniversalMetadataFormatterTest.java
@@ -20,9 +20,14 @@ import com._1c.g5.v8.dt.metadata.mdclass.CatalogAttribute;
 import com._1c.g5.v8.dt.metadata.mdclass.CatalogCommand;
 import com._1c.g5.v8.dt.metadata.mdclass.CatalogForm;
 import com._1c.g5.v8.dt.metadata.mdclass.CatalogTabularSection;
+import com._1c.g5.v8.dt.metadata.mdclass.CommonAttribute;
+import com._1c.g5.v8.dt.metadata.mdclass.CommonAttributeContentItem;
+import com._1c.g5.v8.dt.metadata.mdclass.CommonAttributeUse;
 import com._1c.g5.v8.dt.metadata.mdclass.FormType;
 import com._1c.g5.v8.dt.metadata.mdclass.Indexing;
 import com._1c.g5.v8.dt.metadata.mdclass.MdClassFactory;
+import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
+import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
 import com._1c.g5.v8.dt.metadata.mdclass.TabularSectionAttribute;
 
 /**
@@ -86,6 +91,17 @@ public class UniversalMetadataFormatterTest
         attr.getSynonym().put(EN, synonymEn);
         attr.setType(typeOf(typeName));
         return attr;
+    }
+
+    /** A detached content item suitable for exercising the pure formatter path headlessly. */
+    private static CommonAttributeContentItem newCommonAttributeContentItem(MdObject metadata,
+        CommonAttributeUse use)
+    {
+        CommonAttributeContentItem item = (CommonAttributeContentItem)MdClassFactory.eINSTANCE
+            .create(MdClassPackage.Literals.COMMON_ATTRIBUTE_CONTENT_ITEM);
+        item.setMetadata(metadata);
+        item.setUse(use);
+        return item;
     }
 
     // ==================== format() null / header guards ====================
@@ -238,6 +254,42 @@ public class UniversalMetadataFormatterTest
             md.contains("| Name | Synonym | Group |")); //$NON-NLS-1$
         assertTrue("an unset command group renders as a dash, got:\n" + md, //$NON-NLS-1$
             md.contains("| Refill | Refill | - |")); //$NON-NLS-1$
+    }
+
+    // ==================== CommonAttribute content ====================
+
+    @Test
+    public void testCommonAttributeContentRendersMetadataFqnAndUse()
+    {
+        CommonAttribute commonAttribute = MdClassFactory.eINSTANCE.createCommonAttribute();
+        commonAttribute.setName("Separator"); //$NON-NLS-1$
+        Catalog owner = MdClassFactory.eINSTANCE.createCatalog();
+        owner.setName("Owner|With\nBreak"); //$NON-NLS-1$
+        commonAttribute.getContent().add(
+            newCommonAttributeContentItem(owner, CommonAttributeUse.DONT_USE));
+
+        String md = f.format(commonAttribute, false, EN);
+
+        assertTrue("common-attribute content must use Metadata and Use columns",
+            md.contains("| Metadata | Use |")); //$NON-NLS-1$
+        assertTrue("the owner FQN and use must render in their matching, table-safe cells:\n" + md,
+            md.contains("| Catalog.Owner\\|With Break | DontUse |")); //$NON-NLS-1$
+        assertFalse("the generic EObject fallback must not leak the content-item EClass name",
+            md.contains("CommonAttributeContentItem")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testCommonAttributeContentRendersUnresolvedOwnerMarker()
+    {
+        CommonAttribute commonAttribute = MdClassFactory.eINSTANCE.createCommonAttribute();
+        commonAttribute.setName("Separator"); //$NON-NLS-1$
+        commonAttribute.getContent().add(
+            newCommonAttributeContentItem(null, CommonAttributeUse.AUTO));
+
+        String md = f.format(commonAttribute, false, EN);
+
+        assertTrue("a dangling owner must render an explicit marker instead of a blank cell:\n" + md,
+            md.contains("| [unresolved metadata] | Auto |")); //$NON-NLS-1$
     }
 
     // ==================== formatType direct (single + composite + empty) ====================

--- a/tests/e2e/tools/test_modify_metadata_common_attribute.py
+++ b/tests/e2e/tools/test_modify_metadata_common_attribute.py
@@ -12,8 +12,7 @@ Adding is idempotent (an already-listed owner has its `use` UPDATED, counted und
 than `added`); removing detaches by the owner FQN. The change goes through a BM write transaction and
 force-exports the CommonAttribute `.mdo`. The success payload carries a `content` counts object
 {added, updated, removed}. Read the current content with get_metadata_details on the CommonAttribute
-FQN (a "Content" section listing CommonAttributeContentItem rows - the generic formatter shows the
-item count, and the OWNER FQN is the load-bearing on-disk proof).
+FQN (a "Content" section whose Metadata / Use rows are round-trippable into this payload).
 
 reset: kind="write-metadata" -> reset_fixture()+reset_model() after each test.
 
@@ -27,6 +26,7 @@ from harness import (
     assert_error,
     assert_error_quality,
     assert_contains,
+    assert_not_contains,
     assert_no_diff,
     poll_diff_contains,
     poll_disk_lacks,
@@ -54,10 +54,10 @@ def _details_text(fqn=CA):
 # ──────────────────────────────────────────────────────────────────────────────
 
 @e2e_test(tool="modify_metadata", kind="write-metadata")
-def test_add_owner_persists_and_reads_back():
+def test_add_owner_persists_and_get_details_renders_content_columns():
     # Precondition (anti-cheat): the owner is NOT already attached, so a no-op would FAIL the diff.
     before = _details_text()
-    assert "CommonAttributeContentItem" not in before, \
+    assert "### Content" not in before, \
         "the fixture common attribute must start with an EMPTY content list:\n%s" % before[:400]
 
     r = call("modify_metadata", {
@@ -74,10 +74,17 @@ def test_add_owner_persists_and_reads_back():
     # (1) ON-DISK structure: the owner FQN lands inside a <content> block in the CommonAttribute .mdo.
     poll_diff_contains(OWNER_MDO_TOKEN,
                        ctx="the attached owner must land in a <content> block on disk")
-    # (2) MODEL read-back: the common attribute now carries a content item (empty -> one row).
+    # (2) MODEL read-back: the Content table exposes the round-trippable owner FQN and its use in
+    # the correct columns. The final assertion is the anti-cheat: the pre-fix generic EObject
+    # formatter emitted "| Use | CommonAttributeContentItem |" instead.
     after = _details_text()
-    assert_contains(after, "CommonAttributeContentItem",
-                    "the model read-back must show the new content item")
+    assert_contains(after, "### Content", "the model read-back must show the Content section")
+    assert_contains(after, "| Metadata | Use |",
+                    "the Content table must name the owner and use columns")
+    assert_contains(after, "| Catalog.Catalog | Use |",
+                    "the attached owner FQN and use must render in the matching columns")
+    assert_not_contains(after, "CommonAttributeContentItem",
+                        "the generic EObject EClass value must not leak into Content")
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -127,10 +134,13 @@ def test_readd_is_idempotent_and_updates_use():
     # The use flip landed on disk (Use -> DontUse) for the single, un-duplicated owner.
     poll_diff_contains("<use>DontUse</use>",
                        ctx="the re-add must update the owner's use to DontUse on disk")
-    # anti-cheat: exactly ONE content item exists (no duplicate row in the model read-back).
+    # anti-cheat: exactly ONE owner row exists (no duplicate in the model read-back), and it exposes
+    # the updated use rather than the generic EObject EClass name.
     text = _details_text()
-    assert text.count("CommonAttributeContentItem") == 1, \
+    assert text.count("| Catalog.Catalog | DontUse |") == 1, \
         "the idempotent re-add must NOT duplicate the owner:\n%s" % text[:500]
+    assert_not_contains(text, "CommonAttributeContentItem",
+                        "the content read-back must not use the generic EObject fallback")
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -159,9 +169,9 @@ def test_remove_owner_detaches_it():
     # The owner FQN is gone from the content list on disk (the whole <content> block for it is removed).
     poll_disk_lacks(CA_MDO, OWNER_MDO_TOKEN,
                     ctx="the detached owner's <content> block must be gone from the .mdo")
-    # The model read-back no longer lists a content item (back to an empty content list).
+    # The model read-back no longer lists a Content section (back to an empty content list).
     after = _details_text()
-    assert "CommonAttributeContentItem" not in after, \
+    assert "### Content" not in after, \
         "the model read-back must show the content item removed:\n%s" % after[:500]
 
 


### PR DESCRIPTION
Closes #505.

## Что не так было

Секция `Content` у `CommonAttribute` приходила с разъехавшимися колонками и без единственного, что делает строку осмысленной:

```
| Name     | Value                      |
| DontUse  | CommonAttributeContentItem |
... ~500 одинаковых строк
```

То есть через MCP нельзя было определить, какие объекты разделитель реально разделяет. В модели владелец есть — в `.mdo` пишется `<metadata>Constant.X</metadata>` — он просто не доходил до вывода.

## Причина

`UniversalMetadataFormatter.dispatchContainmentCollection` ветвится по типу первого элемента, а `CommonAttributeContentItem` — это `EObject`, но **не** `MdObject`. Поэтому он проваливался мимо всех специализированных веток в generic-`formatEObjectCollection`, который печатает `formatEObjectReference(item)` в колонку `Name` и имя EClass в жёстко заданную колонку `Value`. Ровно то, что и наблюдалось.

## Что сделано

Отдельная ветка рендерит `| Metadata | Use |`, где `Metadata` — FQN владельца в форме `Type.Name`, той самой, которую принимает payload `content` у `modify_metadata`. Прочитанное round-trip'ится в записываемое (read-side к #507).

Неразрешившийся владелец рендерится явным маркером, а не пустой ячейкой: висячая строка состава не должна выглядеть валидной — в этом репозитории уже наблюдалось, как удаление оставляет ровно такую форму.

**Не капается.** `MAX_DYNAMIC_ROWS` управляет рефлективным дампом свойств/ссылок, а прямые containment-секции (реквизиты, формы, команды) не ограничены — поэтому все ~500 строк рендерятся так же, как в любой сопоставимой секции.

## Проверено

- Tier 1: `BUILD SUCCESS`, `UniversalMetadataFormatterTest` 14/14 (2 новых).
- Tier 2: живой стенд EDT 2026.2.0.289.
- Tier 3: `--filter owner` → **22/22**, fixture clean; новый `test_add_owner_persists_and_get_details_renders_content_columns` отработал.
- Tier 4: conformance — `Baseline check passed`.
- Схема не менялась, golden не тронут.

Контракт вывода форматтера проверяется **только** e2e (так сказано в CLAUDE.md), поэтому e2e обязателен: он проверяет колонки после присоединения известного владельца **и** что литерал `CommonAttributeContentItem` больше не появляется как значение ячейки — а это ровно то, что печатает пре-фикс сервер. Юнит-тесты дополнительно пинят экранирование markdown, потому что имя 1C может содержать `|` или перевод строки.

## Границы

#515 (схлопывание `[N items]` в All Properties и предложение фильтра секций) — другой корень и другой тикет, не трогается. Остальные containment-ветки не менялись.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
