### PR TITLE
launch: three answers that contradicted the log now tell the caller the truth (#545)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/LaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/LaunchTool.java
@@ -341,7 +341,13 @@ public class LaunchTool implements IMcpTool
                 return ToolResult.error("Launch manager is not available").toJson(); //$NON-NLS-1$
             }
 
-            ILaunchConfiguration config = LaunchConfigUtils.findLaunchConfigByName(launchManager, configName);
+            NamedConfigurationResolution named =
+                resolveNamedConfiguration(launchManager, configName);
+            if (named.error() != null)
+            {
+                return named.error();
+            }
+            ILaunchConfiguration config = named.config();
             if (config == null)
             {
                 ToolResult err = ToolResult.error("Launch configuration not found: '" + configName //$NON-NLS-1$
@@ -463,6 +469,84 @@ public class LaunchTool implements IMcpTool
             Activator.logError("Unexpected error during launch by name", e); //$NON-NLS-1$
             return ToolResult.error(
                 "Unexpected error: " + PlatformFailures.describe(e)).toJson(); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Resolves a by-name launch target without changing the supported launch domain.
+     *
+     * <p>The existing runtime-client/Attach lookup runs first and is returned unchanged. Only when
+     * it finds nothing do we inspect the standalone-server type, solely to replace the false
+     * "not found; create it" advice with the real capability boundary and measured workaround.
+     * The standalone type is intentionally not added to
+     * {@link LaunchConfigUtils#ALL_DEBUG_CONFIG_TYPE_IDS}, because the other callers of the shared
+     * lookup do not thereby gain standalone-server support.
+     *
+     * @param launchManager Eclipse launch manager
+     * @param configName exact configuration name
+     * @return the supported configuration, an honest standalone refusal, or neither when absent
+     */
+    static NamedConfigurationResolution resolveNamedConfiguration(ILaunchManager launchManager,
+            String configName)
+    {
+        ILaunchConfiguration config =
+            LaunchConfigUtils.findLaunchConfigByName(launchManager, configName);
+        if (config != null)
+        {
+            return NamedConfigurationResolution.config(config);
+        }
+        ILaunchConfiguration standalone = LaunchConfigUtils.findLaunchConfigByTypeAndName(
+            launchManager, LaunchConfigUtils.STANDALONE_SERVER_LAUNCH_CONFIG_TYPE_ID, configName);
+        if (standalone == null)
+        {
+            return NamedConfigurationResolution.notFound();
+        }
+        String typeId = LaunchConfigUtils.getConfigTypeId(standalone);
+        return NamedConfigurationResolution.error(ToolResult.error("Launch configuration '" //$NON-NLS-1$
+            + standalone.getName() + "' has type '" + typeId + "'. debug_launch starts runtime " //$NON-NLS-1$ //$NON-NLS-2$
+            + "CLIENT configurations; it does not start standalone-server configurations " //$NON-NLS-1$
+            + "directly. Try debug_launch with the project's thin-client configuration instead: " //$NON-NLS-1$
+            + "launching that client has been observed to bring its standalone server up with " //$NON-NLS-1$
+            + "it. " //$NON-NLS-1$
+            + "terminate_launch does accept this same standalone-server configuration when it " //$NON-NLS-1$
+            + "is running.").toJson()); //$NON-NLS-1$
+    }
+
+    /** Result of the supported-plus-diagnostic by-name lookup. */
+    private static final class NamedConfigurationResolution
+    {
+        private final ILaunchConfiguration config;
+        private final String error;
+
+        private NamedConfigurationResolution(ILaunchConfiguration config, String error)
+        {
+            this.config = config;
+            this.error = error;
+        }
+
+        static NamedConfigurationResolution config(ILaunchConfiguration config)
+        {
+            return new NamedConfigurationResolution(config, null);
+        }
+
+        static NamedConfigurationResolution error(String error)
+        {
+            return new NamedConfigurationResolution(null, error);
+        }
+
+        static NamedConfigurationResolution notFound()
+        {
+            return new NamedConfigurationResolution(null, null);
+        }
+
+        ILaunchConfiguration config()
+        {
+            return config;
+        }
+
+        String error()
+        {
+            return error;
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/LaunchTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/LaunchTool.java
@@ -503,12 +503,15 @@ public class LaunchTool implements IMcpTool
         }
         String typeId = LaunchConfigUtils.getConfigTypeId(standalone);
         return NamedConfigurationResolution.error(ToolResult.error("Launch configuration '" //$NON-NLS-1$
-            + standalone.getName() + "' has type '" + typeId + "'. debug_launch starts runtime " //$NON-NLS-1$ //$NON-NLS-2$
+            + standalone.getName() + "' has type '" + typeId + "'. " + NAME //$NON-NLS-1$ //$NON-NLS-2$
+            + " starts runtime " //$NON-NLS-1$
             + "CLIENT configurations; it does not start standalone-server configurations " //$NON-NLS-1$
-            + "directly. Try debug_launch with the project's thin-client configuration instead: " //$NON-NLS-1$
+            + "directly. Try " + NAME //$NON-NLS-1$
+            + " with the project's thin-client configuration instead: " //$NON-NLS-1$
             + "launching that client has been observed to bring its standalone server up with " //$NON-NLS-1$
             + "it. " //$NON-NLS-1$
-            + "terminate_launch does accept this same standalone-server configuration when it " //$NON-NLS-1$
+            + TerminateLaunchTool.NAME
+            + " does accept this same standalone-server configuration when it " //$NON-NLS-1$
             + "is running.").toJson()); //$NON-NLS-1$
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetInfobaseCredentialsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetInfobaseCredentialsTool.java
@@ -363,7 +363,18 @@ public class SetInfobaseCredentialsTool implements IMcpTool
     static TargetResolution resolveLaunchConfigTarget(ILaunchConfiguration cfg,
             BiFunction<ILaunchConfiguration, String, String> applicationIdResolver)
     {
-        String cfgProject = LaunchConfigUtils.readAttribute(cfg, LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+        String cfgProject;
+        try
+        {
+            cfgProject = cfg.getAttribute(LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
+        }
+        catch (CoreException e)
+        {
+            return TargetResolution.error(ToolResult.error("The project binding could not be " //$NON-NLS-1$
+                + "read from launch configuration '" + cfg.getName() //$NON-NLS-1$
+                + "' — refusing to derive a credential target. Fix the configuration, or pass " //$NON-NLS-1$
+                + "projectName + applicationId explicitly.").toJson()); //$NON-NLS-1$
+        }
         String cfgAppId;
         try
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetInfobaseCredentialsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetInfobaseCredentialsTool.java
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -363,7 +364,21 @@ public class SetInfobaseCredentialsTool implements IMcpTool
             BiFunction<ILaunchConfiguration, String, String> applicationIdResolver)
     {
         String cfgProject = LaunchConfigUtils.readAttribute(cfg, LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
-        String cfgAppId = LaunchConfigUtils.readAttribute(cfg, LaunchConfigUtils.ATTR_APPLICATION_ID, ""); //$NON-NLS-1$
+        String cfgAppId;
+        try
+        {
+            // This path selects where a SECRET is written. LaunchConfigUtils.readAttribute is
+            // intentionally lenient and conflates a failed read with an absent attribute, so use
+            // the platform accessor directly here and preserve that distinction.
+            cfgAppId = cfg.getAttribute(LaunchConfigUtils.ATTR_APPLICATION_ID, ""); //$NON-NLS-1$
+        }
+        catch (CoreException e)
+        {
+            return TargetResolution.error(ToolResult.error("The application binding could not be " //$NON-NLS-1$
+                + "read from launch configuration '" + cfg.getName() //$NON-NLS-1$
+                + "' — refusing to derive a credential target. Fix the configuration, or pass " //$NON-NLS-1$
+                + "projectName + applicationId explicitly.").toJson()); //$NON-NLS-1$
+        }
         if (cfgProject.isEmpty())
         {
             return TargetResolution.error(ToolResult.error("Launch configuration '" + cfg.getName() //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetInfobaseCredentialsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/SetInfobaseCredentialsTool.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -22,6 +23,7 @@ import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchManager;
 
 import com._1c.g5.v8.dt.platform.services.model.InfobaseAccess;
+import com.ditrix.edt.mcp.server.Activator;
 import com.ditrix.edt.mcp.server.protocol.JsonSchemaBuilder;
 import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.protocol.McpKeys;
@@ -30,6 +32,7 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool;
 import com.ditrix.edt.mcp.server.utils.ApplicationSupport;
 import com.ditrix.edt.mcp.server.utils.InfobaseAccessSupport;
 import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
+import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils;
 import com.ditrix.edt.mcp.server.utils.McpJobs;
 import com.ditrix.edt.mcp.server.utils.ProjectStateChecker;
 import com.e1c.g5.dt.applications.IApplication;
@@ -201,6 +204,7 @@ public class SetInfobaseCredentialsTool implements IMcpTool
         // Stays null for a projectName + applicationId target: there is then no launch
         // configuration in play, which is an ANSWER configureClient returns — not a skipped step.
         ILaunchConfiguration clientConfig = null;
+        boolean derivedApplicationId = false;
         if (hasName)
         {
             // Resolve the project + applicationId from the launch configuration when a name was given.
@@ -212,6 +216,7 @@ public class SetInfobaseCredentialsTool implements IMcpTool
             projectName = resolved.projectName();
             applicationId = resolved.applicationId();
             clientConfig = resolved.config();
+            derivedApplicationId = resolved.derivedApplicationId();
         }
         else
         {
@@ -229,7 +234,7 @@ public class SetInfobaseCredentialsTool implements IMcpTool
         }
 
         return store(projectName, applicationId, user, password, access,
-            hasName ? configName : null, clientConfig);
+            hasName ? configName : null, clientConfig, derivedApplicationId);
     }
 
     /**
@@ -339,14 +344,80 @@ public class SetInfobaseCredentialsTool implements IMcpTool
             return TargetResolution.error(ToolResult.error("Launch configuration '" + cfg.getName() //$NON-NLS-1$
                 + "' is not a runtime-client config — set_infobase_credentials requires one.").toJson()); //$NON-NLS-1$
         }
+        return resolveLaunchConfigTarget(cfg, LaunchLifecycleUtils::resolveDelegateApplicationId);
+    }
+
+    /**
+     * Resolves the two target attributes of a runtime-client configuration, deriving the
+     * application exactly as EDT's launch delegate does when only the project was persisted.
+     *
+     * <p>The resolver is an argument solely to keep this decision headless-testable. Production
+     * passes {@link LaunchLifecycleUtils#resolveDelegateApplicationId(ILaunchConfiguration, String)};
+     * no target-resolution logic is duplicated here.
+     *
+     * @param cfg the configuration to inspect
+     * @param applicationIdResolver the existing EDT-delegate application resolver
+     * @return a resolved target or a truthful refusal naming the exact missing attribute
+     */
+    static TargetResolution resolveLaunchConfigTarget(ILaunchConfiguration cfg,
+            BiFunction<ILaunchConfiguration, String, String> applicationIdResolver)
+    {
         String cfgProject = LaunchConfigUtils.readAttribute(cfg, LaunchConfigUtils.ATTR_PROJECT_NAME, ""); //$NON-NLS-1$
         String cfgAppId = LaunchConfigUtils.readAttribute(cfg, LaunchConfigUtils.ATTR_APPLICATION_ID, ""); //$NON-NLS-1$
-        if (cfgProject.isEmpty() || cfgAppId.isEmpty())
+        if (cfgProject.isEmpty())
         {
             return TargetResolution.error(ToolResult.error("Launch configuration '" + cfg.getName() //$NON-NLS-1$
-                + "' has no project or applicationId attribute — cannot derive the target.").toJson()); //$NON-NLS-1$
+                + "' is missing ATTR_PROJECT_NAME (read project='', applicationId='" + cfgAppId //$NON-NLS-1$
+                + "') — cannot derive the target. Bind it to a project in EDT, or pass " //$NON-NLS-1$
+                + "projectName + applicationId explicitly.").toJson()); //$NON-NLS-1$
         }
-        return TargetResolution.resolved(cfgProject, cfgAppId, cfg);
+        if (!cfgAppId.isEmpty())
+        {
+            return TargetResolution.resolved(cfgProject, cfgAppId, cfg, false);
+        }
+        String derived = null;
+        try
+        {
+            derived = applicationIdResolver.apply(cfg, cfgProject);
+        }
+        catch (Exception e) // NOSONAR resolution failure becomes the refusal below
+        {
+            // The resolver already owns platform access. Do not replace its decision with a
+            // hand-rolled fallback, and do not let an unchecked platform failure escape the tool.
+            // But do not swallow it in SILENCE either: this whole issue (#545) is about a caller
+            // being told one thing while the log says another, and a bare catch here would leave a
+            // platform API change looking exactly like a configuration that has no application -
+            // with nothing anywhere to tell the two apart. WARNING, not ERROR: the caller's own
+            // answer below is a legitimate refusal, not a server fault.
+            Activator.logWarning("Could not derive the application id for launch configuration '" //$NON-NLS-1$
+                + cfg.getName() + "' of project '" + cfgProject + "': " //$NON-NLS-1$ //$NON-NLS-2$
+                + e.getClass().getName() + ": " + e.getMessage()); //$NON-NLS-1$
+        }
+        if (!isApplicationManagerId(derived))
+        {
+            String returned = derived == null || derived.isEmpty()
+                // Name what the id IS, not who produced it: EDT answers a synthetic
+                // "launch:<config name>" for a configuration that carries no application, and no
+                // application manager resolves that. Reporting it as a target would hand the caller
+                // an id that fails one call later - the exact shape of failure this issue is about.
+                ? "" : " EDT derived only the placeholder id '" + derived //$NON-NLS-1$ //$NON-NLS-2$
+                    + "', which names no application."; //$NON-NLS-1$
+            return TargetResolution.error(ToolResult.error("Launch configuration '" + cfg.getName() //$NON-NLS-1$
+                + "' is missing ATTR_APPLICATION_ID (read project='" + cfgProject //$NON-NLS-1$
+                + "', applicationId=''); EDT could not derive a project-default application " //$NON-NLS-1$
+                + "from that project." + returned + " Cannot derive the target. Bind the " //$NON-NLS-1$ //$NON-NLS-2$
+                + "configuration to an application in EDT, or pass projectName + applicationId " //$NON-NLS-1$
+                + "explicitly.").toJson()); //$NON-NLS-1$
+        }
+        return TargetResolution.resolved(cfgProject, derived, cfg, true);
+    }
+
+    /** Whether a derived id can be handed to {@code IApplicationManager.getApplication}. */
+    private static boolean isApplicationManagerId(String applicationId)
+    {
+        return applicationId != null && !applicationId.isEmpty()
+            && !applicationId.startsWith(LaunchConfigUtils.LAUNCH_APP_ID_PREFIX)
+            && !applicationId.startsWith(LaunchConfigUtils.ATTACH_APP_ID_PREFIX);
     }
 
     /**
@@ -360,19 +431,24 @@ public class SetInfobaseCredentialsTool implements IMcpTool
         private final String error;
         /** The resolved configuration itself - the CLIENT's credentials are written onto it. */
         private final ILaunchConfiguration config;
+        /** Whether EDT's project-default application supplied the id. */
+        private final boolean derivedApplicationId;
 
         private TargetResolution(String projectName, String applicationId, String error,
-            ILaunchConfiguration config)
+            ILaunchConfiguration config, boolean derivedApplicationId)
         {
             this.projectName = projectName;
             this.applicationId = applicationId;
             this.error = error;
             this.config = config;
+            this.derivedApplicationId = derivedApplicationId;
         }
 
-        static TargetResolution resolved(String projectName, String applicationId, ILaunchConfiguration config)
+        static TargetResolution resolved(String projectName, String applicationId,
+                ILaunchConfiguration config, boolean derivedApplicationId)
         {
-            return new TargetResolution(projectName, applicationId, null, config);
+            return new TargetResolution(projectName, applicationId, null, config,
+                derivedApplicationId);
         }
 
         ILaunchConfiguration config()
@@ -382,7 +458,7 @@ public class SetInfobaseCredentialsTool implements IMcpTool
 
         static TargetResolution error(String error)
         {
-            return new TargetResolution(null, null, error, null);
+            return new TargetResolution(null, null, error, null, false);
         }
 
         String projectName()
@@ -399,10 +475,16 @@ public class SetInfobaseCredentialsTool implements IMcpTool
         {
             return error;
         }
+
+        boolean derivedApplicationId()
+        {
+            return derivedApplicationId;
+        }
     }
 
     private String store(String projectName, String applicationId, String user, String password,
-            String access, String clientConfigName, ILaunchConfiguration clientConfig)
+            String access, String clientConfigName, ILaunchConfiguration clientConfig,
+            boolean derivedApplicationId)
     {
         // Prelude on the calling thread: resolving the IApplicationManager is a cheap service lookup.
         ApplicationSupport.ManagerResult mr = ApplicationSupport.resolveManager(projectName);
@@ -419,6 +501,7 @@ public class SetInfobaseCredentialsTool implements IMcpTool
         final String finalAccess = access;
         final String finalClientConfigName = clientConfigName;
         final ILaunchConfiguration finalClientConfig = clientConfig;
+        final boolean finalDerivedApplicationId = derivedApplicationId;
 
         // The model work (getApplication -> storeCredentials -> getName) runs in a bounded background
         // Job. Resolving an application can provoke EDT's background application-update-state recompute,
@@ -470,7 +553,8 @@ public class SetInfobaseCredentialsTool implements IMcpTool
                 // so this provisional record says so rather than claiming a configured client.
                 boolean passwordSet = finalPassword != null && !finalPassword.isEmpty();
                 String storedUser = finalUser == null ? "" : finalUser; //$NON-NLS-1$
-                jobResult.set(buildSuccess(finalProjectName, finalApplicationId, finalApplicationId,
+                jobResult.set(buildSuccess(finalProjectName, finalApplicationId,
+                    finalDerivedApplicationId, finalApplicationId,
                     storedUser, passwordSet, accessKind, finalClientConfigName, CLIENT_WRITE_UNFINISHED));
 
                 // The agent half has committed, so now — and only now — the CLIENT half. Writing it
@@ -479,7 +563,8 @@ public class SetInfobaseCredentialsTool implements IMcpTool
                 String clientError = configureClient(callerAnswered, finalClientConfigName,
                     finalClientConfig, finalUser, finalPassword,
                     InfobaseAccessSupport.isOsAccess(finalAccess));
-                jobResult.set(buildSuccess(finalProjectName, finalApplicationId, finalApplicationId,
+                jobResult.set(buildSuccess(finalProjectName, finalApplicationId,
+                    finalDerivedApplicationId, finalApplicationId,
                     storedUser, passwordSet, accessKind, finalClientConfigName, clientError));
 
                 // Best-effort enrich: replace the applicationId-named success with the real display name.
@@ -488,8 +573,9 @@ public class SetInfobaseCredentialsTool implements IMcpTool
                     String name = application.getName();
                     if (name != null && !name.isEmpty())
                     {
-                        jobResult.set(buildSuccess(finalProjectName, finalApplicationId, name, storedUser,
-                            passwordSet, accessKind, finalClientConfigName, clientError));
+                        jobResult.set(buildSuccess(finalProjectName, finalApplicationId,
+                            finalDerivedApplicationId, name, storedUser, passwordSet, accessKind,
+                            finalClientConfigName, clientError));
                     }
                 }
                 catch (Exception e) // NOSONAR cosmetic read-back — keep the applicationId-named success
@@ -556,6 +642,19 @@ public class SetInfobaseCredentialsTool implements IMcpTool
             String storedUser, boolean passwordSet, InfobaseAccess accessKind, String clientConfigName,
             String clientError)
     {
+        return buildSuccess(projectName, applicationId, false, displayName, storedUser,
+            passwordSet, accessKind, clientConfigName, clientError);
+    }
+
+    /** Same success payload, explicitly reporting a project-default application derivation. */
+    static String buildSuccess(String projectName, String applicationId,
+            boolean derivedApplicationId, String displayName, String storedUser, boolean passwordSet,
+            InfobaseAccess accessKind, String clientConfigName, String clientError)
+    {
+        String derivedNote = derivedApplicationId
+            ? " The launch configuration had no applicationId attribute, so EDT's project-default " //$NON-NLS-1$
+                + "application '" + applicationId + "' was derived for project '" + projectName + "'." //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            : ""; //$NON-NLS-1$
         return ToolResult.success()
             .put(KEY_CLIENT_CONFIGURED, clientConfigName != null && clientError == null)
             .put(McpKeys.PROJECT, projectName)
@@ -566,7 +665,8 @@ public class SetInfobaseCredentialsTool implements IMcpTool
             .put(KEY_PASSWORD_SET, passwordSet)
             .put(McpKeys.MESSAGE, "Stored infobase access credentials for application '" //$NON-NLS-1$
                 + displayName + "' (user '" + storedUser + "', access " //$NON-NLS-1$ //$NON-NLS-2$
-                + accessKind.getName() + "). The update agent used by update_database / " //$NON-NLS-1$
+                + accessKind.getName() + ")." + derivedNote //$NON-NLS-1$
+                + " The update agent used by update_database / " //$NON-NLS-1$
                 + "launch will now authenticate with them. " //$NON-NLS-1$
                 + clientNote(clientConfigName, clientError))
             .toJson();

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseTool.java
@@ -927,6 +927,43 @@ public class UpdateDatabaseTool implements IMcpTool
      * @param applicationId the target application (echoed for the caller's context)
      * @return the error payload
      */
+    /**
+     * The {@code Caused by} clause, or nothing when the failure carries no distinct deeper reason.
+     *
+     * <p>Platform messages end in a period only sometimes, and the hint that follows this clause is
+     * a sentence of its own - so without a terminator the three run together into
+     * {@code "... session open error Caused by: ... Auth fail If the infobase requires ..."}, which
+     * is the reading the caller has to do at the exact moment it is already confused. The clause
+     * therefore closes itself, and opens with one only when the selected message did not.
+     *
+     * <p>When there is no deeper reason this returns the empty string, so the message stays
+     * character-for-character what it was before the cause chain was surfaced.
+     *
+     * @param described the message {@code PlatformFailures.describe} selected
+     * @param rootCause the deeper diagnosis, possibly empty
+     * @return the clause to append, possibly empty
+     */
+    private static String causedBySegment(String described, String rootCause)
+    {
+        if (rootCause.isEmpty())
+        {
+            return ""; //$NON-NLS-1$
+        }
+        return (endsSentence(described) ? " Caused by: " : ". Caused by: ") + rootCause //$NON-NLS-1$ //$NON-NLS-2$
+            + (endsSentence(rootCause) ? "" : "."); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /** Whether this text already closes its own sentence. */
+    private static boolean endsSentence(String text)
+    {
+        if (text == null || text.isEmpty())
+        {
+            return true;
+        }
+        char last = text.charAt(text.length() - 1);
+        return last == '.' || last == '!' || last == '?' || last == ':';
+    }
+
     private static String portConflictError(LaunchUpdateDialogAutoConfirmer.ConflictWatch watch,
         String projectName, String applicationId, boolean terminatedClient)
     {
@@ -1113,12 +1150,16 @@ public class UpdateDatabaseTool implements IMcpTool
     {
         String internalInfoHint = describeInternalInfoHint(e);
         String hint = internalInfoHint.isEmpty() ? describeAuthHint(e) : internalInfoHint;
+        String described = PlatformFailures.describe(e);
+        String rootCause = PlatformFailures.rootCause(e);
         // PlatformFailures, not getMessage(): EDT reports failures as IStatus and only wraps them,
         // so the exception's own message is routinely empty (a cancelled server operation) or
         // generic while the reason sits in the status tree - and "Database update failed: " with
-        // nothing after it tells the caller nothing at all.
+        // nothing after it tells the caller nothing at all. The distinct terminal diagnosis is
+        // composed here rather than changing describe's widely used selection rule.
         ToolResult errorResult = ToolResult.error("Database update failed: " //$NON-NLS-1$
-            + PlatformFailures.describe(e) + describeInfobaseHolder(applicationId) + hint
+            + described + causedBySegment(described, rootCause)
+            + describeInfobaseHolder(applicationId) + hint
             + (portsReassigned
                 ? " NOTE: before this failure EDT had already moved the standalone server to free " //$NON-NLS-1$
                     + "ports and rewritten its configuration " //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchConfigUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchConfigUtils.java
@@ -64,6 +64,10 @@ public final class LaunchConfigUtils
     /** Attach to a locally spawned debug server. */
     public static final String TYPE_LOCAL_RUNTIME = "com._1c.g5.v8.dt.debug.core.LocalRuntime"; //$NON-NLS-1$
 
+    /** EDT standalone-server launch configuration type id. */
+    public static final String STANDALONE_SERVER_LAUNCH_CONFIG_TYPE_ID =
+        "com.e1c.g5.v8.dt.platform.standaloneserver.launchConfigurationType"; //$NON-NLS-1$
+
     /** All debug-launch config types understood by this plugin. */
     public static final List<String> ALL_DEBUG_CONFIG_TYPE_IDS = Collections.unmodifiableList(
         Arrays.asList(LAUNCH_CONFIG_TYPE_ID, TYPE_REMOTE_RUNTIME, TYPE_LOCAL_RUNTIME));
@@ -389,25 +393,54 @@ public final class LaunchConfigUtils
         }
         for (String typeId : ALL_DEBUG_CONFIG_TYPE_IDS)
         {
-            ILaunchConfigurationType type = launchManager.getLaunchConfigurationType(typeId);
-            if (type == null)
+            ILaunchConfiguration config = findLaunchConfigByTypeAndName(launchManager, typeId, name);
+            if (config != null)
             {
-                continue;
+                return config;
             }
-            try
+        }
+        return null;
+    }
+
+    /**
+     * Searches one exact launch-configuration type for an exact configuration name.
+     *
+     * <p>This is deliberately separate from {@link #ALL_DEBUG_CONFIG_TYPE_IDS}: callers that only
+     * support runtime-client/Attach configurations keep their existing search domain, while a
+     * caller that needs to diagnose another known EDT type can look it up without hand-rolling the
+     * Eclipse launch-manager traversal.
+     *
+     * @param launchManager Eclipse launch manager (must not be {@code null})
+     * @param typeId exact launch-configuration type id
+     * @param name exact launch-configuration name
+     * @return the matching configuration, or {@code null}
+     */
+    public static ILaunchConfiguration findLaunchConfigByTypeAndName(ILaunchManager launchManager,
+            String typeId, String name)
+    {
+        if (launchManager == null || typeId == null || typeId.isEmpty()
+            || name == null || name.isEmpty())
+        {
+            return null;
+        }
+        ILaunchConfigurationType type = launchManager.getLaunchConfigurationType(typeId);
+        if (type == null)
+        {
+            return null;
+        }
+        try
+        {
+            for (ILaunchConfiguration config : launchManager.getLaunchConfigurations(type))
             {
-                for (ILaunchConfiguration config : launchManager.getLaunchConfigurations(type))
+                if (name.equals(config.getName()))
                 {
-                    if (name.equals(config.getName()))
-                    {
-                        return config;
-                    }
+                    return config;
                 }
             }
-            catch (CoreException e)
-            {
-                Activator.logError("Error searching launch configurations of type " + typeId, e); //$NON-NLS-1$
-            }
+        }
+        catch (CoreException e)
+        {
+            Activator.logError("Error searching launch configurations of type " + typeId, e); //$NON-NLS-1$
         }
         return null;
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
@@ -144,9 +144,13 @@ public final class PlatformFailures
      * The deepest diagnosis in the bounded failure walk, when it adds information to
      * {@link #describe(Throwable)}.
      *
-     * <p>The walk uses the same two bounded structures as {@code describe}: at most
-     * {@link #MAX_CAUSE_CHAIN_DEPTH} throwable hops, and at every hop the throwable's
-     * {@link IStatus} tree down to {@link #MAX_STATUS_DEPTH}. Within a status tree, greater
+     * <p>The walk uses the same two bounds as {@code describe}: the primary {@code getCause()}
+     * chain is capped at {@link #MAX_CAUSE_CHAIN_DEPTH} throwable hops, and the {@link IStatus}
+     * tree at every primary hop is capped at {@link #MAX_STATUS_DEPTH}. When an exception is
+     * attached anywhere in a status tree, its own {@code getCause()} chain uses that SAME cause
+     * cap, so a child status carrying
+     * {@code RuntimeException("SSH error", new JSchException("Auth fail"))} contributes the
+     * terminal {@code Auth fail} without opening an unbounded walk. Within a status tree, greater
      * structural depth wins; failing children are visited before informational ones, matching the
      * preference used by {@link #statusMessage(IStatus, int)}. Cause-chain depth then wins over an
      * earlier throwable hop. The bounds also stop cyclical throwable/status structures.
@@ -154,13 +158,16 @@ public final class PlatformFailures
      * <p>Messages equal to {@code describe}'s selected headline are excluded as diagnosis
      * candidates throughout both structures. The deepest message that remains wins, so a repeated
      * headline cannot displace a distinct diagnosis even when the repetition sits deeper in the
-     * status tree or later in the cause chain. When no distinct candidate remains, the empty string
-     * is returned so a single-message failure is never repeated. When the deepest distinct message
-     * is the own message of a terminal exception and is short enough to be generic (40 characters
-     * or fewer and no more than four whitespace-separated words), its fully qualified exception
-     * type is prefixed. Thus {@code Auth fail} becomes, for example,
-     * {@code com.jcraft.jsch.JSchException: Auth fail}; longer, self-explanatory platform prose is
-     * returned without a stack-dump-like type prefix.
+     * status tree or later in the cause chain. The formatted result is compared with the headline
+     * again, because adding a type prefix can recreate a headline that differed from the raw
+     * candidate. When no distinct result remains, the empty string is returned so a single-message
+     * failure is never repeated. When the deepest distinct message is genuinely owned by a
+     * terminal exception and is short enough to be generic (40 characters or fewer and no more
+     * than four whitespace-separated words), its fully qualified exception type is prefixed. A
+     * platform wrapper's own message that merely copies its status text retains status provenance
+     * and is not attributed to the wrapper type. Thus an exception-owned {@code Auth fail} becomes,
+     * for example, {@code com.jcraft.jsch.JSchException: Auth fail}; longer, self-explanatory
+     * platform prose is returned without a stack-dump-like type prefix.
      *
      * <p>This method returns only the diagnosis. A caller that displays both messages should compose
      * English prose such as {@code describe(failure) + " Caused by: " + rootCause(failure)}.
@@ -190,23 +197,40 @@ public final class PlatformFailures
         {
             return ""; //$NON-NLS-1$
         }
+        String formatted = deepest.message;
         if (deepest.source != null && deepest.source.getCause() == null
             && deepest.message.equals(trimToNull(deepest.source.getMessage()))
             && isShortGenericMessage(deepest.message))
         {
-            return deepest.source.getClass().getName() + ": " + deepest.message; //$NON-NLS-1$
+            formatted = deepest.source.getClass().getName() + ": " + deepest.message; //$NON-NLS-1$
         }
-        return deepest.message;
+        return selected.equals(formatted) ? "" : formatted; //$NON-NLS-1$
     }
 
     /** Deepest distinct message carried by one throwable hop and its bounded status tree. */
     private static FailureMessage deepestMessageAt(Throwable failure, String selected)
     {
-        String own = trimToNull(failure.getMessage());
-        FailureMessage deepest = own == null || selected.equals(own) ? null
-            : new FailureMessage(own, failure, 0);
+        FailureMessage deepest = ownFailureMessage(failure, 0, selected);
         FailureMessage fromStatus = deepestStatusMessage(statusOf(failure), 0, selected);
         return deeper(deepest, fromStatus);
+    }
+
+    /**
+     * A throwable's distinct own message with honest provenance. Platform exceptions copy their
+     * status message into {@code getMessage()}; that text belongs to the status, not to the generic
+     * wrapper type, so it must not later acquire the wrapper's type prefix.
+     */
+    private static FailureMessage ownFailureMessage(Throwable failure, int depth, String selected)
+    {
+        String own = trimToNull(failure.getMessage());
+        if (own == null || selected.equals(own))
+        {
+            return null;
+        }
+        IStatus status = statusOf(failure);
+        Throwable source = status != null && own.equals(trimToNull(status.getMessage()))
+            ? null : failure;
+        return new FailureMessage(own, source, depth);
     }
 
     /** Deepest distinct message in a bounded status tree; failing children win equal-depth ties. */
@@ -225,12 +249,30 @@ public final class PlatformFailures
             deepest = deepestStatusChildren(children, depth, true, deepest, selected);
             deepest = deepestStatusChildren(children, depth, false, deepest, selected);
         }
-        Throwable carried = status.getException();
-        String carriedMessage = carried == null ? null : trimToNull(carried.getMessage());
-        if (carriedMessage != null && !selected.equals(carriedMessage))
+        deepest = deeper(deepest,
+            deepestCarriedCauseMessage(status.getException(), depth + 1, selected));
+        return deepest;
+    }
+
+    /**
+     * Deepest distinct own message in the cause chain of an exception attached to a status.
+     * Reuses the ordinary cause-chain cap rather than defining a child-specific bound; a cyclical
+     * carried chain therefore terminates under the same contract as the top-level chain.
+     */
+    private static FailureMessage deepestCarriedCauseMessage(Throwable failure, int depth,
+            String selected)
+    {
+        FailureMessage deepest = null;
+        Throwable current = failure;
+        for (int causeDepth = 0; current != null && causeDepth < MAX_CAUSE_CHAIN_DEPTH;
+            causeDepth++)
         {
-            deepest = deeper(deepest,
-                new FailureMessage(carriedMessage, carried, depth + 1));
+            FailureMessage atHop = ownFailureMessage(current, depth + causeDepth, selected);
+            if (atHop != null)
+            {
+                deepest = atHop;
+            }
+            current = current.getCause();
         }
         return deepest;
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
@@ -151,11 +151,14 @@ public final class PlatformFailures
      * preference used by {@link #statusMessage(IStatus, int)}. Cause-chain depth then wins over an
      * earlier throwable hop. The bounds also stop cyclical throwable/status structures.
      *
-     * <p>The raw deepest message is compared with {@code describe}'s selected message BEFORE any
-     * formatting. Equal text returns the empty string so a single-message failure is never repeated.
-     * When the deepest message is the own message of a terminal exception and is short enough to be
-     * generic (40 characters or fewer and no more than four whitespace-separated words), its fully
-     * qualified exception type is prefixed. Thus {@code Auth fail} becomes, for example,
+     * <p>Messages equal to {@code describe}'s selected headline are excluded as diagnosis
+     * candidates throughout both structures. The deepest message that remains wins, so a repeated
+     * headline cannot displace a distinct diagnosis even when the repetition sits deeper in the
+     * status tree or later in the cause chain. When no distinct candidate remains, the empty string
+     * is returned so a single-message failure is never repeated. When the deepest distinct message
+     * is the own message of a terminal exception and is short enough to be generic (40 characters
+     * or fewer and no more than four whitespace-separated words), its fully qualified exception
+     * type is prefixed. Thus {@code Auth fail} becomes, for example,
      * {@code com.jcraft.jsch.JSchException: Auth fail}; longer, self-explanatory platform prose is
      * returned without a stack-dump-like type prefix.
      *
@@ -176,14 +179,14 @@ public final class PlatformFailures
         Throwable current = failure;
         for (int depth = 0; current != null && depth < MAX_CAUSE_CHAIN_DEPTH; depth++)
         {
-            FailureMessage atHop = deepestMessageAt(current);
+            FailureMessage atHop = deepestMessageAt(current, selected);
             if (atHop != null)
             {
                 deepest = atHop;
             }
             current = current.getCause();
         }
-        if (deepest == null || selected.equals(deepest.message))
+        if (deepest == null)
         {
             return ""; //$NON-NLS-1$
         }
@@ -196,33 +199,35 @@ public final class PlatformFailures
         return deepest.message;
     }
 
-    /** Deepest message carried by one throwable hop, including its bounded status tree. */
-    private static FailureMessage deepestMessageAt(Throwable failure)
+    /** Deepest distinct message carried by one throwable hop and its bounded status tree. */
+    private static FailureMessage deepestMessageAt(Throwable failure, String selected)
     {
         String own = trimToNull(failure.getMessage());
-        FailureMessage deepest = own == null ? null : new FailureMessage(own, failure, 0);
-        FailureMessage fromStatus = deepestStatusMessage(statusOf(failure), 0);
+        FailureMessage deepest = own == null || selected.equals(own) ? null
+            : new FailureMessage(own, failure, 0);
+        FailureMessage fromStatus = deepestStatusMessage(statusOf(failure), 0, selected);
         return deeper(deepest, fromStatus);
     }
 
-    /** Deepest message in a bounded status tree; failing children win equal-depth ties. */
-    private static FailureMessage deepestStatusMessage(IStatus status, int depth)
+    /** Deepest distinct message in a bounded status tree; failing children win equal-depth ties. */
+    private static FailureMessage deepestStatusMessage(IStatus status, int depth, String selected)
     {
         if (status == null || depth > MAX_STATUS_DEPTH)
         {
             return null;
         }
         String own = trimToNull(status.getMessage());
-        FailureMessage deepest = own == null ? null : new FailureMessage(own, null, depth);
+        FailureMessage deepest = own == null || selected.equals(own) ? null
+            : new FailureMessage(own, null, depth);
         IStatus[] children = status.getChildren();
         if (children != null)
         {
-            deepest = deepestStatusChildren(children, depth, true, deepest);
-            deepest = deepestStatusChildren(children, depth, false, deepest);
+            deepest = deepestStatusChildren(children, depth, true, deepest, selected);
+            deepest = deepestStatusChildren(children, depth, false, deepest, selected);
         }
         Throwable carried = status.getException();
         String carriedMessage = carried == null ? null : trimToNull(carried.getMessage());
-        if (carriedMessage != null)
+        if (carriedMessage != null && !selected.equals(carriedMessage))
         {
             deepest = deeper(deepest,
                 new FailureMessage(carriedMessage, carried, depth + 1));
@@ -232,7 +237,7 @@ public final class PlatformFailures
 
     /** Walks failing or non-failing child statuses without visiting either group twice. */
     private static FailureMessage deepestStatusChildren(IStatus[] children, int depth,
-            boolean failing, FailureMessage deepest)
+            boolean failing, FailureMessage deepest, String selected)
     {
         for (IStatus child : children)
         {
@@ -240,7 +245,7 @@ public final class PlatformFailures
             {
                 continue;
             }
-            deepest = deeper(deepest, deepestStatusMessage(child, depth + 1));
+            deepest = deeper(deepest, deepestStatusMessage(child, depth + 1, selected));
         }
         return deepest;
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
@@ -6,6 +6,7 @@
 
 package com.ditrix.edt.mcp.server.utils;
 
+import java.util.ArrayDeque;
 import java.util.IdentityHashMap;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -35,18 +36,18 @@ import com.e1c.g5.dt.applications.ApplicationException;
  *
  * <h2>What it does</h2>
  * {@link #describe(Throwable)} walks the failure — the exception chain, and for each hop the
- * {@link IStatus} it carries (message, then children, then the status's own exception) — and
+ * {@link IStatus} it carries (failing children first, then other children, its message, and its
+ * own exception) — and
  * returns the first non-blank message it finds. When the whole failure genuinely carries no text
  * it says so, naming the exception type and the status severity, because "CANCEL, no message" is
  * itself the diagnosis: something aborted the operation rather than failing it.
  *
  * <p>{@link #rootCause(Throwable)} answers a separate, complementary question: after
- * {@code describe} has selected the headline, what is the deepest distinct message provably below
- * that exact position? It tracks whether the headline came from a throwable or a particular status.
- * Only deeper cause-chain hops, descendants of the selected status, and direct
- * {@link IStatus#getException()} edges are eligible; status ancestors and unrelated siblings are
- * not. Callers that need both compose them explicitly; the root-cause helper does not change
- * {@code describe}'s established selection rule.
+ * {@code describe} has selected the headline, what does the deepest distinct CAUSAL throwable hop
+ * say? Throwable causes and exceptions attached to statuses are causal edges; child statuses are
+ * aggregate detail and are interpreted only by {@code describe}'s rule at their owning throwable
+ * hop. Callers that need both compose them explicitly; the root-cause helper does not change
+ * {@code describe}'s established selection rule or invent an ordering among aggregate statuses.
  *
  * <p>{@link #withoutObjectIdentity(String)} answers a SEPARATE question and is meant to be
  * COMPOSED with {@code describe}, never substituted for it. {@code describe} selects the most
@@ -116,28 +117,10 @@ public final class PlatformFailures
         Throwable current = failure;
         for (int depth = 0; current != null && depth < MAX_CAUSE_CHAIN_DEPTH; depth++)
         {
-            // The status tree is consulted BEFORE the throwable's own message whenever that status
-            // HAS children: ApplicationException(IStatus) copies the root message into
-            // getMessage(), so trusting the exception first would again return the headline and
-            // never the child that names the cause.
-            IStatus status = statusOf(current);
-            if (hasChildren(status))
+            FailureMessage atHop = failureMessageAt(current);
+            if (atHop != null)
             {
-                String fromChildren = statusMessage(status, 0);
-                if (fromChildren != null)
-                {
-                    return fromChildren;
-                }
-            }
-            String own = trimToNull(current.getMessage());
-            if (own != null)
-            {
-                return own;
-            }
-            String fromStatus = statusMessage(status, 0);
-            if (fromStatus != null)
-            {
-                return fromStatus;
+                return atHop.message;
             }
             current = current.getCause();
         }
@@ -145,29 +128,29 @@ public final class PlatformFailures
     }
 
     /**
-     * The deepest diagnosis provably below {@link #describe(Throwable)}'s exact source, when it adds
-     * information to that headline.
+     * The deepest diagnosis on a bounded causal path below the failure, when it adds information to
+     * {@link #describe(Throwable)}'s headline.
      *
-     * <p>The source lookup follows {@code describe}'s established preference without changing it.
-     * If the selected text came from an exception, only deeper hops in that exception's bounded
-     * {@code getCause()} chain are eligible, including the complete status tree attached at each
-     * established deeper hop. If it came from a status, only that status's descendants and its
-     * direct {@code getException()} edge are eligible. This excludes every status ancestor and
-     * unrelated sibling while retaining exception-free detail below the selected position.
+     * <p>The walk follows only {@link Throwable#getCause()} and {@link IStatus#getException()}
+     * edges. At each throwable hop, the message is selected by the same rule as {@code describe}:
+     * status children first when present (including the failing-child preference), then the
+     * throwable's own message, then the status fallback. A status tree therefore says what ONE
+     * causal hop means; structural depth within that aggregate never competes with causal depth.
      *
-     * <p>Every status identity is visited at most once during that discovery. This makes aliases
-     * and cycles linear in the number of stored statuses rather than multiplicative in the number
-     * of paths. Each exception chain remains capped at {@link #MAX_CAUSE_CHAIN_DEPTH}, and status
-     * discovery remains capped at {@link #MAX_STATUS_DEPTH}.
+     * <p>Throwable identities are de-duplicated. Each ordinary or status-attached cause chain is
+     * capped at {@link #MAX_CAUSE_CHAIN_DEPTH}, and discovery of attached exceptions is capped at
+     * {@link #MAX_STATUS_DEPTH}. Status aliases are revisited only when reached at a shallower depth,
+     * where the cap can expose children that were previously out of bounds. These rules terminate
+     * cyclic graphs without making the result depend on a deeper alias being visited first.
      *
      * <p>Messages equal to the selected headline are excluded. The formatted result is compared
      * with the headline again, because adding a type prefix can recreate a headline that differed
      * from the raw candidate. When no distinct result remains, the empty string is returned. A
      * short generic message (40 characters or fewer and no more than four words) is prefixed only
-     * when a terminal exception genuinely owns it. A platform wrapper's message that merely copies
-     * its status text retains status provenance and is not attributed to the wrapper type. Thus a
-     * status-carried {@code RuntimeException("SSH error", new JSchException("Auth fail"))} still
-     * contributes {@code com.jcraft.jsch.JSchException: Auth fail}.
+     * when a terminal exception genuinely owns it. Text selected from a status carries no wrapper
+     * provenance. Thus a status-carried
+     * {@code RuntimeException("SSH error", new JSchException("Auth fail"))} still contributes
+     * {@code com.jcraft.jsch.JSchException: Auth fail}.
      *
      * <p>This method returns only the diagnosis. A caller that displays both messages should compose
      * English prose such as {@code describe(failure) + " Caused by: " + rootCause(failure)}.
@@ -182,27 +165,32 @@ public final class PlatformFailures
             return ""; //$NON-NLS-1$
         }
         String selected = describe(failure);
-        FailureMessage described = descriptionMessage(failure,
-            new IdentityHashMap<IStatus, Boolean>());
-        if (described == null || !selected.equals(described.message))
+        FailureMessage deepest = null;
+        ArrayDeque<ThrowableHop> pending = new ArrayDeque<ThrowableHop>();
+        IdentityHashMap<Throwable, Boolean> visitedThrowables =
+            new IdentityHashMap<Throwable, Boolean>();
+        pending.add(new ThrowableHop(failure, 0, 0));
+        visitedThrowables.put(failure, Boolean.TRUE);
+        while (!pending.isEmpty())
         {
-            return ""; //$NON-NLS-1$
-        }
-        IdentityHashMap<IStatus, Boolean> visitedStatuses =
-            new IdentityHashMap<IStatus, Boolean>();
-        FailureMessage deepest;
-        if (described.statusSource != null)
-        {
-            deepest = deepestBelowSelectedStatus(described.statusSource, described.depth, selected,
-                visitedStatuses);
-        }
-        else if (described.source != null)
-        {
-            deepest = deepestBelowSelectedException(described.source, selected, visitedStatuses);
-        }
-        else
-        {
-            return ""; //$NON-NLS-1$
+            ThrowableHop hop = pending.remove();
+            if (hop.causalDepth > 0)
+            {
+                FailureMessage atHop = failureMessageAt(hop.failure);
+                if (atHop != null && !selected.equals(atHop.message)
+                    && (deepest == null || hop.causalDepth > deepest.depth))
+                {
+                    deepest = new FailureMessage(atHop.message, atHop.source, hop.causalDepth);
+                }
+            }
+
+            if (hop.causeDepth + 1 < MAX_CAUSE_CHAIN_DEPTH)
+            {
+                enqueue(hop.failure.getCause(), hop.causalDepth + 1, hop.causeDepth + 1,
+                    pending, visitedThrowables);
+            }
+            enqueueStatusExceptions(statusOf(hop.failure), 0, hop.causalDepth + 1, pending,
+                visitedThrowables, new IdentityHashMap<IStatus, Integer>());
         }
         if (deepest == null)
         {
@@ -218,73 +206,57 @@ public final class PlatformFailures
         return selected.equals(formatted) ? "" : formatted; //$NON-NLS-1$
     }
 
-    /** Finds the exact message source selected by {@link #describe(Throwable)}. */
-    private static FailureMessage descriptionMessage(Throwable failure,
-            IdentityHashMap<IStatus, Boolean> visitedStatuses)
+    /** The exact per-hop rule used by {@link #describe(Throwable)}, with message provenance. */
+    private static FailureMessage failureMessageAt(Throwable failure)
     {
-        Throwable current = failure;
-        for (int depth = 0; current != null && depth < MAX_CAUSE_CHAIN_DEPTH; depth++)
-        {
-            IStatus status = statusOf(current);
-            if (hasChildren(status))
-            {
-                FailureMessage fromChildren = descriptionStatusMessage(status, 0,
-                    visitedStatuses);
-                if (fromChildren != null)
-                {
-                    return fromChildren;
-                }
-            }
-            String own = trimToNull(current.getMessage());
-            if (own != null)
-            {
-                IStatus sourceStatus = status != null
-                    && own.equals(trimToNull(status.getMessage())) ? status : null;
-                return new FailureMessage(own, sourceStatus == null ? current : null,
-                    sourceStatus, depth);
-            }
-            FailureMessage fromStatus = descriptionStatusMessage(status, 0, visitedStatuses);
-            if (fromStatus != null)
-            {
-                return fromStatus;
-            }
-            current = current.getCause();
-        }
-        return null;
-    }
-
-    /**
-     * A throwable's distinct own message with honest provenance. Platform exceptions copy their
-     * status message into {@code getMessage()}; that text belongs to the status, not to the generic
-     * wrapper type, so it must not later acquire the wrapper's type prefix.
-     */
-    private static FailureMessage ownFailureMessage(Throwable failure, int depth, String selected)
-    {
-        String own = trimToNull(failure.getMessage());
-        if (own == null || selected.equals(own))
-        {
-            return null;
-        }
         IStatus status = statusOf(failure);
-        boolean copiedFromStatus = status != null
-            && own.equals(trimToNull(status.getMessage()));
-        return new FailureMessage(own, copiedFromStatus ? null : failure,
-            copiedFromStatus ? status : null, depth);
+        if (hasChildren(status))
+        {
+            String fromChildren = statusMessage(status, 0);
+            if (fromChildren != null)
+            {
+                return new FailureMessage(fromChildren, null, 0);
+            }
+        }
+        String own = trimToNull(failure.getMessage());
+        if (own != null)
+        {
+            boolean copiedFromStatus = status != null
+                && own.equals(trimToNull(status.getMessage()));
+            return new FailureMessage(own, copiedFromStatus ? null : failure, 0);
+        }
+        String fromStatus = statusMessage(status, 0);
+        return fromStatus == null ? null : new FailureMessage(fromStatus, null, 0);
     }
 
-    /**
-     * Locates {@code describe}'s first status message and records the exact status identity that
-     * supplied it. A carried exception is recorded only when the status itself is blank and
-     * {@code describe} therefore falls through to that exception's own message.
-     */
-    private static FailureMessage descriptionStatusMessage(IStatus status, int depth,
-            IdentityHashMap<IStatus, Boolean> visitedStatuses)
+    /** Adds a throwable once; status-attached exceptions start a fresh bounded cause chain. */
+    private static void enqueue(Throwable failure, int causalDepth, int causeDepth,
+            ArrayDeque<ThrowableHop> pending,
+            IdentityHashMap<Throwable, Boolean> visitedThrowables)
     {
-        if (status == null || depth > MAX_STATUS_DEPTH
-            || visitedStatuses.put(status, Boolean.TRUE) != null)
+        if (failure != null && visitedThrowables.put(failure, Boolean.TRUE) == null)
         {
-            return null;
+            pending.add(new ThrowableHop(failure, causalDepth, causeDepth));
         }
+    }
+
+    /** Finds exception edges in a bounded status aggregate; status messages are not candidates. */
+    private static void enqueueStatusExceptions(IStatus status, int statusDepth, int causalDepth,
+            ArrayDeque<ThrowableHop> pending,
+            IdentityHashMap<Throwable, Boolean> visitedThrowables,
+            IdentityHashMap<IStatus, Integer> visitedStatuses)
+    {
+        if (status == null || statusDepth > MAX_STATUS_DEPTH)
+        {
+            return;
+        }
+        Integer previousDepth = visitedStatuses.get(status);
+        if (previousDepth != null && previousDepth.intValue() <= statusDepth)
+        {
+            return;
+        }
+        visitedStatuses.put(status, Integer.valueOf(statusDepth));
+
         IStatus[] children = status.getChildren();
         if (children != null)
         {
@@ -298,133 +270,12 @@ public final class PlatformFailures
                     {
                         continue;
                     }
-                    FailureMessage message = descriptionStatusMessage(child, depth + 1,
-                        visitedStatuses);
-                    if (message != null)
-                    {
-                        return message;
-                    }
+                    enqueueStatusExceptions(child, statusDepth + 1, causalDepth, pending,
+                        visitedThrowables, visitedStatuses);
                 }
             }
         }
-        Throwable carried = status.getException();
-        String own = trimToNull(status.getMessage());
-        if (own != null)
-        {
-            return new FailureMessage(own, null, status, depth);
-        }
-        String carriedMessage = carried == null ? null : trimToNull(carried.getMessage());
-        return carriedMessage == null ? null
-            : new FailureMessage(carriedMessage, carried, null, depth + 1);
-    }
-
-    /** Deepest distinct message below the selected exception's exact cause-chain position. */
-    private static FailureMessage deepestBelowSelectedException(Throwable selectedSource,
-            String selected, IdentityHashMap<IStatus, Boolean> visitedStatuses)
-    {
-        FailureMessage deepest = null;
-        Throwable current = selectedSource;
-        for (int depth = 0; current != null && depth < MAX_CAUSE_CHAIN_DEPTH; depth++)
-        {
-            if (depth > 0)
-            {
-                deepest = deeper(deepest, ownFailureMessage(current, depth, selected));
-                deepest = deeper(deepest, deepestEligibleStatus(statusOf(current), 0,
-                    depth, selected, visitedStatuses));
-            }
-            current = current.getCause();
-        }
-        return deepest;
-    }
-
-    /**
-     * Deepest candidate below a selected status. The status itself is only an anchor: its own
-     * message is the headline and is not reconsidered. Its exception and child statuses are direct
-     * downward edges; ancestors and siblings are unreachable from here by construction.
-     */
-    private static FailureMessage deepestBelowSelectedStatus(IStatus selectedStatus,
-            int selectedStatusDepth, String selected,
-            IdentityHashMap<IStatus, Boolean> visitedStatuses)
-    {
-        if (selectedStatus == null || selectedStatusDepth > MAX_STATUS_DEPTH
-            || visitedStatuses.put(selectedStatus, Boolean.TRUE) != null)
-        {
-            return null;
-        }
-        FailureMessage deepest = deepestThrowableChain(selectedStatus.getException(), 1,
-            selected, visitedStatuses);
-        IStatus[] children = selectedStatus.getChildren();
-        if (children != null)
-        {
-            for (IStatus child : children)
-            {
-                deepest = deeper(deepest, deepestEligibleStatus(child,
-                    selectedStatusDepth + 1, 1, selected, visitedStatuses));
-            }
-        }
-        return deepest;
-    }
-
-    /** All status and exception messages below an already established causal position. */
-    private static FailureMessage deepestEligibleStatus(IStatus status, int statusDepth,
-            int structuralDepth, String selected,
-            IdentityHashMap<IStatus, Boolean> visitedStatuses)
-    {
-        if (status == null || statusDepth > MAX_STATUS_DEPTH
-            || visitedStatuses.put(status, Boolean.TRUE) != null)
-        {
-            return null;
-        }
-        FailureMessage deepest = statusFailureMessage(status, structuralDepth, selected);
-        deepest = deeper(deepest, deepestThrowableChain(status.getException(),
-            structuralDepth + 1, selected, visitedStatuses));
-        IStatus[] children = status.getChildren();
-        if (children != null)
-        {
-            for (IStatus child : children)
-            {
-                deepest = deeper(deepest, deepestEligibleStatus(child, statusDepth + 1,
-                    structuralDepth + 1, selected, visitedStatuses));
-            }
-        }
-        return deepest;
-    }
-
-    /** Deepest message in a direct status-exception edge and its bounded cause chain. */
-    private static FailureMessage deepestThrowableChain(Throwable start, int structuralDepth,
-            String selected, IdentityHashMap<IStatus, Boolean> visitedStatuses)
-    {
-        FailureMessage deepest = null;
-        Throwable current = start;
-        for (int causeDepth = 0; current != null && causeDepth < MAX_CAUSE_CHAIN_DEPTH;
-            causeDepth++)
-        {
-            int candidateDepth = structuralDepth + causeDepth;
-            deepest = deeper(deepest,
-                ownFailureMessage(current, candidateDepth, selected));
-            deepest = deeper(deepest, deepestEligibleStatus(statusOf(current), 0,
-                candidateDepth, selected, visitedStatuses));
-            current = current.getCause();
-        }
-        return deepest;
-    }
-
-    /** A status-owned candidate never borrows the type of an exception it happens to carry. */
-    private static FailureMessage statusFailureMessage(IStatus status, int depth, String selected)
-    {
-        String own = trimToNull(status.getMessage());
-        return own == null || selected.equals(own) ? null
-            : new FailureMessage(own, null, status, depth);
-    }
-
-    /** Greater structural depth wins; the first visited candidate wins a tie. */
-    private static FailureMessage deeper(FailureMessage current, FailureMessage candidate)
-    {
-        if (candidate == null)
-        {
-            return current;
-        }
-        return current == null || candidate.depth > current.depth ? candidate : current;
+        enqueue(status.getException(), causalDepth, 0, pending, visitedThrowables);
     }
 
     /** Deterministic proxy for a terse generic message that benefits from its exception type. */
@@ -453,15 +304,28 @@ public final class PlatformFailures
     {
         final String message;
         final Throwable source;
-        final IStatus statusSource;
         final int depth;
 
-        FailureMessage(String message, Throwable source, IStatus statusSource, int depth)
+        FailureMessage(String message, Throwable source, int depth)
         {
             this.message = message;
             this.source = source;
-            this.statusSource = statusSource;
             this.depth = depth;
+        }
+    }
+
+    /** One causal throwable plus its result depth and position in the current getCause chain. */
+    private static final class ThrowableHop
+    {
+        final Throwable failure;
+        final int causalDepth;
+        final int causeDepth;
+
+        ThrowableHop(Throwable failure, int causalDepth, int causeDepth)
+        {
+            this.failure = failure;
+            this.causalDepth = causalDepth;
+            this.causeDepth = causeDepth;
         }
     }
 
@@ -624,7 +488,8 @@ public final class PlatformFailures
      * @param failingOnly {@code true} to consider only failing children
      * @return the message, or {@code null} when none of the considered children carries one
      */
-    private static String firstChildMessage(IStatus[] children, int depth, boolean failingOnly)
+    private static String firstChildMessage(IStatus[] children, int depth, boolean failingOnly,
+            IdentityHashMap<IStatus, Integer> visitedStatuses)
     {
         for (IStatus child : children)
         {
@@ -632,7 +497,7 @@ public final class PlatformFailures
             {
                 continue;
             }
-            String message = statusMessage(child, depth + 1);
+            String message = statusMessage(child, depth + 1, visitedStatuses);
             if (message != null)
             {
                 return message;
@@ -658,10 +523,23 @@ public final class PlatformFailures
      */
     static String statusMessage(IStatus status, int depth)
     {
+        return statusMessage(status, depth, new IdentityHashMap<IStatus, Integer>());
+    }
+
+    /** Alias-aware implementation; a shallower path may expose children hidden by the depth cap. */
+    private static String statusMessage(IStatus status, int depth,
+            IdentityHashMap<IStatus, Integer> visitedStatuses)
+    {
         if (status == null || depth > MAX_STATUS_DEPTH)
         {
             return null;
         }
+        Integer previousDepth = visitedStatuses.get(status);
+        if (previousDepth != null && previousDepth.intValue() <= depth)
+        {
+            return null;
+        }
+        visitedStatuses.put(status, Integer.valueOf(depth));
         // CHILDREN FIRST when there are any. EDT wraps its results in a MultiStatus whose own
         // message is the generic headline ("Database update failed") while the reason — the busy
         // port, the rejected object — sits in a child. Returning the root first made this helper
@@ -672,12 +550,12 @@ public final class PlatformFailures
             // FAILING children first: an aggregated EDT operation legitimately mixes informational
             // or OK children with the one that failed, and a plain first-with-text rule could turn
             // a database failure into an unrelated progress message.
-            String fromFailing = firstChildMessage(children, depth, true);
+            String fromFailing = firstChildMessage(children, depth, true, visitedStatuses);
             if (fromFailing != null)
             {
                 return fromFailing;
             }
-            String fromAny = firstChildMessage(children, depth, false);
+            String fromAny = firstChildMessage(children, depth, false, visitedStatuses);
             if (fromAny != null)
             {
                 return fromAny;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
@@ -6,7 +6,6 @@
 
 package com.ditrix.edt.mcp.server.utils;
 
-import java.util.ArrayDeque;
 import java.util.IdentityHashMap;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -43,11 +42,11 @@ import com.e1c.g5.dt.applications.ApplicationException;
  * itself the diagnosis: something aborted the operation rather than failing it.
  *
  * <p>{@link #rootCause(Throwable)} answers a separate, complementary question: after
- * {@code describe} has selected the headline, what does the deepest distinct CAUSAL throwable hop
- * say? Throwable causes and exceptions attached to statuses are causal edges; child statuses are
- * aggregate detail and are interpreted only by {@code describe}'s rule at their owning throwable
- * hop. Callers that need both compose them explicitly; the root-cause helper does not change
- * {@code describe}'s established selection rule or invent an ordering among aggregate statuses.
+ * {@code describe} has selected the headline, what does the deepest distinct bounded
+ * {@code getCause()} hop say? Child statuses are aggregate detail and are interpreted only by the
+ * per-hop selection rule at their owning throwable. Callers that need both compose them explicitly;
+ * the root-cause helper does not change {@code describe}'s established selection rule or invent an
+ * ordering among aggregate statuses.
  *
  * <p>{@link #withoutObjectIdentity(String)} answers a SEPARATE question and is meant to be
  * COMPOSED with {@code describe}, never substituted for it. {@code describe} selects the most
@@ -128,31 +127,23 @@ public final class PlatformFailures
     }
 
     /**
-     * The deepest diagnosis on a bounded causal path below the failure, when it adds information to
-     * {@link #describe(Throwable)}'s headline.
+     * The deepest diagnosis on the bounded {@link Throwable#getCause()} path below the failure,
+     * when it adds information to {@link #describe(Throwable)}'s headline.
      *
-     * <p>The walk follows only {@link Throwable#getCause()} and {@link IStatus#getException()}
-     * edges. At each throwable hop, failing status children come first, then the throwable's own
-     * message and status fallback. Unlike {@code describe}, causation never falls back to a
-     * non-failing aggregate child merely because it has text. A status tree therefore says what
-     * ONE causal hop means; structural depth within that aggregate never competes with causal depth.
+     * <p>The walk follows only {@link Throwable#getCause()} and is capped at
+     * {@link #MAX_CAUSE_CHAIN_DEPTH}. At each cause hop, failing status children come first, then the
+     * throwable's own message and status fallback. Unlike {@code describe}, causation never falls
+     * back to a non-failing aggregate child merely because it has text. Messages whose raw or
+     * formatted form equals the headline are skipped at that hop, so a deeper repeat cannot erase
+     * the last distinct diagnosis. A short generic message (40 characters or fewer and no more than
+     * four words) is prefixed only when a terminal exception genuinely owns it. Text selected from a
+     * status carries no wrapper provenance.
      *
-     * <p>Throwable identities are de-duplicated. Each ordinary or status-attached cause chain is
-     * capped at {@link #MAX_CAUSE_CHAIN_DEPTH}, and discovery of attached exceptions is capped at
-     * {@link #MAX_STATUS_DEPTH}. A status exception identical to its current throwable's
-     * {@code getCause()} is the same edge and cannot restart that cause-chain cap. Status aliases are
-     * revisited only when reached at a shallower depth, where the cap can expose children that were
-     * previously out of bounds. These rules terminate cyclic graphs without making the result depend
-     * on a deeper alias being visited first.
-     *
-     * <p>Messages equal to the selected headline are excluded. The formatted result is compared
-     * with the headline again, because adding a type prefix can recreate a headline that differed
-     * from the raw candidate. When no distinct result remains, the empty string is returned. A
-     * short generic message (40 characters or fewer and no more than four words) is prefixed only
-     * when a terminal exception genuinely owns it. Text selected from a status carries no wrapper
-     * provenance. Thus a status-carried
-     * {@code RuntimeException("SSH error", new JSchException("Auth fail"))} still contributes
-     * {@code com.jcraft.jsch.JSchException: Auth fail}.
+     * <p>{@link CoreException#getCause()} exposes the exception carried by its status. EDT aggregate
+     * statuses likewise synthesize their exception from failing children when they have no exception
+     * of their own. Any exception known to those statuses is therefore already represented on the
+     * {@code getCause()} chain. As a known limitation, a plain {@code MultiStatus} with no root
+     * exception contributes no cause clause, even when its children contain additional detail.
      *
      * <p>This method returns only the diagnosis. A caller that displays both messages should compose
      * English prose such as {@code describe(failure) + " Caused by: " + rootCause(failure)}.
@@ -167,46 +158,44 @@ public final class PlatformFailures
             return ""; //$NON-NLS-1$
         }
         String selected = describe(failure);
-        FailureMessage deepest = null;
-        ArrayDeque<ThrowableHop> pending = new ArrayDeque<ThrowableHop>();
-        IdentityHashMap<Throwable, Boolean> visitedThrowables =
-            new IdentityHashMap<Throwable, Boolean>();
-        pending.add(new ThrowableHop(failure, 0, 0));
-        visitedThrowables.put(failure, Boolean.TRUE);
-        while (!pending.isEmpty())
+        String deepest = ""; //$NON-NLS-1$
+        Throwable current = failure.getCause();
+        for (int depth = 1; current != null && depth < MAX_CAUSE_CHAIN_DEPTH; depth++)
         {
-            ThrowableHop hop = pending.remove();
-            if (hop.causalDepth > 0)
+            FailureMessage atHop = causalFailureMessageAt(current);
+            if (atHop != null)
             {
-                FailureMessage atHop = causalFailureMessageAt(hop.failure);
-                if (atHop != null && !selected.equals(atHop.message)
-                    && (deepest == null || hop.causalDepth > deepest.depth))
+                String candidate = formatted(atHop);
+                // Both forms are compared HERE, not after the walk: a deeper hop whose formatted
+                // text recreates the headline must be skipped, leaving the last distinct candidate
+                // standing, rather than replacing it and then being dropped as a repeat.
+                if (!selected.equals(atHop.message) && !selected.equals(candidate))
                 {
-                    deepest = new FailureMessage(atHop.message, atHop.source, hop.causalDepth);
+                    deepest = candidate;
                 }
             }
+            current = current.getCause();
+        }
+        return deepest;
+    }
 
-            Throwable directCause = hop.failure.getCause();
-            if (hop.causeDepth + 1 < MAX_CAUSE_CHAIN_DEPTH)
-            {
-                enqueue(directCause, hop.causalDepth + 1, hop.causeDepth + 1, pending,
-                    visitedThrowables);
-            }
-            enqueueStatusExceptions(statusOf(hop.failure), 0, hop.causalDepth + 1, directCause,
-                pending, visitedThrowables, new IdentityHashMap<IStatus, Integer>());
-        }
-        if (deepest == null)
+    /**
+     * The message with its exception type prefixed when a terminal exception genuinely owns a
+     * short generic text: "Auth fail" alone is not actionable, "com.jcraft.jsch.JSchException:
+     * Auth fail" is. Text selected from a status carries no wrapper provenance.
+     *
+     * @param message the selected message and its source (never {@code null})
+     * @return the text to present
+     */
+    private static String formatted(FailureMessage message)
+    {
+        if (message.source != null && message.source.getCause() == null
+            && message.message.equals(trimToNull(message.source.getMessage()))
+            && isShortGenericMessage(message.message))
         {
-            return ""; //$NON-NLS-1$
+            return message.source.getClass().getName() + ": " + message.message; //$NON-NLS-1$
         }
-        String formatted = deepest.message;
-        if (deepest.source != null && deepest.source.getCause() == null
-            && deepest.message.equals(trimToNull(deepest.source.getMessage()))
-            && isShortGenericMessage(deepest.message))
-        {
-            formatted = deepest.source.getClass().getName() + ": " + deepest.message; //$NON-NLS-1$
-        }
-        return selected.equals(formatted) ? "" : formatted; //$NON-NLS-1$
+        return message.message;
     }
 
     /** The exact per-hop display rule used by {@link #describe(Throwable)}. */
@@ -231,7 +220,7 @@ public final class PlatformFailures
             String fromChildren = statusMessage(status, 0, allowNonFailingChildren);
             if (fromChildren != null)
             {
-                return new FailureMessage(fromChildren, null, 0);
+                return new FailureMessage(fromChildren, null);
             }
         }
         String own = trimToNull(failure.getMessage());
@@ -239,67 +228,10 @@ public final class PlatformFailures
         {
             boolean copiedFromStatus = status != null
                 && own.equals(trimToNull(status.getMessage()));
-            return new FailureMessage(own, copiedFromStatus ? null : failure, 0);
+            return new FailureMessage(own, copiedFromStatus ? null : failure);
         }
         String fromStatus = statusMessage(status, 0, allowNonFailingChildren);
-        return fromStatus == null ? null : new FailureMessage(fromStatus, null, 0);
-    }
-
-    /** Adds a throwable once; status-attached exceptions start a fresh bounded cause chain. */
-    private static void enqueue(Throwable failure, int causalDepth, int causeDepth,
-            ArrayDeque<ThrowableHop> pending,
-            IdentityHashMap<Throwable, Boolean> visitedThrowables)
-    {
-        if (failure != null && visitedThrowables.put(failure, Boolean.TRUE) == null)
-        {
-            pending.add(new ThrowableHop(failure, causalDepth, causeDepth));
-        }
-    }
-
-    /** Finds exception edges in a bounded status aggregate; status messages are not candidates. */
-    private static void enqueueStatusExceptions(IStatus status, int statusDepth, int causalDepth,
-            Throwable directCause, ArrayDeque<ThrowableHop> pending,
-            IdentityHashMap<Throwable, Boolean> visitedThrowables,
-            IdentityHashMap<IStatus, Integer> visitedStatuses)
-    {
-        if (status == null || statusDepth > MAX_STATUS_DEPTH)
-        {
-            return;
-        }
-        Integer previousDepth = visitedStatuses.get(status);
-        if (previousDepth != null && previousDepth.intValue() <= statusDepth)
-        {
-            return;
-        }
-        visitedStatuses.put(status, Integer.valueOf(statusDepth));
-
-        IStatus[] children = status.getChildren();
-        if (children != null)
-        {
-            for (int pass = 0; pass < 2; pass++)
-            {
-                boolean failing = pass == 0;
-                for (IStatus child : children)
-                {
-                    if (child == null
-                        || child.matches(IStatus.ERROR | IStatus.CANCEL) != failing)
-                    {
-                        continue;
-                    }
-                    enqueueStatusExceptions(child, statusDepth + 1, causalDepth, directCause,
-                        pending, visitedThrowables, visitedStatuses);
-                }
-            }
-        }
-        Throwable statusException = status.getException();
-        // CoreException.getCause() is its status exception. It is the SAME cause-chain edge, even
-        // when the ordinary enqueue is stopped by the cap, so admitting it here with depth zero
-        // would make every tenth CoreException restart the documented bound. Genuinely different
-        // status exceptions still begin their own bounded chains.
-        if (statusException != directCause)
-        {
-            enqueue(statusException, causalDepth, 0, pending, visitedThrowables);
-        }
+        return fromStatus == null ? null : new FailureMessage(fromStatus, null);
     }
 
     /** Deterministic proxy for a terse generic message that benefits from its exception type. */
@@ -323,33 +255,16 @@ public final class PlatformFailures
         return words <= 4;
     }
 
-    /** Message plus the source/depth needed for deterministic terminal formatting. */
+    /** Message plus the source needed for deterministic terminal formatting. */
     private static final class FailureMessage
     {
         final String message;
         final Throwable source;
-        final int depth;
 
-        FailureMessage(String message, Throwable source, int depth)
+        FailureMessage(String message, Throwable source)
         {
             this.message = message;
             this.source = source;
-            this.depth = depth;
-        }
-    }
-
-    /** One causal throwable plus its result depth and position in the current getCause chain. */
-    private static final class ThrowableHop
-    {
-        final Throwable failure;
-        final int causalDepth;
-        final int causeDepth;
-
-        ThrowableHop(Throwable failure, int causalDepth, int causeDepth)
-        {
-            this.failure = failure;
-            this.causalDepth = causalDepth;
-            this.causeDepth = causeDepth;
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
@@ -39,6 +39,11 @@ import com.e1c.g5.dt.applications.ApplicationException;
  * it says so, naming the exception type and the status severity, because "CANCEL, no message" is
  * itself the diagnosis: something aborted the operation rather than failing it.
  *
+ * <p>{@link #rootCause(Throwable)} answers a separate, complementary question: after
+ * {@code describe} has selected the headline, what is the deepest distinct diagnosis in the same
+ * bounded failure walk? Callers that need both compose them explicitly; the root-cause helper does
+ * not change {@code describe}'s established selection rule.
+ *
  * <p>{@link #withoutObjectIdentity(String)} answers a SEPARATE question and is meant to be
  * COMPOSED with {@code describe}, never substituted for it. {@code describe} selects the most
  * informative message the failure carries, and that selection is exactly why it cannot cure a
@@ -133,6 +138,157 @@ public final class PlatformFailures
             current = current.getCause();
         }
         return describeTextless(failure);
+    }
+
+    /**
+     * The deepest diagnosis in the bounded failure walk, when it adds information to
+     * {@link #describe(Throwable)}.
+     *
+     * <p>The walk uses the same two bounded structures as {@code describe}: at most
+     * {@link #MAX_CAUSE_CHAIN_DEPTH} throwable hops, and at every hop the throwable's
+     * {@link IStatus} tree down to {@link #MAX_STATUS_DEPTH}. Within a status tree, greater
+     * structural depth wins; failing children are visited before informational ones, matching the
+     * preference used by {@link #statusMessage(IStatus, int)}. Cause-chain depth then wins over an
+     * earlier throwable hop. The bounds also stop cyclical throwable/status structures.
+     *
+     * <p>The raw deepest message is compared with {@code describe}'s selected message BEFORE any
+     * formatting. Equal text returns the empty string so a single-message failure is never repeated.
+     * When the deepest message is the own message of a terminal exception and is short enough to be
+     * generic (40 characters or fewer and no more than four whitespace-separated words), its fully
+     * qualified exception type is prefixed. Thus {@code Auth fail} becomes, for example,
+     * {@code com.jcraft.jsch.JSchException: Auth fail}; longer, self-explanatory platform prose is
+     * returned without a stack-dump-like type prefix.
+     *
+     * <p>This method returns only the diagnosis. A caller that displays both messages should compose
+     * English prose such as {@code describe(failure) + " Caused by: " + rootCause(failure)}.
+     *
+     * @param failure the exception to inspect (may be {@code null})
+     * @return the deepest distinct diagnosis, or the empty string when there is no additional text
+     */
+    public static String rootCause(Throwable failure)
+    {
+        if (failure == null)
+        {
+            return ""; //$NON-NLS-1$
+        }
+        String selected = describe(failure);
+        FailureMessage deepest = null;
+        Throwable current = failure;
+        for (int depth = 0; current != null && depth < MAX_CAUSE_CHAIN_DEPTH; depth++)
+        {
+            FailureMessage atHop = deepestMessageAt(current);
+            if (atHop != null)
+            {
+                deepest = atHop;
+            }
+            current = current.getCause();
+        }
+        if (deepest == null || selected.equals(deepest.message))
+        {
+            return ""; //$NON-NLS-1$
+        }
+        if (deepest.source != null && deepest.source.getCause() == null
+            && deepest.message.equals(trimToNull(deepest.source.getMessage()))
+            && isShortGenericMessage(deepest.message))
+        {
+            return deepest.source.getClass().getName() + ": " + deepest.message; //$NON-NLS-1$
+        }
+        return deepest.message;
+    }
+
+    /** Deepest message carried by one throwable hop, including its bounded status tree. */
+    private static FailureMessage deepestMessageAt(Throwable failure)
+    {
+        String own = trimToNull(failure.getMessage());
+        FailureMessage deepest = own == null ? null : new FailureMessage(own, failure, 0);
+        FailureMessage fromStatus = deepestStatusMessage(statusOf(failure), 0);
+        return deeper(deepest, fromStatus);
+    }
+
+    /** Deepest message in a bounded status tree; failing children win equal-depth ties. */
+    private static FailureMessage deepestStatusMessage(IStatus status, int depth)
+    {
+        if (status == null || depth > MAX_STATUS_DEPTH)
+        {
+            return null;
+        }
+        String own = trimToNull(status.getMessage());
+        FailureMessage deepest = own == null ? null : new FailureMessage(own, null, depth);
+        IStatus[] children = status.getChildren();
+        if (children != null)
+        {
+            deepest = deepestStatusChildren(children, depth, true, deepest);
+            deepest = deepestStatusChildren(children, depth, false, deepest);
+        }
+        Throwable carried = status.getException();
+        String carriedMessage = carried == null ? null : trimToNull(carried.getMessage());
+        if (carriedMessage != null)
+        {
+            deepest = deeper(deepest,
+                new FailureMessage(carriedMessage, carried, depth + 1));
+        }
+        return deepest;
+    }
+
+    /** Walks failing or non-failing child statuses without visiting either group twice. */
+    private static FailureMessage deepestStatusChildren(IStatus[] children, int depth,
+            boolean failing, FailureMessage deepest)
+    {
+        for (IStatus child : children)
+        {
+            if (child == null || child.matches(IStatus.ERROR | IStatus.CANCEL) != failing)
+            {
+                continue;
+            }
+            deepest = deeper(deepest, deepestStatusMessage(child, depth + 1));
+        }
+        return deepest;
+    }
+
+    /** Greater structural depth wins; the first visited candidate wins a tie. */
+    private static FailureMessage deeper(FailureMessage current, FailureMessage candidate)
+    {
+        if (candidate == null)
+        {
+            return current;
+        }
+        return current == null || candidate.depth > current.depth ? candidate : current;
+    }
+
+    /** Deterministic proxy for a terse generic message that benefits from its exception type. */
+    private static boolean isShortGenericMessage(String message)
+    {
+        if (message.length() > 40)
+        {
+            return false;
+        }
+        int words = 0;
+        boolean inWord = false;
+        for (int index = 0; index < message.length(); index++)
+        {
+            boolean whitespace = Character.isWhitespace(message.charAt(index));
+            if (!whitespace && !inWord)
+            {
+                words++;
+            }
+            inWord = !whitespace;
+        }
+        return words <= 4;
+    }
+
+    /** Message plus the source/depth needed for deterministic terminal formatting. */
+    private static final class FailureMessage
+    {
+        final String message;
+        final Throwable source;
+        final int depth;
+
+        FailureMessage(String message, Throwable source, int depth)
+        {
+            this.message = message;
+            this.source = source;
+            this.depth = depth;
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
@@ -6,6 +6,7 @@
 
 package com.ditrix.edt.mcp.server.utils;
 
+import java.util.IdentityHashMap;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -40,9 +41,11 @@ import com.e1c.g5.dt.applications.ApplicationException;
  * itself the diagnosis: something aborted the operation rather than failing it.
  *
  * <p>{@link #rootCause(Throwable)} answers a separate, complementary question: after
- * {@code describe} has selected the headline, what is the deepest distinct diagnosis in the same
- * bounded failure walk? Callers that need both compose them explicitly; the root-cause helper does
- * not change {@code describe}'s established selection rule.
+ * {@code describe} has selected the headline, what is the deepest distinct exception message
+ * provably below that exact source? Status messages are not root-cause candidates: their graph
+ * structure does not prove that an ancestor or sibling caused the selected headline. Callers that
+ * need both compose them explicitly; the root-cause helper does not change {@code describe}'s
+ * established selection rule.
  *
  * <p>{@link #withoutObjectIdentity(String)} answers a SEPARATE question and is meant to be
  * COMPOSED with {@code describe}, never substituted for it. {@code describe} selects the most
@@ -141,33 +144,29 @@ public final class PlatformFailures
     }
 
     /**
-     * The deepest diagnosis in the bounded failure walk, when it adds information to
-     * {@link #describe(Throwable)}.
+     * The deepest exception-owned diagnosis provably below {@link #describe(Throwable)}'s exact
+     * source, when it adds information to that headline.
      *
-     * <p>The walk uses the same two bounds as {@code describe}: the primary {@code getCause()}
-     * chain is capped at {@link #MAX_CAUSE_CHAIN_DEPTH} throwable hops, and the {@link IStatus}
-     * tree at every primary hop is capped at {@link #MAX_STATUS_DEPTH}. When an exception is
-     * attached anywhere in a status tree, its own {@code getCause()} chain uses that SAME cause
-     * cap, so a child status carrying
-     * {@code RuntimeException("SSH error", new JSchException("Auth fail"))} contributes the
-     * terminal {@code Auth fail} without opening an unbounded walk. Within a status tree, greater
-     * structural depth wins; failing children are visited before informational ones, matching the
-     * preference used by {@link #statusMessage(IStatus, int)}. Cause-chain depth then wins over an
-     * earlier throwable hop. The bounds also stop cyclical throwable/status structures.
+     * <p>The source lookup follows {@code describe}'s established preference without changing it.
+     * If the selected text came from a status message, this method returns the empty string: a
+     * status graph cannot prove that another status is its cause. If it came from an exception,
+     * only that exception's bounded {@code getCause()} chain is eligible. Status trees carried by
+     * later exceptions are inspected solely to find exception chains attached below that already
+     * established cause position; status messages themselves never become candidates.
      *
-     * <p>Messages equal to {@code describe}'s selected headline are excluded as diagnosis
-     * candidates throughout both structures. The deepest message that remains wins, so a repeated
-     * headline cannot displace a distinct diagnosis even when the repetition sits deeper in the
-     * status tree or later in the cause chain. The formatted result is compared with the headline
-     * again, because adding a type prefix can recreate a headline that differed from the raw
-     * candidate. When no distinct result remains, the empty string is returned so a single-message
-     * failure is never repeated. When the deepest distinct message is genuinely owned by a
-     * terminal exception and is short enough to be generic (40 characters or fewer and no more
-     * than four whitespace-separated words), its fully qualified exception type is prefixed. A
-     * platform wrapper's own message that merely copies its status text retains status provenance
-     * and is not attributed to the wrapper type. Thus an exception-owned {@code Auth fail} becomes,
-     * for example, {@code com.jcraft.jsch.JSchException: Auth fail}; longer, self-explanatory
-     * platform prose is returned without a stack-dump-like type prefix.
+     * <p>Every status identity is visited at most once during that discovery. This makes aliases
+     * and cycles linear in the number of stored statuses rather than multiplicative in the number
+     * of paths. Each exception chain remains capped at {@link #MAX_CAUSE_CHAIN_DEPTH}, and status
+     * discovery remains capped at {@link #MAX_STATUS_DEPTH}.
+     *
+     * <p>Messages equal to the selected headline are excluded. The formatted result is compared
+     * with the headline again, because adding a type prefix can recreate a headline that differed
+     * from the raw candidate. When no distinct result remains, the empty string is returned. A
+     * short generic message (40 characters or fewer and no more than four words) is prefixed only
+     * when a terminal exception genuinely owns it. A platform wrapper's message that merely copies
+     * its status text retains status provenance and is not attributed to the wrapper type. Thus a
+     * status-carried {@code RuntimeException("SSH error", new JSchException("Auth fail"))} still
+     * contributes {@code com.jcraft.jsch.JSchException: Auth fail}.
      *
      * <p>This method returns only the diagnosis. A caller that displays both messages should compose
      * English prose such as {@code describe(failure) + " Caused by: " + rootCause(failure)}.
@@ -182,17 +181,14 @@ public final class PlatformFailures
             return ""; //$NON-NLS-1$
         }
         String selected = describe(failure);
-        FailureMessage deepest = null;
-        Throwable current = failure;
-        for (int depth = 0; current != null && depth < MAX_CAUSE_CHAIN_DEPTH; depth++)
+        FailureMessage described = descriptionMessage(failure,
+            new IdentityHashMap<IStatus, Boolean>());
+        if (described == null || described.source == null || !selected.equals(described.message))
         {
-            FailureMessage atHop = deepestMessageAt(current, selected);
-            if (atHop != null)
-            {
-                deepest = atHop;
-            }
-            current = current.getCause();
+            return ""; //$NON-NLS-1$
         }
+        FailureMessage deepest = deepestExceptionMessages(described.source, selected,
+            new IdentityHashMap<IStatus, Boolean>());
         if (deepest == null)
         {
             return ""; //$NON-NLS-1$
@@ -207,12 +203,36 @@ public final class PlatformFailures
         return selected.equals(formatted) ? "" : formatted; //$NON-NLS-1$
     }
 
-    /** Deepest distinct message carried by one throwable hop and its bounded status tree. */
-    private static FailureMessage deepestMessageAt(Throwable failure, String selected)
+    /** Finds the exact message source selected by {@link #describe(Throwable)}. */
+    private static FailureMessage descriptionMessage(Throwable failure,
+            IdentityHashMap<IStatus, Boolean> visitedStatuses)
     {
-        FailureMessage deepest = ownFailureMessage(failure, 0, selected);
-        FailureMessage fromStatus = deepestStatusMessage(statusOf(failure), 0, selected);
-        return deeper(deepest, fromStatus);
+        Throwable current = failure;
+        for (int depth = 0; current != null && depth < MAX_CAUSE_CHAIN_DEPTH; depth++)
+        {
+            IStatus status = statusOf(current);
+            if (hasChildren(status))
+            {
+                FailureMessage fromChildren = descriptionStatusMessage(status, 0,
+                    visitedStatuses);
+                if (fromChildren != null)
+                {
+                    return fromChildren;
+                }
+            }
+            String own = trimToNull(current.getMessage());
+            if (own != null)
+            {
+                return new FailureMessage(own, current, depth);
+            }
+            FailureMessage fromStatus = descriptionStatusMessage(status, 0, visitedStatuses);
+            if (fromStatus != null)
+            {
+                return fromStatus;
+            }
+            current = current.getCause();
+        }
+        return null;
     }
 
     /**
@@ -233,61 +253,101 @@ public final class PlatformFailures
         return new FailureMessage(own, source, depth);
     }
 
-    /** Deepest distinct message in a bounded status tree; failing children win equal-depth ties. */
-    private static FailureMessage deepestStatusMessage(IStatus status, int depth, String selected)
+    /**
+     * Locates {@code describe}'s first status message. A status may expose its carried exception's
+     * message as its own; exact equality preserves that exception provenance without attributing
+     * unrelated status prose to it.
+     */
+    private static FailureMessage descriptionStatusMessage(IStatus status, int depth,
+            IdentityHashMap<IStatus, Boolean> visitedStatuses)
     {
-        if (status == null || depth > MAX_STATUS_DEPTH)
+        if (status == null || depth > MAX_STATUS_DEPTH
+            || visitedStatuses.put(status, Boolean.TRUE) != null)
         {
             return null;
         }
-        String own = trimToNull(status.getMessage());
-        FailureMessage deepest = own == null || selected.equals(own) ? null
-            : new FailureMessage(own, null, depth);
         IStatus[] children = status.getChildren();
         if (children != null)
         {
-            deepest = deepestStatusChildren(children, depth, true, deepest, selected);
-            deepest = deepestStatusChildren(children, depth, false, deepest, selected);
+            for (int pass = 0; pass < 2; pass++)
+            {
+                boolean failing = pass == 0;
+                for (IStatus child : children)
+                {
+                    if (child == null
+                        || child.matches(IStatus.ERROR | IStatus.CANCEL) != failing)
+                    {
+                        continue;
+                    }
+                    FailureMessage message = descriptionStatusMessage(child, depth + 1,
+                        visitedStatuses);
+                    if (message != null)
+                    {
+                        return message;
+                    }
+                }
+            }
         }
-        deepest = deeper(deepest,
-            deepestCarriedCauseMessage(status.getException(), depth + 1, selected));
-        return deepest;
+        Throwable carried = status.getException();
+        String own = trimToNull(status.getMessage());
+        if (own != null)
+        {
+            Throwable source = carried != null
+                && own.equals(trimToNull(carried.getMessage())) ? carried : null;
+            return new FailureMessage(own, source, depth);
+        }
+        String carriedMessage = carried == null ? null : trimToNull(carried.getMessage());
+        return carriedMessage == null ? null
+            : new FailureMessage(carriedMessage, carried, depth + 1);
     }
 
-    /**
-     * Deepest distinct own message in the cause chain of an exception attached to a status.
-     * Reuses the ordinary cause-chain cap rather than defining a child-specific bound; a cyclical
-     * carried chain therefore terminates under the same contract as the top-level chain.
-     */
-    private static FailureMessage deepestCarriedCauseMessage(Throwable failure, int depth,
-            String selected)
+    /** Deepest distinct exception message below the selected exception. */
+    private static FailureMessage deepestExceptionMessages(Throwable selectedSource,
+            String selected, IdentityHashMap<IStatus, Boolean> visitedStatuses)
     {
         FailureMessage deepest = null;
-        Throwable current = failure;
-        for (int causeDepth = 0; current != null && causeDepth < MAX_CAUSE_CHAIN_DEPTH;
-            causeDepth++)
+        Throwable current = selectedSource;
+        for (int depth = 0; current != null && depth < MAX_CAUSE_CHAIN_DEPTH; depth++)
         {
-            FailureMessage atHop = ownFailureMessage(current, depth + causeDepth, selected);
-            if (atHop != null)
+            FailureMessage atHop = ownFailureMessage(current, depth, selected);
+            deepest = deeper(deepest, atHop);
+            if (depth > 0)
             {
-                deepest = atHop;
+                deepest = deeper(deepest, deepestCarriedException(
+                    statusOf(current), 0, depth + 1, selected, visitedStatuses));
             }
             current = current.getCause();
         }
         return deepest;
     }
 
-    /** Walks failing or non-failing child statuses without visiting either group twice. */
-    private static FailureMessage deepestStatusChildren(IStatus[] children, int depth,
-            boolean failing, FailureMessage deepest, String selected)
+    /** Exception messages carried below a cause-chain hop; status messages are ignored. */
+    private static FailureMessage deepestCarriedException(IStatus status, int statusDepth,
+            int structuralDepth, String selected,
+            IdentityHashMap<IStatus, Boolean> visitedStatuses)
     {
-        for (IStatus child : children)
+        if (status == null || statusDepth > MAX_STATUS_DEPTH
+            || visitedStatuses.put(status, Boolean.TRUE) != null)
         {
-            if (child == null || child.matches(IStatus.ERROR | IStatus.CANCEL) != failing)
+            return null;
+        }
+        FailureMessage deepest = null;
+        Throwable carried = status.getException();
+        for (int causeDepth = 0; carried != null && causeDepth < MAX_CAUSE_CHAIN_DEPTH;
+            causeDepth++)
+        {
+            deepest = deeper(deepest,
+                ownFailureMessage(carried, structuralDepth + causeDepth, selected));
+            carried = carried.getCause();
+        }
+        IStatus[] children = status.getChildren();
+        if (children != null)
+        {
+            for (IStatus child : children)
             {
-                continue;
+                deepest = deeper(deepest, deepestCarriedException(child, statusDepth + 1,
+                    structuralDepth + 1, selected, visitedStatuses));
             }
-            deepest = deeper(deepest, deepestStatusMessage(child, depth + 1, selected));
         }
         return deepest;
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
@@ -139,11 +139,14 @@ public final class PlatformFailures
      * four words) is prefixed only when a terminal exception genuinely owns it. Text selected from a
      * status carries no wrapper provenance.
      *
-     * <p>{@link CoreException#getCause()} exposes the exception carried by its status. EDT aggregate
-     * statuses likewise synthesize their exception from failing children when they have no exception
-     * of their own. Any exception known to those statuses is therefore already represented on the
-     * {@code getCause()} chain. As a known limitation, a plain {@code MultiStatus} with no root
-     * exception contributes no cause clause, even when its children contain additional detail.
+     * <p>A status-carried failure still reaches this walk, by two separate routes.
+     * {@link ApplicationException}, the shape the update path actually throws, passes its status's
+     * exception to its own cause when built from an {@link IStatus}; {@link CoreException#getCause()}
+     * exposes the same edge for that shape. EDT aggregate statuses in turn synthesize their exception
+     * from failing children when they have none of their own, and the publishing path returns exactly
+     * such an aggregate. Any exception known to those statuses is therefore already represented on the
+     * {@code getCause()} chain. As a known limitation, a plain {@code MultiStatus} with no exception of
+     * its own contributes no cause clause, even when its children carry one.
      *
      * <p>This method returns only the diagnosis. A caller that displays both messages should compose
      * English prose such as {@code describe(failure) + " Caused by: " + rootCause(failure)}.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
@@ -132,16 +132,18 @@ public final class PlatformFailures
      * {@link #describe(Throwable)}'s headline.
      *
      * <p>The walk follows only {@link Throwable#getCause()} and {@link IStatus#getException()}
-     * edges. At each throwable hop, the message is selected by the same rule as {@code describe}:
-     * status children first when present (including the failing-child preference), then the
-     * throwable's own message, then the status fallback. A status tree therefore says what ONE
-     * causal hop means; structural depth within that aggregate never competes with causal depth.
+     * edges. At each throwable hop, failing status children come first, then the throwable's own
+     * message and status fallback. Unlike {@code describe}, causation never falls back to a
+     * non-failing aggregate child merely because it has text. A status tree therefore says what
+     * ONE causal hop means; structural depth within that aggregate never competes with causal depth.
      *
      * <p>Throwable identities are de-duplicated. Each ordinary or status-attached cause chain is
      * capped at {@link #MAX_CAUSE_CHAIN_DEPTH}, and discovery of attached exceptions is capped at
-     * {@link #MAX_STATUS_DEPTH}. Status aliases are revisited only when reached at a shallower depth,
-     * where the cap can expose children that were previously out of bounds. These rules terminate
-     * cyclic graphs without making the result depend on a deeper alias being visited first.
+     * {@link #MAX_STATUS_DEPTH}. A status exception identical to its current throwable's
+     * {@code getCause()} is the same edge and cannot restart that cause-chain cap. Status aliases are
+     * revisited only when reached at a shallower depth, where the cap can expose children that were
+     * previously out of bounds. These rules terminate cyclic graphs without making the result depend
+     * on a deeper alias being visited first.
      *
      * <p>Messages equal to the selected headline are excluded. The formatted result is compared
      * with the headline again, because adding a type prefix can recreate a headline that differed
@@ -176,7 +178,7 @@ public final class PlatformFailures
             ThrowableHop hop = pending.remove();
             if (hop.causalDepth > 0)
             {
-                FailureMessage atHop = failureMessageAt(hop.failure);
+                FailureMessage atHop = causalFailureMessageAt(hop.failure);
                 if (atHop != null && !selected.equals(atHop.message)
                     && (deepest == null || hop.causalDepth > deepest.depth))
                 {
@@ -184,13 +186,14 @@ public final class PlatformFailures
                 }
             }
 
+            Throwable directCause = hop.failure.getCause();
             if (hop.causeDepth + 1 < MAX_CAUSE_CHAIN_DEPTH)
             {
-                enqueue(hop.failure.getCause(), hop.causalDepth + 1, hop.causeDepth + 1,
-                    pending, visitedThrowables);
+                enqueue(directCause, hop.causalDepth + 1, hop.causeDepth + 1, pending,
+                    visitedThrowables);
             }
-            enqueueStatusExceptions(statusOf(hop.failure), 0, hop.causalDepth + 1, pending,
-                visitedThrowables, new IdentityHashMap<IStatus, Integer>());
+            enqueueStatusExceptions(statusOf(hop.failure), 0, hop.causalDepth + 1, directCause,
+                pending, visitedThrowables, new IdentityHashMap<IStatus, Integer>());
         }
         if (deepest == null)
         {
@@ -206,13 +209,26 @@ public final class PlatformFailures
         return selected.equals(formatted) ? "" : formatted; //$NON-NLS-1$
     }
 
-    /** The exact per-hop rule used by {@link #describe(Throwable)}, with message provenance. */
+    /** The exact per-hop display rule used by {@link #describe(Throwable)}. */
     private static FailureMessage failureMessageAt(Throwable failure)
+    {
+        return failureMessageAt(failure, true);
+    }
+
+    /** The per-hop causal rule: no unrelated non-failing child fallback. */
+    private static FailureMessage causalFailureMessageAt(Throwable failure)
+    {
+        return failureMessageAt(failure, false);
+    }
+
+    /** Shared per-hop selection, with message provenance. */
+    private static FailureMessage failureMessageAt(Throwable failure,
+            boolean allowNonFailingChildren)
     {
         IStatus status = statusOf(failure);
         if (hasChildren(status))
         {
-            String fromChildren = statusMessage(status, 0);
+            String fromChildren = statusMessage(status, 0, allowNonFailingChildren);
             if (fromChildren != null)
             {
                 return new FailureMessage(fromChildren, null, 0);
@@ -225,7 +241,7 @@ public final class PlatformFailures
                 && own.equals(trimToNull(status.getMessage()));
             return new FailureMessage(own, copiedFromStatus ? null : failure, 0);
         }
-        String fromStatus = statusMessage(status, 0);
+        String fromStatus = statusMessage(status, 0, allowNonFailingChildren);
         return fromStatus == null ? null : new FailureMessage(fromStatus, null, 0);
     }
 
@@ -242,7 +258,7 @@ public final class PlatformFailures
 
     /** Finds exception edges in a bounded status aggregate; status messages are not candidates. */
     private static void enqueueStatusExceptions(IStatus status, int statusDepth, int causalDepth,
-            ArrayDeque<ThrowableHop> pending,
+            Throwable directCause, ArrayDeque<ThrowableHop> pending,
             IdentityHashMap<Throwable, Boolean> visitedThrowables,
             IdentityHashMap<IStatus, Integer> visitedStatuses)
     {
@@ -270,12 +286,20 @@ public final class PlatformFailures
                     {
                         continue;
                     }
-                    enqueueStatusExceptions(child, statusDepth + 1, causalDepth, pending,
-                        visitedThrowables, visitedStatuses);
+                    enqueueStatusExceptions(child, statusDepth + 1, causalDepth, directCause,
+                        pending, visitedThrowables, visitedStatuses);
                 }
             }
         }
-        enqueue(status.getException(), causalDepth, 0, pending, visitedThrowables);
+        Throwable statusException = status.getException();
+        // CoreException.getCause() is its status exception. It is the SAME cause-chain edge, even
+        // when the ordinary enqueue is stopped by the cap, so admitting it here with depth zero
+        // would make every tenth CoreException restart the documented bound. Genuinely different
+        // status exceptions still begin their own bounded chains.
+        if (statusException != directCause)
+        {
+            enqueue(statusException, causalDepth, 0, pending, visitedThrowables);
+        }
     }
 
     /** Deterministic proxy for a terse generic message that benefits from its exception type. */
@@ -486,9 +510,12 @@ public final class PlatformFailures
      * @param children the child statuses (never {@code null})
      * @param depth the parent's recursion depth
      * @param failingOnly {@code true} to consider only failing children
+     * @param allowNonFailingChildren whether nested aggregates may use their display fallback
+     * @param visitedStatuses shallowest depth already visited for each status identity
      * @return the message, or {@code null} when none of the considered children carries one
      */
     private static String firstChildMessage(IStatus[] children, int depth, boolean failingOnly,
+            boolean allowNonFailingChildren,
             IdentityHashMap<IStatus, Integer> visitedStatuses)
     {
         for (IStatus child : children)
@@ -497,7 +524,8 @@ public final class PlatformFailures
             {
                 continue;
             }
-            String message = statusMessage(child, depth + 1, visitedStatuses);
+            String message = statusMessage(child, depth + 1, allowNonFailingChildren,
+                visitedStatuses);
             if (message != null)
             {
                 return message;
@@ -523,11 +551,18 @@ public final class PlatformFailures
      */
     static String statusMessage(IStatus status, int depth)
     {
-        return statusMessage(status, depth, new IdentityHashMap<IStatus, Integer>());
+        return statusMessage(status, depth, true);
+    }
+
+    /** Selects status text while optionally disabling display's non-failing child fallback. */
+    private static String statusMessage(IStatus status, int depth, boolean allowNonFailingChildren)
+    {
+        return statusMessage(status, depth, allowNonFailingChildren,
+            new IdentityHashMap<IStatus, Integer>());
     }
 
     /** Alias-aware implementation; a shallower path may expose children hidden by the depth cap. */
-    private static String statusMessage(IStatus status, int depth,
+    private static String statusMessage(IStatus status, int depth, boolean allowNonFailingChildren,
             IdentityHashMap<IStatus, Integer> visitedStatuses)
     {
         if (status == null || depth > MAX_STATUS_DEPTH)
@@ -547,18 +582,23 @@ public final class PlatformFailures
         IStatus[] children = status.getChildren();
         if (children != null)
         {
-            // FAILING children first: an aggregated EDT operation legitimately mixes informational
-            // or OK children with the one that failed, and a plain first-with-text rule could turn
-            // a database failure into an unrelated progress message.
-            String fromFailing = firstChildMessage(children, depth, true, visitedStatuses);
+            // "Failing" deliberately matches statusMessage's established display pass exactly:
+            // IStatus.matches(ERROR | CANCEL). Display and causation agree on that term; causation
+            // alone stops after this pass so an INFO/OK sibling cannot be presented as a cause.
+            String fromFailing = firstChildMessage(children, depth, true,
+                allowNonFailingChildren, visitedStatuses);
             if (fromFailing != null)
             {
                 return fromFailing;
             }
-            String fromAny = firstChildMessage(children, depth, false, visitedStatuses);
-            if (fromAny != null)
+            if (allowNonFailingChildren)
             {
-                return fromAny;
+                String fromAny = firstChildMessage(children, depth, false,
+                    allowNonFailingChildren, visitedStatuses);
+                if (fromAny != null)
+                {
+                    return fromAny;
+                }
             }
         }
         String own = trimToNull(status.getMessage());

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/PlatformFailures.java
@@ -41,11 +41,12 @@ import com.e1c.g5.dt.applications.ApplicationException;
  * itself the diagnosis: something aborted the operation rather than failing it.
  *
  * <p>{@link #rootCause(Throwable)} answers a separate, complementary question: after
- * {@code describe} has selected the headline, what is the deepest distinct exception message
- * provably below that exact source? Status messages are not root-cause candidates: their graph
- * structure does not prove that an ancestor or sibling caused the selected headline. Callers that
- * need both compose them explicitly; the root-cause helper does not change {@code describe}'s
- * established selection rule.
+ * {@code describe} has selected the headline, what is the deepest distinct message provably below
+ * that exact position? It tracks whether the headline came from a throwable or a particular status.
+ * Only deeper cause-chain hops, descendants of the selected status, and direct
+ * {@link IStatus#getException()} edges are eligible; status ancestors and unrelated siblings are
+ * not. Callers that need both compose them explicitly; the root-cause helper does not change
+ * {@code describe}'s established selection rule.
  *
  * <p>{@link #withoutObjectIdentity(String)} answers a SEPARATE question and is meant to be
  * COMPOSED with {@code describe}, never substituted for it. {@code describe} selects the most
@@ -144,15 +145,15 @@ public final class PlatformFailures
     }
 
     /**
-     * The deepest exception-owned diagnosis provably below {@link #describe(Throwable)}'s exact
-     * source, when it adds information to that headline.
+     * The deepest diagnosis provably below {@link #describe(Throwable)}'s exact source, when it adds
+     * information to that headline.
      *
      * <p>The source lookup follows {@code describe}'s established preference without changing it.
-     * If the selected text came from a status message, this method returns the empty string: a
-     * status graph cannot prove that another status is its cause. If it came from an exception,
-     * only that exception's bounded {@code getCause()} chain is eligible. Status trees carried by
-     * later exceptions are inspected solely to find exception chains attached below that already
-     * established cause position; status messages themselves never become candidates.
+     * If the selected text came from an exception, only deeper hops in that exception's bounded
+     * {@code getCause()} chain are eligible, including the complete status tree attached at each
+     * established deeper hop. If it came from a status, only that status's descendants and its
+     * direct {@code getException()} edge are eligible. This excludes every status ancestor and
+     * unrelated sibling while retaining exception-free detail below the selected position.
      *
      * <p>Every status identity is visited at most once during that discovery. This makes aliases
      * and cycles linear in the number of stored statuses rather than multiplicative in the number
@@ -183,12 +184,26 @@ public final class PlatformFailures
         String selected = describe(failure);
         FailureMessage described = descriptionMessage(failure,
             new IdentityHashMap<IStatus, Boolean>());
-        if (described == null || described.source == null || !selected.equals(described.message))
+        if (described == null || !selected.equals(described.message))
         {
             return ""; //$NON-NLS-1$
         }
-        FailureMessage deepest = deepestExceptionMessages(described.source, selected,
-            new IdentityHashMap<IStatus, Boolean>());
+        IdentityHashMap<IStatus, Boolean> visitedStatuses =
+            new IdentityHashMap<IStatus, Boolean>();
+        FailureMessage deepest;
+        if (described.statusSource != null)
+        {
+            deepest = deepestBelowSelectedStatus(described.statusSource, described.depth, selected,
+                visitedStatuses);
+        }
+        else if (described.source != null)
+        {
+            deepest = deepestBelowSelectedException(described.source, selected, visitedStatuses);
+        }
+        else
+        {
+            return ""; //$NON-NLS-1$
+        }
         if (deepest == null)
         {
             return ""; //$NON-NLS-1$
@@ -223,7 +238,10 @@ public final class PlatformFailures
             String own = trimToNull(current.getMessage());
             if (own != null)
             {
-                return new FailureMessage(own, current, depth);
+                IStatus sourceStatus = status != null
+                    && own.equals(trimToNull(status.getMessage())) ? status : null;
+                return new FailureMessage(own, sourceStatus == null ? current : null,
+                    sourceStatus, depth);
             }
             FailureMessage fromStatus = descriptionStatusMessage(status, 0, visitedStatuses);
             if (fromStatus != null)
@@ -248,15 +266,16 @@ public final class PlatformFailures
             return null;
         }
         IStatus status = statusOf(failure);
-        Throwable source = status != null && own.equals(trimToNull(status.getMessage()))
-            ? null : failure;
-        return new FailureMessage(own, source, depth);
+        boolean copiedFromStatus = status != null
+            && own.equals(trimToNull(status.getMessage()));
+        return new FailureMessage(own, copiedFromStatus ? null : failure,
+            copiedFromStatus ? status : null, depth);
     }
 
     /**
-     * Locates {@code describe}'s first status message. A status may expose its carried exception's
-     * message as its own; exact equality preserves that exception provenance without attributing
-     * unrelated status prose to it.
+     * Locates {@code describe}'s first status message and records the exact status identity that
+     * supplied it. A carried exception is recorded only when the status itself is blank and
+     * {@code describe} therefore falls through to that exception's own message.
      */
     private static FailureMessage descriptionStatusMessage(IStatus status, int depth,
             IdentityHashMap<IStatus, Boolean> visitedStatuses)
@@ -292,37 +311,62 @@ public final class PlatformFailures
         String own = trimToNull(status.getMessage());
         if (own != null)
         {
-            Throwable source = carried != null
-                && own.equals(trimToNull(carried.getMessage())) ? carried : null;
-            return new FailureMessage(own, source, depth);
+            return new FailureMessage(own, null, status, depth);
         }
         String carriedMessage = carried == null ? null : trimToNull(carried.getMessage());
         return carriedMessage == null ? null
-            : new FailureMessage(carriedMessage, carried, depth + 1);
+            : new FailureMessage(carriedMessage, carried, null, depth + 1);
     }
 
-    /** Deepest distinct exception message below the selected exception. */
-    private static FailureMessage deepestExceptionMessages(Throwable selectedSource,
+    /** Deepest distinct message below the selected exception's exact cause-chain position. */
+    private static FailureMessage deepestBelowSelectedException(Throwable selectedSource,
             String selected, IdentityHashMap<IStatus, Boolean> visitedStatuses)
     {
         FailureMessage deepest = null;
         Throwable current = selectedSource;
         for (int depth = 0; current != null && depth < MAX_CAUSE_CHAIN_DEPTH; depth++)
         {
-            FailureMessage atHop = ownFailureMessage(current, depth, selected);
-            deepest = deeper(deepest, atHop);
             if (depth > 0)
             {
-                deepest = deeper(deepest, deepestCarriedException(
-                    statusOf(current), 0, depth + 1, selected, visitedStatuses));
+                deepest = deeper(deepest, ownFailureMessage(current, depth, selected));
+                deepest = deeper(deepest, deepestEligibleStatus(statusOf(current), 0,
+                    depth, selected, visitedStatuses));
             }
             current = current.getCause();
         }
         return deepest;
     }
 
-    /** Exception messages carried below a cause-chain hop; status messages are ignored. */
-    private static FailureMessage deepestCarriedException(IStatus status, int statusDepth,
+    /**
+     * Deepest candidate below a selected status. The status itself is only an anchor: its own
+     * message is the headline and is not reconsidered. Its exception and child statuses are direct
+     * downward edges; ancestors and siblings are unreachable from here by construction.
+     */
+    private static FailureMessage deepestBelowSelectedStatus(IStatus selectedStatus,
+            int selectedStatusDepth, String selected,
+            IdentityHashMap<IStatus, Boolean> visitedStatuses)
+    {
+        if (selectedStatus == null || selectedStatusDepth > MAX_STATUS_DEPTH
+            || visitedStatuses.put(selectedStatus, Boolean.TRUE) != null)
+        {
+            return null;
+        }
+        FailureMessage deepest = deepestThrowableChain(selectedStatus.getException(), 1,
+            selected, visitedStatuses);
+        IStatus[] children = selectedStatus.getChildren();
+        if (children != null)
+        {
+            for (IStatus child : children)
+            {
+                deepest = deeper(deepest, deepestEligibleStatus(child,
+                    selectedStatusDepth + 1, 1, selected, visitedStatuses));
+            }
+        }
+        return deepest;
+    }
+
+    /** All status and exception messages below an already established causal position. */
+    private static FailureMessage deepestEligibleStatus(IStatus status, int statusDepth,
             int structuralDepth, String selected,
             IdentityHashMap<IStatus, Boolean> visitedStatuses)
     {
@@ -331,25 +375,46 @@ public final class PlatformFailures
         {
             return null;
         }
-        FailureMessage deepest = null;
-        Throwable carried = status.getException();
-        for (int causeDepth = 0; carried != null && causeDepth < MAX_CAUSE_CHAIN_DEPTH;
-            causeDepth++)
-        {
-            deepest = deeper(deepest,
-                ownFailureMessage(carried, structuralDepth + causeDepth, selected));
-            carried = carried.getCause();
-        }
+        FailureMessage deepest = statusFailureMessage(status, structuralDepth, selected);
+        deepest = deeper(deepest, deepestThrowableChain(status.getException(),
+            structuralDepth + 1, selected, visitedStatuses));
         IStatus[] children = status.getChildren();
         if (children != null)
         {
             for (IStatus child : children)
             {
-                deepest = deeper(deepest, deepestCarriedException(child, statusDepth + 1,
+                deepest = deeper(deepest, deepestEligibleStatus(child, statusDepth + 1,
                     structuralDepth + 1, selected, visitedStatuses));
             }
         }
         return deepest;
+    }
+
+    /** Deepest message in a direct status-exception edge and its bounded cause chain. */
+    private static FailureMessage deepestThrowableChain(Throwable start, int structuralDepth,
+            String selected, IdentityHashMap<IStatus, Boolean> visitedStatuses)
+    {
+        FailureMessage deepest = null;
+        Throwable current = start;
+        for (int causeDepth = 0; current != null && causeDepth < MAX_CAUSE_CHAIN_DEPTH;
+            causeDepth++)
+        {
+            int candidateDepth = structuralDepth + causeDepth;
+            deepest = deeper(deepest,
+                ownFailureMessage(current, candidateDepth, selected));
+            deepest = deeper(deepest, deepestEligibleStatus(statusOf(current), 0,
+                candidateDepth, selected, visitedStatuses));
+            current = current.getCause();
+        }
+        return deepest;
+    }
+
+    /** A status-owned candidate never borrows the type of an exception it happens to carry. */
+    private static FailureMessage statusFailureMessage(IStatus status, int depth, String selected)
+    {
+        String own = trimToNull(status.getMessage());
+        return own == null || selected.equals(own) ? null
+            : new FailureMessage(own, null, status, depth);
     }
 
     /** Greater structural depth wins; the first visited candidate wins a tie. */
@@ -388,12 +453,14 @@ public final class PlatformFailures
     {
         final String message;
         final Throwable source;
+        final IStatus statusSource;
         final int depth;
 
-        FailureMessage(String message, Throwable source, int depth)
+        FailureMessage(String message, Throwable source, IStatus statusSource, int depth)
         {
             this.message = message;
             this.source = source;
+            this.statusSource = statusSource;
             this.depth = depth;
         }
     }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/META-INF/MANIFEST.MF
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Fragment-Host: com.ditrix.edt.mcp.server;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: com.ditrix.edt.mcp.server.tests
 Import-Package: com._1c.g5.v8.dt.dcs.typedvalue,
+ com.jcraft.jsch,
  org.junit;version="4.13.0",
  org.junit.runner;version="4.13.0",
  org.junit.runners;version="4.13.0",

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/LaunchToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/LaunchToolTest.java
@@ -415,7 +415,12 @@ public class LaunchToolTest
         assertNotNull(error);
         assertTrue(error.contains(name));
         assertTrue(error.contains(STANDALONE_SERVER_TYPE_ID));
-        assertTrue(error.contains("debug_launch starts runtime CLIENT configurations")); //$NON-NLS-1$
+        assertTrue(error.contains(". " + LaunchTool.NAME //$NON-NLS-1$
+            + " starts runtime CLIENT configurations")); //$NON-NLS-1$
+        assertTrue(error.contains("Try " + LaunchTool.NAME //$NON-NLS-1$
+            + " with the project's thin-client configuration")); //$NON-NLS-1$
+        assertFalse("the refusal must not name the unadvertised legacy alias: " + error, //$NON-NLS-1$
+            error.contains("debug_launch")); //$NON-NLS-1$
         assertTrue(error.contains("thin-client configuration")); //$NON-NLS-1$
         // The workaround is stated as OBSERVED, not guaranteed: it is the issue reporter's
         // measurement on one workspace, and the platform sources do not show a client launch
@@ -424,7 +429,7 @@ public class LaunchToolTest
         assertTrue(error, error.contains("observed to bring its standalone server up")); //$NON-NLS-1$
         assertFalse("the workaround must not be promised as a guaranteed side effect: " + error, //$NON-NLS-1$
             error.contains("starts its standalone server as a side effect")); //$NON-NLS-1$
-        assertTrue(error.contains("terminate_launch")); //$NON-NLS-1$
+        assertTrue(error.contains(TerminateLaunchTool.NAME));
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/LaunchToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/LaunchToolTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -33,6 +34,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.model.IDebugTarget;
 import org.eclipse.debug.core.model.IThread;
@@ -42,6 +44,7 @@ import org.mockito.Mockito;
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 import com.ditrix.edt.mcp.server.tools.impl.LaunchTool.AlreadyRunningContext;
 import com.ditrix.edt.mcp.server.utils.ExternalInfobaseChangesPolicy;
+import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
 import com.ditrix.edt.mcp.server.utils.LaunchLifecycleUtils.ExistingClientSession;
 import com.e1c.g5.dt.applications.ApplicationUpdateState;
 import com.e1c.g5.dt.applications.ApplicationUpdateType;
@@ -70,6 +73,40 @@ import com.google.gson.JsonParser;
  */
 public class LaunchToolTest
 {
+    private static final String STANDALONE_SERVER_TYPE_ID =
+        "com.e1c.g5.v8.dt.platform.standaloneserver.launchConfigurationType"; //$NON-NLS-1$
+
+    /** Reflective baseline-safe access to the new by-name resolution seam. */
+    private static Object resolveNamedConfiguration(ILaunchManager launchManager, String name)
+    {
+        try
+        {
+            Method method = LaunchTool.class.getDeclaredMethod(
+                "resolveNamedConfiguration", ILaunchManager.class, String.class); //$NON-NLS-1$
+            method.setAccessible(true);
+            return method.invoke(null, launchManager, name);
+        }
+        catch (ReflectiveOperationException e)
+        {
+            throw new AssertionError("the by-name configuration resolution seam is missing or unusable", e); //$NON-NLS-1$
+        }
+    }
+
+    /** Reads one no-argument accessor from the by-name resolution result. */
+    private static Object namedResolutionValue(Object resolution, String accessor)
+    {
+        try
+        {
+            Method method = resolution.getClass().getDeclaredMethod(accessor);
+            method.setAccessible(true);
+            return method.invoke(resolution);
+        }
+        catch (ReflectiveOperationException e)
+        {
+            throw new AssertionError("named-resolution accessor is missing: " + accessor, e); //$NON-NLS-1$
+        }
+    }
+
     @Test
     public void testName()
     {
@@ -348,6 +385,68 @@ public class LaunchToolTest
         params.put("projectName", "MyProject"); //$NON-NLS-1$ //$NON-NLS-2$
         String result = new LaunchTool().execute(params);
         assertTrue(result.contains("applicationId is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testStandaloneServerConfigurationGetsAnHonestRefusal() throws Exception
+    {
+        String name = "Standalone server for B"; //$NON-NLS-1$
+        assertEquals(STANDALONE_SERVER_TYPE_ID, LaunchConfigUtils.class
+            .getField("STANDALONE_SERVER_LAUNCH_CONFIG_TYPE_ID").get(null)); //$NON-NLS-1$
+        ILaunchManager launchManager = mock(ILaunchManager.class);
+        ILaunchConfigurationType runtimeType = mock(ILaunchConfigurationType.class);
+        ILaunchConfigurationType standaloneType = mock(ILaunchConfigurationType.class);
+        ILaunchConfiguration standalone = mock(ILaunchConfiguration.class);
+        when(launchManager.getLaunchConfigurationType(LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID))
+            .thenReturn(runtimeType);
+        when(launchManager.getLaunchConfigurations(runtimeType))
+            .thenReturn(new ILaunchConfiguration[0]);
+        when(launchManager.getLaunchConfigurationType(STANDALONE_SERVER_TYPE_ID))
+            .thenReturn(standaloneType);
+        when(launchManager.getLaunchConfigurations(standaloneType))
+            .thenReturn(new ILaunchConfiguration[] { standalone });
+        when(standalone.getName()).thenReturn(name);
+        when(standalone.getType()).thenReturn(standaloneType);
+        when(standaloneType.getIdentifier()).thenReturn(STANDALONE_SERVER_TYPE_ID);
+
+        Object resolution = resolveNamedConfiguration(launchManager, name);
+        String error = (String)namedResolutionValue(resolution, "error"); //$NON-NLS-1$
+
+        assertNotNull(error);
+        assertTrue(error.contains(name));
+        assertTrue(error.contains(STANDALONE_SERVER_TYPE_ID));
+        assertTrue(error.contains("debug_launch starts runtime CLIENT configurations")); //$NON-NLS-1$
+        assertTrue(error.contains("thin-client configuration")); //$NON-NLS-1$
+        // The workaround is stated as OBSERVED, not guaranteed: it is the issue reporter's
+        // measurement on one workspace, and the platform sources do not show a client launch
+        // starting the server. Promising it outright would repeat, in the fix, the very defect
+        // this issue is about - a tool asserting more than it knows.
+        assertTrue(error, error.contains("observed to bring its standalone server up")); //$NON-NLS-1$
+        assertFalse("the workaround must not be promised as a guaranteed side effect: " + error, //$NON-NLS-1$
+            error.contains("starts its standalone server as a side effect")); //$NON-NLS-1$
+        assertTrue(error.contains("terminate_launch")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRuntimeClientConfigurationResolutionIsUnaffected() throws Exception
+    {
+        String name = "B Thin Client"; //$NON-NLS-1$
+        ILaunchManager launchManager = mock(ILaunchManager.class);
+        ILaunchConfigurationType runtimeType = mock(ILaunchConfigurationType.class);
+        ILaunchConfiguration runtime = mock(ILaunchConfiguration.class);
+        when(launchManager.getLaunchConfigurationType(LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID))
+            .thenReturn(runtimeType);
+        when(launchManager.getLaunchConfigurations(runtimeType))
+            .thenReturn(new ILaunchConfiguration[] { runtime });
+        when(runtime.getName()).thenReturn(name);
+
+        Object resolution = resolveNamedConfiguration(launchManager, name);
+
+        assertSame("the existing runtime-client lookup result must flow through unchanged", runtime, //$NON-NLS-1$
+            namedResolutionValue(resolution, "config")); //$NON-NLS-1$
+        assertNull(namedResolutionValue(resolution, "error")); //$NON-NLS-1$
+        verify(launchManager, never()).getLaunchConfigurationType(
+            STANDALONE_SERVER_TYPE_ID);
     }
 
     // ==================== performLaunch headless routing ====================

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/SetInfobaseCredentialsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/SetInfobaseCredentialsToolTest.java
@@ -310,6 +310,32 @@ public class SetInfobaseCredentialsToolTest
             success.contains("project-default application 'app-derived' was derived for project 'B'")); //$NON-NLS-1$
     }
 
+    @Test
+    public void testUnreadableApplicationBindingIsRefusedWithoutDerivation() throws CoreException
+    {
+        String configName = "B Thin Client"; //$NON-NLS-1$
+        ILaunchConfiguration config = runtimeConfig(configName, "B", "app-other"); //$NON-NLS-1$ //$NON-NLS-2$
+        when(config.getAttribute(LaunchConfigUtils.ATTR_APPLICATION_ID, "")) //$NON-NLS-1$
+            .thenThrow(new CoreException(new Status(IStatus.ERROR,
+                "com.ditrix.edt.mcp.server.tests", "attribute store is unreadable"))); //$NON-NLS-1$ //$NON-NLS-2$
+        AtomicBoolean derived = new AtomicBoolean();
+
+        Object resolution = resolveLaunchTarget(config, (cfg, project) ->
+        {
+            derived.set(true);
+            return "app-wrong"; //$NON-NLS-1$
+        });
+        String error = (String)resolutionValue(resolution, "error"); //$NON-NLS-1$
+
+        assertFalse("an unreadable binding must never be treated as an absent one", derived.get()); //$NON-NLS-1$
+        assertNotNull("the credential target must be refused before any write", error); //$NON-NLS-1$
+        assertTrue(error.contains("binding could not be read")); //$NON-NLS-1$
+        assertTrue(error.contains(configName));
+        assertTrue(error.contains("pass projectName + applicationId explicitly")); //$NON-NLS-1$
+        assertNull("a refused resolution exposes no configuration to the client writer", //$NON-NLS-1$
+            resolutionValue(resolution, "config")); //$NON-NLS-1$
+    }
+
     // ==================== Pure storeOutcome seam (no live EDT, no jobs framework) ====================
 
     /** A representative SUCCESS JSON the bounded Job records the instant updateSettings commits. */

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/SetInfobaseCredentialsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/SetInfobaseCredentialsToolTest.java
@@ -245,9 +245,10 @@ public class SetInfobaseCredentialsToolTest
     }
 
     @Test
-    public void testLaunchTargetNamesOnlyTheMissingProjectAttribute() throws CoreException
+    public void testMissingProjectBindingKeepsRebindRecommendation() throws CoreException
     {
-        ILaunchConfiguration config = runtimeConfig("B Thin Client", "", "app-b"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        String configName = "B Thin Client"; //$NON-NLS-1$
+        ILaunchConfiguration config = runtimeConfig(configName, "", "app-b"); //$NON-NLS-1$ //$NON-NLS-2$
         Object resolution = resolveLaunchTarget(config, (cfg, project) ->
         {
             fail("application resolution must not run without a project"); //$NON-NLS-1$
@@ -255,10 +256,32 @@ public class SetInfobaseCredentialsToolTest
         });
         String error = (String)resolutionValue(resolution, "error"); //$NON-NLS-1$
 
-        assertTrue(error.contains("ATTR_PROJECT_NAME")); //$NON-NLS-1$
-        assertFalse(error.contains("missing ATTR_APPLICATION_ID")); //$NON-NLS-1$
-        assertTrue(error.contains("project=''")); //$NON-NLS-1$
-        assertTrue(error.contains("applicationId='app-b'")); //$NON-NLS-1$
+        assertEquals("{\"success\":false,\"error\":\"Launch configuration '" + configName //$NON-NLS-1$
+            + "' is missing ATTR_PROJECT_NAME (read project='', applicationId='app-b') — cannot " //$NON-NLS-1$
+            + "derive the target. Bind it to a project in EDT, or pass projectName + applicationId " //$NON-NLS-1$
+            + "explicitly.\"}", error); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testUnreadableProjectBindingIsRefusedWithoutRebindRecommendation() throws CoreException
+    {
+        String configName = "B Thin Client"; //$NON-NLS-1$
+        ILaunchConfiguration config = runtimeConfig(configName, "B", "app-other"); //$NON-NLS-1$ //$NON-NLS-2$
+        when(config.getAttribute(LaunchConfigUtils.ATTR_PROJECT_NAME, "")) //$NON-NLS-1$
+            .thenThrow(new CoreException(new Status(IStatus.ERROR,
+                "com.ditrix.edt.mcp.server.tests", "attribute store is unreadable"))); //$NON-NLS-1$ //$NON-NLS-2$
+
+        Object resolution = resolveLaunchTarget(config, (cfg, project) -> "app-wrong"); //$NON-NLS-1$
+        String error = (String)resolutionValue(resolution, "error"); //$NON-NLS-1$
+
+        assertEquals("{\"success\":false,\"error\":\"The project binding could not be read from " //$NON-NLS-1$
+            + "launch configuration '" + configName //$NON-NLS-1$
+            + "' — refusing to derive a credential target. " //$NON-NLS-1$
+            + "Fix the configuration, or pass projectName + applicationId explicitly.\"}", error); //$NON-NLS-1$
+        assertFalse("an unreadable binding must not be reported as missing", //$NON-NLS-1$
+            error.contains("is missing ATTR_PROJECT_NAME")); //$NON-NLS-1$
+        assertFalse("an unreadable binding must not recommend rebinding it", //$NON-NLS-1$
+            error.contains("Bind it to a project in EDT")); //$NON-NLS-1$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/SetInfobaseCredentialsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/SetInfobaseCredentialsToolTest.java
@@ -7,6 +7,7 @@
 package com.ditrix.edt.mcp.server.tools.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -20,6 +21,7 @@ import static org.mockito.Mockito.when;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -29,6 +31,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -36,6 +39,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.junit.Test;
 
@@ -60,6 +64,52 @@ import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
  */
 public class SetInfobaseCredentialsToolTest
 {
+    /** Reflective baseline-safe access to the new launch-target resolution seam. */
+    private static Object resolveLaunchTarget(ILaunchConfiguration config,
+            BiFunction<ILaunchConfiguration, String, String> applicationIdResolver)
+    {
+        try
+        {
+            Method method = SetInfobaseCredentialsTool.class.getDeclaredMethod(
+                "resolveLaunchConfigTarget", ILaunchConfiguration.class, BiFunction.class); //$NON-NLS-1$
+            method.setAccessible(true);
+            return method.invoke(null, config, applicationIdResolver);
+        }
+        catch (ReflectiveOperationException e)
+        {
+            throw new AssertionError("the launch-target resolution seam is missing or unusable", e); //$NON-NLS-1$
+        }
+    }
+
+    /** Reads one no-argument accessor from the target-resolution result. */
+    private static Object resolutionValue(Object resolution, String accessor)
+    {
+        try
+        {
+            Method method = resolution.getClass().getDeclaredMethod(accessor);
+            method.setAccessible(true);
+            return method.invoke(resolution);
+        }
+        catch (ReflectiveOperationException e)
+        {
+            throw new AssertionError("target-resolution accessor is missing: " + accessor, e); //$NON-NLS-1$
+        }
+    }
+
+    /** Runtime-client config with exactly the two target attributes under test. */
+    private static ILaunchConfiguration runtimeConfig(String name, String project,
+            String applicationId) throws CoreException
+    {
+        ILaunchConfiguration config = mock(ILaunchConfiguration.class);
+        ILaunchConfigurationType type = mock(ILaunchConfigurationType.class);
+        when(config.getName()).thenReturn(name);
+        when(config.getType()).thenReturn(type);
+        when(type.getIdentifier()).thenReturn(LaunchConfigUtils.LAUNCH_CONFIG_TYPE_ID);
+        when(config.getAttribute(LaunchConfigUtils.ATTR_PROJECT_NAME, "")).thenReturn(project); //$NON-NLS-1$
+        when(config.getAttribute(LaunchConfigUtils.ATTR_APPLICATION_ID, "")).thenReturn(applicationId); //$NON-NLS-1$
+        return config;
+    }
+
     @Test
     public void testName()
     {
@@ -192,6 +242,72 @@ public class SetInfobaseCredentialsToolTest
         assertNotNull(result);
         assertTrue("missing applicationId must produce an error", //$NON-NLS-1$
             result.contains("applicationId is required")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testLaunchTargetNamesOnlyTheMissingProjectAttribute() throws CoreException
+    {
+        ILaunchConfiguration config = runtimeConfig("B Thin Client", "", "app-b"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        Object resolution = resolveLaunchTarget(config, (cfg, project) ->
+        {
+            fail("application resolution must not run without a project"); //$NON-NLS-1$
+            return null;
+        });
+        String error = (String)resolutionValue(resolution, "error"); //$NON-NLS-1$
+
+        assertTrue(error.contains("ATTR_PROJECT_NAME")); //$NON-NLS-1$
+        assertFalse(error.contains("missing ATTR_APPLICATION_ID")); //$NON-NLS-1$
+        assertTrue(error.contains("project=''")); //$NON-NLS-1$
+        assertTrue(error.contains("applicationId='app-b'")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testLaunchTargetNamesOnlyTheMissingApplicationIdAttribute() throws CoreException
+    {
+        ILaunchConfiguration config = runtimeConfig("B Thin Client", "B", ""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        Object resolution = resolveLaunchTarget(config, (cfg, project) -> null);
+        String error = (String)resolutionValue(resolution, "error"); //$NON-NLS-1$
+
+        assertTrue(error.contains("ATTR_APPLICATION_ID")); //$NON-NLS-1$
+        assertFalse(error.contains("missing ATTR_PROJECT_NAME")); //$NON-NLS-1$
+        assertTrue(error.contains("project='B'")); //$NON-NLS-1$
+        assertTrue(error.contains("applicationId=''")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSyntheticDerivedApplicationIdIsStillRefused() throws CoreException
+    {
+        String configName = "B Thin Client"; //$NON-NLS-1$
+        ILaunchConfiguration config = runtimeConfig(configName, "B", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        Object resolution = resolveLaunchTarget(config,
+            (cfg, project) -> LaunchConfigUtils.LAUNCH_APP_ID_PREFIX + configName);
+        String error = (String)resolutionValue(resolution, "error"); //$NON-NLS-1$
+
+        assertNotNull("a debug-tracking id must not be passed to IApplicationManager", error); //$NON-NLS-1$
+        assertTrue(error.contains("could not derive a project-default application")); //$NON-NLS-1$
+        assertTrue(error.contains("launch:" + configName)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testApplicationIdIsDerivedAndReportedWhenOnlyProjectIsPersisted() throws Exception
+    {
+        ILaunchConfiguration config = runtimeConfig("B Thin Client", "B", ""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        Object resolution = resolveLaunchTarget(config, (cfg, project) -> "app-derived"); //$NON-NLS-1$
+
+        assertNull(resolutionValue(resolution, "error")); //$NON-NLS-1$
+        assertEquals("B", resolutionValue(resolution, "projectName")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("app-derived", resolutionValue(resolution, "applicationId")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(Boolean.TRUE, resolutionValue(resolution, "derivedApplicationId")); //$NON-NLS-1$
+
+        Method buildSuccess = SetInfobaseCredentialsTool.class.getDeclaredMethod("buildSuccess", //$NON-NLS-1$
+            String.class, String.class, boolean.class, String.class, String.class,
+            boolean.class, InfobaseAccess.class, String.class, String.class);
+        buildSuccess.setAccessible(true);
+        String success = (String)buildSuccess.invoke(null, "B", "app-derived", true, //$NON-NLS-1$ //$NON-NLS-2$
+            "Infobase B", "Admin", true, InfobaseAccess.INFOBASE, //$NON-NLS-1$ //$NON-NLS-2$
+            "B Thin Client", null); //$NON-NLS-1$
+        assertTrue("the caller must see exactly which application the tool derived", //$NON-NLS-1$
+            success.contains("project-default application 'app-derived' was derived for project 'B'")); //$NON-NLS-1$
     }
 
     // ==================== Pure storeOutcome seam (no live EDT, no jobs framework) ====================

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
@@ -520,6 +520,24 @@ public class UpdateDatabaseToolTest
             error.contains("Caused by")); //$NON-NLS-1$
     }
 
+    @Test
+    public void testApplicationFailureDoesNotReverseMultiStatusParentAndChild()
+    {
+        MultiStatus status = new MultiStatus(STATUS_PLUGIN_ID, 0,
+            "Database update failed", null); //$NON-NLS-1$
+        status.add(new Status(IStatus.ERROR, STATUS_PLUGIN_ID, "Auth fail")); //$NON-NLS-1$
+        String error = JsonParser.parseString(UpdateDatabaseTool.buildApplicationErrorResult(
+            new ApplicationException(status), "ProjectB", "app-b", false)).getAsJsonObject() //$NON-NLS-1$ //$NON-NLS-2$
+            .get("error").getAsString(); //$NON-NLS-1$
+
+        assertTrue("the child remains the selected headline: " + error, //$NON-NLS-1$
+            error.startsWith("Database update failed: Auth fail")); //$NON-NLS-1$
+        assertFalse("the parent must never be presented as the child's cause: " + error, //$NON-NLS-1$
+            error.contains("Caused by: Database update failed")); //$NON-NLS-1$
+        assertFalse("there is no proven deeper diagnosis, so there must be no cause clause: " //$NON-NLS-1$
+            + error, error.contains("Caused by")); //$NON-NLS-1$
+    }
+
     // ============ Unexpected (non-ApplicationException) failures, #453 ============
 
     /** Plugin id used for the synthetic statuses below; no live EDT is involved. */

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
@@ -506,6 +506,26 @@ public class UpdateDatabaseToolTest
     }
 
     @Test
+    public void testApplicationFailureIncludesExceptionFreeStatusDetailBelowCauseHop()
+    {
+        MultiStatus status = new MultiStatus(STATUS_PLUGIN_ID, 0,
+            "Infobase authentication error", null); //$NON-NLS-1$
+        status.add(new Status(IStatus.ERROR, STATUS_PLUGIN_ID, "Auth fail")); //$NON-NLS-1$
+        ApplicationException failure = new ApplicationException(
+            "Infobase connection runtime session open error", new CoreException(status)); //$NON-NLS-1$
+
+        String error = JsonParser.parseString(UpdateDatabaseTool.buildApplicationErrorResult(
+            failure, "ProjectB", "app-b", false)).getAsJsonObject() //$NON-NLS-1$ //$NON-NLS-2$
+            .get("error").getAsString(); //$NON-NLS-1$
+
+        assertTrue("the exception-free child below the established cause hop must reach the caller: "
+            + error, error.contains("Infobase connection runtime session open error. " //$NON-NLS-1$
+                + "Caused by: Auth fail.")); //$NON-NLS-1$
+        assertFalse("the copied MultiStatus headline is not the actionable cause: " + error,
+            error.contains("Caused by: Infobase authentication error")); //$NON-NLS-1$
+    }
+
+    @Test
     public void testApplicationFailureDoesNotRepeatFormattedHeadlineAsCause()
     {
         ApplicationException failure =

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,10 +37,14 @@ import org.junit.Test;
 
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 import com.ditrix.edt.mcp.server.tools.impl.UpdateDatabaseTool.ApplicationFallback; // same package: explicit for the nested seam type
+import com.ditrix.edt.mcp.server.utils.ExternalInfobaseChangesPolicy;
 import com.ditrix.edt.mcp.server.utils.LaunchConfigUtils;
+import com.ditrix.edt.mcp.server.utils.LaunchUpdateDialogAutoConfirmer;
 import com.e1c.g5.dt.applications.ApplicationException;
 import com.e1c.g5.dt.applications.IApplication;
 import com.e1c.g5.dt.applications.IApplicationManager;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 /**
  * Tests for {@link UpdateDatabaseTool}.
@@ -415,6 +420,89 @@ public class UpdateDatabaseToolTest
 
         assertTrue("result must still carry the credentials hint when InternalInfo does not match", //$NON-NLS-1$
             result.contains("set_infobase_credentials")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testGenericFailureAddsTerminalCauseWithoutChangingSpecificRefusals() throws Exception
+    {
+        ApplicationException generic = new ApplicationException(
+            "Infobase connection runtime session open error", //$NON-NLS-1$
+            new RuntimeException("Infobase authentication error", //$NON-NLS-1$
+                new IllegalStateException("Auth fail"))); //$NON-NLS-1$
+        String genericError = JsonParser.parseString(UpdateDatabaseTool.buildApplicationErrorResult(
+            generic, "ProjectB", "app-b", false)).getAsJsonObject() //$NON-NLS-1$ //$NON-NLS-2$
+            .get("error").getAsString(); //$NON-NLS-1$
+        // Punctuated, because this is the message the caller reads at its most confused moment. The
+        // platform headline ends without a period and the credentials hint that follows is its own
+        // sentence, so an unterminated clause yields "... open error Caused by: ... Auth fail If the
+        // infobase requires ..." - three sentences run into one.
+        assertTrue("the generic path must compose the selected headline with the terminal cause", //$NON-NLS-1$
+            genericError.contains("Database update failed: Infobase connection runtime session " //$NON-NLS-1$
+                + "open error. Caused by: java.lang.IllegalStateException: Auth fail.")); //$NON-NLS-1$
+        assertFalse("the clause must not run into the headline: " + genericError, //$NON-NLS-1$
+            genericError.contains("open error Caused by")); //$NON-NLS-1$
+
+        // A failure with nothing deeper to say must read EXACTLY as it did before the cause chain
+        // was surfaced - the composition may add a clause, never punctuation of its own.
+        String soleMessage = "Infobase connection runtime session open error"; //$NON-NLS-1$
+        String withoutCause = JsonParser.parseString(UpdateDatabaseTool.buildApplicationErrorResult(
+            new ApplicationException(soleMessage), "ProjectB", "app-b", false)) //$NON-NLS-1$ //$NON-NLS-2$
+            .getAsJsonObject().get("error").getAsString(); //$NON-NLS-1$
+        assertTrue("a single-message failure must gain no Caused by clause: " + withoutCause, //$NON-NLS-1$
+            withoutCause.startsWith("Database update failed: " + soleMessage) //$NON-NLS-1$
+                && !withoutCause.contains("Caused by")); //$NON-NLS-1$
+
+        LaunchUpdateDialogAutoConfirmer.ConflictWatch portWatch =
+            LaunchUpdateDialogAutoConfirmer.beginConflictWatch(null);
+        try
+        {
+            Method recordPortConflict = portWatch.getClass().getDeclaredMethod(
+                "recordPortConflict", String.class, String.class); //$NON-NLS-1$
+            recordPortConflict.setAccessible(true);
+            recordPortConflict.invoke(portWatch, "port 8429 is already in use", //$NON-NLS-1$
+                LaunchUpdateDialogAutoConfirmer.PORT_REASON_POLICY);
+            Method formatPortConflict = UpdateDatabaseTool.class.getDeclaredMethod(
+                "portConflictError", portWatch.getClass(), String.class, String.class, //$NON-NLS-1$
+                boolean.class);
+            formatPortConflict.setAccessible(true);
+            JsonObject portResult = JsonParser.parseString((String)formatPortConflict.invoke(null,
+                portWatch, "ProjectB", "app-b", false)).getAsJsonObject(); //$NON-NLS-1$ //$NON-NLS-2$
+            String expectedPortError = "Database update failed: " //$NON-NLS-1$
+                + LaunchUpdateDialogAutoConfirmer.portConflictError(
+                    "port 8429 is already in use", //$NON-NLS-1$
+                    LaunchUpdateDialogAutoConfirmer.PORT_REASON_POLICY)
+                + " The infobase was NOT changed."; //$NON-NLS-1$
+            assertEquals("the specific port-conflict path must remain byte-for-byte unchanged", //$NON-NLS-1$
+                expectedPortError, portResult.get("error").getAsString()); //$NON-NLS-1$
+        }
+        finally
+        {
+            portWatch.close();
+        }
+
+        LaunchUpdateDialogAutoConfirmer.ConflictWatch cancelWatch =
+            LaunchUpdateDialogAutoConfirmer.beginConflictWatch(null);
+        try
+        {
+            Method recordCancel = cancelWatch.getClass().getDeclaredMethod("record", String.class); //$NON-NLS-1$
+            recordCancel.setAccessible(true);
+            recordCancel.invoke(cancelWatch, LaunchUpdateDialogAutoConfirmer.CANCEL_REASON_POLICY);
+            Method formatCancellation = UpdateDatabaseTool.class.getDeclaredMethod(
+                "declinedUpdateResult", cancelWatch.getClass(), //$NON-NLS-1$
+                ExternalInfobaseChangesPolicy.class);
+            formatCancellation.setAccessible(true);
+            JsonObject cancelResult = JsonParser.parseString((String)formatCancellation.invoke(null,
+                cancelWatch, ExternalInfobaseChangesPolicy.OVERRIDE)).getAsJsonObject();
+            assertEquals("the specific cancellation path must remain byte-for-byte unchanged", //$NON-NLS-1$
+                ExternalInfobaseChangesPolicy.declinedUpdateError(
+                    ExternalInfobaseChangesPolicy.OVERRIDE,
+                    LaunchUpdateDialogAutoConfirmer.CANCEL_REASON_POLICY),
+                cancelResult.get("error").getAsString()); //$NON-NLS-1$
+        }
+        finally
+        {
+            cancelWatch.close();
+        }
     }
 
     // ============ Unexpected (non-ApplicationException) failures, #453 ============

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
@@ -526,6 +526,45 @@ public class UpdateDatabaseToolTest
     }
 
     @Test
+    public void testApplicationFailureDoesNotUseInformationalStatusChildAsCause()
+    {
+        MultiStatus status = new MultiStatus(STATUS_PLUGIN_ID, 0, "", null); //$NON-NLS-1$
+        status.add(new Status(IStatus.ERROR, STATUS_PLUGIN_ID, "")); //$NON-NLS-1$
+        status.add(new Status(IStatus.CANCEL, STATUS_PLUGIN_ID, "")); //$NON-NLS-1$
+        status.add(new Status(IStatus.INFO, STATUS_PLUGIN_ID, "Cleanup completed")); //$NON-NLS-1$
+        ApplicationException failure = new ApplicationException(
+            "Infobase connection runtime session open error", new CoreException(status)); //$NON-NLS-1$
+
+        String error = JsonParser.parseString(UpdateDatabaseTool.buildApplicationErrorResult(
+            failure, "ProjectB", "app-b", false)).getAsJsonObject() //$NON-NLS-1$ //$NON-NLS-2$
+            .get("error").getAsString(); //$NON-NLS-1$
+
+        assertFalse("an informational sibling is not a cause: " + error, //$NON-NLS-1$
+            error.contains("Cleanup completed")); //$NON-NLS-1$
+        assertFalse("blank failing children establish no cause clause: " + error, //$NON-NLS-1$
+            error.contains("Caused by")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testApplicationFailureStillUsesCausalHopsOwnStatusMessage()
+    {
+        MultiStatus status = new MultiStatus(STATUS_PLUGIN_ID, 0, "Connection refused", null); //$NON-NLS-1$
+        status.add(new Status(IStatus.ERROR, STATUS_PLUGIN_ID, "")); //$NON-NLS-1$
+        status.add(new Status(IStatus.INFO, STATUS_PLUGIN_ID, "Cleanup completed")); //$NON-NLS-1$
+        ApplicationException failure = new ApplicationException(
+            "Infobase connection runtime session open error", new CoreException(status)); //$NON-NLS-1$
+
+        String error = JsonParser.parseString(UpdateDatabaseTool.buildApplicationErrorResult(
+            failure, "ProjectB", "app-b", false)).getAsJsonObject() //$NON-NLS-1$ //$NON-NLS-2$
+            .get("error").getAsString(); //$NON-NLS-1$
+
+        assertTrue("the causal hop's own statement remains eligible: " + error, //$NON-NLS-1$
+            error.contains("Caused by: Connection refused.")); //$NON-NLS-1$
+        assertFalse("an informational sibling must not displace the hop's own statement: " + error, //$NON-NLS-1$
+            error.contains("Cleanup completed")); //$NON-NLS-1$
+    }
+
+    @Test
     public void testApplicationFailureDoesNotRepeatFormattedHeadlineAsCause()
     {
         ApplicationException failure =

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/UpdateDatabaseToolTest.java
@@ -505,6 +505,21 @@ public class UpdateDatabaseToolTest
         }
     }
 
+    @Test
+    public void testApplicationFailureDoesNotRepeatFormattedHeadlineAsCause()
+    {
+        ApplicationException failure =
+            new ApplicationException(new IllegalStateException("Auth fail")); //$NON-NLS-1$
+        String error = JsonParser.parseString(UpdateDatabaseTool.buildApplicationErrorResult(
+            failure, "ProjectB", "app-b", false)).getAsJsonObject() //$NON-NLS-1$ //$NON-NLS-2$
+            .get("error").getAsString(); //$NON-NLS-1$
+
+        assertTrue("the selected headline must still be present: " + error, //$NON-NLS-1$
+            error.startsWith("Database update failed: java.lang.IllegalStateException: Auth fail")); //$NON-NLS-1$
+        assertFalse("the formatted headline must not be repeated in a Caused by clause: " + error, //$NON-NLS-1$
+            error.contains("Caused by")); //$NON-NLS-1$
+    }
+
     // ============ Unexpected (non-ApplicationException) failures, #453 ============
 
     /** Plugin id used for the synthetic statuses below; no live EDT is involved. */

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PlatformFailuresTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PlatformFailuresTest.java
@@ -22,6 +22,7 @@ import org.eclipse.core.runtime.Status;
 import org.junit.Test;
 
 import com.e1c.g5.dt.applications.ApplicationException;
+import com.jcraft.jsch.JSchException;
 
 /**
  * Tests for {@link PlatformFailures}: an EDT failure must never reach a caller as an empty
@@ -376,6 +377,76 @@ public class PlatformFailuresTest
 
         assertEquals("a short generic terminal message needs its exception type", //$NON-NLS-1$
             "java.lang.IllegalStateException: Auth fail", rootCause(failure)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRootCauseAddsNothingWhenFormattingRecreatesTheHeadline()
+    {
+        Throwable failure = new RuntimeException(new IllegalStateException("Auth fail")); //$NON-NLS-1$
+
+        assertEquals("the formatted diagnosis must not repeat the selected headline", //$NON-NLS-1$
+            "", rootCause(failure)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRootCauseDoesNotAttributeCopiedStatusTextToApplicationException()
+    {
+        IStatus status = new Status(IStatus.ERROR, PLUGIN, "Auth fail", null); //$NON-NLS-1$
+        Throwable failure = new RuntimeException("Database update failed", //$NON-NLS-1$
+            new ApplicationException(status));
+
+        String diagnosis = rootCause(failure);
+        assertEquals("the status owns the text, so the generic wrapper must add no provenance", //$NON-NLS-1$
+            "Auth fail", diagnosis); //$NON-NLS-1$
+        assertFalse("the wrapper type must be absent from the diagnosis: " + diagnosis, //$NON-NLS-1$
+            diagnosis.contains(ApplicationException.class.getName()));
+    }
+
+    @Test
+    public void testRootCauseFollowsCauseOfExceptionCarriedByChildStatus()
+    {
+        MultiStatus status = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
+        status.add(new Status(IStatus.ERROR, PLUGIN, "", //$NON-NLS-1$
+            new RuntimeException("SSH error", new JSchException("Auth fail")))); //$NON-NLS-1$ //$NON-NLS-2$
+        ApplicationException failure = new ApplicationException(status);
+
+        assertEquals("the fixture headline comes from the child status's carried exception", //$NON-NLS-1$
+            "SSH error", PlatformFailures.describe(failure)); //$NON-NLS-1$
+        assertEquals("the carried exception's terminal cause is the actionable diagnosis", //$NON-NLS-1$
+            "com.jcraft.jsch.JSchException: Auth fail", rootCause(failure)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRootCauseCapsCauseChainCarriedByChildStatus()
+    {
+        Throwable carried = new RuntimeException("level-11"); //$NON-NLS-1$
+        for (int level = 10; level >= 0; level--)
+        {
+            carried = new RuntimeException("level-" + level, carried); //$NON-NLS-1$
+        }
+        MultiStatus status = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
+        status.add(new Status(IStatus.ERROR, PLUGIN, "", carried)); //$NON-NLS-1$
+
+        ApplicationException failure = new ApplicationException(status);
+        assertEquals("the fixture headline is the first carried throwable hop", "level-0", //$NON-NLS-1$ //$NON-NLS-2$
+            PlatformFailures.describe(failure));
+        assertEquals("the carried chain must reuse the ten-hop cause cap", "level-9", //$NON-NLS-1$ //$NON-NLS-2$
+            rootCause(failure));
+    }
+
+    @Test
+    public void testRootCauseCycleGuardAppliesToCauseChainCarriedByChildStatus()
+    {
+        CyclicFailure first = new CyclicFailure("cycle-a"); //$NON-NLS-1$
+        CyclicFailure second = new CyclicFailure("cycle-b"); //$NON-NLS-1$
+        first.setNext(second);
+        second.setNext(first);
+        MultiStatus status = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
+        status.add(new Status(IStatus.ERROR, PLUGIN, "", first)); //$NON-NLS-1$
+
+        ApplicationException failure = new ApplicationException(status);
+        assertEquals("the bounded carried walk must stop instead of looping forever", "cycle-b", //$NON-NLS-1$ //$NON-NLS-2$
+            rootCause(failure));
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PlatformFailuresTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PlatformFailuresTest.java
@@ -282,23 +282,24 @@ public class PlatformFailuresTest
     }
 
     @Test
-    public void testRootCauseFindsDistinctStatusMessageWhenHopRepeatsHeadline()
+    public void testRootCauseNeverReportsMultiStatusParentAsCauseOfSelectedChild()
     {
-        String headline = "Database update failed"; //$NON-NLS-1$
-        String detail = "port 8429 is already in use"; //$NON-NLS-1$
-        MultiStatus status = new MultiStatus(PLUGIN, 0, headline, null);
-        status.add(new Status(IStatus.ERROR, PLUGIN, headline));
-        status.add(new Status(IStatus.ERROR, PLUGIN, detail));
+        String parent = "Database update failed"; //$NON-NLS-1$
+        String child = "Auth fail"; //$NON-NLS-1$
+        MultiStatus status = new MultiStatus(PLUGIN, 0, parent, null);
+        status.add(new Status(IStatus.ERROR, PLUGIN, child));
         ApplicationException failure = new ApplicationException(status);
 
-        assertEquals("the fixture must select the repeated headline", headline, //$NON-NLS-1$
+        assertEquals("describe must continue to promote the failing child", child, //$NON-NLS-1$
             PlatformFailures.describe(failure));
-        assertEquals("a headline candidate must not hide a tied distinct status message", //$NON-NLS-1$
-            detail, rootCause(failure));
+        String diagnosis = rootCause(failure);
+        assertEquals("an ancestor status is not a cause of its selected child", "", diagnosis); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("the parent text must never be emitted as the child's cause", //$NON-NLS-1$
+            diagnosis.contains(parent));
     }
 
     @Test
-    public void testRootCauseKeepsDistinctStatusWhenDeeperStatusRepeatsHeadline()
+    public void testRootCauseDoesNotTurnASelectedStatusAncestorIntoACause()
     {
         String headline = "Database update failed"; //$NON-NLS-1$
         String detail = "publishing was refused because the infobase is locked"; //$NON-NLS-1$
@@ -310,8 +311,8 @@ public class PlatformFailuresTest
 
         assertEquals("the fixture must select the deeper repeated headline", headline, //$NON-NLS-1$
             PlatformFailures.describe(failure));
-        assertEquals("a deeper repeated headline must not suppress a shallower distinct diagnosis", //$NON-NLS-1$
-            detail, rootCause(failure));
+        assertEquals("a status ancestor cannot be reported as its selected descendant's cause", //$NON-NLS-1$
+            "", rootCause(failure)); //$NON-NLS-1$
     }
 
     @Test
@@ -337,24 +338,53 @@ public class PlatformFailuresTest
             rootCause(failure));
     }
 
-    @Test
-    public void testRootCauseHonoursTheStatusTreeCap()
+    @Test(timeout = 1000)
+    public void testRootCauseVisitsAnAliasedStatusGraphOnlyOncePerIdentity()
     {
-        MultiStatus root = new MultiStatus(PLUGIN, 0, "status-0", null); //$NON-NLS-1$
-        MultiStatus current = root;
-        for (int depth = 1; depth <= 5; depth++)
+        IStatus shared = new Status(IStatus.ERROR, PLUGIN, ""); //$NON-NLS-1$
+        for (int depth = 0; depth < 4; depth++)
         {
-            MultiStatus child = new MultiStatus(PLUGIN, 0, "status-" + depth, null); //$NON-NLS-1$
+            MultiStatus aliases = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
+            for (int reference = 0; reference < 100; reference++)
+            {
+                aliases.add(shared);
+            }
+            shared = aliases;
+        }
+        MultiStatus carried = new MultiStatus(PLUGIN, 0, "wrapper detail", null); //$NON-NLS-1$
+        carried.add(shared);
+        Throwable failure = new RuntimeException("headline", new CoreException(carried)); //$NON-NLS-1$
+
+        assertEquals("400 stored aliases must not expand into roughly 100 million visits", //$NON-NLS-1$
+            "wrapper detail", //$NON-NLS-1$
+            rootCause(failure));
+    }
+
+    @Test
+    public void testRootCauseStatusDiscoveryStopsAtItsDepthBoundary()
+    {
+        String boundaryMessage = "boundary diagnosis"; //$NON-NLS-1$
+        String beyondMessage = "beyond-depth diagnosis"; //$NON-NLS-1$
+        MultiStatus root = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
+        MultiStatus current = root;
+        for (int depth = 1; depth < 4; depth++)
+        {
+            MultiStatus child = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
             current.add(child);
             current = child;
         }
-        ApplicationException failure = new ApplicationException(root);
+        MultiStatus boundary = new MultiStatus(PLUGIN, 0, "", //$NON-NLS-1$
+            new RuntimeException(boundaryMessage));
+        current.add(boundary);
+        boundary.add(new Status(IStatus.ERROR, PLUGIN, "", //$NON-NLS-1$
+            new IllegalStateException(beyondMessage)));
+        Throwable failure = new RuntimeException("headline", new CoreException(root)); //$NON-NLS-1$
 
-        assertEquals("describe itself stops at the deepest permitted status", "status-4", //$NON-NLS-1$ //$NON-NLS-2$
-            PlatformFailures.describe(failure));
-        assertEquals("the out-of-cap status must be ignored while the deepest in-cap distinct " //$NON-NLS-1$
-            + "diagnosis survives", "status-3", //$NON-NLS-1$ //$NON-NLS-2$
-            rootCause(failure));
+        String diagnosis = rootCause(failure);
+        assertEquals("a carried exception at status depth four must remain discoverable", //$NON-NLS-1$
+            "java.lang.RuntimeException: " + boundaryMessage, diagnosis); //$NON-NLS-1$
+        assertFalse("a carried exception at status depth five must be outside the walk: " //$NON-NLS-1$
+            + diagnosis, diagnosis.contains(beyondMessage));
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PlatformFailuresTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PlatformFailuresTest.java
@@ -253,6 +253,67 @@ public class PlatformFailuresTest
     }
 
     @Test
+    public void testRootCauseKeepsMiddleDiagnosisWhenTerminalRepeatsHeadline()
+    {
+        String headline = "Database update failed"; //$NON-NLS-1$
+        String detail = "port 8429 is already in use"; //$NON-NLS-1$
+        Throwable failure = new RuntimeException(headline,
+            new RuntimeException(detail, new IllegalStateException(headline)));
+
+        assertEquals("a repeated terminal headline must not erase the distinct middle diagnosis", //$NON-NLS-1$
+            detail, rootCause(failure));
+    }
+
+    @Test
+    public void testRootCauseCycleEndingOnHeadlineKeepsDistinctDiagnosis()
+    {
+        String headline = "Database update failed"; //$NON-NLS-1$
+        String detail = "port 8429 is already in use"; //$NON-NLS-1$
+        CyclicFailure first = new CyclicFailure(headline);
+        CyclicFailure middle = new CyclicFailure(detail);
+        CyclicFailure last = new CyclicFailure(headline);
+        first.setNext(middle);
+        middle.setNext(last);
+        last.setNext(first);
+
+        assertEquals("the final bounded hop must not erase the cycle's distinct diagnosis", //$NON-NLS-1$
+            detail, rootCause(first));
+    }
+
+    @Test
+    public void testRootCauseFindsDistinctStatusMessageWhenHopRepeatsHeadline()
+    {
+        String headline = "Database update failed"; //$NON-NLS-1$
+        String detail = "port 8429 is already in use"; //$NON-NLS-1$
+        MultiStatus status = new MultiStatus(PLUGIN, 0, headline, null);
+        status.add(new Status(IStatus.ERROR, PLUGIN, headline));
+        status.add(new Status(IStatus.ERROR, PLUGIN, detail));
+        ApplicationException failure = new ApplicationException(status);
+
+        assertEquals("the fixture must select the repeated headline", headline, //$NON-NLS-1$
+            PlatformFailures.describe(failure));
+        assertEquals("a headline candidate must not hide a tied distinct status message", //$NON-NLS-1$
+            detail, rootCause(failure));
+    }
+
+    @Test
+    public void testRootCauseKeepsDistinctStatusWhenDeeperStatusRepeatsHeadline()
+    {
+        String headline = "Database update failed"; //$NON-NLS-1$
+        String detail = "publishing was refused because the infobase is locked"; //$NON-NLS-1$
+        MultiStatus status = new MultiStatus(PLUGIN, 0, headline, null);
+        MultiStatus detailStatus = new MultiStatus(PLUGIN, 0, detail, null);
+        detailStatus.add(new Status(IStatus.ERROR, PLUGIN, headline));
+        status.add(detailStatus);
+        ApplicationException failure = new ApplicationException(status);
+
+        assertEquals("the fixture must select the deeper repeated headline", headline, //$NON-NLS-1$
+            PlatformFailures.describe(failure));
+        assertEquals("a deeper repeated headline must not suppress a shallower distinct diagnosis", //$NON-NLS-1$
+            detail, rootCause(failure));
+    }
+
+    @Test
     public void testRootCauseAddsNothingWhenTheDeepestMessageEqualsDescribe()
     {
         Throwable failure = new RuntimeException("same diagnosis", //$NON-NLS-1$
@@ -290,7 +351,8 @@ public class PlatformFailuresTest
 
         assertEquals("describe itself stops at the deepest permitted status", "status-4", //$NON-NLS-1$ //$NON-NLS-2$
             PlatformFailures.describe(failure));
-        assertEquals("the out-of-cap status must not become a second diagnosis", "", //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("the out-of-cap status must be ignored while the deepest in-cap distinct " //$NON-NLS-1$
+            + "diagnosis survives", "status-3", //$NON-NLS-1$ //$NON-NLS-2$
             rootCause(failure));
     }
 

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PlatformFailuresTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PlatformFailuresTest.java
@@ -447,6 +447,20 @@ public class PlatformFailuresTest
     }
 
     @Test
+    public void testRootCauseFollowsExceptionOfSelectedStatusWithDifferentMessage()
+    {
+        MultiStatus status = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
+        status.add(new Status(IStatus.ERROR, PLUGIN, "Infobase authentication error", //$NON-NLS-1$
+            new JSchException("Auth fail"))); //$NON-NLS-1$
+        ApplicationException failure = new ApplicationException(status);
+
+        assertEquals("the status text remains the selected headline", //$NON-NLS-1$
+            "Infobase authentication error", PlatformFailures.describe(failure)); //$NON-NLS-1$
+        assertEquals("IStatus.getException is a direct causal edge despite different text", //$NON-NLS-1$
+            "com.jcraft.jsch.JSchException: Auth fail", rootCause(failure)); //$NON-NLS-1$
+    }
+
+    @Test
     public void testRootCauseCapsCauseChainCarriedByChildStatus()
     {
         Throwable carried = new RuntimeException("level-11"); //$NON-NLS-1$

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PlatformFailuresTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PlatformFailuresTest.java
@@ -398,6 +398,20 @@ public class PlatformFailuresTest
     }
 
     @Test(timeout = 1000)
+    public void testRootCauseDoesNotResetCauseChainCapAcrossCoreExceptionStatus()
+    {
+        Throwable failure = new IllegalStateException("beyond-cap diagnosis"); //$NON-NLS-1$
+        for (int level = 10; level >= 0; level--)
+        {
+            failure = new CoreException(
+                new Status(IStatus.ERROR, PLUGIN, "level-" + level, failure)); //$NON-NLS-1$
+        }
+
+        assertEquals("a CoreException's duplicate status edge must not reset the ten-hop cap", //$NON-NLS-1$
+            "level-9", rootCause(failure)); //$NON-NLS-1$
+    }
+
+    @Test(timeout = 1000)
     public void testRootCauseVisitsAnAliasedStatusGraphOnlyOncePerIdentity()
     {
         IStatus shared = new Status(IStatus.ERROR, PLUGIN, ""); //$NON-NLS-1$

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PlatformFailuresTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PlatformFailuresTest.java
@@ -254,6 +254,18 @@ public class PlatformFailuresTest
     }
 
     @Test
+    public void testRootCauseKeepsTheIssue545JSchExceptionDiagnosis()
+    {
+        Throwable failure = new ApplicationException(
+            "Infobase connection runtime session open error", //$NON-NLS-1$
+            new RuntimeException("Infobase authentication error", //$NON-NLS-1$
+                new JSchException("Auth fail"))); //$NON-NLS-1$
+
+        assertEquals("the issue's terminal SSH diagnosis must keep its honest provenance", //$NON-NLS-1$
+            "com.jcraft.jsch.JSchException: Auth fail", rootCause(failure)); //$NON-NLS-1$
+    }
+
+    @Test
     public void testRootCauseKeepsMiddleDiagnosisWhenTerminalRepeatsHeadline()
     {
         String headline = "Database update failed"; //$NON-NLS-1$
@@ -296,6 +308,53 @@ public class PlatformFailuresTest
         assertEquals("an ancestor status is not a cause of its selected child", "", diagnosis); //$NON-NLS-1$ //$NON-NLS-2$
         assertFalse("the parent text must never be emitted as the child's cause", //$NON-NLS-1$
             diagnosis.contains(parent));
+    }
+
+    @Test
+    public void testRootCauseDoesNotFollowAChildExceptionBackIntoItsMultiStatusParent()
+    {
+        String parentMessage = "Database update failed"; //$NON-NLS-1$
+        String childMessage = "Auth fail"; //$NON-NLS-1$
+        MultiStatus parent = new MultiStatus(PLUGIN, 0, parentMessage, null);
+        CoreException backEdge = new CoreException(parent);
+        parent.add(new Status(IStatus.ERROR, PLUGIN, childMessage, backEdge));
+        parent.add(new Status(IStatus.ERROR, PLUGIN, "unrelated sibling")); //$NON-NLS-1$
+        ApplicationException failure = new ApplicationException(parent);
+
+        assertEquals("the child remains the headline despite its exception back-edge", //$NON-NLS-1$
+            childMessage, PlatformFailures.describe(failure));
+        assertEquals("the back-edge cannot turn the aggregate parent or sibling into a cause", //$NON-NLS-1$
+            "", rootCause(failure)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRootCauseDoesNotEstablishProvenanceFromAnAliasedStatusPath()
+    {
+        MultiStatus parent = new MultiStatus(PLUGIN, 0, "Database update failed", null); //$NON-NLS-1$
+        MultiStatus alias = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
+        alias.add(new Status(IStatus.ERROR, PLUGIN, "Auth fail")); //$NON-NLS-1$
+
+        MultiStatus deep = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
+        MultiStatus current = deep;
+        for (int depth = 1; depth < 3; depth++)
+        {
+            MultiStatus child = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
+            current.add(child);
+            current = child;
+        }
+        current.add(alias);
+        parent.add(deep);
+        parent.add(alias);
+
+        CoreException backEdge = new CoreException(parent);
+        parent.add(new Status(IStatus.ERROR, PLUGIN, "Auth fail", backEdge)); //$NON-NLS-1$
+        parent.add(new Status(IStatus.ERROR, PLUGIN, "unrelated sibling")); //$NON-NLS-1$
+        ApplicationException failure = new ApplicationException(parent);
+
+        assertEquals("describe revisits the alias through its shallower in-cap path", //$NON-NLS-1$
+            "Auth fail", PlatformFailures.describe(failure)); //$NON-NLS-1$
+        assertEquals("a later text match cannot stand in for the selected status identity", //$NON-NLS-1$
+            "", rootCause(failure)); //$NON-NLS-1$
     }
 
     @Test
@@ -458,6 +517,23 @@ public class PlatformFailuresTest
             "Infobase authentication error", PlatformFailures.describe(failure)); //$NON-NLS-1$
         assertEquals("IStatus.getException is a direct causal edge despite different text", //$NON-NLS-1$
             "com.jcraft.jsch.JSchException: Auth fail", rootCause(failure)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRootCauseUsesTheFailingChildRuleAtEachCausalHop()
+    {
+        MultiStatus status = new MultiStatus(PLUGIN, 0, "Infobase authentication error", null); //$NON-NLS-1$
+        status.add(new Status(IStatus.ERROR, PLUGIN, "Auth fail")); //$NON-NLS-1$
+        MultiStatus progress = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
+        MultiStatus nestedProgress = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
+        nestedProgress.add(new Status(IStatus.INFO, PLUGIN, "Cleanup completed")); //$NON-NLS-1$
+        progress.add(nestedProgress);
+        status.add(progress);
+        Throwable failure = new ApplicationException(
+            "Infobase connection runtime session open error", new CoreException(status)); //$NON-NLS-1$
+
+        assertEquals("the cause hop must describe its failure, not its deepest progress child", //$NON-NLS-1$
+            "Auth fail", rootCause(failure)); //$NON-NLS-1$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PlatformFailuresTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PlatformFailuresTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Method;
 import java.util.regex.Pattern;
 
 import org.eclipse.core.runtime.CoreException;
@@ -50,6 +51,44 @@ public class PlatformFailuresTest
      * report a leaked "@abc" as clean.
      */
     private static final Pattern ANY_IDENTITY = Pattern.compile("@[0-9a-fA-F]+");
+
+    /** Invokes the new API reflectively so every regression test runs and fails on the baseline. */
+    private static String rootCause(Throwable failure)
+    {
+        try
+        {
+            Method method = PlatformFailures.class.getMethod("rootCause", Throwable.class); //$NON-NLS-1$
+            return (String)method.invoke(null, failure);
+        }
+        catch (ReflectiveOperationException e)
+        {
+            throw new AssertionError("PlatformFailures.rootCause(Throwable) is missing or unusable", e); //$NON-NLS-1$
+        }
+    }
+
+    /** Throwable with a deliberately cyclical cause chain. */
+    private static final class CyclicFailure extends RuntimeException
+    {
+        private static final long serialVersionUID = 1L;
+
+        private Throwable next;
+
+        CyclicFailure(String message)
+        {
+            super(message);
+        }
+
+        void setNext(Throwable next)
+        {
+            this.next = next;
+        }
+
+        @Override
+        public synchronized Throwable getCause()
+        {
+            return next;
+        }
+    }
 
     @Test
     public void testOwnMessageWins()
@@ -197,6 +236,84 @@ public class PlatformFailuresTest
     {
         assertEquals("surrounding whitespace is not part of the reason", "boom",
             PlatformFailures.describe(new ApplicationException("  boom  ")));
+    }
+
+    @Test
+    public void testRootCauseReturnsTheDeepestDistinctMessageInAThreeDeepChain()
+    {
+        Throwable terminal = new IllegalStateException(
+            "SSH key authentication was rejected by the remote designer agent"); //$NON-NLS-1$
+        Throwable middle = new RuntimeException("Infobase authentication error", terminal); //$NON-NLS-1$
+        Throwable failure = new ApplicationException(
+            "Infobase connection runtime session open error", middle); //$NON-NLS-1$
+
+        assertEquals("the deepest distinct diagnosis must reach the caller", //$NON-NLS-1$
+            "SSH key authentication was rejected by the remote designer agent", //$NON-NLS-1$
+            rootCause(failure));
+    }
+
+    @Test
+    public void testRootCauseAddsNothingWhenTheDeepestMessageEqualsDescribe()
+    {
+        Throwable failure = new RuntimeException("same diagnosis", //$NON-NLS-1$
+            new IllegalStateException("same diagnosis")); //$NON-NLS-1$
+
+        assertEquals("equal selected and terminal messages must not be repeated", "", //$NON-NLS-1$ //$NON-NLS-2$
+            rootCause(failure));
+    }
+
+    @Test
+    public void testRootCauseHonoursTheCauseChainCap()
+    {
+        Throwable failure = new RuntimeException("level-11"); //$NON-NLS-1$
+        for (int level = 10; level >= 0; level--)
+        {
+            failure = new RuntimeException("level-" + level, failure); //$NON-NLS-1$
+        }
+
+        assertEquals("only the first ten throwable hops may be inspected", "level-9", //$NON-NLS-1$ //$NON-NLS-2$
+            rootCause(failure));
+    }
+
+    @Test
+    public void testRootCauseHonoursTheStatusTreeCap()
+    {
+        MultiStatus root = new MultiStatus(PLUGIN, 0, "status-0", null); //$NON-NLS-1$
+        MultiStatus current = root;
+        for (int depth = 1; depth <= 5; depth++)
+        {
+            MultiStatus child = new MultiStatus(PLUGIN, 0, "status-" + depth, null); //$NON-NLS-1$
+            current.add(child);
+            current = child;
+        }
+        ApplicationException failure = new ApplicationException(root);
+
+        assertEquals("describe itself stops at the deepest permitted status", "status-4", //$NON-NLS-1$ //$NON-NLS-2$
+            PlatformFailures.describe(failure));
+        assertEquals("the out-of-cap status must not become a second diagnosis", "", //$NON-NLS-1$ //$NON-NLS-2$
+            rootCause(failure));
+    }
+
+    @Test
+    public void testRootCauseCycleGuardStopsACyclicalCauseChain()
+    {
+        CyclicFailure first = new CyclicFailure("cycle-a"); //$NON-NLS-1$
+        CyclicFailure second = new CyclicFailure("cycle-b"); //$NON-NLS-1$
+        first.setNext(second);
+        second.setNext(first);
+
+        assertEquals("the bounded walk must stop instead of looping forever", "cycle-b", //$NON-NLS-1$ //$NON-NLS-2$
+            rootCause(first));
+    }
+
+    @Test
+    public void testRootCausePrefixesTheTerminalTypeForAShortGenericMessage()
+    {
+        Throwable failure = new RuntimeException("runtime session open error", //$NON-NLS-1$
+            new IllegalStateException("Auth fail")); //$NON-NLS-1$
+
+        assertEquals("a short generic terminal message needs its exception type", //$NON-NLS-1$
+            "java.lang.IllegalStateException: Auth fail", rootCause(failure)); //$NON-NLS-1$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PlatformFailuresTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/PlatformFailuresTest.java
@@ -434,33 +434,6 @@ public class PlatformFailuresTest
     }
 
     @Test
-    public void testRootCauseStatusDiscoveryStopsAtItsDepthBoundary()
-    {
-        String boundaryMessage = "boundary diagnosis"; //$NON-NLS-1$
-        String beyondMessage = "beyond-depth diagnosis"; //$NON-NLS-1$
-        MultiStatus root = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
-        MultiStatus current = root;
-        for (int depth = 1; depth < 4; depth++)
-        {
-            MultiStatus child = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
-            current.add(child);
-            current = child;
-        }
-        MultiStatus boundary = new MultiStatus(PLUGIN, 0, "", //$NON-NLS-1$
-            new RuntimeException(boundaryMessage));
-        current.add(boundary);
-        boundary.add(new Status(IStatus.ERROR, PLUGIN, "", //$NON-NLS-1$
-            new IllegalStateException(beyondMessage)));
-        Throwable failure = new RuntimeException("headline", new CoreException(root)); //$NON-NLS-1$
-
-        String diagnosis = rootCause(failure);
-        assertEquals("a carried exception at status depth four must remain discoverable", //$NON-NLS-1$
-            "java.lang.RuntimeException: " + boundaryMessage, diagnosis); //$NON-NLS-1$
-        assertFalse("a carried exception at status depth five must be outside the walk: " //$NON-NLS-1$
-            + diagnosis, diagnosis.contains(beyondMessage));
-    }
-
-    @Test
     public void testRootCauseCycleGuardStopsACyclicalCauseChain()
     {
         CyclicFailure first = new CyclicFailure("cycle-a"); //$NON-NLS-1$
@@ -492,6 +465,23 @@ public class PlatformFailuresTest
     }
 
     @Test
+    public void testRootCauseKeepsTheDistinctMiddleWhenTheTerminalFormatsIntoTheHeadline()
+    {
+        Throwable terminal = new IllegalStateException("Auth fail"); //$NON-NLS-1$
+        Throwable middle = new RuntimeException("useful detail", terminal); //$NON-NLS-1$
+        Throwable failure = new RuntimeException(
+            new IllegalStateException("Auth fail", middle)); //$NON-NLS-1$
+
+        assertEquals("the fixture headline must come from the cause-only constructor", //$NON-NLS-1$
+            "java.lang.IllegalStateException: Auth fail", PlatformFailures.describe(failure)); //$NON-NLS-1$
+        String diagnosis = rootCause(failure);
+        assertEquals("the formatted terminal repeat must not erase the distinct middle", //$NON-NLS-1$
+            "useful detail", diagnosis); //$NON-NLS-1$
+        assertFalse("the repeated terminal diagnosis must be absent: " + diagnosis, //$NON-NLS-1$
+            diagnosis.contains("Auth fail")); //$NON-NLS-1$
+    }
+
+    @Test
     public void testRootCauseDoesNotAttributeCopiedStatusTextToApplicationException()
     {
         IStatus status = new Status(IStatus.ERROR, PLUGIN, "Auth fail", null); //$NON-NLS-1$
@@ -503,34 +493,6 @@ public class PlatformFailuresTest
             "Auth fail", diagnosis); //$NON-NLS-1$
         assertFalse("the wrapper type must be absent from the diagnosis: " + diagnosis, //$NON-NLS-1$
             diagnosis.contains(ApplicationException.class.getName()));
-    }
-
-    @Test
-    public void testRootCauseFollowsCauseOfExceptionCarriedByChildStatus()
-    {
-        MultiStatus status = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
-        status.add(new Status(IStatus.ERROR, PLUGIN, "", //$NON-NLS-1$
-            new RuntimeException("SSH error", new JSchException("Auth fail")))); //$NON-NLS-1$ //$NON-NLS-2$
-        ApplicationException failure = new ApplicationException(status);
-
-        assertEquals("the fixture headline comes from the child status's carried exception", //$NON-NLS-1$
-            "SSH error", PlatformFailures.describe(failure)); //$NON-NLS-1$
-        assertEquals("the carried exception's terminal cause is the actionable diagnosis", //$NON-NLS-1$
-            "com.jcraft.jsch.JSchException: Auth fail", rootCause(failure)); //$NON-NLS-1$
-    }
-
-    @Test
-    public void testRootCauseFollowsExceptionOfSelectedStatusWithDifferentMessage()
-    {
-        MultiStatus status = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
-        status.add(new Status(IStatus.ERROR, PLUGIN, "Infobase authentication error", //$NON-NLS-1$
-            new JSchException("Auth fail"))); //$NON-NLS-1$
-        ApplicationException failure = new ApplicationException(status);
-
-        assertEquals("the status text remains the selected headline", //$NON-NLS-1$
-            "Infobase authentication error", PlatformFailures.describe(failure)); //$NON-NLS-1$
-        assertEquals("IStatus.getException is a direct causal edge despite different text", //$NON-NLS-1$
-            "com.jcraft.jsch.JSchException: Auth fail", rootCause(failure)); //$NON-NLS-1$
     }
 
     @Test
@@ -548,39 +510,6 @@ public class PlatformFailuresTest
 
         assertEquals("the cause hop must describe its failure, not its deepest progress child", //$NON-NLS-1$
             "Auth fail", rootCause(failure)); //$NON-NLS-1$
-    }
-
-    @Test
-    public void testRootCauseCapsCauseChainCarriedByChildStatus()
-    {
-        Throwable carried = new RuntimeException("level-11"); //$NON-NLS-1$
-        for (int level = 10; level >= 0; level--)
-        {
-            carried = new RuntimeException("level-" + level, carried); //$NON-NLS-1$
-        }
-        MultiStatus status = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
-        status.add(new Status(IStatus.ERROR, PLUGIN, "", carried)); //$NON-NLS-1$
-
-        ApplicationException failure = new ApplicationException(status);
-        assertEquals("the fixture headline is the first carried throwable hop", "level-0", //$NON-NLS-1$ //$NON-NLS-2$
-            PlatformFailures.describe(failure));
-        assertEquals("the carried chain must reuse the ten-hop cause cap", "level-9", //$NON-NLS-1$ //$NON-NLS-2$
-            rootCause(failure));
-    }
-
-    @Test
-    public void testRootCauseCycleGuardAppliesToCauseChainCarriedByChildStatus()
-    {
-        CyclicFailure first = new CyclicFailure("cycle-a"); //$NON-NLS-1$
-        CyclicFailure second = new CyclicFailure("cycle-b"); //$NON-NLS-1$
-        first.setNext(second);
-        second.setNext(first);
-        MultiStatus status = new MultiStatus(PLUGIN, 0, "", null); //$NON-NLS-1$
-        status.add(new Status(IStatus.ERROR, PLUGIN, "", first)); //$NON-NLS-1$
-
-        ApplicationException failure = new ApplicationException(status);
-        assertEquals("the bounded carried walk must stop instead of looping forever", "cycle-b", //$NON-NLS-1$ //$NON-NLS-2$
-            rootCause(failure));
     }
 
     @Test


### PR DESCRIPTION
Issue #545 is an unattended session's report: nine cases where the tool RESULT said one thing and `.metadata/.log` said another, so an agent acting on the result alone took the wrong next step.

**This PR does three of the nine — the ones provable in code and by unit test.** The scope is stated here rather than folded into a `Closes #545`, because narrowing the work is the maintainer's call, not mine.

## Done

**1. The failure's real cause never reached the caller.** `update_database` answered `Infobase connection runtime session open error` eleven times while the log carried, the same second, `Caused by: … SSH session with Desginer agent` and `Caused by: JSchException: Auth fail`. `PlatformFailures.describe` returns the FIRST non-blank message in the walk — by construction the outermost, generic headline.

`describe` is unchanged. Its own javadoc says selecting the text and processing it are two questions answered by two methods in that order, and it is used widely. A new `rootCause` walks the same bounded structures for the deepest distinct message, returns empty when that equals the headline, and prefixes the exception type only when the message is short enough to be generic — `Auth fail` alone is not actionable, `com.jcraft.jsch.JSchException: Auth fail` is. The clause punctuates itself, because the headline usually does not and the credentials hint after it is its own sentence.

**2. The preferred credentials target was unusable.** `set_infobase_credentials` refused a launch configuration for having "no project or applicationId attribute" when the `.launch` plainly carries `ATTR_PROJECT_NAME` — the guard demanded both under one message. Each missing attribute is now named separately, and when only the project is persisted the application is derived through `LaunchLifecycleUtils.resolveDelegateApplicationId`.

Not `getApplicationIdFor`: that was my first instruction and it was wrong. It answers a synthetic `launch:<config name>` which, as `LaunchTool`'s own comment records, no `IApplicationManager` knows — it would have swapped a truthful refusal for a target that fails one call later, the exact shape of failure this issue is about. A derived id that names no application is still refused, and quoted so the caller sees why; a successful derivation reports which application it resolved to. The derivation failure is logged at WARNING instead of swallowed — a bare catch would make a platform API change look identical to a configuration with no application.

**3. `debug_launch` denied the existence of a configuration it had just listed.** `list_configurations` returns the standalone-server row and `terminate_launch` accepts it, while `debug_launch` answered `not found. Create it in EDT first.` — advice to create something that exists. Cause: the standalone type id appeared **nowhere** in the sources and the by-name lookup searches only `ALL_DEBUG_CONFIG_TYPE_IDS`.

`debug_launch` still does **not** start a standalone server — that needs live validation on a stand and is deliberately out of scope. What changes is that the refusal stops lying: it names the type, says `debug_launch` starts runtime CLIENT configurations, and says `terminate_launch` accepts this same configuration, so the asymmetry is legible. The thin-client workaround is stated as **observed, not promised** — it is the reporter's measurement on one workspace and the platform sources do not show a client launch starting the server; a test forbids the guaranteeing phrasing. `ALL_DEBUG_CONFIG_TYPE_IDS` is untouched (every caller of the shared lookup would otherwise have gained standalone support); a type-specific lookup was extracted instead.

## Not done, and why

| # | Finding | Why not here |
|---|---|---|
| 2 | `set_infobase_credentials` returns `success: true`, next call logs "no/invalid stored credentials" | Needs a live credentialed infobase to tell "stored under a different key" from "stored and rejected" — the whole point of the finding |
| 4 | `debug_launch` returns `launching` for a launch that never starts; `recentLaunchFailures` stays empty | Needs a reproducible failing launch on a stand |
| 6 | A failed `update_database` leaves the standalone server stopped | Needs a running server to stop; `StandaloneServerStateRecovery` behaviour is only observable live |
| 7 | `get_applications` reports a stale `updateState` after an update | Needs a real update to complete |
| 8 | `read_module_source` hangs the server on a ~4,700-line module | Separate performance work (a size guard or a paged read), not an error-quality fix |

## Verification

`bash source/compile.sh` — BUILD SUCCESS, 5921 tests, 0 failures, 0 errors, 1 skipped. Every new test was checked red before the change; the one pre-existing assertion this touched (the run-on `Caused by` shape) fails against the new punctuation, which is what makes it discriminating.

Live verification of the three findings on a stand is **not** part of this PR: all three are pure result-construction paths with unit coverage, but the SSH-auth case that produced finding 1 cannot be reproduced here.
