### PR TITLE
get_metadata_objects: find an object by its localized Synonym (#516)

### DIFF
--- a/docs/tools/get_metadata_objects.md
+++ b/docs/tools/get_metadata_objects.md
@@ -8,6 +8,7 @@ Discover metadata objects available in a 1C configuration. Parameters and exampl
 | projectName | yes | string | EDT project name (required) |
 | metadataType | — | string | Type filter (case-insensitive), default 'all'. Accepts 'all' or any standard metadata type name (the FQN token). English resolves in singular OR plural ('ScheduledJob', 'Role', 'httpServices'); Russian resolves in the spelling 1C registers for that type, which for most types is the singular alone ('Справочник', 'ОбщаяФорма'). Single value only - not an array. In an EXTERNAL-OBJECTS project the vocabulary is all / externalDataProcessors / externalReports instead - that project holds its own roots, not a configuration. |
 | nameFilter | — | string | Case-insensitive substring matched against Name only (not Synonym) |
+| textFilter | — | string | Case-insensitive substring matched against Name or Synonym selected by language; mutually exclusive with nameFilter |
 | limit | — | integer | Max rows (default from preferences: 100, max 1000) |
 | language | — | string | Synonym language code, e.g. 'en'/'ru' (default: configuration default) |
 
@@ -16,13 +17,14 @@ List the metadata objects of a 1C configuration as a flat Markdown table. Each r
 
 ## When to use
 - Discover what objects exist in a configuration before drilling into one.
-- Find an object by a partial Name (`nameFilter`) or narrow to a single kind (`metadataType`).
+- Find an object by a partial programmatic Name (`nameFilter`), by Name or localized Synonym (`textFilter`), or narrow to a single kind (`metadataType`).
 - To inspect one object's attributes/forms/etc., follow up with `get_metadata_details` using the Name and Type from this table.
 
 ## Parameter details
 - `projectName` (required) - EDT project name.
 - `metadataType` - which kind to list; default `all`. Matching is case-insensitive, and it is a single string, not an array. Accepts `all` or any standard metadata type name - the FQN token. **English resolves in singular or plural** (`ScheduledJob`, `Role`, `HTTPServices`), so the legacy tokens `documents`, `commonModules`, `xdtoPackages` keep working unchanged. **Russian resolves in the spelling 1C registers for that type**, which for most types is the singular alone: `Справочник` and `Справочники` both work (Catalog registers both), while `ОбщиеФормы` does NOT - CommonForm registers only `ОбщаяФорма`. An unrecognized value returns an error naming the bad value and listing every available configuration type. There is no `types` array parameter.
 - `nameFilter` - case-insensitive substring matched against the object **Name only**, never the Synonym. Omit to list everything of the chosen type.
+- `textFilter` - case-insensitive substring matched against the object **Name or Synonym**. The effective language is resolved exactly like the Synonym column: from `language` when supplied, otherwise from the configuration language settings. Mutually exclusive with `nameFilter`.
 - `limit` - max rows returned; default from preferences (100), clamped to 1000. A truncation notice is appended when results are capped, while **Total** still reports the full count.
 - `language` - language code for the Synonym column (e.g. `en`, `ru`). Defaults to the configuration's default language.
 
@@ -48,10 +50,13 @@ answered from the base configuration it is linked to.
 - Only scheduled jobs, via the type-name token: `{projectName: "MyProject", metadataType: "ScheduledJob"}` (equivalent to `metadataType: "scheduledJobs"`).
 - Only XDTO packages: `{projectName: "MyProject", metadataType: "xdtoPackages"}` (or the type name `XDTOPackage` / `ПакетXDTO`). This is how you get the `XDTOPackage.<Name>` FQN the XDTO tools need - `create_metadata` / `modify_metadata` / `delete_metadata` on a package member, and `validate_xdto_package`.
 - Filter by name: `{projectName: "MyProject", nameFilter: "Order"}`.
+- Filter by name or localized synonym: `{projectName: "MyProject", textFilter: "Sales order", language: "en"}`.
 - Russian synonyms: `{projectName: "MyProject", language: "ru"}`.
 
 ## Notes & gotchas
 - `nameFilter` matches the programmatic Name, never the localized synonym; searching by a translated caption will not match.
+- `textFilter` checks the Synonym in the effective language - the SAME value the Synonym column shows, resolved by the same helper. When an object has no synonym in that language the column and the filter both fall back to its first non-empty synonym, so such an object can still match text from another language; an object with a synonym in the effective language is never matched against its other languages. An object matching both Name and Synonym is returned once.
+- Pass either `nameFilter` or `textFilter`, not both.
 - `Subsystem` lists top-level roots only. Nested subsystems are not directly addressable as `Subsystem.<Name>`; use `list_subsystems` for the complete tree and its paths.
 - The Synonym is keyed by language **code** (`en`/`ru`), not the language's display name; an unconfigured language yields an empty synonym, not an error.
 - Output is Markdown; table cells are escaped so a `|` in a comment or synonym does not break the table.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/get_metadata_objects.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/get_metadata_objects.md
@@ -2,13 +2,14 @@ List the metadata objects of a 1C configuration as a flat Markdown table. Each r
 
 ## When to use
 - Discover what objects exist in a configuration before drilling into one.
-- Find an object by a partial Name (`nameFilter`) or narrow to a single kind (`metadataType`).
+- Find an object by a partial programmatic Name (`nameFilter`), by Name or localized Synonym (`textFilter`), or narrow to a single kind (`metadataType`).
 - To inspect one object's attributes/forms/etc., follow up with `get_metadata_details` using the Name and Type from this table.
 
 ## Parameter details
 - `projectName` (required) - EDT project name.
 - `metadataType` - which kind to list; default `all`. Matching is case-insensitive, and it is a single string, not an array. Accepts `all` or any standard metadata type name - the FQN token. **English resolves in singular or plural** (`ScheduledJob`, `Role`, `HTTPServices`), so the legacy tokens `documents`, `commonModules`, `xdtoPackages` keep working unchanged. **Russian resolves in the spelling 1C registers for that type**, which for most types is the singular alone: `Справочник` and `Справочники` both work (Catalog registers both), while `ОбщиеФормы` does NOT - CommonForm registers only `ОбщаяФорма`. An unrecognized value returns an error naming the bad value and listing every available configuration type. There is no `types` array parameter.
 - `nameFilter` - case-insensitive substring matched against the object **Name only**, never the Synonym. Omit to list everything of the chosen type.
+- `textFilter` - case-insensitive substring matched against the object **Name or Synonym**. The effective language is resolved exactly like the Synonym column: from `language` when supplied, otherwise from the configuration language settings. Mutually exclusive with `nameFilter`.
 - `limit` - max rows returned; default from preferences (100), clamped to 1000. A truncation notice is appended when results are capped, while **Total** still reports the full count.
 - `language` - language code for the Synonym column (e.g. `en`, `ru`). Defaults to the configuration's default language.
 
@@ -34,10 +35,13 @@ answered from the base configuration it is linked to.
 - Only scheduled jobs, via the type-name token: `{projectName: "MyProject", metadataType: "ScheduledJob"}` (equivalent to `metadataType: "scheduledJobs"`).
 - Only XDTO packages: `{projectName: "MyProject", metadataType: "xdtoPackages"}` (or the type name `XDTOPackage` / `ПакетXDTO`). This is how you get the `XDTOPackage.<Name>` FQN the XDTO tools need - `create_metadata` / `modify_metadata` / `delete_metadata` on a package member, and `validate_xdto_package`.
 - Filter by name: `{projectName: "MyProject", nameFilter: "Order"}`.
+- Filter by name or localized synonym: `{projectName: "MyProject", textFilter: "Sales order", language: "en"}`.
 - Russian synonyms: `{projectName: "MyProject", language: "ru"}`.
 
 ## Notes & gotchas
 - `nameFilter` matches the programmatic Name, never the localized synonym; searching by a translated caption will not match.
+- `textFilter` checks the Synonym in the effective language - the SAME value the Synonym column shows, resolved by the same helper. When an object has no synonym in that language the column and the filter both fall back to its first non-empty synonym, so such an object can still match text from another language; an object with a synonym in the effective language is never matched against its other languages. An object matching both Name and Synonym is returned once.
+- Pass either `nameFilter` or `textFilter`, not both.
 - `Subsystem` lists top-level roots only. Nested subsystems are not directly addressable as `Subsystem.<Name>`; use `list_subsystems` for the complete tree and its paths.
 - The Synonym is keyed by language **code** (`en`/`ru`), not the language's display name; an unconfigured language yields an empty synonym, not an error.
 - Output is Markdown; table cells are escaped so a `|` in a comment or synonym does not break the table.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/InputSchemaCompactor.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/InputSchemaCompactor.java
@@ -132,6 +132,8 @@ public final class InputSchemaCompactor
         keep.put("get_markers", asSet("markerKind", "priority")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         // Two filters that are mutually exclusive and differ in matching semantics.
         keep.put("get_project_errors", asSet("objects", "objectFqns")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        // Name-only compatibility filter vs Name-or-localized-Synonym discovery filter.
+        keep.put("get_metadata_objects", asSet("nameFilter", "textFilter")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         // 'callers' vs 'callees' - the enum values alone do not say which way they point.
         // methodName is REQUIRED for callers/callees and optional only for the module-wide
         // 'outgoing' mode - a conditional the schema states nowhere. The committed

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataObjectsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataObjectsTool.java
@@ -68,6 +68,16 @@ public class GetMetadataObjectsTool implements IMcpTool
 
     private static final String LIMIT = "limit"; //$NON-NLS-1$
 
+    private static final String NAME_FILTER = "nameFilter"; //$NON-NLS-1$
+    private static final String TEXT_FILTER = "textFilter"; //$NON-NLS-1$
+
+    /** The two deliberately separate filtering contracts exposed by this tool. */
+    enum FilterMode
+    {
+        NAME,
+        TEXT
+    }
+
     @Override
     public String getName()
     {
@@ -96,8 +106,11 @@ public class GetMetadataObjectsTool implements IMcpTool
                 "In an EXTERNAL-OBJECTS project the vocabulary is " + //$NON-NLS-1$
                 "all / externalDataProcessors / externalReports instead - that project holds its " + //$NON-NLS-1$
                 "own roots, not a configuration.") //$NON-NLS-1$
-            .stringProperty("nameFilter", //$NON-NLS-1$
+            .stringProperty(NAME_FILTER,
                 "Case-insensitive substring matched against Name only (not Synonym)") //$NON-NLS-1$
+            .stringProperty(TEXT_FILTER,
+                "Case-insensitive substring matched against Name or Synonym selected by language; " + //$NON-NLS-1$
+                "mutually exclusive with nameFilter") //$NON-NLS-1$
             .integerProperty(LIMIT,
                 "Max rows (default from preferences: 100, max 1000)") //$NON-NLS-1$
             .stringProperty("language", //$NON-NLS-1$
@@ -127,7 +140,8 @@ public class GetMetadataObjectsTool implements IMcpTool
     {
         String projectName = JsonUtils.extractStringArgument(params, McpKeys.PROJECT_NAME);
         String metadataType = JsonUtils.extractStringArgument(params, "metadataType"); //$NON-NLS-1$
-        String nameFilter = JsonUtils.extractStringArgument(params, "nameFilter"); //$NON-NLS-1$
+        String nameFilter = JsonUtils.extractStringArgument(params, NAME_FILTER);
+        String textFilter = JsonUtils.extractStringArgument(params, TEXT_FILTER);
         String language = JsonUtils.extractStringArgument(params, "language"); //$NON-NLS-1$
 
         // Validate required parameter
@@ -135,6 +149,15 @@ public class GetMetadataObjectsTool implements IMcpTool
         if (err != null)
         {
             return err;
+        }
+
+        if (hasFilter(nameFilter) && hasFilter(textFilter))
+        {
+            return ToolResult.error("Use either nameFilter or textFilter, not both. Received " //$NON-NLS-1$
+                + "nameFilter='" + nameFilter + "' and " //$NON-NLS-1$ //$NON-NLS-2$
+                + "textFilter='" + textFilter + "'. " //$NON-NLS-1$ //$NON-NLS-2$
+                + "nameFilter matches only the programmatic Name; textFilter matches Name or " //$NON-NLS-1$
+                + "Synonym in the effective language selected by language.").toJson(); //$NON-NLS-1$
         }
 
         // Set defaults
@@ -152,7 +175,9 @@ public class GetMetadataObjectsTool implements IMcpTool
         // Execute on UI thread
         AtomicReference<String> resultRef = new AtomicReference<>();
         final String mdType = metadataType;
-        final String filter = nameFilter;
+        final boolean useTextFilter = hasFilter(textFilter);
+        final String filter = useTextFilter ? textFilter : nameFilter;
+        final FilterMode filterMode = useTextFilter ? FilterMode.TEXT : FilterMode.NAME;
         final int maxResults = limit;
         final String lang = language; // null means use config default
         
@@ -160,7 +185,8 @@ public class GetMetadataObjectsTool implements IMcpTool
         display.syncExec(() -> {
             try
             {
-                String result = getMetadataObjectsInternal(projectName, mdType, filter, maxResults, lang);
+                String result = getMetadataObjectsInternal(projectName, mdType, filter, filterMode,
+                    maxResults, lang);
                 resultRef.set(result);
             }
             catch (Exception e)
@@ -185,7 +211,7 @@ public class GetMetadataObjectsTool implements IMcpTool
      * Internal implementation that runs on UI thread.
      */
     private String getMetadataObjectsInternal(String projectName, String metadataType,
-                                               String nameFilter, int limit, String language)
+        String filter, FilterMode filterMode, int limit, String language)
     {
         // Resolve the project and its configuration
         ProjectContext.ConfigurationResult resolved = ProjectContext.resolveMetadataRoot(projectName);
@@ -208,8 +234,8 @@ public class GetMetadataObjectsTool implements IMcpTool
         // and unrelated configuration objects took their place.
         if (scope.isExternalObjects())
         {
-            return externalObjectsOutput(projectName, scope, metadataType, nameFilter, limit,
-                effectiveLanguage);
+            return externalObjectsOutput(projectName, scope, metadataType, filter, filterMode,
+                limit, effectiveLanguage);
         }
 
         // Normalize the caller's bilingual type spelling to the canonical English FQN token.
@@ -235,14 +261,16 @@ public class GetMetadataObjectsTool implements IMcpTool
             {
                 if (!info.isStandalone())
                 {
-                    total += collectMetadataObjects(config, info, objects, nameFilter, limit);
+                    total += collectMetadataObjects(config, info, objects, filter, filterMode,
+                        limit, effectiveLanguage);
                 }
             }
         }
         else
         {
             MetadataTypeUtils.MetadataTypeInfo info = MetadataTypeUtils.resolve(normalizedType);
-            total = collectMetadataObjects(config, info, objects, nameFilter, limit);
+            total = collectMetadataObjects(config, info, objects, filter, filterMode, limit,
+                effectiveLanguage);
         }
 
         // An object's ORIGIN (core vs extension-adopted vs extension-own) is only
@@ -269,13 +297,14 @@ public class GetMetadataObjectsTool implements IMcpTool
      * @param projectName the project the caller named
      * @param scope the external-objects resolution root
      * @param metadataType the caller's raw type filter
-     * @param nameFilter the caller's case-insensitive Name substring, or {@code null}
+     * @param filter the caller's case-insensitive substring, or {@code null}
+     * @param filterMode whether the substring matches Name only or Name / effective Synonym
      * @param limit max rows
      * @param language the resolved synonym language code (may be {@code null})
      * @return the Markdown listing, or a JSON error for a type this project cannot hold
      */
     private String externalObjectsOutput(String projectName, MetadataScope scope, // NOSONAR signature is inherent / public-or-test-contract; a parameter-object would not improve clarity
-        String metadataType, String nameFilter, int limit, String language)
+        String metadataType, String filter, FilterMode filterMode, int limit, String language)
     {
         String category = normalizeExternalMetadataType(metadataType);
         if (category == null)
@@ -292,12 +321,12 @@ public class GetMetadataObjectsTool implements IMcpTool
         if (TYPE_ALL.equals(category) || TYPE_EXTERNAL_DATA_PROCESSORS.equals(category))
         {
             total += collectExternalObjects(scope, TOKEN_EXTERNAL_DATA_PROCESSOR, objects,
-                nameFilter, limit);
+                filter, filterMode, limit, language);
         }
         if (TYPE_ALL.equals(category) || TYPE_EXTERNAL_REPORTS.equals(category))
         {
-            total += collectExternalObjects(scope, TOKEN_EXTERNAL_REPORT, objects, nameFilter,
-                limit);
+            total += collectExternalObjects(scope, TOKEN_EXTERNAL_REPORT, objects, filter,
+                filterMode, limit, language);
         }
         // An external-objects project holds no adopted objects, so it has no Origin column.
         return formatOutput(projectName, objects, total, limit, language, metadataType, false, true);
@@ -344,10 +373,11 @@ public class GetMetadataObjectsTool implements IMcpTool
     }
 
     /**
-     * Appends the external objects of one TYPE, honouring the Name substring filter.
+     * Appends the external objects of one TYPE, honouring the selected substring filter.
      */
     private int collectExternalObjects(MetadataScope scope, String typeToken,
-        List<MetadataInfo> objects, String filter, int limit)
+        List<MetadataInfo> objects, String filter, FilterMode filterMode, int limit,
+        String language)
     {
         List<? extends MdObject> found = scope.objects(typeToken);
         if (found == null)
@@ -358,7 +388,7 @@ public class GetMetadataObjectsTool implements IMcpTool
         int total = 0;
         for (MdObject object : found)
         {
-            if (!matchesFilter(object.getName(), filter))
+            if (!matches(object, filter, filterMode, language))
             {
                 continue;
             }
@@ -552,9 +582,13 @@ public class GetMetadataObjectsTool implements IMcpTool
             managerModule);
     }
     
-    /** Counts one configuration collection and materializes only rows that can be displayed. */
-    private int collectMetadataObjects(Configuration config, MetadataTypeUtils.MetadataTypeInfo typeInfo,
-        List<MetadataInfo> objects, String filter, int limit)
+    /**
+     * Counts one configuration collection and materializes only rows that can be displayed.
+     * Package-private so pure model filtering can be unit-tested without the workbench.
+     */
+    int collectMetadataObjects(Configuration config, MetadataTypeUtils.MetadataTypeInfo typeInfo,
+        List<MetadataInfo> objects, String filter, FilterMode filterMode, int limit,
+        String language)
     {
         if (typeInfo == null)
         {
@@ -571,7 +605,7 @@ public class GetMetadataObjectsTool implements IMcpTool
         int total = 0;
         for (MdObject object : found)
         {
-            if (!matchesFilter(object.getName(), filter))
+            if (!matches(object, filter, filterMode, language))
             {
                 continue;
             }
@@ -623,13 +657,32 @@ public class GetMetadataObjectsTool implements IMcpTool
         return info;
     }
     
-    private boolean matchesFilter(String name, String filter)
+    /** One filtering decision shared by configuration and external-object collection. */
+    boolean matches(MdObject mdObject, String filter, FilterMode filterMode, String language)
     {
         if (filter == null || filter.isEmpty())
         {
             return true;
         }
-        return name != null && name.toLowerCase().contains(filter.toLowerCase());
+        String lowerFilter = filter.toLowerCase();
+        String name = mdObject == null ? null : mdObject.getName();
+        if (name != null && name.toLowerCase().contains(lowerFilter))
+        {
+            return true;
+        }
+        if (mdObject == null || filterMode != FilterMode.TEXT)
+        {
+            return false;
+        }
+        EMap<String, String> synonyms = mdObject.getSynonym();
+        String synonym = MetadataLanguageUtils.getSynonymForLanguage(
+            synonyms == null ? null : synonyms.map(), language);
+        return synonym.toLowerCase().contains(lowerFilter);
+    }
+
+    private static boolean hasFilter(String filter)
+    {
+        return filter != null && !filter.isEmpty();
     }
     
     private boolean hasModule(Module module)
@@ -656,7 +709,7 @@ public class GetMetadataObjectsTool implements IMcpTool
     /**
      * Holds metadata object information.
      */
-    private static class MetadataInfo
+    static class MetadataInfo
     {
         String name;
         java.util.Map<String, String> synonyms = new java.util.HashMap<>();

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataObjectsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetMetadataObjectsToolTest.java
@@ -12,12 +12,18 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
 
+import com._1c.g5.v8.dt.metadata.mdclass.CommonModule;
+import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
+import com._1c.g5.v8.dt.metadata.mdclass.MdClassFactory;
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils;
 
 /**
  * Tests for {@link GetMetadataObjectsTool}.
@@ -25,10 +31,9 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
  * Covers tool metadata (name/constant, response type, description, input schema,
  * output schema, result file name, guide) and the {@code projectName}
  * required-argument validation in {@code execute(Map)} that returns BEFORE the
- * first {@code PlatformUI.getWorkbench().getDisplay()} call. Everything past that
- * call (project/configuration resolution, metadata collection including the
- * "Unknown metadata type" branch, collection and formatting) needs a live EDT
- * workspace and is covered by the E2E suite.
+ * first {@code PlatformUI.getWorkbench().getDisplay()} call. Pure {@link CommonModule}
+ * matching and collection are covered directly; project/scope resolution and final
+ * formatting need a live EDT workspace and are covered by the E2E suite.
  */
 public class GetMetadataObjectsToolTest
 {
@@ -84,6 +89,7 @@ public class GetMetadataObjectsToolTest
         assertTrue(schema.contains("\"projectName\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"metadataType\"")); //$NON-NLS-1$
         assertTrue(schema.contains("\"nameFilter\"")); //$NON-NLS-1$
+        assertTrue(schema.contains("\"textFilter\"")); //$NON-NLS-1$
     }
 
     @Test
@@ -111,6 +117,8 @@ public class GetMetadataObjectsToolTest
         assertTrue("metadataType must NOT be required", //$NON-NLS-1$
             !requiredBlock.contains("\"metadataType\"")); //$NON-NLS-1$
         assertFalse("nameFilter must NOT be required", requiredBlock.contains("\"nameFilter\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("textFilter must NOT be required", //$NON-NLS-1$
+            requiredBlock.contains("\"textFilter\"")); //$NON-NLS-1$
         assertFalse("limit must NOT be required", requiredBlock.contains("\"limit\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertFalse("language must NOT be required", requiredBlock.contains("\"language\"")); //$NON-NLS-1$ //$NON-NLS-2$
     }
@@ -164,13 +172,14 @@ public class GetMetadataObjectsToolTest
     {
         // The exhaustive per-tool detail moved out of the always-loaded
         // description/schema and into the on-demand guide channel. The guide
-        // must be non-empty and still carry the type vocabulary, the Name-only
-        // filter rule, and the module/subsystem boundaries.
+        // must be non-empty and still carry the type vocabulary, both text-filter
+        // rules, and the module/subsystem boundaries.
         String guide = new GetMetadataObjectsTool().getGuide();
         assertNotNull(guide);
         assertTrue(guide.length() > 0);
         assertTrue(guide.contains("HTTPService")); //$NON-NLS-1$
         assertTrue(guide.contains("nameFilter")); //$NON-NLS-1$
+        assertTrue(guide.contains("textFilter")); //$NON-NLS-1$
         assertTrue(guide.contains("ManagerModule")); //$NON-NLS-1$
         assertTrue(guide.contains("list_subsystems")); //$NON-NLS-1$
     }
@@ -228,6 +237,144 @@ public class GetMetadataObjectsToolTest
         assertTrue(result.contains("projectName is required")); //$NON-NLS-1$
         assertTrue("an invalid metadataType must NOT leak through before the projectName guard", //$NON-NLS-1$
             !result.contains("Unknown metadata type")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNameAndTextFiltersAreMutuallyExclusive()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectName", "AnyProject"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("nameFilter", "DebtAdjustment"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("textFilter", "Debt adjustment"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        String result = new GetMetadataObjectsTool().execute(params);
+
+        assertTrue(result.contains("\"success\":false")); //$NON-NLS-1$
+        assertTrue(result.contains("Use either nameFilter or textFilter, not both")); //$NON-NLS-1$
+        assertTrue(result.contains("nameFilter='DebtAdjustment'")); //$NON-NLS-1$
+        assertTrue(result.contains("textFilter='Debt adjustment'")); //$NON-NLS-1$
+        assertTrue(result.contains("programmatic Name")); //$NON-NLS-1$
+        assertTrue(result.contains("effective language")); //$NON-NLS-1$
+    }
+
+    // ==================== Name / localized-text matching (pure model logic) ====================
+
+    @Test
+    public void testTextFilterMatchesEnglishNameCaseInsensitively()
+    {
+        CommonModule object = metadataObject("DebtAdjustment", "Debt adjustment", //$NON-NLS-1$ //$NON-NLS-2$
+            "\u041A\u043E\u0440\u0440\u0435\u043A\u0442\u0438\u0440\u043E\u0432\u043A\u0430 " //$NON-NLS-1$
+            + "\u0434\u043E\u043B\u0433\u0430"); //$NON-NLS-1$
+
+        assertTrue(new GetMetadataObjectsTool().matches(object, "adjust", //$NON-NLS-1$
+            GetMetadataObjectsTool.FilterMode.TEXT, "en")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testTextFilterMatchesRussianNameCaseInsensitively()
+    {
+        String russianName = "\u0412\u0437\u0430\u0438\u043C\u043E\u0437\u0430\u0447\u0435\u0442"; //$NON-NLS-1$
+        CommonModule object = metadataObject(russianName, "Offset", //$NON-NLS-1$
+            "\u041A\u043E\u0440\u0440\u0435\u043A\u0442\u0438\u0440\u043E\u0432\u043A\u0430 " //$NON-NLS-1$
+            + "\u0434\u043E\u043B\u0433\u0430"); //$NON-NLS-1$
+
+        assertTrue(new GetMetadataObjectsTool().matches(object,
+            "\u0437\u0430\u0447\u0435\u0442", //$NON-NLS-1$
+            GetMetadataObjectsTool.FilterMode.TEXT, "en")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testTextFilterMatchesRussianSynonymInRussian()
+    {
+        CommonModule object = metadataObject("DebtOffset", "Debt offset", //$NON-NLS-1$ //$NON-NLS-2$
+            "\u041A\u043E\u0440\u0440\u0435\u043A\u0442\u0438\u0440\u043E\u0432\u043A\u0430 " //$NON-NLS-1$
+            + "\u0434\u043E\u043B\u0433\u0430"); //$NON-NLS-1$
+
+        assertTrue(new GetMetadataObjectsTool().matches(object,
+            "\u043A\u043E\u0440\u0440\u0435\u043A\u0442", //$NON-NLS-1$
+            GetMetadataObjectsTool.FilterMode.TEXT, "ru")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testTextFilterDoesNotMatchSynonymFromAnotherLanguage()
+    {
+        CommonModule object = metadataObject("DebtOffset", "Debt offset", //$NON-NLS-1$ //$NON-NLS-2$
+            "\u041A\u043E\u0440\u0440\u0435\u043A\u0442\u0438\u0440\u043E\u0432\u043A\u0430 " //$NON-NLS-1$
+            + "\u0434\u043E\u043B\u0433\u0430"); //$NON-NLS-1$
+
+        assertFalse(new GetMetadataObjectsTool().matches(object, "Debt offset", //$NON-NLS-1$
+            GetMetadataObjectsTool.FilterMode.TEXT, "ru")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testNameFilterRemainsNameOnly()
+    {
+        CommonModule object = metadataObject("DebtOffset", "Human caption", //$NON-NLS-1$ //$NON-NLS-2$
+            "\u041F\u043E\u0434\u043F\u0438\u0441\u044C"); //$NON-NLS-1$
+        GetMetadataObjectsTool tool = new GetMetadataObjectsTool();
+
+        assertTrue(tool.matches(object, "offset", //$NON-NLS-1$
+            GetMetadataObjectsTool.FilterMode.NAME, "en")); //$NON-NLS-1$
+        assertFalse(tool.matches(object, "Human caption", //$NON-NLS-1$
+            GetMetadataObjectsTool.FilterMode.NAME, "en")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testTextFilterMatchingBothFieldsProducesOneResult()
+    {
+        CommonModule object = metadataObject("SharedCaption", "SharedCaption", //$NON-NLS-1$ //$NON-NLS-2$
+            "\u041E\u0431\u0449\u0430\u044F\u041F\u043E\u0434\u043F\u0438\u0441\u044C"); //$NON-NLS-1$
+        Configuration config = MdClassFactory.eINSTANCE.createConfiguration();
+        config.getCommonModules().add(object);
+        List<GetMetadataObjectsTool.MetadataInfo> rows = new ArrayList<>();
+
+        int total = new GetMetadataObjectsTool().collectMetadataObjects(config,
+            MetadataTypeUtils.resolve("CommonModule"), rows, "caption", //$NON-NLS-1$ //$NON-NLS-2$
+            GetMetadataObjectsTool.FilterMode.TEXT, 10, "en"); //$NON-NLS-1$
+
+        assertEquals("an object matching both fields must count once", 1, total); //$NON-NLS-1$
+        assertEquals("an object matching both fields must produce one row", 1, rows.size()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testEmptyOrAbsentTextFilterDoesNotFilter()
+    {
+        CommonModule object = metadataObject("AnyName", "Any caption", //$NON-NLS-1$ //$NON-NLS-2$
+            "\u041B\u044E\u0431\u0430\u044F\u041F\u043E\u0434\u043F\u0438\u0441\u044C"); //$NON-NLS-1$
+        GetMetadataObjectsTool tool = new GetMetadataObjectsTool();
+
+        assertTrue(tool.matches(object, null, GetMetadataObjectsTool.FilterMode.TEXT, "ru")); //$NON-NLS-1$
+        assertTrue(tool.matches(object, "", GetMetadataObjectsTool.FilterMode.TEXT, "ru")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * The corner the shared resolver decides, pinned so it stays a decision: an object with NO
+     * synonym in the effective language falls back to its first non-empty one - exactly what the
+     * Synonym COLUMN displays for that row - so the filter can match text from another language.
+     * Matching what the caller can see in the table is the point; diverging from the column would
+     * make a visible row unfindable by the text printed in it.
+     */
+    @Test
+    public void testTextFilterFallsBackToTheDisplayedSynonymWhenTheLanguageHasNone()
+    {
+        CommonModule object = MdClassFactory.eINSTANCE.createCommonModule();
+        object.setName("DebtOffset"); //$NON-NLS-1$
+        object.getSynonym().put("ru", "\u041A\u043E\u0440\u0440\u0435\u043A\u0442\u0438\u0440\u043E\u0432\u043A\u0430 " //$NON-NLS-1$
+            + "\u0434\u043E\u043B\u0433\u0430"); //$NON-NLS-2$
+
+        assertTrue("an object whose only synonym is the one the column shows must be findable "
+            + "by that text", new GetMetadataObjectsTool().matches(object, "\u043A\u043E\u0440\u0440\u0435\u043A\u0442",
+                GetMetadataObjectsTool.FilterMode.TEXT, "en")); //$NON-NLS-1$
+    }
+
+    private static CommonModule metadataObject(String name, String englishSynonym,
+        String russianSynonym)
+    {
+        CommonModule object = MdClassFactory.eINSTANCE.createCommonModule();
+        object.setName(name);
+        object.getSynonym().put("en", englishSynonym); //$NON-NLS-1$
+        object.getSynonym().put("ru", russianSynonym); //$NON-NLS-1$
+        return object;
     }
 
     // ==================== metadataType normalization (pure logic, no workbench) ====================

--- a/tests/e2e/tools/test_get_metadata_objects.py
+++ b/tests/e2e/tools/test_get_metadata_objects.py
@@ -3,7 +3,7 @@ e2e tests for get_metadata_objects (kind: read).
 
 Read tool: returns a MARKDOWN table (Name, Synonym, Comment, Type, ObjectModule,
 ManagerModule) of the configuration's metadata objects, with optional filtering by
-metadataType / nameFilter. ResponseType is MARKDOWN, so the payload is in r.text
+metadataType / nameFilter / textFilter. ResponseType is MARKDOWN, so the payload is in r.text
 (NOT r.structured).
 
 Happy paths assert that real fixture objects appear in the table; every test ends
@@ -29,6 +29,7 @@ Fixture inventory used (TestConfiguration, English Names):
   Catalog.Catalog, CommonModule.Error, CommonModule.OK,
   CommonForm.Form, CommonTemplate.PrintForm, HTTPService.ProbeService,
   Subsystem.Subsystem, CommonAttribute.CommonAttribute, SessionParameter.SessionParameter.
+  CommonTemplate.PrintForm has the English Synonym "Print Form".
 """
 
 from harness import (
@@ -127,6 +128,19 @@ def test_namefilter_narrows_results():
 
 
 @e2e_test(tool="get_metadata_objects", kind="read")
+def test_textfilter_matches_fixture_synonym_in_selected_language():
+    # CommonTemplate.PrintForm has Name="PrintForm" but Synonym(en)="Print Form" in the
+    # checked-in fixture. The space makes this a synonym-only match, not a Name match.
+    r = call("get_metadata_objects",
+             {"projectName": PROJECT, "metadataType": "commonTemplates",
+              "textFilter": "print form", "language": "en"})
+    assert_ok(r, "get_metadata_objects textFilter=print form language=en")
+    assert_contains(r.text, "| PrintForm | Print Form |",
+                    "textFilter must match the fixture's effective-language synonym")
+    assert_no_diff("a read tool must not touch the project on disk")
+
+
+@e2e_test(tool="get_metadata_objects", kind="read")
 def test_filter_by_english_type_name_token_returns_only_that_type():
     # issue #289 fix: metadataType now ALSO accepts a standard type-name token (the FQN
     # form, e.g. "CommonModule"), not just the legacy category token ("commonModules").
@@ -163,6 +177,42 @@ def test_filter_by_russian_type_name_token_returns_only_that_type():
 # ──────────────────────────────────────────────────────────────────────────────
 # Negative matrix (mandatory)
 # ──────────────────────────────────────────────────────────────────────────────
+
+@e2e_test(tool="get_metadata_objects", kind="read")
+def test_namefilter_still_ignores_the_synonym():
+    """The other half of the additive contract: nameFilter must NOT have gained Synonym.
+
+    Same object, same text, same language as the textFilter test above - only the parameter
+    differs. "print form" occurs solely in CommonTemplate.PrintForm's Synonym, never in its
+    Name, so a nameFilter hit here would mean the published Name-only contract silently
+    widened. Without this the textFilter test alone would pass just as happily on a build
+    that made BOTH parameters search synonyms.
+    """
+    r = call("get_metadata_objects",
+             {"projectName": PROJECT, "metadataType": "commonTemplates",
+              "nameFilter": "print form", "language": "en"})
+    assert_ok(r, "get_metadata_objects nameFilter=print form language=en")
+    assert_not_contains(r.text, "| PrintForm |",
+                        "nameFilter matches the programmatic Name only, never the Synonym")
+    assert_no_diff("a read tool must not touch the project on disk")
+
+
+@e2e_test(tool="get_metadata_objects", kind="read")
+def test_namefilter_and_textfilter_are_mutually_exclusive():
+    name_value = "PrintForm"
+    text_value = "Print Form"
+    r = call("get_metadata_objects",
+             {"projectName": PROJECT, "nameFilter": name_value,
+              "textFilter": text_value, "language": "en"})
+    err = assert_error(r, "nameFilter and textFilter together")
+    assert_error_quality(
+        err,
+        names=["nameFilter", name_value, "textFilter", text_value],
+        suggests=["Use either", "programmatic Name", "effective language"],
+        ctx="mutually exclusive filters name both values and explain their roles",
+    )
+    assert_no_diff("an invalid call must not touch the project on disk")
+
 
 @e2e_test(tool="get_metadata_objects", kind="read")
 def test_missing_projectname_errors_clearly():

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -2146,9 +2146,14 @@
           "type": "string"
         },
         "nameFilter": {
+          "description": "Case-insensitive substring matched against Name only (not Synonym)",
           "type": "string"
         },
         "projectName": {
+          "type": "string"
+        },
+        "textFilter": {
+          "description": "Case-insensitive substring matched against Name or Synonym selected by language; mutually exclusive with nameFilter",
           "type": "string"
         }
       },


### PR DESCRIPTION
Closes #516.

## The gap

`get_metadata_objects` filtered on the programmatic `Name` only, while the `Synonym` was already read, localized and printed in the same table. An agent starts from what the user said — the Synonym — so discovery dead-ended at the first step. On the reporter's UNF configuration (16 711 objects) `nameFilter="Корректировка долга"` returns 0, although `Document.Взаимозачет` carries exactly that synonym.

Listing everything instead is not an option: `limit` caps at 1000, there is no pagination, and a real stand hits the transport size. So `0 matches` could not be read as "no such object" — the same false-absence class as #447.

## The contract (as specified in the issue)

`textFilter` is **additive**: case-insensitive substring against `Name` **OR** the `Synonym` in the effective language, resolved by the same helper that fills the Synonym column.

`nameFilter` keeps its published Name-only contract. Widening it in place would silently change existing result sets — and under a small `limit`, new synonym matches could push out rows a client used to get.

Passing both is refused, naming both values and what each parameter does.

Both collector branches — configuration objects and external data processors/reports — go through **one** matcher rather than a third copy.

## The bilingual corner, pinned rather than inherited

`MetadataLanguageUtils.getSynonymForLanguage` falls back to the first non-empty synonym when the effective language has none. That is not a leak of "search every language": it is exactly what the **Synonym column displays** for that row. Diverging from the column would make a visible row unfindable by the text printed in it. The guide states this and a test pins it, so it stays a decision.

An object with a synonym in the effective language is never matched against its other languages — also tested.

## Live proof (dev stand, EDT 2026.2.0.289)

```
textFilter="print form"  language=en -> CommonTemplate.PrintForm found (synonym-only: the space cannot match the Name)
nameFilter="print form"  language=en -> NOT found (Name-only contract intact)
nameFilter="printform"   language=en -> found (no regression)
both filters                          -> error naming both values and both roles
```

The second line is the one that matters: without it a green run would be just as happy on a build where BOTH parameters searched synonyms, which is precisely what the issue asks not to happen.

## Verification

- `bash source/compile.sh` — BUILD SUCCESS, 5898 unit tests, 0 failures.
- `python docs/validate_agent_skills.py` — clean.
- Redeployed live; deployed jar verified to carry `textFilter` and the new guide.
- Golden regenerated from the live server; the delta is the new `textFilter` plus the restored `nameFilter` description.
- e2e: `get_metadata_objects` 19/19, `tools_list` 2/2, `extension` 21/21, `external_object` 13/13, fixture clean.
- Conformance: no new failures vs the baseline.

## One deliberate token cost

`get_metadata_objects` is added to the `InputSchemaCompactor` keep-list so both filter descriptions survive into `tools/list`. That is paid on every request. It earns it here: the whole point of the feature is that the caller must not have to guess which of two similarly named filters to use, and without the descriptions that choice is a coin flip.

## Not covered live

The fixture declares English only, so the Russian side (Russian `Name`, Russian `Synonym` with `language=ru`, and the non-match against another language's synonym) is covered by unit tests rather than a live probe.
