### PR TITLE
Пачка мелких: merge_rules спрашивает согласие и выключен в read-only пресетах, пустая строка больше не пропуск, identity локализованной строки структурна (#557, #558)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolPreset.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/preferences/ToolPreset.java
@@ -132,7 +132,8 @@ public enum ToolPreset
     /**
      * Builds the Code Review preset: disable apps (including external-object builds and credential
      * writes), debug, refactoring (including adoption into an extension), translation,
-     * write_module_source, apply_quick_fix, and the state-mutating workspace export/import tools.
+     * write_module_source, merge_rules, apply_quick_fix, and the state-mutating workspace
+     * export/import tools.
      * {@code export_common_picture} remains enabled: despite its name, it is a pure model read that
      * returns the selected PNG as base64 and never writes a file.
      */
@@ -144,6 +145,7 @@ public enum ToolPreset
         disabled.addAll(ToolGroup.REFACTORING.getToolNames());
         disabled.addAll(ToolGroup.TRANSLATION.getToolNames());
         disabled.add("write_module_source"); //$NON-NLS-1$
+        disabled.add("merge_rules"); //$NON-NLS-1$
         disabled.add("export_configuration_to_xml"); //$NON-NLS-1$
         disabled.add("import_configuration_from_xml"); //$NON-NLS-1$
         disabled.add("apply_quick_fix"); //$NON-NLS-1$
@@ -153,8 +155,9 @@ public enum ToolPreset
     /**
      * Builds the Analysis Only preset: disable apps (including external-object builds and credential
      * writes), debug, the entire BSL Code group (both read and write tools — analysis is metadata-
-     * and error-level only), refactoring (including adoption into an extension), apply_quick_fix,
-     * the state-mutating workspace export/import tools, and the LanguageTool translation tools.
+     * and error-level only), refactoring (including adoption into an extension), merge_rules,
+     * apply_quick_fix, the state-mutating workspace export/import tools, and the LanguageTool
+     * translation tools.
      * {@code export_common_picture} remains enabled because it only reads model content and returns
      * base64; it does not export to the filesystem.
      */
@@ -166,6 +169,7 @@ public enum ToolPreset
         disabled.addAll(ToolGroup.BSL_CODE.getToolNames());
         disabled.addAll(ToolGroup.REFACTORING.getToolNames());
         disabled.addAll(ToolGroup.TRANSLATION.getToolNames());
+        disabled.add("merge_rules"); //$NON-NLS-1$
         disabled.add("export_configuration_to_xml"); //$NON-NLS-1$
         disabled.add("import_configuration_from_xml"); //$NON-NLS-1$
         disabled.add("apply_quick_fix"); //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CompareConfigurationsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CompareConfigurationsTool.java
@@ -378,9 +378,14 @@ public class CompareConfigurationsTool implements IMcpTool
             return scopeError;
         }
         List<String> scope = JsonUtils.extractArrayArgument(params, KEY_SCOPE);
+        // Presence, then value - the same spelling and the same transport-level null caveat as
+        // releaseComparisonId and scope above. McpProtocolHandler.extractToolParams drops a JSON
+        // null before this map is built, so null still arrives as an omission; a blank STRING is
+        // present and must not silently launch without the decisions its caller asked to apply.
+        boolean mergeRulesAsked = params != null && params.containsKey(KEY_MERGE_RULES_FILE);
         String mergeRulesFile =
             trimToNull(JsonUtils.extractStringArgument(params, KEY_MERGE_RULES_FILE));
-        String rulesError = validateMergeRulesFile(mergeRulesFile);
+        String rulesError = validateMergeRulesFile(mergeRulesAsked, mergeRulesFile);
         if (rulesError != null)
         {
             return rulesError;
@@ -739,14 +744,21 @@ public class CompareConfigurationsTool implements IMcpTool
      * zip holds an entry for THIS comparison is therefore asked in the launch, by
      * {@code ComparisonEngine.restoreMergeSettings}, and still before anything is handed to EDT.
      *
-     * @param mergeRulesFile the caller's path, or {@code null}
+     * @param present whether the caller sent the key at all, in the sense this map can answer
+     * @param mergeRulesFile the caller's trimmed path, or {@code null}
      * @return an error result, or {@code null} when the path is usable
      */
-    private static String validateMergeRulesFile(String mergeRulesFile)
+    private static String validateMergeRulesFile(boolean present, String mergeRulesFile)
     {
         if (mergeRulesFile == null)
         {
-            return null;
+            return present
+                ? ToolResult.error("'" + KEY_MERGE_RULES_FILE //$NON-NLS-1$
+                    + "' was sent blank, so it names no merge-rules file. Nothing was started. " //$NON-NLS-1$
+                    + "Pass the absolute path of the '.xml' or '.zip' whose decisions should be " //$NON-NLS-1$
+                    + "applied, or omit the parameter entirely to compare without pre-set " //$NON-NLS-1$
+                    + "rules.").toJson() //$NON-NLS-1$
+                : null;
         }
         Path path;
         try

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/MergeRulesTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/MergeRulesTool.java
@@ -41,6 +41,8 @@ import com.ditrix.edt.mcp.server.protocol.JsonUtils;
 import com.ditrix.edt.mcp.server.protocol.McpKeys;
 import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
+import com.ditrix.edt.mcp.server.utils.ConsentPreview;
+import com.ditrix.edt.mcp.server.utils.DestructiveConsentGate;
 import com.ditrix.edt.mcp.server.utils.MarkdownUtils;
 import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils;
 import com.ditrix.edt.mcp.server.utils.Pagination;
@@ -183,7 +185,24 @@ public class MergeRulesTool implements IMcpTool
     private static final List<String> WRITE_ONLY_PARAMETERS =
         List.of(KEY_BASED_ON, KEY_DECISIONS, KEY_COMPARISON_ID);
 
+    /**
+     * Asks the destructive-consent gate. A package-private seam: production delegates to the
+     * singleton gate, while a unit test substitutes REJECT / TIMEOUT / UNATTENDED to prove the
+     * replacement never reaches the codec.
+     */
+    @FunctionalInterface
+    interface ConsentRequester
+    {
+        /**
+         * @param toolName the gated tool's name
+         * @param preview what the user is being asked to authorize
+         * @return the verdict
+         */
+        DestructiveConsentGate.ConsentDecision request(String toolName, ConsentPreview preview);
+    }
+
     private final MergeRuleAuthoritySupplier authoritySupplier;
+    private final ConsentRequester consentRequester;
 
     /**
      * Creates the tool with the production authority - the one that asks a live comparison, over
@@ -211,7 +230,15 @@ public class MergeRulesTool implements IMcpTool
      */
     public MergeRulesTool(MergeRuleAuthoritySupplier authoritySupplier)
     {
+        this(authoritySupplier,
+            (tool, preview) -> DestructiveConsentGate.getInstance().requireConsent(tool, preview));
+    }
+
+    /** Test seam constructor for the comparison authority and destructive-consent verdict. */
+    MergeRulesTool(MergeRuleAuthoritySupplier authoritySupplier, ConsentRequester consentRequester)
+    {
         this.authoritySupplier = authoritySupplier;
+        this.consentRequester = consentRequester;
     }
 
     /**
@@ -308,6 +335,7 @@ public class MergeRulesTool implements IMcpTool
         String mode = JsonUtils.extractStringArgument(params, KEY_MODE);
         String filePath = JsonUtils.extractStringArgument(params, KEY_FILE_PATH);
         String basedOn = JsonUtils.extractStringArgument(params, KEY_BASED_ON);
+        boolean comparisonAsked = params != null && params.containsKey(KEY_COMPARISON_ID);
         String comparisonId = JsonUtils.extractStringArgument(params, KEY_COMPARISON_ID);
         List<JsonObject> decisions = JsonUtils.extractObjectArray(params, KEY_DECISIONS);
         int limit = Pagination.clampLimit(JsonUtils.extractIntArgument(params, McpKeys.LIMIT, DEFAULT_LIMIT),
@@ -354,6 +382,19 @@ public class MergeRulesTool implements IMcpTool
         }
         if (MODE_WRITE.equals(mode))
         {
+            // Presence, then value - exactly the boundary releaseComparisonId and scope use in
+            // compare_configurations. McpProtocolHandler.extractToolParams drops a JSON null before
+            // this map is built, so null still arrives as an omission; a blank STRING is present
+            // and must not fall through to authority(null), which means "whichever comparison is
+            // running" and can validate against a comparison the caller never named.
+            if (comparisonAsked && !isSet(comparisonId))
+            {
+                return ToolResult.error("'" + KEY_COMPARISON_ID //$NON-NLS-1$
+                    + "' was sent blank, so it names no comparison. Nothing was written. Pass the " //$NON-NLS-1$
+                    + "comparisonId returned by compare_configurations, or omit the parameter " //$NON-NLS-1$
+                    + "entirely to use the running comparison when one is available and report " //$NON-NLS-1$
+                    + "the write as NOT VALIDATED otherwise.").toJson(); //$NON-NLS-1$
+            }
             // The shared extractor keeps only JSON objects and discards the rest without a word, so
             // a malformed element would be written off silently and the report would state a
             // decision count lower than what the caller sent - this tool's whole contract is that
@@ -965,6 +1006,25 @@ public class MergeRulesTool implements IMcpTool
         if (refusal != null)
         {
             return refusal;
+        }
+
+        // The destructive gate is the LAST check before the codec replaces the existing file. It
+        // is asked only for the one destructive call shape: the target existed and basedOn named
+        // that same file, so Target.MAY_BE_REPLACED was earned. Fresh writes and replacement
+        // attempts refused above never prompt.
+        if (targetPolicy == MergeRulesCodec.Target.MAY_BE_REPLACED)
+        {
+            ConsentPreview preview = new ConsentPreview("Replace merge-rules file", //$NON-NLS-1$
+                "This replaces the existing merge-rules file at '" + file //$NON-NLS-1$
+                    + "' after carrying its decisions into the new file.", //$NON-NLS-1$
+                1, Collections.singletonList(file.toString()));
+            DestructiveConsentGate.ConsentDecision decision =
+                consentRequester.request(NAME, preview);
+            if (decision != DestructiveConsentGate.ConsentDecision.ALLOW)
+            {
+                return ToolResult.error(
+                    DestructiveConsentGate.consentDeniedMessage(decision, NAME)).toJson();
+            }
         }
 
         try

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGate.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGate.java
@@ -121,9 +121,10 @@ public final class DestructiveConsentGate // NOSONAR intentional singleton (Ecli
      * The frozen set of destructive tool NAMEs the gate protects: the five
      * always-destructive tools plus the conditionally destructive ones —
      * {@code modify_metadata} and {@code dcs} (gated only for a destructive retype),
-     * {@code git} (gated per write-capable subcommand) and {@code evaluate_expression}
-     * (gated always, because arbitrary BSL cannot be classified). Each tool decides
-     * when to call, the gate does not.
+     * {@code git} (gated per write-capable subcommand), {@code merge_rules} (gated only
+     * when write mode replaces the file named by {@code basedOn}) and
+     * {@code evaluate_expression} (gated always, because arbitrary BSL cannot be
+     * classified). Each tool decides when to call, the gate does not.
      *
      * <p>Related to but deliberately NOT equal to
      * {@code ToolAnnotationClassifier.DESTRUCTIVE_TOOLS}: that MCP-hint list carries
@@ -142,6 +143,9 @@ public final class DestructiveConsentGate // NOSONAR intentional singleton (Ecli
         "update_database", //$NON-NLS-1$
         "modify_metadata", //$NON-NLS-1$
         "dcs", //$NON-NLS-1$
+        // Conditionally destructive like modify_metadata: read mode and a write to a free path
+        // destroy nothing; only write mode's same-path basedOn update replaces an existing file.
+        "merge_rules", //$NON-NLS-1$
         // Conditionally destructive like modify_metadata: the tool asks for its WRITE-CAPABLE
         // subcommands (everything but status/diff/log/show/blame/ls-files/rev-parse/describe), since
         // whether one destroys work depends on git's per-subcommand option grammar - see

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataPropertyIntrospector.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/MetadataPropertyIntrospector.java
@@ -8,6 +8,7 @@ package com.ditrix.edt.mcp.server.utils;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import org.eclipse.emf.common.util.EList;
@@ -886,7 +887,7 @@ public final class MetadataPropertyIntrospector
             switch (kind)
             {
                 case LOCALIZED_STRING:
-                    return Rendered.of(renderLocalizedString(value));
+                    return renderLocalizedString(value);
                 case TYPE_DESCRIPTION:
                     return value instanceof TypeDescription
                         ? renderTypeDescription((TypeDescription)value) : Rendered.ABSENT;
@@ -925,27 +926,67 @@ public final class MetadataPropertyIntrospector
     }
 
     @SuppressWarnings("unchecked")
-    private static String renderLocalizedString(Object value)
+    private static Rendered renderLocalizedString(Object value)
     {
         if (!(value instanceof EMap<?, ?>))
         {
-            return null;
+            return Rendered.ABSENT;
         }
         EMap<String, String> map = (EMap<String, String>)value;
         if (map.isEmpty())
         {
-            return null;
+            return Rendered.ABSENT;
         }
-        StringBuilder sb = new StringBuilder();
+        StringBuilder display = new StringBuilder();
         for (java.util.Map.Entry<String, String> entry : map.entrySet())
         {
-            if (sb.length() > 0)
+            if (display.length() > 0)
             {
-                sb.append(", "); //$NON-NLS-1$
+                display.append(", "); //$NON-NLS-1$
             }
-            sb.append(entry.getKey()).append('=').append(entry.getValue());
+            display.append(entry.getKey()).append('=').append(entry.getValue());
         }
-        return sb.toString();
+        return Rendered.of(display.toString(), localizedStringIdentity(map));
+    }
+
+    /**
+     * Builds a canonical structural identity for a localized-string map.
+     * <p>
+     * The display deliberately stays the compact {@code language=value, ...} form, but neither
+     * separator is structural there: both are legal inside a localized value. Length-prefixing
+     * every key and value makes the boundary unambiguous, while sorting makes map insertion order
+     * irrelevant to equality. A {@code null} is encoded separately from an empty string.
+     *
+     * @param map the non-empty localized-string map
+     * @return an identity that cannot collide merely because display separators occur in data
+     */
+    private static String localizedStringIdentity(EMap<String, String> map)
+    {
+        List<java.util.Map.Entry<String, String>> entries = new ArrayList<>(map.entrySet());
+        Comparator<String> strings = Comparator.nullsFirst(Comparator.naturalOrder());
+        entries.sort((left, right) -> {
+            int byKey = strings.compare(left.getKey(), right.getKey());
+            return byKey != 0 ? byKey : strings.compare(left.getValue(), right.getValue());
+        });
+
+        StringBuilder identity = new StringBuilder().append(entries.size()).append(':');
+        for (java.util.Map.Entry<String, String> entry : entries)
+        {
+            appendIdentityPart(identity, entry.getKey());
+            appendIdentityPart(identity, entry.getValue());
+        }
+        return identity.toString();
+    }
+
+    /** Appends one nullable string in a self-delimiting form. */
+    private static void appendIdentityPart(StringBuilder identity, String value)
+    {
+        if (value == null)
+        {
+            identity.append("-1:"); //$NON-NLS-1$
+            return;
+        }
+        identity.append(value.length()).append(':').append(value);
     }
 
     /**

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolPresetTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/preferences/ToolPresetTest.java
@@ -167,6 +167,20 @@ public class ToolPresetTest
             ToolPreset.CODE_REVIEW.getDisabledTools().contains("get_project_errors"));
     }
 
+    /**
+     * merge_rules is not a read-only comparison helper: write mode creates files and can replace
+     * the file named by basedOn. Both presets promise no writing, so leaving it enabled would make
+     * the preset description false even though the comparison tools around it are analytical.
+     */
+    @Test
+    public void testBothReadOnlyPresetsDisableMergeRules()
+    {
+        assertTrue("ANALYSIS_ONLY should disable merge_rules", //$NON-NLS-1$
+            ToolPreset.ANALYSIS_ONLY.getDisabledTools().contains("merge_rules")); //$NON-NLS-1$
+        assertTrue("CODE_REVIEW should disable merge_rules", //$NON-NLS-1$
+            ToolPreset.CODE_REVIEW.getDisabledTools().contains("merge_rules")); //$NON-NLS-1$
+    }
+
     // === Preset matching ===
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CompareConfigurationsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CompareConfigurationsToolTest.java
@@ -451,6 +451,33 @@ public class CompareConfigurationsToolTest
         assertEquals(0, backend.starts());
     }
 
+    /**
+     * An empty string is a supplied merge-rules request, not an omission. Treating it as absent
+     * starts a comparison without the decisions the caller asked to apply and occupies EDT's
+     * single comparison slot with different merge behaviour.
+     */
+    @Test
+    public void testAnEmptyMergeRulesFileIsRefusedRatherThanSilentlyIgnored()
+    {
+        String result = tool.execute(request(Map.of("mergeRulesFile", "", //$NON-NLS-1$ //$NON-NLS-2$
+            "waitSeconds", "10"))); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertEquals("an empty rules path must not start a comparison", 0, backend.starts()); //$NON-NLS-1$
+        assertContains(errorMessage(result), "mergeRulesFile"); //$NON-NLS-1$
+    }
+
+    /** Omission still deliberately starts a comparison without pre-set merge decisions. */
+    @Test
+    public void testAnOmittedMergeRulesFileStillMeansNoPreSetRules()
+    {
+        tool.execute(request(Map.of("waitSeconds", "10"))); //$NON-NLS-1$ //$NON-NLS-2$
+
+        LaunchRequest seen = backend.lastRequest();
+        assertNotNull(seen);
+        assertNull("an omitted mergeRulesFile must stay absent", seen.getMergeRulesFile()); //$NON-NLS-1$
+        assertEquals(1, backend.starts());
+    }
+
     // ============ mergeRulesFile is ABSOLUTE, like the two path parameters of merge_rules ============
     //
     // Paths.get(value) never fails on a relative path and Files.isReadable answers for whatever it

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/MergeRulesToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/MergeRulesToolTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
@@ -57,6 +58,7 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 import com.ditrix.edt.mcp.server.tools.impl.MergeRulesTool.EngineRuleAuthority;
 import com.ditrix.edt.mcp.server.tools.impl.MergeRulesTool.MergeRuleAuthority;
 import com.ditrix.edt.mcp.server.tools.impl.MergeRulesTool.RuleSnapshot;
+import com.ditrix.edt.mcp.server.utils.DestructiveConsentGate.ConsentDecision;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -83,6 +85,10 @@ public class MergeRulesToolTest
     /** The exact set of input parameters {@code execute()} reads. Keep in lockstep with the schema. */
     private static final String[] EXECUTE_PARAMS =
         {"mode", "filePath", "basedOn", "decisions", "comparisonId", "limit"}; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+
+    /** Existing behavioural tests opt into the destructive same-path update explicitly. */
+    private static final MergeRulesTool.ConsentRequester ALLOW_CONSENT =
+        (toolName, preview) -> ConsentDecision.ALLOW;
 
     private static final String FIXTURE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" //$NON-NLS-1$
         + "<Settings Format_version=\"2.0\">\n" //$NON-NLS-1$
@@ -890,6 +896,53 @@ public class MergeRulesToolTest
         assertFalse("write mode must not answer with read mode's refusal: " + result, //$NON-NLS-1$
             result.contains("write-only")); //$NON-NLS-1$
         assertFalse("a refused call must leave no file behind", Files.exists(target)); //$NON-NLS-1$
+    }
+
+    /**
+     * A sent blank comparisonId is not omission: authority(null) means whichever comparison is
+     * running, so accepting it could validate and write against a comparison the caller did not
+     * name.
+     */
+    @Test
+    public void testAnEmptyComparisonIdIsRefusedInsteadOfUsingTheRunningComparison()
+        throws IOException
+    {
+        Path target = file("empty-comparison-id.xml"); //$NON-NLS-1$
+        AtomicInteger authorityCalls = new AtomicInteger();
+        MergeRulesTool tool = new MergeRulesTool(id -> {
+            authorityCalls.incrementAndGet();
+            return Optional.empty();
+        }, ALLOW_CONSENT);
+
+        String result = tool.execute(params("mode", "write", "filePath", target.toString(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            "comparisonId", "", //$NON-NLS-1$ //$NON-NLS-2$
+            "decisions", "[{\"path\":[],\"rule\":\"DoNotMerge\"}]")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertErrorNaming(result, "comparisonId", "blank"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("a blank id must not fall back to authority(null)", 0, //$NON-NLS-1$
+            authorityCalls.get());
+        assertFalse("a refused blank id must leave no file behind", Files.exists(target)); //$NON-NLS-1$
+    }
+
+    /** Omission still deliberately permits the tool's unvalidated no-comparison write. */
+    @Test
+    public void testAnOmittedComparisonIdStillMeansNoComparisonWasNamed() throws IOException
+    {
+        Path target = file("omitted-comparison-id.xml"); //$NON-NLS-1$
+        AtomicReference<String> authorityId = new AtomicReference<>("not called"); //$NON-NLS-1$
+        MergeRulesTool tool = new MergeRulesTool(id -> {
+            authorityId.set(id);
+            return Optional.empty();
+        }, ALLOW_CONSENT);
+
+        String result = tool.execute(params("mode", "write", "filePath", target.toString(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            "decisions", "[{\"path\":[],\"rule\":\"DoNotMerge\"}]")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertTrue("an omitted id must still author an unvalidated file: " + result, //$NON-NLS-1$
+            result.contains("NOT VALIDATED")); //$NON-NLS-1$
+        assertNull("omission must ask for the running comparison, not invent an id", //$NON-NLS-1$
+            authorityId.get());
+        assertTrue("the unvalidated file must actually be written", Files.exists(target)); //$NON-NLS-1$
     }
 
     // ==================== read ====================
@@ -1926,7 +1979,7 @@ public class MergeRulesToolTest
         Path archive = file("rules.zip"); //$NON-NLS-1$
         writeArchive(archive, null);
         MergeRulesTool tool = new MergeRulesTool(
-            id -> Optional.of(authority("cmp-7", EVERY_RULE))); //$NON-NLS-1$
+            id -> Optional.of(authority("cmp-7", EVERY_RULE)), ALLOW_CONSENT); //$NON-NLS-1$
 
         String result = tool.execute(params("mode", "write", "filePath", archive.toString(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             "basedOn", archive.toString(), //$NON-NLS-1$
@@ -2003,7 +2056,7 @@ public class MergeRulesToolTest
             out.closeEntry();
         }
         MergeRulesTool tool = new MergeRulesTool(
-            id -> Optional.of(authority("cmp-7", EVERY_RULE))); //$NON-NLS-1$
+            id -> Optional.of(authority("cmp-7", EVERY_RULE)), ALLOW_CONSENT); //$NON-NLS-1$
 
         String result = tool.execute(params("mode", "write", "filePath", archive.toString(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             "basedOn", archive.toString(), //$NON-NLS-1$
@@ -2030,7 +2083,7 @@ public class MergeRulesToolTest
             out.closeEntry();
         }
         MergeRulesTool tool = new MergeRulesTool(
-            id -> Optional.of(authority("cmp-7", EVERY_RULE))); //$NON-NLS-1$
+            id -> Optional.of(authority("cmp-7", EVERY_RULE)), ALLOW_CONSENT); //$NON-NLS-1$
 
         String result = tool.execute(params("mode", "write", "filePath", archive.toString(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             "basedOn", archive.toString(), //$NON-NLS-1$
@@ -2062,7 +2115,7 @@ public class MergeRulesToolTest
             out.closeEntry();
         }
         MergeRulesTool tool = new MergeRulesTool(
-            id -> Optional.of(authority("cmp-7", EVERY_RULE))); //$NON-NLS-1$
+            id -> Optional.of(authority("cmp-7", EVERY_RULE)), ALLOW_CONSENT); //$NON-NLS-1$
 
         String result = tool.execute(params("mode", "write", "filePath", archive.toString(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             "basedOn", archive.toString(), //$NON-NLS-1$
@@ -2081,7 +2134,7 @@ public class MergeRulesToolTest
         // something they never had.
         Path archive = file("source.zip"); //$NON-NLS-1$
         MergeRulesTool tool = new MergeRulesTool(
-            id -> Optional.of(authority("cmp-7", EVERY_RULE))); //$NON-NLS-1$
+            id -> Optional.of(authority("cmp-7", EVERY_RULE)), ALLOW_CONSENT); //$NON-NLS-1$
         tool.execute(params("mode", "write", "filePath", archive.toString(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             "decisions", "[{\"path\":[],\"rule\":\"DoNotMerge\"}]")); //$NON-NLS-1$ //$NON-NLS-2$
 
@@ -2495,7 +2548,8 @@ public class MergeRulesToolTest
     {
         Path target = seedFixture();
         MergeRulesTool tool = new MergeRulesTool(id -> Optional.of(authority("cmp-7", //$NON-NLS-1$
-            List.of("GetFromOther", "DoNotMerge", "MergePrioritizingMain")))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            List.of("GetFromOther", "DoNotMerge", "MergePrioritizingMain"))), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            ALLOW_CONSENT);
 
         String result = tool.execute(params("mode", "write", "filePath", target.toString(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             "basedOn", target.toString(), //$NON-NLS-1$
@@ -3994,6 +4048,120 @@ public class MergeRulesToolTest
             read(target).contains("<Node Key=\"$$Root$$\" MergeRule=\"DoNotMerge\"/>")); //$NON-NLS-1$
     }
 
+    // ============ Only a validated same-path replacement asks for destructive consent ============
+
+    /**
+     * Read mode and a fresh write destroy nothing and therefore never ask. The same file becomes
+     * destructive only when filePath and basedOn name it as the target to replace.
+     */
+    @Test
+    public void testConsentIsAskedOnlyForTheSamePathReplace() throws IOException
+    {
+        AtomicInteger consentCalls = new AtomicInteger();
+        MergeRulesTool tool = new MergeRulesTool(id -> Optional.empty(), (toolName, preview) -> {
+            consentCalls.incrementAndGet();
+            return ConsentDecision.ALLOW;
+        });
+        Path readable = seed("consent-read.xml", NO_RULE_AT_ALL); //$NON-NLS-1$
+        tool.execute(params("mode", "read", "filePath", readable.toString())); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+        Path target = file("consent-fresh.xml"); //$NON-NLS-1$
+        String fresh = tool.execute(params("mode", "write", "filePath", target.toString(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            "decisions", "[{\"path\":[],\"rule\":\"DoNotMerge\"}]")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertTrue("the fresh write must succeed without consent: " + fresh, //$NON-NLS-1$
+            fresh.startsWith("# Merge rules written:")); //$NON-NLS-1$
+        assertEquals("read and fresh-write paths must not ask", 0, consentCalls.get()); //$NON-NLS-1$
+
+        String replace = tool.execute(params("mode", "write", "filePath", target.toString(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            "basedOn", target.toString(), //$NON-NLS-1$
+            "decisions", "[{\"path\":[\"catalogs\"],\"rule\":\"GetFromOther\"}]")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertTrue("the allowed replacement must succeed: " + replace, //$NON-NLS-1$
+            replace.startsWith("# Merge rules written:")); //$NON-NLS-1$
+        assertEquals("the destructive replacement must ask exactly once", 1, //$NON-NLS-1$
+            consentCalls.get());
+    }
+
+    /**
+     * Every refusal verdict is terminal: the caller gets a structured refusal and the existing
+     * bytes remain exact.
+     * <p>
+     * What is asserted here is this TOOL's contract - refused means nothing was written - and not
+     * the wording of each verdict, which is shared by every gated tool and pinned once in
+     * {@code DestructiveConsentGateTest}. Demanding the tool's name in all three texts would only
+     * push this test into rewriting a message that #277 deliberately froze.
+     * </p>
+     */
+    @Test
+    public void testEveryNonAllowConsentVerdictPreventsTheReplacement() throws IOException
+    {
+        for (ConsentDecision decision : List.of(ConsentDecision.REJECT, ConsentDecision.TIMEOUT,
+            ConsentDecision.UNATTENDED))
+        {
+            Path target = seed("consent-" + decision.name() + ".xml", FIXTURE); //$NON-NLS-1$ //$NON-NLS-2$
+            MergeRulesTool tool = new MergeRulesTool(id -> Optional.empty(),
+                (toolName, preview) -> decision);
+
+            String result = tool.execute(params("mode", "write", "filePath", target.toString(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                "basedOn", target.toString(), //$NON-NLS-1$
+                "decisions", "[{\"path\":[\"catalogs\"],\"rule\":\"DoNotMerge\"}]")); //$NON-NLS-1$ //$NON-NLS-2$
+
+            assertErrorNaming(result);
+            assertEquals(decision + " must leave the original file byte-for-byte unchanged", //$NON-NLS-1$
+                FIXTURE, read(target));
+        }
+    }
+
+    /**
+     * The gate is asked with THIS tool's name, which is what makes the prompt and the audit line
+     * say which tool wants the replacement. Asserted at the call rather than in the message,
+     * because the message is shared and frozen.
+     */
+    @Test
+    public void testTheGateIsAskedUnderTheToolsOwnName() throws IOException
+    {
+        Path target = seed("consent-tool-name.xml", FIXTURE); //$NON-NLS-1$
+        AtomicReference<String> askedFor = new AtomicReference<>();
+        MergeRulesTool tool = new MergeRulesTool(id -> Optional.empty(), (toolName, preview) -> {
+            askedFor.set(toolName);
+            return ConsentDecision.REJECT;
+        });
+
+        tool.execute(params("mode", "write", "filePath", target.toString(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            "basedOn", target.toString(), //$NON-NLS-1$
+            "decisions", "[{\"path\":[\"catalogs\"],\"rule\":\"DoNotMerge\"}]")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertEquals("the gate must be asked for merge_rules", "merge_rules", askedFor.get()); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * The prompt follows comparison validation. Asking before this refusal would make a human
+     * authorize a replacement the tool already knows it cannot perform.
+     */
+    @Test
+    public void testComparisonValidationRefusesBeforeConsentIsAsked() throws IOException
+    {
+        Path target = seed("consent-after-validation.xml", NO_RULE_AT_ALL); //$NON-NLS-1$
+        AtomicInteger consentCalls = new AtomicInteger();
+        MergeRulesTool tool = new MergeRulesTool(
+            id -> Optional.of(authority("cmp-validate", List.of())), //$NON-NLS-1$
+            (toolName, preview) -> {
+                consentCalls.incrementAndGet();
+                return ConsentDecision.ALLOW;
+            });
+
+        String result = tool.execute(params("mode", "write", "filePath", target.toString(), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            "basedOn", target.toString(), "comparisonId", "cmp-validate", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            "decisions", "[{\"path\":[],\"rule\":\"DoNotMerge\"}]")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertErrorNaming(result, "offers no merge rule", "Nothing was written"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("a validation refusal must happen before any consent request", 0, //$NON-NLS-1$
+            consentCalls.get());
+        assertEquals("validation refusal must preserve the existing file", NO_RULE_AT_ALL, //$NON-NLS-1$
+            read(target));
+    }
+
     // ============ A same-path rewrite may not detach two names of one file ============
 
     @Test
@@ -4756,7 +4924,7 @@ public class MergeRulesToolTest
                 Thread.currentThread().interrupt();
             }
             return Optional.empty();
-        });
+        }, ALLOW_CONSENT);
 
         AtomicReference<String> firstResult = new AtomicReference<>();
         Thread first = new Thread(() -> firstResult.set(parking.execute(params("mode", "write", //$NON-NLS-1$ //$NON-NLS-2$
@@ -4857,7 +5025,7 @@ public class MergeRulesToolTest
 
     private String call(Map<String, String> params)
     {
-        return new MergeRulesTool().execute(params);
+        return new MergeRulesTool(id -> Optional.empty(), ALLOW_CONSENT).execute(params);
     }
 
     private static Map<String, String> params(String... keyValues)

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGateTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGateTest.java
@@ -184,7 +184,7 @@ public class DestructiveConsentGateTest
         assertEquals("GATED_TOOLS must be exactly the frozen set", //$NON-NLS-1$
             Set.of("delete_metadata", "rename_metadata_object", "delete_project", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
                 "delete_infobase", "update_database", "modify_metadata", "dcs", "git", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
-                "evaluate_expression"), //$NON-NLS-1$
+                "merge_rules", "evaluate_expression"), //$NON-NLS-1$ //$NON-NLS-2$
             DestructiveConsentGate.GATED_TOOLS);
     }
 
@@ -197,7 +197,9 @@ public class DestructiveConsentGateTest
         // evaluate_expression (arbitrary BSL: usually a read, occasionally a mutation, and nothing
         // in the call says which - which is exactly why the GATE asks every time while the HINT,
         // one per tool, keeps describing the typical read). Those four carry their own annotations
-        // and are deliberately NOT in the always-destructive classifier list.
+        // and are deliberately NOT in the always-destructive classifier list. merge_rules is also
+        // gated conditionally, but its per-tool hint stays destructive because replacing a rules
+        // file is a primary capability of its write mode.
         Set<String> conditionallyDestructive =
             Set.of("modify_metadata", "dcs", "git", "evaluate_expression"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
         for (String tool : DestructiveConsentGate.GATED_TOOLS)

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataPropertyIntrospectorTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataPropertyIntrospectorTest.java
@@ -725,6 +725,33 @@ public class MetadataPropertyIntrospectorTest
             "en=Weight".equals(synonym.currentValue)); //$NON-NLS-1$
     }
 
+    /**
+     * Display separators are data too. These two localized maps intentionally render the same
+     * compact text, but one has one language entry and the other has two; their comparison
+     * identities must preserve that structural difference without changing what a reader sees.
+     */
+    @Test
+    public void testLocalizedIdentityCannotCollideThroughDisplaySeparators()
+    {
+        String greeting = "\u041F\u0440\u0438\u0432\u0435\u0442"; //$NON-NLS-1$
+        CatalogAttribute oneEntry = newAttribute();
+        oneEntry.getSynonym().put("en", "Hello, ru=" + greeting); //$NON-NLS-1$ //$NON-NLS-2$
+        CatalogAttribute twoEntries = newAttribute();
+        twoEntries.getSynonym().put("en", "Hello"); //$NON-NLS-1$ //$NON-NLS-2$
+        twoEntries.getSynonym().put("ru", greeting); //$NON-NLS-1$
+
+        PropertyInfo one = MetadataPropertyIntrospector.find(oneEntry, "synonym"); //$NON-NLS-1$
+        PropertyInfo two = MetadataPropertyIntrospector.find(twoEntries, "synonym"); //$NON-NLS-1$
+
+        String unchangedDisplay = "en=Hello, ru=" + greeting; //$NON-NLS-1$
+        assertEquals("the one-entry display must remain compact", unchangedDisplay, //$NON-NLS-1$
+            one.currentValue);
+        assertEquals("the two-entry display must remain compact", unchangedDisplay, //$NON-NLS-1$
+            two.currentValue);
+        assertFalse("structurally different localized maps must not identify alike", //$NON-NLS-1$
+            one.valueIdentity.equals(two.valueIdentity));
+    }
+
     @Test
     public void testEnumCurrentValueSharesAllowedVocabulary()
     {


### PR DESCRIPTION
Два P1-бага из бэклога, оба — находки бота на #484, пришедшие за две минуты до вливания. Пять дефектов, по коммиту на issue.

### #557 — merge_rules помечен разрушающим, но ни один механизм его не видел

**Согласие не спрашивалось вообще.** `ToolAnnotationClassifier` относит `merge_rules` к разрушающим (в режиме `write` инструмент ЗАМЕНЯЕТ файл, названный `basedOn`), но имени не было в `DestructiveConsentGate.GATED_TOOLS`, а в самом инструменте — ноль обращений к гейту. MCP-клиент перезаписывал архив даже при `ask_always`.

Теперь гейт спрашивает — условно, как у `modify_metadata` и `git`: режим `read` и запись по свободному пути не разрушают ничего. Вопрос стоит ПОСЛЕДНИМ шагом перед заменой и только для `Target.MAY_BE_REPLACED`, поэтому вызов, который всё равно закончится отказом валидации, никому не показывает диалог.

**Оба read-only пресета оставляли его включённым.** `ANALYSIS_ONLY` и `CODE_REVIEW` перечисляют исключения поимённо, `merge_rules` не входит ни в одну из отключаемых групп — а оба обещают «no writing».

Слова отказа REJECT намеренно НЕ тронуты: они общие для всех гейтящихся инструментов и заморожены #277, чей тест пинит их точным равенством. Привязка к инструменту доказывается на месте вызова (гейт спрашивается под именем `merge_rules`), а замороженный текст сохраняет свою защиту.

Уже сохранённые профили пользователей НЕ мигрируются — это меняет сохранённый выбор безопасности и требует отдельного решения; оставлено в issue.

### #558 — пустая строка как пропуск, и display-строка как identity

**Присланная пустая строка снова читалась как «не прислали», в двух местах.** Ровно эта форма уже чинилась дважды в этой же области (`releaseComparisonId`, `scope`), поэтому обе правки повторяют то же написание: присутствие по КЛЮЧУ, потом отказ на пустом значении.

- `merge_rules` / `comparisonId`: пустое значение проваливалось в `authority(null)` — «то сравнение, которое сейчас идёт», либо вообще запись БЕЗ валидации. Тест пинит и то, что при пустом id authority не спрашивается вовсе.
- `compare_configurations` / `mergeRulesFile`: пустое молча становилось отсутствием, сравнение стартовало БЕЗ решений и занимало единственный слот EDT. Тест пинит, что сравнение не стартует.

Обе сохраняют честную оговорку предыдущих двух: `extractToolParams` выбрасывает JSON `null` до построения карты, поэтому явный `null` остаётся пропуском — это правило транспорта для всех инструментов. Пропуск при этом остаётся осмысленным и проверяется отдельно: это изменение того, ЧТО считается присланным, а у него две стороны.

**Identity локализованной строки строилась из отображаемого текста**, склеенного через `, ` и `=` — ни один из разделителей не структурный, оба легальны внутри значения. Поэтому `{en: "Hello, ru=Привет"}` и `{en: "Hello", ru: "Привет"}` давали ОДНУ identity, а после #484 сравнение идёт именно по ней — то есть два материально разных набора отчёт мог назвать равными. Теперь identity длиноprefixed и самоограничивающаяся, сортируется (порядок карты не влияет) и различает `null` и пустую строку. Отображаемый текст не изменился — тест утверждает это для обеих карт, прежде чем утверждать, что identity различаются.

---

**Проверка — прочтите это перед вливанием.** Локальный `source/compile.sh` НЕ доведён до конца, и не из-за кода: оба плагина компилируются успешно, все семь новых тестов ОТРАБОТАЛИ и прошли, падений тестов нет ни в одном прогоне — но JVM тестового рантайма дважды умирает посреди прогона с нативным OOM (`hs_err_pid*`: `mmap failed ... G1 virtual space`, затем `malloc ... Chunk::new`). Машина занята параллельной сборкой в других репозиториях (`wt-split`, `wt-exact`, `wt-harness`), commit charge 35.9 ГБ из 39 ГБ. Поэтому вердикт здесь за CI: он гоняет ту же сборку на своём раннере.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
