### PR TITLE
create_project умеет засеять корневой объект проекта внешних объектов (#580)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/create_metadata.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/create_metadata.md
@@ -99,9 +99,9 @@ A `language` CODE must be one the configuration DECLARES (`get_configuration_pro
 Members of an external data processor / report are created the same way as a configuration
 object's - `ExternalDataProcessor.<Name>.Attribute.<Attr>`, `....Form.<F>`, and the
 form content under it. Two limits are structural, not gaps in addressing:
-- the ROOT object itself cannot be created here (it is created with its project, in EDT or by
-  importing an .epf/.erf; `create_project` with `projectKind=externalObjects` makes the empty
-  project only);
+- the ROOT object itself cannot be created here; seed it with `create_project` using
+  `projectKind=externalObjects` and `externalObject='ExternalDataProcessor.<Name>'` (or
+  `ExternalReport.<Name>`), or import an existing `.epf` / `.erf`;
 - an external data processor / report has no `Command` collection in the platform model, so
   `....Command.<Name>` is refused with the list of kinds the object does accept.
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/create_project.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/create_project.md
@@ -11,8 +11,9 @@ a base project, or an external data processors/reports project.
   Use this to override metadata objects (`adopt_metadata_object`) or add BSL interceptors
   without modifying the base configuration.
 - **externalObjects** — create an external data processors/reports project. The project
-  will be empty and ready for adding external data processors or external reports via
-  `create_metadata`.
+  may be seeded with its root `ExternalDataProcessor` / `ExternalReport` in the same call,
+  after which its members are ready for authoring via `create_metadata`. Omit the root when
+  creating an empty project for a later `.epf` / `.erf` import.
 
 The `name` must not already exist as a workspace project (the tool rejects duplicates).
 
@@ -57,6 +58,11 @@ The `name` must not already exist as a workspace project (the tool rejects dupli
 ### externalObjects kind
 
 - **version** (optional): platform version string. Default: `Version.LATEST`.
+- **externalObject** (optional): root object to seed, addressed as
+  `ExternalDataProcessor.<Name>` or `ExternalReport.<Name>`. The TYPE token is resolved by
+  the shared bilingual metadata resolver, so its registered Russian spellings work too;
+  `<Name>` is the programmatic 1C identifier, not a synonym. A bare Name is rejected rather
+  than guessed. Omit this parameter to preserve an empty project for the import workflow.
 - **scriptVariant** (optional, `Russian` or `English`): applied post-create via
   `IExternalObjectProjectManager.setScriptVariant`. Non-fatal on failure (see
   `scriptVariantNote` in response).
@@ -110,6 +116,16 @@ External objects project:
 {"projectKind": "externalObjects", "name": "MyExternal"}
 ```
 
+External data processor project with its root object:
+
+```json
+{
+  "projectKind": "externalObjects",
+  "name": "MyExternal",
+  "externalObject": "ExternalDataProcessor.MyProcessor"
+}
+```
+
 External objects with version:
 
 ```json
@@ -129,6 +145,16 @@ External objects with version:
 2. `create_metadata` — add metadata objects (Catalog, Document, CommonModule, etc.).
 3. `write_module_source` — fill module BSL code.
 4. `update_database` — start the first infobase from the configuration.
+
+## Workflow (external object)
+
+1. `create_project` with `projectKind=externalObjects` and an `externalObject` FQN — create
+   the project and its root in one operation. Omit `externalObject` only when a later import
+   will supply the root.
+2. `create_metadata` — add attributes, tabular sections, forms, templates, and form content
+   below that root FQN.
+3. `write_module_source` — fill the root and form modules.
+4. `build_external_objects` — produce the `.epf` / `.erf` artifact.
 
 ## Response fields
 
@@ -169,3 +195,5 @@ On success the response includes:
 - **externalObjects scriptVariant is post-create and non-fatal.** If `setScriptVariant`
   fails after lifecycle wait, the project is still created. Check `scriptVariantNote` in
   the response for details.
+- **Omitting externalObject is intentional.** It creates the same empty external-objects
+  project as before, ready for an import that supplies its root object.

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/create_project.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/create_project.md
@@ -60,9 +60,15 @@ The `name` must not already exist as a workspace project (the tool rejects dupli
 - **version** (optional): platform version string. Default: `Version.LATEST`.
 - **externalObject** (optional): root object to seed, addressed as
   `ExternalDataProcessor.<Name>` or `ExternalReport.<Name>`. The TYPE token is resolved by
-  the shared bilingual metadata resolver, so its registered Russian spellings work too;
-  `<Name>` is the programmatic 1C identifier, not a synonym. A bare Name is rejected rather
-  than guessed. Omit this parameter to preserve an empty project for the import workflow.
+  the shared bilingual metadata resolver, so its registered Russian spellings work too, and
+  is never normalized. `<Name>` is the programmatic 1C identifier, not a synonym. A bare Name
+  is rejected rather than guessed. Omit this parameter to preserve an empty project for the
+  import workflow.
+- **normalizeYo** (optional, default `true`): normalize `ё`->`е` / `Ё`->`Е` in the seeded
+  root NAME before identifier validation. `ё` in a Name is flagged by the 1C standard
+  `mdo-ru-name-unallowed-letter`, so the default stores a compliant Name. Set `false` to keep
+  `ё` exactly as supplied. The result names rewritten fields under `normalized`; this never
+  changes the externalObject TYPE token.
 - **scriptVariant** (optional, `Russian` or `English`): applied post-create via
   `IExternalObjectProjectManager.setScriptVariant`. Non-fatal on failure (see
   `scriptVariantNote` in response).
@@ -126,6 +132,17 @@ External data processor project with its root object:
 }
 ```
 
+To deliberately preserve `ё` in the root Name:
+
+```json
+{
+  "projectKind": "externalObjects",
+  "name": "MyExternal",
+  "externalObject": "ExternalReport.Всё",
+  "normalizeYo": false
+}
+```
+
 External objects with version:
 
 ```json
@@ -159,6 +176,8 @@ External objects with version:
 ## Response fields
 
 On success the response includes:
+- `action` — `created` after a completed create (and on the unchanged empty-project slow
+  path); `verificationRequired` when a seeded create exceeded the wait window.
 - `project` — the workspace project name (the round-trip key for sibling tools).
 - `projectKind` — kind of project created.
 - `name` — the Configuration name (configuration and extension only).
@@ -166,8 +185,17 @@ On success the response includes:
 - `prefix` / `purpose` — extension-only attributes applied.
 - `scriptVariant` — script variant applied or inherited.
 - `version` — platform version used for project creation.
+- `externalObject` — canonical FQN of the seeded root, including the stored (possibly
+  normalized) Name, when a root was requested.
+- `externalObjectConfirmed` — on the slow seeded-root path, whether that FQN was actually
+  observed through the same metadata scope used by `get_metadata_objects`.
+- `normalized` — fields rewritten by the default `ё`->`е` normalization; `name` here means
+  the seeded root Name.
 - `state` — `ready` when the lifecycle STARTED event was received (project is fully
-  indexed); `created` when the timeout elapsed before STARTED.
+  indexed); `created` when the timeout elapsed before STARTED and creation is otherwise
+  confirmed; `rootConfirmed` / `rootUnconfirmed` records whether a requested root was
+  observed during a slow create. Both slow seeded-root states use
+  `action=verificationRequired`, not `created`, because the create job has not finished.
 - `codestyle` — `{applied: bool, note: string, autoSortNote: string}` reporting the
   v8codestyle preference write result.
 - `synonymNote` — present only when the synonym (configuration/extension) could not be
@@ -183,7 +211,17 @@ On success the response includes:
   configuration's project name. Passing an extension project name returns an error.
 - **After creation, wait for `state=ready`** before calling `adopt_metadata_object` or
   other project-dependent tools; the new project must complete lifecycle indexing.
-  If `state=created` is returned, retry after a few seconds or call `revalidate_objects`.
+  If `state=created` is returned, retry the dependent call after a few seconds or call
+  `revalidate_objects`.
+- **A slow seeded root is verified, not recreated.** If creation exceeds the wait window,
+  the tool makes a best-effort read through the metadata scope. An unresolvable root may
+  simply mean indexing is still running. The response always reports
+  `action=verificationRequired`, the requested canonical `externalObject`, and the observed
+  result as `state=rootConfirmed` / `state=rootUnconfirmed` plus
+  `externalObjectConfirmed=true` / `false`. Once indexing finishes, verify it with
+  `get_metadata_objects`. Do not repeat `create_project`: the existing project container will
+  make the duplicate-project guard refuse the retry, whether or not EDT eventually attaches
+  the root.
 - **autoSortTopObjects is not yet applied.** See `codestyle.autoSortNote` in the response.
 - **Client-side timeouts.** Creation can take a couple of minutes on a busy workspace (the
   tool waits for the create operation and then for lifecycle STARTED). If your MCP client

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/InputSchemaCompactor.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/InputSchemaCompactor.java
@@ -260,10 +260,12 @@ public final class InputSchemaCompactor
         // a second keep.put() for create_project would silently drop the first.
         // baseProjectName completes the projectKind story: for an extension it is REQUIRED
         // (validateExtensionBaseProject rejects a blank one), while `required` lists only
-        // projectKind and name. Fourth parameter of this tool whose contract lives in prose
-        // - one schema serving three project kinds is the worst case for compaction.
+        // projectKind and name. This tool has several contracts that live in prose because one
+        // schema serves three project kinds - the worst case for compaction.
+        // externalObject is similarly conditional and its string schema cannot express either
+        // the Type.Name shape or that omission deliberately creates an empty import target.
         keep.put("create_project", asSet("autoSortTopObjects", "scriptVariant", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-            "version", "baseProjectName")); //$NON-NLS-1$ //$NON-NLS-2$
+            "version", "baseProjectName", "externalObject")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         // The parameter is ACCEPTED and then discarded (execute() reads it only for schema
         // parity; the class doc reserves it for a future release). Stripped to a bare
         // boolean it reads as a working option, and the response says otherwise only after

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/InputSchemaCompactor.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/protocol/InputSchemaCompactor.java
@@ -264,8 +264,10 @@ public final class InputSchemaCompactor
         // schema serves three project kinds - the worst case for compaction.
         // externalObject is similarly conditional and its string schema cannot express either
         // the Type.Name shape or that omission deliberately creates an empty import target.
+        // normalizeYo has the same silent-rewrite default as create_metadata below: without its
+        // prose a caller cannot know that a requested root Name may be stored differently.
         keep.put("create_project", asSet("autoSortTopObjects", "scriptVariant", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-            "version", "baseProjectName", "externalObject")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            "version", "baseProjectName", "externalObject", "normalizeYo")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
         // The parameter is ACCEPTED and then discarded (execute() reads it only for schema
         // parity; the class doc reserves it for a future release). Stripped to a bare
         // boolean it reads as a working option, and the response says otherwise only after

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
@@ -514,17 +514,17 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
      * {@code ExternalReport}, which is the ROOT of an external-objects project rather than an entry
      * in a {@code Configuration} collection.
      *
-     * <p>Such an object is created together with its project (an EDT wizard action, or an
-     * {@code .epf} import), not by adding a row to a configuration collection, so this tool cannot
-     * make one - and says which tool does what instead of leaving the caller with the generic
-     * "cannot resolve a create target". Its MEMBERS (attributes, tabular sections, forms and their
-     * content) ARE creatable once the object exists; that is the rest of issue #309.</p>
+     * <p>Such an object is created together with its project (or supplied by an {@code .epf}/{@code
+     * .erf} import), not by adding a row to a configuration collection, so this tool cannot make one
+     * - and says which tool does what instead of leaving the caller with the generic "cannot resolve
+     * a create target". Its MEMBERS (attributes, tabular sections, forms and their content) ARE
+     * creatable once the object exists; that is the rest of issue #309.</p>
      *
      * @param normFqn the normalized FQN
      * @return the ready-to-return JSON error, or {@code null} when the FQN is not a standalone
      *     top-level address (the caller then falls through to the generic message)
      */
-    private static String standaloneTopLevelRefusal(String normFqn)
+    static String standaloneTopLevelRefusal(String normFqn)
     {
         String[] parts = normFqn.split("\\."); //$NON-NLS-1$
         if (parts.length != 2)
@@ -538,9 +538,9 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         }
         return ToolResult.error("create_metadata cannot create a top-level '" //$NON-NLS-1$
             + info.getEnglishSingular() + "': it is the ROOT object of an external-objects project, " //$NON-NLS-1$
-            + "not an entry in a configuration collection. Create it in EDT (New > External data " //$NON-NLS-1$
-            + "processor / report) or import an existing .epf/.erf; create_project " //$NON-NLS-1$
-            + "(projectKind=externalObjects) makes the empty PROJECT only. Its members " //$NON-NLS-1$
+            + "not an entry in a configuration collection. Call create_project with " //$NON-NLS-1$
+            + "projectKind=externalObjects and externalObject='" + normFqn //$NON-NLS-1$
+            + "' to seed it, or import an existing .epf/.erf. Its members " //$NON-NLS-1$
             + "('" + normFqn + ".Attribute.X', '" + normFqn + ".Form.Y', form content) can be " //$NON-NLS-1$ //$NON-NLS-2$
             + "created here once the object exists.").toJson(); //$NON-NLS-1$
     }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateProjectTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateProjectTool.java
@@ -19,6 +19,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.emf.common.util.EMap;
+import org.eclipse.emf.ecore.EClass;
 import org.osgi.framework.Bundle;
 import org.osgi.service.prefs.BackingStoreException;
 
@@ -37,6 +38,7 @@ import com._1c.g5.v8.dt.metadata.mdclass.ConfigurationExtensionPurpose;
 import com._1c.g5.v8.dt.metadata.mdclass.Language;
 import com._1c.g5.v8.dt.metadata.mdclass.MdClassFactory;
 import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
+import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
 import com._1c.g5.v8.dt.metadata.mdclass.ObjectBelonging;
 import com._1c.g5.v8.dt.metadata.mdclass.ScriptVariant;
 import com._1c.g5.v8.dt.platform.version.Version;
@@ -49,6 +51,8 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool;
 import com.ditrix.edt.mcp.server.utils.LifecycleWaiter;
 import com.ditrix.edt.mcp.server.utils.McpJobs;
 import com.ditrix.edt.mcp.server.utils.MetadataLanguageUtils;
+import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils;
+import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils.MetadataTypeInfo;
 import com.ditrix.edt.mcp.server.utils.ProjectContext;
 
 /**
@@ -63,7 +67,8 @@ import com.ditrix.edt.mcp.server.utils.ProjectContext;
  * fully reviewed machinery from the former extension-only tool:
  * <ol>
  *   <li>Validates inputs and checks that neither the new project nor the base are missing.</li>
- *   <li>Constructs a {@link Configuration} object (or not, for externalObjects).</li>
+ *   <li>Constructs a {@link Configuration}, or an optional external-object root, through the
+ *       version-aware {@link IModelObjectFactory}.</li>
  *   <li>Calls the appropriate project manager's {@code create()} method in a background
  *       {@link Job} (never on the UI thread — unattended-safety rule) via the shared
  *       {@link #runCreateJob} helper, and joins with a {@link #CREATE_TIMEOUT_MS} timeout.</li>
@@ -121,6 +126,9 @@ public class CreateProjectTool implements IMcpTool
 
     /** Parameter/output key: platform version string. */
     private static final String KEY_VERSION = "version"; //$NON-NLS-1$
+
+    /** Parameter key: optional external-object root to seed during project creation. */
+    private static final String KEY_EXTERNAL_OBJECT = "externalObject"; //$NON-NLS-1$
 
     /** Parameter/output key: extension name prefix. */
     private static final String KEY_PREFIX = "prefix"; //$NON-NLS-1$
@@ -210,6 +218,11 @@ public class CreateProjectTool implements IMcpTool
                 "Platform version string, e.g. '8.3.27' (configuration and externalObjects only; " //$NON-NLS-1$
                     + "for extension: REJECTED — version is always inherited from the base configuration). " //$NON-NLS-1$
                     + "Default: Version.LATEST when omitted.") //$NON-NLS-1$
+            .stringProperty(KEY_EXTERNAL_OBJECT,
+                "Optional root to seed for projectKind=externalObjects: " //$NON-NLS-1$
+                    + "'ExternalDataProcessor.<Name>' or 'ExternalReport.<Name>'; the TYPE token may be " //$NON-NLS-1$
+                    + "English or Russian, and Name is a programmatic identifier. Omit for an empty project; " //$NON-NLS-1$
+                    + "REJECTED for other project kinds.") //$NON-NLS-1$
             .stringProperty("baseProjectName", //$NON-NLS-1$
                 "Name of the BASE configuration EDT project (required for extension; " //$NON-NLS-1$
                     + "REJECTED for configuration and externalObjects). " //$NON-NLS-1$
@@ -299,6 +312,7 @@ public class CreateProjectTool implements IMcpTool
         String configName = JsonUtils.extractStringArgument(params, "name"); //$NON-NLS-1$
         String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
         String versionStr = JsonUtils.extractStringArgument(params, KEY_VERSION);
+        String externalObjectStr = JsonUtils.extractStringArgument(params, KEY_EXTERNAL_OBJECT);
         String baseProjectName = JsonUtils.extractStringArgument(params, "baseProjectName"); //$NON-NLS-1$
         String prefix = JsonUtils.extractStringArgument(params, KEY_PREFIX);
         String synonym = JsonUtils.extractStringArgument(params, "synonym"); //$NON-NLS-1$
@@ -325,10 +339,20 @@ public class CreateProjectTool implements IMcpTool
         // 3. Validate kind-specific parameter constraints
         String constraintErr = validateKindConstraints(new KindConstraintInputs(projectKind, isExtension,
             isExternalObjects, versionStr, baseProjectName, prefix, purposeStr, compatModeStr, synonym, comment,
-            scriptVariantStr));
+            scriptVariantStr, externalObjectStr));
         if (constraintErr != null)
         {
             return constraintErr;
+        }
+
+        ExternalObjectSpec externalObject = null;
+        if (isExternalObjects && externalObjectStr != null)
+        {
+            externalObject = resolveExternalObject(externalObjectStr);
+            if (externalObject.error != null)
+            {
+                return externalObject.error;
+            }
         }
 
         // 4. Validate 'name'
@@ -361,7 +385,8 @@ public class CreateProjectTool implements IMcpTool
 
         // Dispatch to kind-specific handler
         CreateRequest request = new CreateRequest(configName, projectName, versionStr, baseProjectName, prefix,
-            synonym, comment, purposeStr, compatModeStr, scriptVariantStr, standardChecks, commonChecks);
+            synonym, comment, purposeStr, compatModeStr, scriptVariantStr, externalObject, standardChecks,
+            commonChecks);
         if (isExtension)
         {
             return executeExtension(request);
@@ -443,6 +468,11 @@ public class CreateProjectTool implements IMcpTool
         {
             return err;
         }
+        err = validateExternalObjectParam(in);
+        if (err != null)
+        {
+            return err;
+        }
         return validateScriptVariantValue(in);
     }
 
@@ -520,6 +550,22 @@ public class CreateProjectTool implements IMcpTool
     }
 
     /**
+     * Rejects {@code externalObject} outside the one project kind whose create API accepts it.
+     *
+     * @return a ready-to-return JSON error string, or {@code null} when valid
+     */
+    private static String validateExternalObjectParam(KindConstraintInputs in)
+    {
+        if (!in.isExternalObjects && in.externalObjectStr != null)
+        {
+            return ToolResult.error("externalObject '" + in.externalObjectStr //$NON-NLS-1$
+                + "' is only valid for projectKind=externalObjects. Remove externalObject or set " //$NON-NLS-1$
+                + "projectKind=externalObjects.").toJson(); //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
      * Strict scriptVariant value validation: must be exactly {@code "Russian"} or {@code "English"}
      * (case-insensitive) when supplied for configuration or externalObjects.
      *
@@ -535,6 +581,59 @@ public class CreateProjectTool implements IMcpTool
                 + "'. Allowed values: 'Russian', 'English'.").toJson(); //$NON-NLS-1$
         }
         return null;
+    }
+
+    /**
+     * Resolves an optional external-object root address without touching the workbench. The TYPE
+     * token is interpreted only by the shared bilingual {@link MetadataTypeUtils} catalogue; the
+     * resolved kind then selects one of the two root EClasses accepted by EDT's external-project
+     * creation API.
+     *
+     * @param value external-object FQN supplied by the caller
+     * @return the resolved EClass/name pair, or a ready-to-return validation error
+     */
+    static ExternalObjectSpec resolveExternalObject(String value)
+    {
+        String normalized = value == null ? null : value.trim();
+        String[] parts = normalized == null ? new String[0] : normalized.split("\\.", -1); //$NON-NLS-1$
+        if (parts.length != 2)
+        {
+            return ExternalObjectSpec.failure(invalidExternalObjectShape(value));
+        }
+
+        MetadataTypeInfo info = MetadataTypeUtils.resolve(parts[0]);
+        EClass eClass;
+        if (info == MetadataTypeInfo.EXTERNAL_DATA_PROCESSOR)
+        {
+            eClass = MdClassPackage.Literals.EXTERNAL_DATA_PROCESSOR;
+        }
+        else if (info == MetadataTypeInfo.EXTERNAL_REPORT)
+        {
+            eClass = MdClassPackage.Literals.EXTERNAL_REPORT;
+        }
+        else
+        {
+            return ExternalObjectSpec.failure(invalidExternalObjectShape(value));
+        }
+
+        String objectName = parts[1];
+        if (!isValidIdentifier(objectName))
+        {
+            return ExternalObjectSpec.failure(ToolResult.error("Invalid externalObject '" + value //$NON-NLS-1$
+                + "': root Name '" + objectName + "' must start with a letter or underscore and contain only " //$NON-NLS-1$ //$NON-NLS-2$
+                + "letters, digits and underscores. Use 'ExternalDataProcessor.<Name>' or " //$NON-NLS-1$
+                + "'ExternalReport.<Name>'.").toJson()); //$NON-NLS-1$
+        }
+
+        return ExternalObjectSpec.success(eClass, objectName, info.getEnglishSingular() + "." + objectName); //$NON-NLS-1$
+    }
+
+    /** Returns the common actionable error for a malformed or unsupported root address. */
+    private static String invalidExternalObjectShape(String value)
+    {
+        return ToolResult.error("Invalid externalObject '" + value //$NON-NLS-1$
+            + "'. Expected 'ExternalDataProcessor.<Name>' or 'ExternalReport.<Name>'; " //$NON-NLS-1$
+            + "the TYPE token may also be Russian.").toJson(); //$NON-NLS-1$
     }
 
     // ─────────────────────── EXTENSION path ──────────────────────────────────
@@ -948,11 +1047,40 @@ public class CreateProjectTool implements IMcpTool
                 "IExternalObjectProjectManager service not available. The EDT platform may not be ready.").toJson(); //$NON-NLS-1$
         }
 
+        MdObject externalObject = null;
+        if (req.externalObject != null)
+        {
+            IModelObjectFactory factory = Activator.getDefault().getModelObjectFactory();
+            if (factory == null)
+            {
+                return ToolResult.error("IModelObjectFactory service not available; cannot seed externalObject '" //$NON-NLS-1$
+                    + req.externalObject.canonicalFqn + "'. Retry after EDT finishes starting, or omit " //$NON-NLS-1$
+                    + "externalObject to create an empty project.").toJson(); //$NON-NLS-1$
+            }
+            try
+            {
+                externalObject = createExternalObjectRoot(factory, req.externalObject, version);
+            }
+            catch (RuntimeException e)
+            {
+                return ToolResult.error("Failed to initialize externalObject '" + req.externalObject.canonicalFqn //$NON-NLS-1$
+                    + "': " + e.getMessage() + ". Retry after EDT finishes starting, or omit externalObject " //$NON-NLS-1$ //$NON-NLS-2$
+                    + "to create an empty project.").toJson(); //$NON-NLS-1$
+            }
+            if (externalObject == null)
+            {
+                return ToolResult.error("Failed to initialize externalObject '" + req.externalObject.canonicalFqn //$NON-NLS-1$
+                    + "'. Retry after EDT finishes starting, or omit externalObject to create an empty project.") //$NON-NLS-1$
+                    .toJson();
+            }
+        }
+
         // Create the external objects project in a background Job
         final IProject[] createdHolder = new IProject[1];
         final Throwable[] errorHolder = new Throwable[1];
         final String finalEffectiveProjectName = effectiveProjectName;
         final Version finalVersion = version;
+        final MdObject finalExternalObject = externalObject;
 
         Job createJob = new Job(LOG_PREFIX + finalEffectiveProjectName)
         {
@@ -961,9 +1089,10 @@ public class CreateProjectTool implements IMcpTool
             {
                 try
                 {
-                    // null, null = empty project (no pre-seeded MdObject, no parent)
+                    // A null external object preserves the legitimate empty-project/import workflow;
+                    // the second null means the project has no parent configuration.
                     createdHolder[0] = extObjMgr.create(
-                        finalEffectiveProjectName, finalVersion, null, null, monitor);
+                        finalEffectiveProjectName, finalVersion, finalExternalObject, null, monitor);
                 }
                 catch (Throwable t)
                 {
@@ -1004,6 +1133,21 @@ public class CreateProjectTool implements IMcpTool
         return buildExternalObjectsSuccessResponse(new ExternalObjectsSuccessInputs(extObjMgr,
             finalEffectiveProjectName, configName, finalVersion, createdHolder[0], projectState,
             scriptVariantStr, codestyleMap));
+    }
+
+    /**
+     * Creates the detached root exactly like the Configuration paths: version-aware factory first,
+     * then default-reference filling, then the caller's programmatic Name.
+     */
+    static MdObject createExternalObjectRoot(IModelObjectFactory factory, ExternalObjectSpec spec, Version version)
+    {
+        MdObject root = factory.create(spec.eClass, version);
+        if (root != null)
+        {
+            factory.fillDefaultReferences(root);
+            root.setName(spec.objectName);
+        }
+        return root;
     }
 
     /**
@@ -1347,10 +1491,11 @@ public class CreateProjectTool implements IMcpTool
         final String synonym;
         final String comment;
         final String scriptVariantStr;
+        final String externalObjectStr;
 
         private KindConstraintInputs(String projectKind, boolean isExtension, boolean isExternalObjects, // NOSONAR signature is inherent / public-or-test-contract; a parameter-object would not improve clarity
             String versionStr, String baseProjectName, String prefix, String purposeStr, String compatModeStr,
-            String synonym, String comment, String scriptVariantStr)
+            String synonym, String comment, String scriptVariantStr, String externalObjectStr)
         {
             this.projectKind = projectKind;
             this.isExtension = isExtension;
@@ -1363,6 +1508,7 @@ public class CreateProjectTool implements IMcpTool
             this.synonym = synonym;
             this.comment = comment;
             this.scriptVariantStr = scriptVariantStr;
+            this.externalObjectStr = externalObjectStr;
         }
     }
 
@@ -1383,12 +1529,13 @@ public class CreateProjectTool implements IMcpTool
         final String purposeStr;
         final String compatModeStr;
         final String scriptVariantStr;
+        final ExternalObjectSpec externalObject;
         final boolean standardChecks;
         final boolean commonChecks;
 
         private CreateRequest(String configName, String projectName, String versionStr, String baseProjectName, // NOSONAR signature is inherent / public-or-test-contract; a parameter-object would not improve clarity
             String prefix, String synonym, String comment, String purposeStr, String compatModeStr,
-            String scriptVariantStr, boolean standardChecks, boolean commonChecks)
+            String scriptVariantStr, ExternalObjectSpec externalObject, boolean standardChecks, boolean commonChecks)
         {
             this.configName = configName;
             this.projectName = projectName;
@@ -1400,6 +1547,7 @@ public class CreateProjectTool implements IMcpTool
             this.purposeStr = purposeStr;
             this.compatModeStr = compatModeStr;
             this.scriptVariantStr = scriptVariantStr;
+            this.externalObject = externalObject;
             this.standardChecks = standardChecks;
             this.commonChecks = commonChecks;
         }
@@ -1496,6 +1644,33 @@ public class CreateProjectTool implements IMcpTool
             this.scriptVariant = scriptVariant;
             this.langCode = langCode;
             this.langName = langName;
+        }
+    }
+
+    /** Headless-safe resolution of an external-object root parameter. */
+    static final class ExternalObjectSpec
+    {
+        final String error;
+        final EClass eClass;
+        final String objectName;
+        final String canonicalFqn;
+
+        private ExternalObjectSpec(String error, EClass eClass, String objectName, String canonicalFqn)
+        {
+            this.error = error;
+            this.eClass = eClass;
+            this.objectName = objectName;
+            this.canonicalFqn = canonicalFqn;
+        }
+
+        static ExternalObjectSpec failure(String error)
+        {
+            return new ExternalObjectSpec(error, null, null, null);
+        }
+
+        static ExternalObjectSpec success(EClass eClass, String objectName, String canonicalFqn)
+        {
+            return new ExternalObjectSpec(null, eClass, objectName, canonicalFqn);
         }
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateProjectTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateProjectTool.java
@@ -50,6 +50,7 @@ import com.ditrix.edt.mcp.server.protocol.ToolResult;
 import com.ditrix.edt.mcp.server.tools.IMcpTool;
 import com.ditrix.edt.mcp.server.utils.LifecycleWaiter;
 import com.ditrix.edt.mcp.server.utils.McpJobs;
+import com.ditrix.edt.mcp.server.utils.MdNameNormalizer;
 import com.ditrix.edt.mcp.server.utils.MetadataLanguageUtils;
 import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils;
 import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils.MetadataTypeInfo;
@@ -129,6 +130,12 @@ public class CreateProjectTool implements IMcpTool
 
     /** Parameter key: optional external-object root to seed during project creation. */
     private static final String KEY_EXTERNAL_OBJECT = "externalObject"; //$NON-NLS-1$
+
+    /** Parameter key: whether Russian yo is normalized in a seeded root Name. */
+    private static final String KEY_NORMALIZE_YO = "normalizeYo"; //$NON-NLS-1$
+
+    /** Output key: whether the requested external-object root was observed after a slow create. */
+    private static final String KEY_EXTERNAL_OBJECT_CONFIRMED = "externalObjectConfirmed"; //$NON-NLS-1$
 
     /** Parameter/output key: extension name prefix. */
     private static final String KEY_PREFIX = "prefix"; //$NON-NLS-1$
@@ -221,8 +228,14 @@ public class CreateProjectTool implements IMcpTool
             .stringProperty(KEY_EXTERNAL_OBJECT,
                 "Optional root to seed for projectKind=externalObjects: " //$NON-NLS-1$
                     + "'ExternalDataProcessor.<Name>' or 'ExternalReport.<Name>'; the TYPE token may be " //$NON-NLS-1$
-                    + "English or Russian, and Name is a programmatic identifier. Omit for an empty project; " //$NON-NLS-1$
+                    + "English or Russian and is not normalized; Name is a programmatic identifier whose " //$NON-NLS-1$
+                    + "'ё'/'Ё' is normalized by default according to normalizeYo. Omit for an empty project; " //$NON-NLS-1$
                     + "REJECTED for other project kinds.") //$NON-NLS-1$
+            .booleanProperty(KEY_NORMALIZE_YO,
+                "Normalize the Russian letter 'ё'->'е' / 'Ё'->'Е' in the seeded externalObject root " //$NON-NLS-1$
+                    + "NAME (default true). 'ё' in a Name is flagged by the 1C standard " //$NON-NLS-1$
+                    + "mdo-ru-name-unallowed-letter, so normalizing on input stores a compliant name. " //$NON-NLS-1$
+                    + "Set false to keep 'ё' exactly as supplied. The TYPE token is never normalized.") //$NON-NLS-1$
             .stringProperty("baseProjectName", //$NON-NLS-1$
                 "Name of the BASE configuration EDT project (required for extension; " //$NON-NLS-1$
                     + "REJECTED for configuration and externalObjects). " //$NON-NLS-1$
@@ -268,8 +281,11 @@ public class CreateProjectTool implements IMcpTool
     public String getOutputSchema()
     {
         return JsonSchemaBuilder.object()
-            .booleanProperty("success", "Whether the project was created", true) //$NON-NLS-1$ //$NON-NLS-2$
-            .stringProperty(McpKeys.ACTION, "'created' on success") //$NON-NLS-1$
+            .booleanProperty("success", //$NON-NLS-1$
+                "Whether the tool returned project status instead of an immediate error; inspect action and " //$NON-NLS-1$
+                    + "externalObjectConfirmed for a slow seeded create", true)
+            .stringProperty(McpKeys.ACTION,
+                "'created' on completion; 'verificationRequired' for every slow seeded create") //$NON-NLS-1$
             .stringProperty(McpKeys.PROJECT,
                 "EDT workspace project name of the created project (round-trip key for sibling tools)") //$NON-NLS-1$
             .stringProperty(KEY_PROJECT_KIND, "Kind of project created: configuration, extension, or externalObjects") //$NON-NLS-1$
@@ -281,7 +297,15 @@ public class CreateProjectTool implements IMcpTool
             .stringProperty(KEY_PURPOSE, "ConfigurationExtensionPurpose value applied (extension only, conditional)") //$NON-NLS-1$
             .stringProperty(KEY_SCRIPT_VARIANT, "ScriptVariant applied or inherited") //$NON-NLS-1$
             .stringProperty(KEY_VERSION, "Platform version string used for project creation") //$NON-NLS-1$
-            .stringProperty(KEY_STATE, "'ready' when lifecycle STARTED was reached, 'created' otherwise") //$NON-NLS-1$
+            .stringProperty(KEY_EXTERNAL_OBJECT,
+                "Canonical FQN of the seeded external-object root, when requested") //$NON-NLS-1$
+            .booleanProperty(KEY_EXTERNAL_OBJECT_CONFIRMED,
+                "Whether a requested root was observed through metadata scope resolution on the slow path") //$NON-NLS-1$
+            .stringArrayProperty("normalized", //$NON-NLS-1$
+                "Fields whose value was rewritten by the 'ё'->'е' normalization (when any)") //$NON-NLS-1$
+            .stringProperty(KEY_STATE,
+                "'ready' when lifecycle STARTED was reached, 'created' otherwise, or " //$NON-NLS-1$
+                    + "'rootConfirmed'/'rootUnconfirmed' when a slow seeded create requires verification") //$NON-NLS-1$
             .objectProperty(KEY_CODESTYLE,
                 "v8codestyle preference application result: {applied: bool, note: string, autoSortNote: string}") //$NON-NLS-1$
             .stringProperty(KEY_SYNONYM_NOTE,
@@ -320,6 +344,7 @@ public class CreateProjectTool implements IMcpTool
         String purposeStr = JsonUtils.extractStringArgument(params, KEY_PURPOSE);
         String compatModeStr = JsonUtils.extractStringArgument(params, "compatibilityMode"); //$NON-NLS-1$
         String scriptVariantStr = JsonUtils.extractStringArgument(params, KEY_SCRIPT_VARIANT);
+        boolean normalizeYo = JsonUtils.extractBooleanArgument(params, KEY_NORMALIZE_YO, true);
         boolean standardChecks = JsonUtils.extractBooleanArgument(params, PREF_STANDARD_CHECKS, true);
         boolean commonChecks = JsonUtils.extractBooleanArgument(params, PREF_COMMON_CHECKS, true);
         // autoSortTopObjects is read to satisfy schema parity; not yet applied (see class-level doc)
@@ -348,7 +373,7 @@ public class CreateProjectTool implements IMcpTool
         ExternalObjectSpec externalObject = null;
         if (isExternalObjects && externalObjectStr != null)
         {
-            externalObject = resolveExternalObject(externalObjectStr);
+            externalObject = resolveExternalObject(externalObjectStr, normalizeYo);
             if (externalObject.error != null)
             {
                 return externalObject.error;
@@ -594,6 +619,15 @@ public class CreateProjectTool implements IMcpTool
      */
     static ExternalObjectSpec resolveExternalObject(String value)
     {
+        return resolveExternalObject(value, true);
+    }
+
+    /**
+     * Resolves and, by default, yo-normalizes only the root Name. The TYPE token is looked up
+     * exactly as supplied and is never passed through the name normalizer.
+     */
+    static ExternalObjectSpec resolveExternalObject(String value, boolean normalizeYo)
+    {
         String normalized = value == null ? null : value.trim();
         String[] parts = normalized == null ? new String[0] : normalized.split("\\.", -1); //$NON-NLS-1$
         if (parts.length != 2)
@@ -616,7 +650,8 @@ public class CreateProjectTool implements IMcpTool
             return ExternalObjectSpec.failure(invalidExternalObjectShape(value));
         }
 
-        String objectName = parts[1];
+        MdNameNormalizer.Report normReport = new MdNameNormalizer.Report(normalizeYo);
+        String objectName = normReport.apply("name", parts[1]); //$NON-NLS-1$
         if (!isValidIdentifier(objectName))
         {
             return ExternalObjectSpec.failure(ToolResult.error("Invalid externalObject '" + value //$NON-NLS-1$
@@ -625,7 +660,8 @@ public class CreateProjectTool implements IMcpTool
                 + "'ExternalReport.<Name>'.").toJson()); //$NON-NLS-1$
         }
 
-        return ExternalObjectSpec.success(eClass, objectName, info.getEnglishSingular() + "." + objectName); //$NON-NLS-1$
+        return ExternalObjectSpec.success(eClass, objectName, info.getEnglishSingular() + "." + objectName, //$NON-NLS-1$
+            normReport);
     }
 
     /** Returns the common actionable error for a malformed or unsupported root address. */
@@ -1105,9 +1141,10 @@ public class CreateProjectTool implements IMcpTool
         CreateJobResult jobResult = runCreateJob(createJob, finalEffectiveProjectName, KIND_EXTERNAL_OBJECTS);
         if (jobResult.status == CreateStatus.SLOW_EXISTS)
         {
-            // Creation completed past the wait window — build the full externalObjects response
+            // Creation exceeded the wait window. A requested root needs its own read-back:
+            // the project container existing does not prove EDT attached the root before cancel.
             return buildExternalObjectsSlowResponse(finalEffectiveProjectName, configName,
-                finalVersion, scriptVariantStr);
+                finalVersion, scriptVariantStr, req.externalObject);
         }
         if (jobResult.errorJson != null)
         {
@@ -1132,7 +1169,7 @@ public class CreateProjectTool implements IMcpTool
 
         return buildExternalObjectsSuccessResponse(new ExternalObjectsSuccessInputs(extObjMgr,
             finalEffectiveProjectName, configName, finalVersion, createdHolder[0], projectState,
-            scriptVariantStr, codestyleMap));
+            scriptVariantStr, codestyleMap, req.externalObject));
     }
 
     /**
@@ -1194,17 +1231,85 @@ public class CreateProjectTool implements IMcpTool
         {
             result.put(KEY_SCRIPT_VARIANT_NOTE, scriptVariantNote);
         }
+        if (in.externalObject != null)
+        {
+            result.put(KEY_EXTERNAL_OBJECT, in.externalObject.canonicalFqn);
+            in.externalObject.normReport.addTo(result);
+        }
         return result.toJson();
     }
 
     /**
-     * Builds the externalObjects slow-path response (creation completed past the wait window).
+     * Builds the externalObjects slow-path response (creation exceeded the wait window).
      * When a {@code scriptVariantStr} was supplied, emits the canonical ScriptVariant literal
      * and a note that setScriptVariant was skipped.
      *
      * @return the response JSON string
      */
-    private static String buildExternalObjectsSlowResponse(String effectiveProjectName, String configName,
+    static String buildExternalObjectsSlowResponse(String effectiveProjectName, String configName,
+        Version version, String scriptVariantStr, ExternalObjectSpec externalObject)
+    {
+        if (externalObject == null)
+        {
+            // This is the pre-seeded-root response byte-for-byte: project existence is the complete
+            // fact for the intentional empty-project workflow, so its old answer remains correct.
+            return buildEmptyExternalObjectsSlowResponse(effectiveProjectName, configName, version,
+                scriptVariantStr);
+        }
+
+        boolean rootConfirmed = confirmExternalObject(effectiveProjectName, externalObject);
+        String rootState = rootConfirmed ? "rootConfirmed" : "rootUnconfirmed"; //$NON-NLS-1$ //$NON-NLS-2$
+        String typeToken = externalObject.canonicalFqn.substring(0,
+            externalObject.canonicalFqn.indexOf('.'));
+        String verification = " Once indexing finishes, verify the root with " //$NON-NLS-1$
+            + "get_metadata_objects (projectName='" + effectiveProjectName //$NON-NLS-1$
+            + "', metadataType='" + typeToken + "'). Do not repeat create_project: the " //$NON-NLS-1$ //$NON-NLS-2$
+            + "duplicate-project guard will refuse the existing project."; //$NON-NLS-1$
+        String message;
+        if (rootConfirmed)
+        {
+            message = "External objects project '" + effectiveProjectName //$NON-NLS-1$
+                + "' exists after creation exceeded the " + (CREATE_TIMEOUT_MS / 1000) //$NON-NLS-1$
+                + "s wait window; requested root '" + externalObject.canonicalFqn //$NON-NLS-1$
+                + "' was CONFIRMED through metadata scope resolution, but project creation did " //$NON-NLS-1$
+                + "not finish within the wait window." + verification; //$NON-NLS-1$
+        }
+        else
+        {
+            message = "External objects project '" + effectiveProjectName //$NON-NLS-1$
+                + "' exists after creation exceeded the " + (CREATE_TIMEOUT_MS / 1000) //$NON-NLS-1$
+                + "s wait window, but requested root '" + externalObject.canonicalFqn //$NON-NLS-1$
+                + "' was NOT CONFIRMED. EDT may still be indexing the project, or creation may fail " //$NON-NLS-1$
+                + "after creating its container." + verification; //$NON-NLS-1$
+        }
+
+        ToolResult slowResult = ToolResult.success()
+            .put(McpKeys.ACTION, "verificationRequired") //$NON-NLS-1$
+            .put(McpKeys.PROJECT, effectiveProjectName)
+            .put(KEY_PROJECT_KIND, KIND_EXTERNAL_OBJECTS)
+            .put("name", configName) //$NON-NLS-1$
+            .put(KEY_VERSION, version.toString())
+            .put(KEY_STATE, rootState)
+            .put(KEY_EXTERNAL_OBJECT, externalObject.canonicalFqn)
+            .put(KEY_EXTERNAL_OBJECT_CONFIRMED, rootConfirmed)
+            .put(KEY_CODESTYLE, slowPathCodestyleMap())
+            .put(McpKeys.MESSAGE, message);
+        externalObject.normReport.addTo(slowResult);
+        if (scriptVariantStr != null && !scriptVariantStr.isEmpty())
+        {
+            // Emit canonical literal (normalized from user input casing)
+            ScriptVariant slowSv = SCRIPT_RUSSIAN.equalsIgnoreCase(scriptVariantStr)
+                ? ScriptVariant.RUSSIAN : ScriptVariant.ENGLISH;
+            slowResult.put(KEY_SCRIPT_VARIANT, slowSv.getLiteral());
+            String slowScriptNote =
+                "setScriptVariant skipped: creation exceeded the wait window; set the project preferences manually if needed."; //$NON-NLS-1$
+            slowResult.put(KEY_SCRIPT_VARIANT_NOTE, slowScriptNote);
+        }
+        return slowResult.toJson();
+    }
+
+    /** The unchanged slow response for an intentionally empty external-objects project. */
+    private static String buildEmptyExternalObjectsSlowResponse(String effectiveProjectName, String configName,
         Version version, String scriptVariantStr)
     {
         ToolResult slowResult = ToolResult.success()
@@ -1220,7 +1325,6 @@ public class CreateProjectTool implements IMcpTool
                 + (CREATE_TIMEOUT_MS / 1000) + MSG_WAIT_WINDOW_SUFFIX);
         if (scriptVariantStr != null && !scriptVariantStr.isEmpty())
         {
-            // Emit canonical literal (normalized from user input casing)
             ScriptVariant slowSv = SCRIPT_RUSSIAN.equalsIgnoreCase(scriptVariantStr)
                 ? ScriptVariant.RUSSIAN : ScriptVariant.ENGLISH;
             slowResult.put(KEY_SCRIPT_VARIANT, slowSv.getLiteral());
@@ -1229,6 +1333,33 @@ public class CreateProjectTool implements IMcpTool
             slowResult.put(KEY_SCRIPT_VARIANT_NOTE, slowScriptNote);
         }
         return slowResult.toJson();
+    }
+
+    /**
+     * Best-effort read-back through the same metadata scope used by get_metadata_objects. A false
+     * answer includes every transient case (not started, still indexing, or a momentarily failed
+     * root-set read); none is promoted to a second tool error.
+     */
+    private static boolean confirmExternalObject(String effectiveProjectName, ExternalObjectSpec externalObject)
+    {
+        try
+        {
+            ProjectContext.ConfigurationResult resolved =
+                ProjectContext.resolveMetadataRoot(effectiveProjectName);
+            if (!resolved.ok())
+            {
+                return false;
+            }
+            int dot = externalObject.canonicalFqn.indexOf('.');
+            String typeToken = externalObject.canonicalFqn.substring(0, dot);
+            return resolved.scope().findObject(typeToken, externalObject.objectName) != null;
+        }
+        catch (RuntimeException e)
+        {
+            // Indexing may legitimately make the root unreadable here. The structured false is the
+            // caller-visible fact; logging this expected slow-path race as an error would be noise.
+            return false;
+        }
     }
 
     /**
@@ -1343,8 +1474,8 @@ public class CreateProjectTool implements IMcpTool
         OK,
         /**
          * Job timed out but the project already exists in the workspace (slow creation
-         * past the wait window). The caller must build the full kind-specific response
-         * with {@code state="created"} and {@code codestyle.applied=false}.
+         * past the wait window). Existence is the only fact this status carries; the caller
+         * must build a kind-specific response and verify any finer-grained mutation it needs.
          */
         SLOW_EXISTS,
         /** Job timed out and the project does NOT exist — return an error response. */
@@ -1654,23 +1785,27 @@ public class CreateProjectTool implements IMcpTool
         final EClass eClass;
         final String objectName;
         final String canonicalFqn;
+        final MdNameNormalizer.Report normReport;
 
-        private ExternalObjectSpec(String error, EClass eClass, String objectName, String canonicalFqn)
+        private ExternalObjectSpec(String error, EClass eClass, String objectName, String canonicalFqn,
+            MdNameNormalizer.Report normReport)
         {
             this.error = error;
             this.eClass = eClass;
             this.objectName = objectName;
             this.canonicalFqn = canonicalFqn;
+            this.normReport = normReport;
         }
 
         static ExternalObjectSpec failure(String error)
         {
-            return new ExternalObjectSpec(error, null, null, null);
+            return new ExternalObjectSpec(error, null, null, null, null);
         }
 
-        static ExternalObjectSpec success(EClass eClass, String objectName, String canonicalFqn)
+        static ExternalObjectSpec success(EClass eClass, String objectName, String canonicalFqn,
+            MdNameNormalizer.Report normReport)
         {
-            return new ExternalObjectSpec(null, eClass, objectName, canonicalFqn);
+            return new ExternalObjectSpec(null, eClass, objectName, canonicalFqn, normReport);
         }
     }
 
@@ -1688,10 +1823,11 @@ public class CreateProjectTool implements IMcpTool
         final String projectState;
         final String scriptVariantStr;
         final Map<String, Object> codestyleMap;
+        final ExternalObjectSpec externalObject;
 
         private ExternalObjectsSuccessInputs(IExternalObjectProjectManager extObjMgr, String effectiveProjectName, // NOSONAR signature is inherent / public-or-test-contract; a parameter-object would not improve clarity
             String configName, Version version, IProject createdProject, String projectState,
-            String scriptVariantStr, Map<String, Object> codestyleMap)
+            String scriptVariantStr, Map<String, Object> codestyleMap, ExternalObjectSpec externalObject)
         {
             this.extObjMgr = extObjMgr;
             this.effectiveProjectName = effectiveProjectName;
@@ -1701,6 +1837,7 @@ public class CreateProjectTool implements IMcpTool
             this.projectState = projectState;
             this.scriptVariantStr = scriptVariantStr;
             this.codestyleMap = codestyleMap;
+            this.externalObject = externalObject;
         }
     }
 
@@ -2046,7 +2183,7 @@ public class CreateProjectTool implements IMcpTool
      * <ul>
      *   <li>{@link CreateStatus#OK} — job completed in time; caller checks {@code errorHolder}.</li>
      *   <li>{@link CreateStatus#SLOW_EXISTS} — timed out but project already exists; caller
-     *       builds the full kind-specific success response with {@code state="created"}.</li>
+     *       builds a kind-specific response without inferring any finer-grained mutation.</li>
      *   <li>{@link CreateStatus#TIMED_OUT} — timed out and project absent; {@code errorJson}
      *       is ready to return.</li>
      *   <li>{@link CreateStatus#INTERRUPTED} — job interrupted; {@code errorJson} is ready

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataToolTest.java
@@ -56,6 +56,21 @@ public class CreateMetadataToolTest
     }
 
     @Test
+    public void testStandaloneRootRefusalPointsToCreateProjectExternalObject()
+    {
+        String fqn = "ExternalDataProcessor.MyProc"; //$NON-NLS-1$
+        String result = CreateMetadataTool.standaloneTopLevelRefusal(fqn);
+        assertNotNull(result);
+        assertTrue("refusal must point to create_project", result.contains("create_project")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("refusal must name the externalObjects project kind", //$NON-NLS-1$
+            result.contains("projectKind=externalObjects")); //$NON-NLS-1$
+        assertTrue("refusal must give the new externalObject parameter value", //$NON-NLS-1$
+            result.contains("externalObject='" + fqn + "'")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("refusal must no longer send the caller to the EDT UI", //$NON-NLS-1$
+            result.contains("Create it in EDT")); //$NON-NLS-1$
+    }
+
+    @Test
     public void testInputSchemaContainsAllParameters()
     {
         String schema = new CreateMetadataTool().getInputSchema();

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateProjectToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateProjectToolTest.java
@@ -9,14 +9,18 @@ package com.ditrix.edt.mcp.server.tools.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.emf.ecore.EClass;
 import org.junit.Test;
 
+import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
+import com.ditrix.edt.mcp.server.tools.impl.CreateProjectTool.ExternalObjectSpec;
 
 /**
  * Unit tests for {@link CreateProjectTool}.
@@ -84,6 +88,7 @@ public class CreateProjectToolTest
         String guide = new CreateProjectTool().getGuide();
         assertTrue("guide must document projectKind", guide.contains("projectKind")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("guide must document baseProjectName", guide.contains("baseProjectName")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("guide must document externalObject", guide.contains("externalObject")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("guide must document purpose", guide.contains("purpose")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("guide must document autoSortTopObjects limitation", //$NON-NLS-1$
             guide.contains("autoSortTopObjects")); //$NON-NLS-1$
@@ -98,6 +103,7 @@ public class CreateProjectToolTest
         assertTrue("schema must declare name", schema.contains("\"name\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("schema must declare projectName", schema.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("schema must declare version", schema.contains("\"version\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("schema must declare externalObject", schema.contains("\"externalObject\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("schema must declare baseProjectName", schema.contains("\"baseProjectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("schema must declare prefix", schema.contains("\"prefix\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("schema must declare synonym", schema.contains("\"synonym\"")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -134,6 +140,8 @@ public class CreateProjectToolTest
             tail.contains("\"projectName\",") || tail.contains(",\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertFalse("baseProjectName must NOT be required", //$NON-NLS-1$
             tail.contains("\"baseProjectName\",") || tail.contains(",\"baseProjectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("externalObject must NOT be required", //$NON-NLS-1$
+            tail.contains("\"externalObject\",") || tail.contains(",\"externalObject\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertFalse("prefix must NOT be required", //$NON-NLS-1$
             tail.contains("\"prefix\",") || tail.contains(",\"prefix\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertFalse("synonym must NOT be required", //$NON-NLS-1$
@@ -156,6 +164,61 @@ public class CreateProjectToolTest
     }
 
     // ────────── Argument-validation sentinels (return before any EDT API call) ──────────
+
+    @Test
+    public void testExternalObjectResolvesBothEnglishRootKinds()
+    {
+        assertExternalObjectResolution("ExternalDataProcessor.MyProc", //$NON-NLS-1$
+            MdClassPackage.Literals.EXTERNAL_DATA_PROCESSOR, "MyProc", "ExternalDataProcessor.MyProc"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertExternalObjectResolution("ExternalReport.MyReport", //$NON-NLS-1$
+            MdClassPackage.Literals.EXTERNAL_REPORT, "MyReport", "ExternalReport.MyReport"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testExternalObjectResolvesBothRussianRootKinds()
+    {
+        assertExternalObjectResolution(
+            "\u0412\u043D\u0435\u0448\u043D\u044F\u044F\u041E\u0431\u0440\u0430\u0431\u043E\u0442\u043A\u0430.MyProc", //$NON-NLS-1$
+            MdClassPackage.Literals.EXTERNAL_DATA_PROCESSOR, "MyProc", "ExternalDataProcessor.MyProc"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertExternalObjectResolution(
+            "\u0412\u043D\u0435\u0448\u043D\u0438\u0439\u041E\u0442\u0447\u0435\u0442.MyReport", //$NON-NLS-1$
+            MdClassPackage.Literals.EXTERNAL_REPORT, "MyReport", "ExternalReport.MyReport"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testExternalObjectUnknownTypeNamesBothValidKinds()
+    {
+        ExternalObjectSpec spec = CreateProjectTool.resolveExternalObject("UnknownRoot.MyObject"); //$NON-NLS-1$
+        assertNotNull(spec.error);
+        assertTrue("error must name the bad externalObject", spec.error.contains("UnknownRoot.MyObject")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("error must name both supported root kinds", //$NON-NLS-1$
+            spec.error.contains("ExternalDataProcessor") && spec.error.contains("ExternalReport")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testExternalObjectBareNameShowsExpectedShape()
+    {
+        ExternalObjectSpec spec = CreateProjectTool.resolveExternalObject("MyProc"); //$NON-NLS-1$
+        assertNotNull(spec.error);
+        assertTrue("error must name the bare value", spec.error.contains("MyProc")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("error must show the ExternalDataProcessor shape", //$NON-NLS-1$
+            spec.error.contains("ExternalDataProcessor.<Name>")); //$NON-NLS-1$
+        assertTrue("error must show the ExternalReport shape", //$NON-NLS-1$
+            spec.error.contains("ExternalReport.<Name>")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExternalObjectRejectedForOtherProjectKinds()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("projectKind", "configuration"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("name", "MyConfig"); //$NON-NLS-1$ //$NON-NLS-2$
+        params.put("externalObject", "ExternalReport.MyReport"); //$NON-NLS-1$ //$NON-NLS-2$
+        String result = new CreateProjectTool().execute(params);
+        assertTrue("externalObject on configuration must be an error", result.contains("\"success\":false")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("error must name the bad value", result.contains("ExternalReport.MyReport")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("error must explain the valid project kind", result.contains("projectKind=externalObjects")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
 
     @Test
     public void testMissingProjectKindErrors()
@@ -333,5 +396,15 @@ public class CreateProjectToolTest
         String result = new CreateProjectTool().execute(params);
         assertNotNull(result);
         assertTrue("result must contain 'success'", result.contains("success")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    private static void assertExternalObjectResolution(String value, EClass expectedEClass,
+        String expectedName, String expectedFqn)
+    {
+        ExternalObjectSpec spec = CreateProjectTool.resolveExternalObject(value);
+        assertNull("valid externalObject must not carry an error", spec.error); //$NON-NLS-1$
+        assertEquals(expectedEClass, spec.eClass);
+        assertEquals(expectedName, spec.objectName);
+        assertEquals(expectedFqn, spec.canonicalFqn);
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateProjectToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateProjectToolTest.java
@@ -11,6 +11,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -18,7 +20,11 @@ import java.util.Map;
 import org.eclipse.emf.ecore.EClass;
 import org.junit.Test;
 
+import com._1c.g5.v8.dt.core.model.IModelObjectFactory;
+import com._1c.g5.v8.dt.metadata.mdclass.MdClassFactory;
 import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
+import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
+import com._1c.g5.v8.dt.platform.version.Version;
 import com.ditrix.edt.mcp.server.tools.IMcpTool.ResponseType;
 import com.ditrix.edt.mcp.server.tools.impl.CreateProjectTool.ExternalObjectSpec;
 
@@ -89,6 +95,9 @@ public class CreateProjectToolTest
         assertTrue("guide must document projectKind", guide.contains("projectKind")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("guide must document baseProjectName", guide.contains("baseProjectName")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("guide must document externalObject", guide.contains("externalObject")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("guide must document normalizeYo", guide.contains("normalizeYo")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("guide must document slow-root verification", //$NON-NLS-1$
+            guide.contains("get_metadata_objects") && guide.contains("duplicate-project guard")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("guide must document purpose", guide.contains("purpose")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("guide must document autoSortTopObjects limitation", //$NON-NLS-1$
             guide.contains("autoSortTopObjects")); //$NON-NLS-1$
@@ -104,6 +113,7 @@ public class CreateProjectToolTest
         assertTrue("schema must declare projectName", schema.contains("\"projectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("schema must declare version", schema.contains("\"version\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("schema must declare externalObject", schema.contains("\"externalObject\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("schema must declare normalizeYo", schema.contains("\"normalizeYo\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("schema must declare baseProjectName", schema.contains("\"baseProjectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("schema must declare prefix", schema.contains("\"prefix\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("schema must declare synonym", schema.contains("\"synonym\"")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -142,6 +152,8 @@ public class CreateProjectToolTest
             tail.contains("\"baseProjectName\",") || tail.contains(",\"baseProjectName\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertFalse("externalObject must NOT be required", //$NON-NLS-1$
             tail.contains("\"externalObject\",") || tail.contains(",\"externalObject\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("normalizeYo must NOT be required", //$NON-NLS-1$
+            tail.contains("\"normalizeYo\",") || tail.contains(",\"normalizeYo\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertFalse("prefix must NOT be required", //$NON-NLS-1$
             tail.contains("\"prefix\",") || tail.contains(",\"prefix\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertFalse("synonym must NOT be required", //$NON-NLS-1$
@@ -161,6 +173,10 @@ public class CreateProjectToolTest
         assertTrue("outputSchema must declare baseProject", schema.contains("\"baseProject\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("outputSchema must declare state", schema.contains("\"state\"")); //$NON-NLS-1$ //$NON-NLS-2$
         assertTrue("outputSchema must declare codestyle", schema.contains("\"codestyle\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare externalObject", schema.contains("\"externalObject\"")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("outputSchema must declare externalObjectConfirmed", //$NON-NLS-1$
+            schema.contains("\"externalObjectConfirmed\"")); //$NON-NLS-1$
+        assertTrue("outputSchema must declare normalized", schema.contains("\"normalized\"")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     // ────────── Argument-validation sentinels (return before any EDT API call) ──────────
@@ -183,6 +199,83 @@ public class CreateProjectToolTest
         assertExternalObjectResolution(
             "\u0412\u043D\u0435\u0448\u043D\u0438\u0439\u041E\u0442\u0447\u0435\u0442.MyReport", //$NON-NLS-1$
             MdClassPackage.Literals.EXTERNAL_REPORT, "MyReport", "ExternalReport.MyReport"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testExternalObjectYoNameIsStoredNormalizedByDefaultAndReported()
+    {
+        ExternalObjectSpec spec = CreateProjectTool.resolveExternalObject(
+            "ExternalReport.\u0412\u0441\u0451"); //$NON-NLS-1$
+        assertNull(spec.error);
+        assertEquals("\u0412\u0441\u0435", spec.objectName); //$NON-NLS-1$
+        assertEquals("ExternalReport.\u0412\u0441\u0435", spec.canonicalFqn); //$NON-NLS-1$
+
+        MdObject root = createRootFromSpec(spec);
+        assertEquals("the Name handed to EDT must already be normalized", //$NON-NLS-1$
+            "\u0412\u0441\u0435", root.getName()); //$NON-NLS-1$
+
+        String result = CreateProjectTool.buildExternalObjectsSlowResponse(
+            "NoSuchYoProjectForCreateProjectToolTest", "YoProject", Version.LATEST, null, spec); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("result must report the canonical stored root FQN", //$NON-NLS-1$
+            result.contains("ExternalReport.\u0412\u0441\u0435")); //$NON-NLS-1$
+        assertTrue("result must report the rewritten Name through MdNameNormalizer.Report", //$NON-NLS-1$
+            result.contains("\"normalized\":[\"name\"]")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExternalObjectYoNameIsKeptWhenNormalizationDisabled()
+    {
+        ExternalObjectSpec spec = CreateProjectTool.resolveExternalObject(
+            "ExternalReport.\u0412\u0441\u0451", false); //$NON-NLS-1$
+        assertNull(spec.error);
+        assertEquals("\u0412\u0441\u0451", spec.objectName); //$NON-NLS-1$
+        assertEquals("ExternalReport.\u0412\u0441\u0451", spec.canonicalFqn); //$NON-NLS-1$
+        assertEquals("normalizeYo=false must preserve the Name handed to EDT exactly", //$NON-NLS-1$
+            "\u0412\u0441\u0451", createRootFromSpec(spec).getName()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSlowSeededRootAnswerRequiresVerificationWhenUnconfirmed()
+    {
+        ExternalObjectSpec spec =
+            CreateProjectTool.resolveExternalObject("ExternalDataProcessor.UnconfirmedRoot"); //$NON-NLS-1$
+        // A deliberately absent project makes the package-visible response seam's best-effort
+        // metadata-scope read return false. Production reaches this builder only after exists().
+        String result = CreateProjectTool.buildExternalObjectsSlowResponse(
+            "NoSuchSlowProjectForCreateProjectToolTest", "SlowProject", Version.LATEST, null, spec); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertTrue("slow answer must name the requested root", //$NON-NLS-1$
+            result.contains("ExternalDataProcessor.UnconfirmedRoot")); //$NON-NLS-1$
+        assertTrue("slow answer must report that the root was not confirmed", //$NON-NLS-1$
+            result.contains("\"externalObjectConfirmed\":false")); //$NON-NLS-1$
+        assertTrue("an unresolved read-back is information, not a second tool error", //$NON-NLS-1$
+            result.contains("\"success\":true")); //$NON-NLS-1$
+        assertTrue("slow answer must require verification", //$NON-NLS-1$
+            result.contains("\"action\":\"verificationRequired\"")); //$NON-NLS-1$
+        assertFalse("an unconfirmed root must not use the created action", //$NON-NLS-1$
+            result.contains("\"action\":\"created\"")); //$NON-NLS-1$
+        assertFalse("an unconfirmed root must not use the created state", //$NON-NLS-1$
+            result.contains("\"state\":\"created\"")); //$NON-NLS-1$
+        assertTrue("slow answer must name the metadata verification route", //$NON-NLS-1$
+            result.contains("get_metadata_objects")); //$NON-NLS-1$
+        assertTrue("slow answer must explain that retry hits the duplicate guard", //$NON-NLS-1$
+            result.contains("Do not repeat create_project") && result.contains("duplicate-project guard")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void testSlowEmptyProjectAnswerKeepsExistingCreatedSemantics()
+    {
+        String result = CreateProjectTool.buildExternalObjectsSlowResponse(
+            "NoSuchEmptyProjectForCreateProjectToolTest", "EmptyProject", Version.LATEST, null, null); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("empty-project slow path must retain the created action", //$NON-NLS-1$
+            result.contains("\"action\":\"created\"")); //$NON-NLS-1$
+        assertTrue("empty-project slow path must retain the created state", //$NON-NLS-1$
+            result.contains("\"state\":\"created\"")); //$NON-NLS-1$
+        assertFalse("empty-project slow path must not gain seeded-root status fields", //$NON-NLS-1$
+            result.contains("externalObjectConfirmed") || result.contains("verificationRequired")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("empty-project slow path must retain its existing message", //$NON-NLS-1$
+            result.contains("External objects project 'NoSuchEmptyProjectForCreateProjectToolTest' created " //$NON-NLS-1$
+                + "(creation completed past the 120s wait window; project now exists).")); //$NON-NLS-1$
     }
 
     @Test
@@ -406,5 +499,13 @@ public class CreateProjectToolTest
         assertEquals(expectedEClass, spec.eClass);
         assertEquals(expectedName, spec.objectName);
         assertEquals(expectedFqn, spec.canonicalFqn);
+    }
+
+    private static MdObject createRootFromSpec(ExternalObjectSpec spec)
+    {
+        IModelObjectFactory factory = mock(IModelObjectFactory.class);
+        MdObject root = MdClassFactory.eINSTANCE.createExternalReport();
+        doReturn(root).when(factory).create(spec.eClass, Version.LATEST);
+        return CreateProjectTool.createExternalObjectRoot(factory, spec, Version.LATEST);
     }
 }

--- a/tests/e2e/tools/test_create_project.py
+++ b/tests/e2e/tools/test_create_project.py
@@ -9,11 +9,12 @@ HAPPY PATH:
   verifies it appears in list_projects, then deletes it via delete_project (cleanup).
 - configuration round-trip: creates a fresh standalone configuration, verifies it
   appears in list_projects, then deletes it.
-- externalObjects round-trip: creates a fresh external objects project, verifies it
-  appears in list_projects, then deletes it.
+- externalObjects round-trips: a seeded project exposes its root through the metadata
+  read tools, while omitting externalObject still creates an empty import target.
 
 NEGATIVE: missing projectKind, invalid projectKind, missing baseProjectName for
-extension, baseProjectName rejected for configuration, duplicate name guard.
+extension, baseProjectName rejected for configuration, invalid externalObject shapes,
+duplicate name guard.
 """
 
 from harness import (
@@ -23,6 +24,7 @@ from harness import (
     assert_error_quality,
     assert_contains,
     assert_no_diff,
+    settle_or_fail,
     wait_for_project_ready,
     e2e_test,
     PROJECT,
@@ -32,6 +34,8 @@ from harness import (
 NEW_EXT = "CreateProjTest_Ext_e2e"
 NEW_CONFIG = "CreateProjTest_Config_e2e"
 NEW_EXT_OBJ = "CreateProjTest_ExtObj_e2e"
+NEW_EXT_OBJ_SEEDED = "CreateProjTest_ExtObjSeeded_e2e"
+SEEDED_ROOT = "ExternalDataProcessor.CreateProjSeededRoot_e2e"
 
 
 def _ensure_absent(name):
@@ -104,6 +108,38 @@ def test_nonexistent_base_project_errors():
     e = assert_error(r, "nonexistent base project")
     assert_error_quality(e, names=[bad], suggests=["list_projects"],
                          ctx="nonexistent base project named + list_projects hint")
+    assert_no_diff("a rejected call must not touch the fixture")
+
+
+@e2e_test(tool="create_project", kind="action")
+def test_external_object_bare_name_errors_with_expected_shape():
+    """A root must include its bilingual type token; a bare Name is never guessed."""
+    bad = "BareExternalRoot"
+    r = call("create_project", {
+        "projectKind": "externalObjects",
+        "name": NEW_EXT_OBJ,
+        "externalObject": bad,
+    })
+    e = assert_error(r, "bare externalObject Name")
+    assert_error_quality(e, names=[bad],
+                         suggests=["ExternalDataProcessor.<Name>", "ExternalReport.<Name>"],
+                         ctx="bare root error names the value and both accepted shapes")
+    assert_no_diff("a rejected call must not touch the fixture")
+
+
+@e2e_test(tool="create_project", kind="action")
+def test_external_object_unknown_type_errors_with_valid_kinds():
+    """An unknown root type is rejected with the two kinds EDT can attach."""
+    bad = "UnknownExternalRoot.MyObject"
+    r = call("create_project", {
+        "projectKind": "externalObjects",
+        "name": NEW_EXT_OBJ,
+        "externalObject": bad,
+    })
+    e = assert_error(r, "unknown externalObject type")
+    assert_error_quality(e, names=[bad],
+                         suggests=["ExternalDataProcessor", "ExternalReport"],
+                         ctx="unknown root type names the value and both valid kinds")
     assert_no_diff("a rejected call must not touch the fixture")
 
 
@@ -183,8 +219,43 @@ def test_create_configuration_then_delete():
 # ── HAPPY PATH (externalObjects) ──────────────────────────────────────────────
 
 @e2e_test(tool="create_project", kind="action")
+def test_create_external_objects_with_seeded_root_then_delete():
+    """Seed the project root and resolve it through both metadata read routes."""
+    _ensure_absent(NEW_EXT_OBJ_SEEDED)
+    try:
+        r = call("create_project", {
+            "projectKind": "externalObjects",
+            "name": NEW_EXT_OBJ_SEEDED,
+            "externalObject": SEEDED_ROOT,
+        })
+        assert_ok(r, "create_project externalObjects with seeded root")
+        assert r.structured is not None, "response must carry structuredContent"
+        assert r.structured.get("project") == NEW_EXT_OBJ_SEEDED, \
+            "seeded project must use the requested project name, got %r" % r.structured
+        settle_or_fail("reading the root seeded by create_project")
+
+        roots = call("get_metadata_objects", {"projectName": NEW_EXT_OBJ_SEEDED})
+        assert_ok(roots, "list the newly seeded external-object root")
+        assert_contains(roots.text, "CreateProjSeededRoot_e2e",
+                        "get_metadata_objects must see the seeded root Name")
+        assert_contains(roots.text, "ExternalDataProcessor",
+                        "get_metadata_objects must see the seeded root type")
+
+        details = call("get_metadata_details", {
+            "projectName": NEW_EXT_OBJ_SEEDED,
+            "objectFqns": [SEEDED_ROOT],
+        })
+        assert_ok(details, "read the newly seeded external-object root")
+        assert_contains(details.text, "ExternalDataProcessor: CreateProjSeededRoot_e2e",
+                        "get_metadata_details must resolve the seeded root FQN")
+    finally:
+        _ensure_absent(NEW_EXT_OBJ_SEEDED)
+
+    assert_no_diff("the fixture must be untouched after the seeded-project round-trip")
+
+@e2e_test(tool="create_project", kind="action")
 def test_create_external_objects_then_delete():
-    """Create a fresh external objects project, verify it, then clean up."""
+    """Omitting externalObject must preserve the empty-project import workflow."""
     _ensure_absent(NEW_EXT_OBJ)
     try:
         r = call("create_project", {"projectKind": "externalObjects", "name": NEW_EXT_OBJ})
@@ -198,11 +269,18 @@ def test_create_external_objects_then_delete():
         assert proj_name == NEW_EXT_OBJ, \
             "project must default to 'name', got %r" % proj_name
 
-        # Verify it appears in list_projects
-        wait_for_project_ready()
+        # Verify it appears in list_projects and that the model remains empty.
+        settle_or_fail("checking an unseeded external-objects project")
         lp = call("list_projects", {})
         assert_contains(lp.text, NEW_EXT_OBJ,
                         "new externalObjects project must appear in list_projects")
+
+        roots = call("get_metadata_objects", {"projectName": NEW_EXT_OBJ})
+        assert_ok(roots, "list roots of an unseeded external-objects project")
+        assert_contains(roots.text, "**Total:** 0 objects",
+                        "omitting externalObject must leave the project empty")
+        assert_contains(roots.text, "No metadata objects found.",
+                        "the empty project must report that it has no roots")
 
     finally:
         _ensure_absent(NEW_EXT_OBJ)

--- a/tests/e2e/tools/test_external_objects_project.py
+++ b/tests/e2e/tools/test_external_objects_project.py
@@ -263,7 +263,7 @@ def test_extobj_top_level_create_is_refused_with_the_way_to_do_it():
     r = call("create_metadata",
              {"projectName": EXT_OBJECTS_PROJECT, "fqn": "ExternalDataProcessor.E2eNewProc"})
     e = assert_error(r, "a top-level external data processor")
-    assert_error_quality(e, names=["ExternalDataProcessor", "create_project"],
+    assert_error_quality(e, names=["ExternalDataProcessor", "create_project", "externalObject"],
                          ctx="the refusal must say what DOES create such an object")
     assert_no_diff_rel(EXT_OBJECTS_REL, "a refused call must not touch the fixture")
 

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -742,11 +742,15 @@
           "type": "string"
         },
         "externalObject": {
-          "description": "Optional root to seed for projectKind=externalObjects: 'ExternalDataProcessor.<Name>' or 'ExternalReport.<Name>'; the TYPE token may be English or Russian, and Name is a programmatic identifier. Omit for an empty project; REJECTED for other project kinds.",
+          "description": "Optional root to seed for projectKind=externalObjects: 'ExternalDataProcessor.<Name>' or 'ExternalReport.<Name>'; the TYPE token may be English or Russian and is not normalized; Name is a programmatic identifier whose 'ё'/'Ё' is normalized by default according to normalizeYo. Omit for an empty project; REJECTED for other project kinds.",
           "type": "string"
         },
         "name": {
           "type": "string"
+        },
+        "normalizeYo": {
+          "description": "Normalize the Russian letter 'ё'->'е' / 'Ё'->'Е' in the seeded externalObject root NAME (default true). 'ё' in a Name is flagged by the 1C standard mdo-ru-name-unallowed-letter, so normalizing on input stores a compliant name. Set false to keep 'ё' exactly as supplied. The TYPE token is never normalized.",
+          "type": "boolean"
         },
         "prefix": {
           "type": "string"
@@ -807,11 +811,23 @@
         "codestyle": {
           "type": "object"
         },
+        "externalObject": {
+          "type": "string"
+        },
+        "externalObjectConfirmed": {
+          "type": "boolean"
+        },
         "message": {
           "type": "string"
         },
         "name": {
           "type": "string"
+        },
+        "normalized": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "prefix": {
           "type": "string"

--- a/tests/e2e/tools_list.golden.json
+++ b/tests/e2e/tools_list.golden.json
@@ -741,6 +741,10 @@
         "compatibilityMode": {
           "type": "string"
         },
+        "externalObject": {
+          "description": "Optional root to seed for projectKind=externalObjects: 'ExternalDataProcessor.<Name>' or 'ExternalReport.<Name>'; the TYPE token may be English or Russian, and Name is a programmatic identifier. Omit for an empty project; REJECTED for other project kinds.",
+          "type": "string"
+        },
         "name": {
           "type": "string"
         },


### PR DESCRIPTION
Закрывает #580.

## Что было

Проект внешних объектов, созданный через MCP, никак не мог получить свой корневой `ExternalDataProcessor` / `ExternalReport`: `create_metadata` этот FQN отклоняет, а в тексте отказа предлагалось открыть EDT. Автономный сценарий обрывался ровно между «проект создан» и «первый объект» — репортёру пришлось один раз нажать `New > External data processor` руками, после чего формы, реквизиты, DynamicList, штатные команды, BSL и сборка `.epf` прошли через MCP без единой ручной правки XML.

## Почему чинилось не там, где отказывало

Отказ был прав насчёт себя и неправ насчёт того, где живёт возможность. EDT принимает корневой объект **параметром создания проекта**:

```java
IExternalObjectProjectManager.create(String projectName, Version version,
                                     MdObject externalObject, IProject parent, IProgressMonitor monitor)
```

а наш `create_project` передавал туда `null` — с комментарием «null, null = empty project». Импорт EDT тоже передаёт `null`, но там объект приносит сам `.epf`. Добавить корень «потом», через `create_metadata`, этот API не предполагает.

## Что изменено

`create_project` получил **один** необязательный параметр, значимый только при `projectKind=externalObjects`: корень, который нужно засеять, адресуемый так же, как адресуется всё остальное в этом сервере — TYPE-токен плюс Name (`ExternalDataProcessor.<Имя>`), через общий двуязычный резолвер, и только те два вида, которыми такой проект может быть укоренён. Голое имя без токена отклоняется с ожидаемой формой, а не угадывается; параметр при другом `projectKind` отклоняется, а не игнорируется молча.

Без параметра поведение остаётся **ровно прежним** — пустой проект: это законное состояние, которое заполняет импорт. Умолчание не менялось.

Корень строится тем же version-aware фабричным вызовом, которым этот же инструмент уже строит `Configuration`, а не руками. Это не предположение: `MdRuntimeModule` (строки 308 и 321) привязывает `EXTERNAL_DATA_PROCESSOR` и `EXTERNAL_REPORT` к их инициализаторам, а `ExternalDataProcessorInitializer.create` выставляет uuid, контейнер produced types с инициализированным `objectType` и вложенные объекты. Собирать это вручную значило бы разойтись с тем, что делает штатное `New` в EDT.

Отказ `create_metadata` теперь называет существующий маршрут вместо отправки в GUI, а e2e, который этот отказ фиксирует, **усилен** — он требует упоминания нового параметра.

## Тесты

Юнит: оба вида корня по-английски и по-русски, отказ по неизвестному типу с перечислением двух допустимых, отказ на голое имя, отказ при другом `projectKind`, объявление параметра в схеме. `CreateProjectToolTest` 31, `CreateMetadataToolTest` 34 — 0 падений локально.

E2E: проект с параметром — корень виден через `get_metadata_objects` и `get_metadata_details`; без параметра — по-прежнему пусто; ошибки актуальны.

Полный прогон локально не доходит из-за нативного OOM тестовой JVM (ограничение машины, не ветки) — гейт на CI.

## Что засеянный корень представляет собой на диске (проверено на стенде)

Сборка этой ветки развёрнута на стенд, через живой MCP создан проект внешних объектов с `externalObject: ExternalDataProcessor.ПроверкаЗасева`. На диске появился полноценный MDO, а не заглушка:

```xml
<mdclass:ExternalDataProcessor xmlns:mdclass="http://g5.1c.ru/v8/dt/metadata/mdclass" uuid="a1a89010-...">
  <producedTypes>
    <objectType typeId="9ee8f280-..." valueTypeId="0a96cf46-..."/>
  </producedTypes>
  <name>ПроверкаЗасева</name>
  <containedObjects classId="c3831ec8-d8d5-4f93-8a22-f9bfae07327f" objectId="2f08b138-..."/>
</mdclass:ExternalDataProcessor>
```

Это ровно тот скелет, который пишет сам EDT: сравнение с корнем из фикстуры `tests/ExternalObjects` (он сделан не нами) даёт тот же набор — `uuid`, `producedTypes/objectType` с `typeId` и `valueTypeId`, `name`; у фикстуры сверх этого только необязательное содержимое (синоним, основная форма, реквизиты). То есть сценарий из задачи — «проект создаётся, а корень создать нечем» — закрыт, и корень не пустышка: без `producedTypes` платформа объект не приняла бы.

Чего этим НЕ доказано: что `.epf` собирается. Для сборки нужны привязанная инфобаза и разрешимый рантайм 1С; на этой машине сейчас нет запаса commit-памяти даже для устойчивой работы EDT, поэтому `build_external_objects` не запускался. Если у него не окажется предусловий, инструмент обязан вернуть внятную ошибку предусловия — это отдельно закреплено e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

