### PR TITLE
validate_query: an extension's query resolves in the union of its own and the base model (#460)

### DIFF
--- a/docs/tools/validate_query.md
+++ b/docs/tools/validate_query.md
@@ -10,7 +10,7 @@ Validate 1C:Enterprise query language (QL) text against a project, returning syn
 | dcsMode | — | boolean | true for Data Composition System queries (allows DCS-specific syntax). Default: false. |
 
 ## Guide
-Validates 1C:Enterprise query language (QL) text in the context of a project, using EDT's Xtext QL infrastructure. It parses the query and runs full semantic validation, so it catches both grammar errors and references to tables/fields that do not exist in the project's metadata. The query is validated only; nothing is written to the model or executed.
+Validates 1C:Enterprise query language (QL) text in the context of a project, using EDT's Xtext QL infrastructure. It parses the query and runs full semantic validation, so it catches both grammar errors and references to tables/fields that do not exist in the project's effective metadata model. For a configuration extension, that model is the union of the extension's own metadata and the base configuration's metadata. The query is validated only; nothing is written to the model or executed.
 
 ## When to use
 - Before pasting a query string into a BSL module, to confirm it parses and all referenced metadata resolves.
@@ -18,7 +18,7 @@ Validates 1C:Enterprise query language (QL) text in the context of a project, us
 - For queries that drive a Data Composition Schema (set `dcsMode=true`).
 
 ## Parameter details
-- `projectName` (required) - EDT project name; the query is resolved against this project's metadata, so table and field names must exist there.
+- `projectName` (required) - EDT project name. A configuration project validates in its own model. A configuration extension validates in a union scope containing its own objects and the base configuration's objects, including inherited fields of borrowed objects.
 - `queryText` (required) - the complete query text. Query parameters (`&SearchString`) are allowed and need not be bound. Example: `SELECT Ref FROM Catalog.Products WHERE Description LIKE &SearchString`.
 - `dcsMode` - default `false`. Set `true` only for queries used inside a Data Composition Schema; this enables DCS-specific syntax (e.g. `{...}` braces, dataset fields) that a plain query would reject, and is echoed back as `dcsMode` in the result.
 
@@ -34,7 +34,7 @@ JSON with `valid` (true when there are zero issues), `dcsMode`, `errorCount`, `w
 
 ## Gotchas
 - `success:true` means the tool ran; check `valid` for whether the query itself is error-free. A successful run can still report `valid:false` with issues.
-- A field/table that exists in the platform but not in THIS project resolves as a semantic error - pass the project that actually owns the metadata.
+- For an extension project, the union scope resolves both extension-owned objects and base-configuration objects, including inherited fields of borrowed objects.
 - If QL language support is unavailable the tool returns an error rather than a validation result.
 
 ---

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/validate_query.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/validate_query.md
@@ -1,4 +1,4 @@
-Validates 1C:Enterprise query language (QL) text in the context of a project, using EDT's Xtext QL infrastructure. It parses the query and runs full semantic validation, so it catches both grammar errors and references to tables/fields that do not exist in the project's metadata. The query is validated only; nothing is written to the model or executed.
+Validates 1C:Enterprise query language (QL) text in the context of a project, using EDT's Xtext QL infrastructure. It parses the query and runs full semantic validation, so it catches both grammar errors and references to tables/fields that do not exist in the project's effective metadata model. For a configuration extension, that model is the union of the extension's own metadata and the base configuration's metadata. The query is validated only; nothing is written to the model or executed.
 
 ## When to use
 - Before pasting a query string into a BSL module, to confirm it parses and all referenced metadata resolves.
@@ -6,7 +6,7 @@ Validates 1C:Enterprise query language (QL) text in the context of a project, us
 - For queries that drive a Data Composition Schema (set `dcsMode=true`).
 
 ## Parameter details
-- `projectName` (required) - EDT project name; the query is resolved against this project's metadata, so table and field names must exist there.
+- `projectName` (required) - EDT project name. A configuration project validates in its own model. A configuration extension validates in a union scope containing its own objects and the base configuration's objects, including inherited fields of borrowed objects.
 - `queryText` (required) - the complete query text. Query parameters (`&SearchString`) are allowed and need not be bound. Example: `SELECT Ref FROM Catalog.Products WHERE Description LIKE &SearchString`.
 - `dcsMode` - default `false`. Set `true` only for queries used inside a Data Composition Schema; this enables DCS-specific syntax (e.g. `{...}` braces, dataset fields) that a plain query would reject, and is echoed back as `dcsMode` in the result.
 
@@ -22,5 +22,5 @@ JSON with `valid` (true when there are zero issues), `dcsMode`, `errorCount`, `w
 
 ## Gotchas
 - `success:true` means the tool ran; check `valid` for whether the query itself is error-free. A successful run can still report `valid:false` with issues.
-- A field/table that exists in the platform but not in THIS project resolves as a semantic error - pass the project that actually owns the metadata.
+- For an extension project, the union scope resolves both extension-owned objects and base-configuration objects, including inherited fields of borrowed objects.
 - If QL language support is unavailable the tool returns an error rather than a validation result.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ValidateQueryTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ValidateQueryTool.java
@@ -205,6 +205,8 @@ public class ValidateQueryTool implements IMcpTool
             if (resource instanceof QlDcsResource)
             {
                 QlDcsResource qlResource = (QlDcsResource) resource;
+                // Match EDT's query editor: use the extension + base model union; regular projects are a no-op.
+                qlResource.setParentScopeAware(true);
                 qlResource.addOptions("DcsValidationModeOption", dcsMode); //$NON-NLS-1$
                 qlResource.setPreComputeAnnounceAlias(dcsMode);
             }

--- a/tests/e2e/tools/test_modify_metadata_common_attribute.py
+++ b/tests/e2e/tools/test_modify_metadata_common_attribute.py
@@ -161,11 +161,15 @@ def test_separator_accepts_constant_owner():
     assert owner_token in on_disk, \
         "the Constant owner must land in the separator's <content> block on disk"
 
-    # MODEL read-back: #505 does not yet render owner names, but a fresh target changing from zero to
-    # one CommonAttributeContentItem still proves get_metadata_details sees the attached content row.
+    # MODEL read-back: the Content table names the attached owner and its use. Written against the
+    # pre-#505 output this asserted one raw "CommonAttributeContentItem" EClass row; #505 replaced
+    # that fallback with the named row, so the anti-cheat is now the reverse - the EClass name must
+    # be gone AND exactly one owner row must carry this Constant.
     after = _details_text(separator_fqn)
-    assert after.count("CommonAttributeContentItem") == 1, \
+    assert after.count("| %s | Use |" % constant_fqn) == 1, \
         "get_metadata_details must read back exactly one attached owner row:\n%s" % after[:700]
+    assert_not_contains(after, "CommonAttributeContentItem",
+                        "the generic EObject EClass value must not leak into Content")
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/e2e/tools/test_validate_query.py
+++ b/tests/e2e/tools/test_validate_query.py
@@ -20,7 +20,7 @@ rubber-stamping.
 
 from harness import (
     call, assert_ok, assert_error, assert_error_quality,
-    assert_contains, assert_no_diff, e2e_test, PROJECT,
+    assert_contains, assert_no_diff, e2e_test, PROJECT, TESTS_PROJECT,
 )
 
 
@@ -53,6 +53,55 @@ def test_valid_query_against_fixture_catalog_is_clean():
     # a stale 'Done' placeholder).
     assert_contains(r.text, "valid", "success digest must reflect the result keys")
 
+    assert_no_diff("validate_query is read-only; nothing may change on disk")
+
+
+@e2e_test(tool="validate_query", kind="read")
+def test_extension_union_scope_resolves_inherited_field():
+    r = call("validate_query", {
+        "projectName": TESTS_PROJECT,
+        "queryText": "ВЫБРАТЬ Ссылка, Наименование ИЗ Справочник.Catalog",
+    })
+    assert_ok(r, "extension union scope must resolve inherited fields")
+    assert r.structured is not None, \
+        "extension validation must return structuredContent; got: %r" % (r.text,)
+    assert r.structured.get("valid") is True, \
+        "the inherited field must be valid in the union scope: %r" % (r.structured,)
+    assert r.structured.get("issues") == [], \
+        "the inherited field must produce no issues: %r" % (r.structured,)
+    assert_no_diff("validate_query is read-only; nothing may change on disk")
+
+
+@e2e_test(tool="validate_query", kind="read")
+def test_extension_union_scope_resolves_extension_owned_object():
+    r = call("validate_query", {
+        "projectName": TESTS_PROJECT,
+        "queryText": "ВЫБРАТЬ Ссылка, ExtValue ИЗ Справочник.tests_ExtOnly",
+    })
+    assert_ok(r, "extension union scope must resolve extension-owned objects")
+    assert r.structured is not None, \
+        "extension validation must return structuredContent; got: %r" % (r.text,)
+    assert r.structured.get("valid") is True, \
+        "the extension-owned object must be valid in the union scope: %r" % (r.structured,)
+    assert r.structured.get("issues") == [], \
+        "the extension-owned object must produce no issues: %r" % (r.structured,)
+    assert_no_diff("validate_query is read-only; nothing may change on disk")
+
+
+@e2e_test(tool="validate_query", kind="read")
+def test_extension_union_scope_rejects_unknown_borrowed_field():
+    r = call("validate_query", {
+        "projectName": TESTS_PROJECT,
+        "queryText": "ВЫБРАТЬ НетТакогоПоля ИЗ Справочник.Catalog",
+    })
+    assert_ok(r, "extension union scope must still run semantic validation")
+    assert r.structured is not None, \
+        "extension validation must return structuredContent; got: %r" % (r.text,)
+    assert r.structured.get("valid") is False, \
+        "an unknown field must be invalid in the union scope: %r" % (r.structured,)
+    issues = r.structured.get("issues") or []
+    assert any("not found" in str(issue.get("message", "")).lower() for issue in issues), \
+        "the unknown field must produce a 'not found' issue: %r" % (issues,)
     assert_no_diff("validate_query is read-only; nothing may change on disk")
 
 

--- a/tests/tests/src/Catalogs/tests_ExtOnly/tests_ExtOnly.mdo
+++ b/tests/tests/src/Catalogs/tests_ExtOnly/tests_ExtOnly.mdo
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mdclass:Catalog xmlns:mdclass="http://g5.1c.ru/v8/dt/metadata/mdclass" uuid="9dab50dd-10f9-490f-a855-533b8aec603d">
+  <producedTypes>
+    <objectType typeId="f76ded7b-c60e-4ccd-93ec-05c57e799cb6" valueTypeId="a66f6ade-0bae-4c70-915a-2799be9b03bf"/>
+    <refType typeId="d2b56ca5-4396-4306-8810-de56fdbc9ad8" valueTypeId="e257d90d-5641-4e7d-b320-bf292b7f74b9"/>
+    <selectionType typeId="115385fb-db74-4912-a02e-9c8fb793fb5c" valueTypeId="990f76fb-c693-4790-9386-2540b8461972"/>
+    <listType typeId="4dbc2b54-42da-4aa7-9fa6-11035b0aad8b" valueTypeId="af9b8eb5-eaaa-4e08-886c-82864a421f56"/>
+    <managerType typeId="013b7ef7-b84a-4f50-a161-206efb243f2d" valueTypeId="695d533b-18fd-48df-b694-3c1d77b3c0a1"/>
+  </producedTypes>
+  <name>tests_ExtOnly</name>
+  <synonym>
+    <key>en</key>
+    <value>Extension-owned catalog</value>
+  </synonym>
+  <useStandardCommands>true</useStandardCommands>
+  <inputByString>Catalog.tests_ExtOnly.StandardAttribute.Code</inputByString>
+  <inputByString>Catalog.tests_ExtOnly.StandardAttribute.Description</inputByString>
+  <fullTextSearchOnInputByString>DontUse</fullTextSearchOnInputByString>
+  <createOnInput>Use</createOnInput>
+  <fullTextSearch>Use</fullTextSearch>
+  <objectPresentation>
+    <key>en</key>
+    <value>Extension-owned catalog item</value>
+  </objectPresentation>
+  <listPresentation>
+    <key>en</key>
+    <value>Extension-owned catalogs</value>
+  </listPresentation>
+  <levelCount>2</levelCount>
+  <foldersOnTop>true</foldersOnTop>
+  <codeLength>9</codeLength>
+  <descriptionLength>25</descriptionLength>
+  <codeType>String</codeType>
+  <codeAllowedLength>Variable</codeAllowedLength>
+  <checkUnique>true</checkUnique>
+  <autonumbering>true</autonumbering>
+  <defaultPresentation>AsDescription</defaultPresentation>
+  <editType>InDialog</editType>
+  <choiceMode>BothWays</choiceMode>
+  <attributes uuid="72d9e986-5470-4208-9931-e4af37bf52e4">
+    <name>ExtValue</name>
+    <type>
+      <types>String</types>
+      <stringQualifiers>
+        <length>50</length>
+      </stringQualifiers>
+    </type>
+  </attributes>
+</mdclass:Catalog>

--- a/tests/tests/src/Configuration/Configuration.mdo
+++ b/tests/tests/src/Configuration/Configuration.mdo
@@ -47,4 +47,5 @@
   <commonModules>CommonModule.tests_MathHelper</commonModules>
   <commonModules>CommonModule.tests_SampleTests</commonModules>
   <catalogs>Catalog.Catalog</catalogs>
+  <catalogs>Catalog.tests_ExtOnly</catalogs>
 </mdclass:Configuration>

--- a/tests/tests/src/Roles/tests_DefaultRole/Rights.rights
+++ b/tests/tests/src/Roles/tests_DefaultRole/Rights.rights
@@ -3,4 +3,31 @@
 	<setForNewObjects>true</setForNewObjects>
 	<setForAttributesByDefault>true</setForAttributesByDefault>
 	<independentRightsOfChildObjects>false</independentRightsOfChildObjects>
+	<object>
+		<name>Catalog.tests_ExtOnly</name>
+		<right>
+			<name>Delete</name>
+			<value>false</value>
+		</right>
+		<right>
+			<name>InteractiveDelete</name>
+			<value>false</value>
+		</right>
+		<right>
+			<name>InteractiveDeletePredefinedData</name>
+			<value>false</value>
+		</right>
+		<right>
+			<name>InteractiveSetDeletionMarkPredefinedData</name>
+			<value>false</value>
+		</right>
+		<right>
+			<name>InteractiveClearDeletionMarkPredefinedData</name>
+			<value>false</value>
+		</right>
+		<right>
+			<name>InteractiveDeleteMarkedPredefinedData</name>
+			<value>false</value>
+		</right>
+	</object>
 </Rights>


### PR DESCRIPTION
Closes #460.

## The defect

A query addressed to a configuration **extension** was parsed with the extension's model alone. An inherited field of a borrowed object then resolved as an error, although the query is valid at runtime:

```
validate_query("TestConfiguration.tests", "ВЫБРАТЬ Ссылка, Наименование ИЗ Справочник.Catalog")
-> valid:false, "Field 'Наименование' not found"
```

The issue was found by reading code and was never reproduced live; it reproduces exactly as described. Note the detail a code reading does not give: the borrowed **table** resolved fine, only its inherited fields did not — the adopted `Catalog.mdo` in an extension is a partial copy that carries no attributes of its own.

## The fix

EDT has the mechanism and we simply never switched it on. With `QlResource.setParentScopeAware(true)`:

- `QlGlobalScopeProvider` builds a `CompositeScope` = platform scope + **parent configuration's** scope + the extension's own scope;
- `DynamicDbViewFieldComputer.getCombinedFields` merges a borrowed object's fields with the parent's.

EDT's own query editor (`QuerySchemaBuilder.parse`, `QueryTextEditDialog`) sets the flag on the resource before `addOptions` / `setPreComputeAnnounceAlias` and before `load`. Our code already made those two calls and skipped the first one. The setter checks for an extension project itself, so the call is unconditional and a no-op for a configuration project — no classification, no base-project resolution and no fallback on our side.

The scope is a **union, not a substitution**, which is the point: an extension-owned table stays resolvable, and the base configuration still does not see extension objects.

## Live proof (dev stand, EDT 2026.2.0.289)

| project | query | before | after |
|---|---|---|---|
| `TestConfiguration.tests` | inherited `Наименование` on the adopted `Справочник.Catalog` | `valid:false` — Field not found | `valid:true` |
| `TestConfiguration.tests` | extension-owned `Справочник.tests_ExtOnly` | `valid:false` — Table not found | `valid:true` |
| `TestConfiguration.tests` | `ВЫБРАТЬ НетТакогоПоля ИЗ Справочник.Catalog` | `valid:false` | `valid:false` (validation is still real) |
| `TestConfiguration` (base) | extension-owned `Справочник.tests_ExtOnly` | `valid:false` | `valid:false` (the union is directional) |

## Fixture

The extension fixture gains its own `Catalog.tests_ExtOnly` (attribute `ExtValue`). Without it no green run could tell this fix from one that merely swapped the validation context to the base project — which is exactly what the first revision of this PR did, and what the review caught. The object was given presentations and had its six auto-granted role rights unset, so it contributes no new problems to the fixture.

## Verification

- `bash source/compile.sh` — BUILD SUCCESS, unit tests green (output schema unchanged, so `tools_list.golden.json` is untouched).
- Redeployed live; deployed jar verified to contain the change.
- e2e `--filter validate_query`: 9/9, fixture clean.

---

## Unrelated: this PR also unbreaks master's e2e

`master` is red independently of this change. #524 and #526 were each green on the same base and collide once both are merged: `test_separator_accepts_constant_owner` (from #524) pinned the pre-#505 read-back — exactly one raw `CommonAttributeContentItem` EClass row — and #526 replaced that generic EObject fallback with the named `| <owner FQN> | <use> |` row, so the count is now 0.

The assertion is inverted to the shipped contract (one named owner row, EClass name absent — the anti-cheat the neighbouring tests already use). It rides in this PR because #528's own CI cannot go green on a red master; it is a separate commit and unrelated to #460.
