### PR TITLE
dcs: успешная запись DynamicList больше не выдаётся за отказ (#581)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DcsModelComparison.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DcsModelComparison.java
@@ -108,6 +108,14 @@ public final class DcsModelComparison
             }
             Object expectedValue = expected.eGet(expectedFeature);
             Object actualValue = actual.eGet(actualFeature);
+            if (expectedFeature
+                == FormPackage.Literals.DYNAMIC_LIST_EXT_INFO__LIST_SETTINGS
+                && expectedValue == null && actualValue != null)
+            {
+                // The platform materializes a default settings carrier after commit, so its
+                // presence cannot contradict a request that did not author listSettings (issue #581).
+                continue;
+            }
             String difference;
             if (expectedFeature instanceof EAttribute)
             {

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DcsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/DcsToolTest.java
@@ -117,6 +117,8 @@ public class DcsToolTest
         assertNotNull(error);
         assertTrue(error, error.contains("Applied is withheld")); //$NON-NLS-1$
         assertTrue(error, error.contains("post-commit read")); //$NON-NLS-1$
+        assertTrue(error, error.contains("requested content is attached")); //$NON-NLS-1$
+        assertTrue(error, error.contains("Re-run dcs action='get' before any retry")); //$NON-NLS-1$
         assertTrue(error, error.contains(address));
         assertTrue(error, error.contains("root/listSettings/selection")); //$NON-NLS-1$
     }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/DcsSettingsWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/DcsSettingsWriterTest.java
@@ -684,6 +684,76 @@ public class DcsSettingsWriterTest
         assertTrue(difference, difference.contains("root/selection")); //$NON-NLS-1$
     }
 
+    @Test
+    public void testDynamicListComparisonAllowsMaterializedDefaultListSettings()
+    {
+        DynamicListExtInfo expected = FormFactory.eINSTANCE.createDynamicListExtInfo();
+        DynamicListExtInfo actual = FormFactory.eINSTANCE.createDynamicListExtInfo();
+        actual.setListSettings(com._1c.g5.v8.dt.dcs.model.settings.DcsFactory.eINSTANCE
+            .createDataCompositionSettings());
+
+        assertNull(expected.getListSettings());
+        assertNotNull(actual.getListSettings());
+        assertNull(DcsModelComparison.firstDifference(expected, actual));
+    }
+
+    @Test
+    public void testDynamicListComparisonRejectsMissingAuthoredListSettings()
+    {
+        DynamicListExtInfo expected = FormFactory.eINSTANCE.createDynamicListExtInfo();
+        expected.setListSettings(com._1c.g5.v8.dt.dcs.model.settings.DcsFactory.eINSTANCE
+            .createDataCompositionSettings());
+        DynamicListExtInfo actual = FormFactory.eINSTANCE.createDynamicListExtInfo();
+
+        String difference = DcsModelComparison.firstDifference(expected, actual);
+
+        assertNotNull(difference);
+        assertTrue(difference, difference.contains("root/listSettings")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testDynamicListComparisonStillDescendsIntoAuthoredListSettings()
+    {
+        DynamicListExtInfo expected = FormFactory.eINSTANCE.createDynamicListExtInfo();
+        DataCompositionSettings expectedSettings =
+            com._1c.g5.v8.dt.dcs.model.settings.DcsFactory.eINSTANCE
+                .createDataCompositionSettings();
+        expectedSettings.setItemsUserSettingID("expected"); //$NON-NLS-1$
+        expected.setListSettings(expectedSettings);
+        DynamicListExtInfo actual = FormFactory.eINSTANCE.createDynamicListExtInfo();
+        DataCompositionSettings actualSettings =
+            com._1c.g5.v8.dt.dcs.model.settings.DcsFactory.eINSTANCE
+                .createDataCompositionSettings();
+        actualSettings.setItemsUserSettingID("actual"); //$NON-NLS-1$
+        actual.setListSettings(actualSettings);
+
+        String difference = DcsModelComparison.firstDifference(expected, actual);
+
+        assertNotNull(difference);
+        assertTrue(difference, difference.contains(
+            "root/listSettings/itemsUserSettingID")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testComparisonRejectsUnexpectedValueOnOtherFeature()
+    {
+        DataCompositionSettings expected =
+            com._1c.g5.v8.dt.dcs.model.settings.DcsFactory.eINSTANCE
+                .createDataCompositionSettings();
+        DataCompositionSettings actual =
+            com._1c.g5.v8.dt.dcs.model.settings.DcsFactory.eINSTANCE
+                .createDataCompositionSettings();
+        actual.setSelection(com._1c.g5.v8.dt.dcs.model.settings.DcsFactory.eINSTANCE
+            .createDataCompositionSelectedFields());
+
+        assertNull(expected.getSelection());
+        assertNotNull(actual.getSelection());
+        String difference = DcsModelComparison.firstDifference(expected, actual);
+
+        assertNotNull(difference);
+        assertTrue(difference, difference.contains("root/selection")); //$NON-NLS-1$
+    }
+
     private static DataCompositionSchema schemaWithVariant()
     {
         DataCompositionSchema schema = DcsFactory.eINSTANCE.createDataCompositionSchema();

--- a/tests/e2e/tools/test_dcs.py
+++ b/tests/e2e/tools/test_dcs.py
@@ -2833,8 +2833,12 @@ def test_dynamic_list_without_authored_settings_is_not_reported_as_a_failed_writ
     assert_not_contains(written.text, "mutationCommitted",
                         "a committed write must not be dressed as a failure")
 
-    # The verdict is only trustworthy if the write actually landed: read the model back.
+    # The verdict is only trustworthy if the write actually landed: read the model back. The
+    # read must be asserted OK first - a dcs failure names the full target FQN, which contains
+    # the catalog name, so the marker check alone would pass on "DCS root target ... was not
+    # found" and prove nothing.
     back = _get(root, "dynamicList")
+    assert_ok(back, "the written dynamic list must read back")
     assert_contains(back.text, catalog_name,
                     "the read-back must show the main table the write asked for")
 

--- a/tests/e2e/tools/test_dcs.py
+++ b/tests/e2e/tools/test_dcs.py
@@ -14,9 +14,11 @@ import xml.etree.ElementTree as ET
 from harness import (
     PROJECT,
     PROJECT_DIR,
+    assert_contains,
     assert_error,
     assert_error_quality,
     assert_no_diff,
+    assert_not_contains,
     assert_ok,
     call,
     diff,
@@ -2789,6 +2791,52 @@ def test_field_collection_replace_refuses_omitting_selected_field_and_preserves_
                          ctx="field collection replacement names the retained reference")
     assert read_disk(dcs_rel) == before_disk, \
         "a refused field collection replacement must leave Template.dcs byte-for-byte unchanged"
+
+
+@e2e_test(tool="dcs", kind="write-metadata")
+def test_dynamic_list_without_authored_settings_is_not_reported_as_a_failed_write():
+    """A write that authors NO listSettings must still answer success (issue #581).
+
+    The post-commit verification compares what was written against a re-read, and the platform
+    materializes a default DataCompositionSettings carrier on the committed object by itself.
+    A write that never mentioned listSettings therefore came back as
+    'success=false, mutationCommitted=true' with 'root/listSettings: expected <null>, actual
+    DataCompositionSettings' - the mutation had landed and the caller was told it had not, which
+    is the shape that makes an unattended agent retry or start repairing correct content.
+
+    The body here is deliberately the MINIMAL one from the report - main table plus flags, no
+    query, no fields, no parameters - because every richer body authors settings and so never
+    reproduced this. The read-back proves the write really did land, so a future regression
+    cannot be waved away as a merely cosmetic verdict.
+    """
+    catalog_name = "E2EDcsListNoSettings"
+    catalog = "Catalog." + catalog_name
+    form = catalog + ".Form.ListForm"
+    root = form + ".Attribute.List"
+    for fqn, why in ((catalog, "catalog"), (form, "form"), (root, "attribute")):
+        assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": fqn}),
+                  "seed the %s" % why)
+        wait_for_project_ready()
+
+    written = _write(root, "upsert", "dynamicList", {
+        "mainTable": catalog,
+        "customQuery": False,
+        "dynamicDataRead": True,
+        "autoFillAvailableFields": True,
+    })
+    assert_ok(written, "a dynamic list without authored settings must be reported as written")
+    # The exact refusal wording, not the bare word 'listSettings': a successful answer may
+    # legitimately name the feature, and an assertion forbidding the word would then fail for a
+    # reason that has nothing to do with this defect.
+    assert_not_contains(written.text, "post-commit read",
+                        "the materialized settings carrier must not read as a verification miss")
+    assert_not_contains(written.text, "mutationCommitted",
+                        "a committed write must not be dressed as a failure")
+
+    # The verdict is only trustworthy if the write actually landed: read the model back.
+    back = _get(root, "dynamicList")
+    assert_contains(back.text, catalog_name,
+                    "the read-back must show the main table the write asked for")
 
 
 @e2e_test(tool="dcs", kind="write-metadata")


### PR DESCRIPTION
Закрывает #581.

## Что было

`dcs` записывал DynamicList, мутация **коммитилась и результат был правильным** — последующее чтение, сборка `.epf` платформой и открытая форма это подтвердили, — но инструмент отвечал `success=false, mutationCommitted=true` с причиной:

```
root/listSettings: expected <null>, actual DataCompositionSettings
```

Для автономного агента это худшая форма неверного ответа: запись состоялась, инструмент сказал обратное, и следующий шаг — лишний повтор или «починка» того, что уже верно.

## Причина

Post-commit сравнение (`DcsModelComparison.firstDifference`) намеренно охватывает `listSettings`, хотя это не containment-ссылка: настройки, которые мы **авторски записали**, обязаны оказаться прикреплёнными, иначе ответ не доказывает результат. Чего сравнение не учитывало — EDT сам материализует пустой носитель настроек на закоммиченном объекте. Запрос, который про `listSettings` вообще не говорил, таким объектом опровергнут быть не может.

## Что изменено

Ровно одно правило и только для этой ссылки: **отсутствующее ожидаемое значение против присутствующего фактического** больше не считается расхождением.

Асимметрия и узость намеренные:

- настройки, которые мы записали, **пропавшие** после коммита — по-прежнему отказ (это то, ради чего проверка и существует);
- если настройки есть с обеих сторон, они сравниваются целиком, включая вложенные пути;
- никакая другая фича не получает правила «у фактического могут быть лишние» — общее послабление уничтожило бы смысл проверки.

Безопасность асимметрии опирается на факт из кода, а не на предположение: писатель никогда не сохраняет `null`-носитель — единственный путь (`DcsDynamicListWriter.commitSettingsCarrierWithAttachment`) создаёт его, если носителя нет. Значит, пустое ожидаемое значение может означать только «эта запись не авторствовала настройки», но не «эта запись их удалила». (Единственное место, где `setListSettings(null)` вообще вызывается, — построение отсоединённого снимка в `snapshot`, на аргумент это не влияет.)

## Тесты

Юнит (`DcsSettingsWriterTest`), все четыре угла правила: материализованный носитель при отсутствующем ожидаемом — не расхождение; авторские настройки, пропавшие в факте, — расхождение; различие **внутри** настроек по-прежнему сообщается с внутренним путём; та же форма «пусто/присутствует» на другой фиче — по-прежнему расхождение.

E2E (`test_dcs.py`) — **минимальное** тело из отчёта: основная таблица и флаги, без запроса, полей и параметров. Именно поэтому дефект и не ловился раньше: любое более богатое тело авторствует настройки. Тест дополнительно перечитывает модель, чтобы будущая регрессия не была списана на «косметический вердикт», и целится в саму фразу отказа, а не в слово `listSettings`, которое успешный ответ может упоминать законно.

Локально: `Dcs*Test` — 91 тест, 0 падений (полный прогон на этой машине не доходит до конца из-за нативного OOM тестовой JVM, гейт — CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
