### PR TITLE
Ограничить пробу шелла в гейте согласия вместо бесконечного ожидания заклиненного UI

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGate.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGate.java
@@ -218,7 +218,19 @@ public final class DestructiveConsentGate // NOSONAR intentional singleton (Ecli
          * ({@link DestructiveConsentGate#ENV_DESTRUCTIVE_CONSENT}{@code =allow}, step 1) rather
          * than something the absence of a display grants on their behalf.</p>
          */
-        UNATTENDED
+        UNATTENDED,
+        /**
+         * The workbench exists but its UI thread did not answer the bounded shell probe within
+         * {@link DestructiveConsentGate#SHELL_PROBE_TIMEOUT_MS} — so no dialog was ever shown.
+         *
+         * <p>Separate from {@link #TIMEOUT} because the remedies differ: that verdict means a
+         * dialog WAS shown and nobody answered it within
+         * {@link DestructiveConsentGate#CONSENT_PROMPT_TIMEOUT_SECONDS}, so "answer it promptly"
+         * and "allow the tool in Preferences" are the right advice. Here they are not: the probe
+         * runs BEFORE the policy is read, so a preference allowance cannot get through a wedged
+         * UI either — only freeing the UI thread, or the launch-time bypass, does.</p>
+         */
+        UI_UNRESPONSIVE
     }
 
     /**
@@ -284,7 +296,7 @@ public final class DestructiveConsentGate // NOSONAR intentional singleton (Ecli
             Activator.logInfo("Destructive-consent gate: the UI thread did not answer within " //$NON-NLS-1$
                 + SHELL_PROBE_TIMEOUT_MS + "ms — refusing '" + toolName //$NON-NLS-1$
                 + "' rather than waiting on it."); //$NON-NLS-1$
-            return ConsentDecision.TIMEOUT;
+            return ConsentDecision.UI_UNRESPONSIVE;
         }
         Shell shell = probe.shell();
         if (display == null || display.isDisposed() || shell == null)
@@ -336,6 +348,19 @@ public final class DestructiveConsentGate // NOSONAR intentional singleton (Ecli
                 + "nothing was changed. To run it unattended, set " + ENV_DESTRUCTIVE_CONSENT //$NON-NLS-1$
                 + "=allow on the EDT process at launch; otherwise re-run it on an EDT workbench " //$NON-NLS-1$
                 + "with a window open and answer the confirmation dialog."; //$NON-NLS-1$
+        }
+        if (decision == ConsentDecision.UI_UNRESPONSIVE)
+        {
+            // No dialog was ever shown, and the wait was the probe's, not the prompt's: naming the
+            // prompt budget or the Preferences allowance here would send the operator after a
+            // dialog that does not exist and a setting the wedged probe never reaches.
+            return "Destructive operation '" + toolName + "' was refused because the EDT workbench " //$NON-NLS-1$ //$NON-NLS-2$
+                + "did not answer within " + SHELL_PROBE_TIMEOUT_MS + " ms: its UI thread is busy " //$NON-NLS-1$ //$NON-NLS-2$
+                + "or wedged, so no confirmation dialog could be shown and nothing was changed. " //$NON-NLS-1$
+                + "Free the UI thread (finish or cancel what the workbench is doing, or restart " //$NON-NLS-1$
+                + "it) and re-run; for an unattended run set " + ENV_DESTRUCTIVE_CONSENT //$NON-NLS-1$
+                + "=allow on the EDT process at launch. A Preferences allowance does NOT help " //$NON-NLS-1$
+                + "here - the gate asks for the workbench before it reads the policy."; //$NON-NLS-1$
         }
         if (decision == ConsentDecision.TIMEOUT)
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGate.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGate.java
@@ -156,6 +156,19 @@ public final class DestructiveConsentGate // NOSONAR intentional singleton (Ecli
         "evaluate_expression" //$NON-NLS-1$
     );
 
+    /**
+     * How long the headless probe waits for the UI thread before giving up on it.
+     * <p>
+     * Short on purpose. This is not the human's thinking time - that is
+     * {@link #CONSENT_PROMPT_TIMEOUT_SECONDS}, and it starts later. This is only "is there a
+     * workbench able to answer at all", a question a healthy UI thread answers in microseconds.
+     * A wedged one never answers, and the wait for it used to be unbounded: the gate is called
+     * from a worker thread that holds the caller's lock, so every later call for the same
+     * resource queued behind a wait with no end.
+     * </p>
+     */
+    static final long SHELL_PROBE_TIMEOUT_MS = 5_000L;
+
     private static final DestructiveConsentGate INSTANCE = new DestructiveConsentGate();
 
     /**
@@ -247,11 +260,33 @@ public final class DestructiveConsentGate // NOSONAR intentional singleton (Ecli
             return ConsentDecision.ALLOW;
         }
 
-        // Step 2 — headless probe: never syncExec / block without a live display+shell. With no
-        // human to ask, the answer is NO. Consent for an unattended run comes from the operator
-        // at launch (step 1), not from the absence of a display.
+        // Step 2 — headless probe: never block forever, and never grant consent because no UI
+        // answered. With no human to ask, the answer is NO; consent for an unattended run comes
+        // from the operator at launch (step 1), not from the absence of a display.
+        //
+        // The probe is BOUNDED. It used to ask the UI thread with an unbounded syncExec, so on a
+        // workbench whose UI thread is wedged this call never returned - and it is reached from a
+        // worker thread that is holding the caller's lock (merge_rules holds its path mutex),
+        // so every later call for the same resource queued behind a wait that could not end.
+        //
+        // The ORDER is deliberately unchanged. Reading the policy first would answer ALLOW on a
+        // display-less EDT for ALLOW_ALL, for a per-tool allowance and for a session allowance -
+        // exactly where #566 decided the gate must refuse - so the reorder that was tried once
+        // (b1180580) had to be reverted (b1d14680). The fix here is the WAIT, not the sequence.
         Display display = LaunchLifecycleUtils.workbenchDisplayOrNull();
-        Shell shell = display != null ? LaunchLifecycleUtils.grabActiveShell() : null;
+        LaunchLifecycleUtils.ShellProbe probe =
+            LaunchLifecycleUtils.grabActiveShellWithin(SHELL_PROBE_TIMEOUT_MS);
+        if (probe.outcome() == LaunchLifecycleUtils.ShellProbeOutcome.TIMED_OUT)
+        {
+            // NOT reported as headless: this workbench exists and simply did not answer, so the
+            // remedy is to free the UI thread. TIMEOUT already says that in words, and says it
+            // without claiming the operator is running without a display.
+            Activator.logInfo("Destructive-consent gate: the UI thread did not answer within " //$NON-NLS-1$
+                + SHELL_PROBE_TIMEOUT_MS + "ms — refusing '" + toolName //$NON-NLS-1$
+                + "' rather than waiting on it."); //$NON-NLS-1$
+            return ConsentDecision.TIMEOUT;
+        }
+        Shell shell = probe.shell();
         if (display == null || display.isDisposed() || shell == null)
         {
             Activator.logInfo("Destructive-consent gate: no active UI session — refusing '" //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
@@ -2765,6 +2765,15 @@ public final class LaunchLifecycleUtils
         {
             return new ShellProbe(ShellProbeOutcome.NO_SHELL, null);
         }
+        if (display.getThread() == Thread.currentThread())
+        {
+            // Already ON the UI thread (rename_metadata_object asks the consent gate from inside
+            // its syncExec scope). Posting the question here and then waiting for it would block
+            // the very thread that has to run it: the latch could not be counted down before the
+            // deadline, so the probe would ALWAYS time out. There is nothing to wait for on this
+            // thread - read the shell inline, which is what the syncExec form did here.
+            return inlineShellAnswer(activeOrFirstShell(display));
+        }
         final Shell[] holder = new Shell[1];
         CountDownLatch answered = new CountDownLatch(1);
         try
@@ -2786,6 +2795,23 @@ public final class LaunchLifecycleUtils
             return new ShellProbe(ShellProbeOutcome.NO_SHELL, null);
         }
         return awaitShellAnswer(answered, holder, timeoutMillis);
+    }
+
+    /**
+     * Turns a shell read that needed no waiting into an outcome.
+     * <p>
+     * Package-visible for the test that pins the property this branch must keep: an answer given
+     * INLINE is never a timeout. "No shell" and "nobody answered" are different verdicts with
+     * different remedies, and the caller on the UI thread has, by definition, an answer.
+     * </p>
+     *
+     * @param shell the shell read on the calling (UI) thread, or {@code null} when there is none
+     * @return {@link ShellProbeOutcome#SHELL} with that shell, else {@link ShellProbeOutcome#NO_SHELL}
+     */
+    static ShellProbe inlineShellAnswer(Shell shell)
+    {
+        return shell != null ? new ShellProbe(ShellProbeOutcome.SHELL, shell)
+            : new ShellProbe(ShellProbeOutcome.NO_SHELL, null);
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/LaunchLifecycleUtils.java
@@ -2665,18 +2665,163 @@ public final class LaunchLifecycleUtils
             return null;
         }
         final Shell[] holder = new Shell[1];
-        display.syncExec(() -> {
-            holder[0] = display.getActiveShell();
-            if (holder[0] == null)
-            {
-                Shell[] shells = display.getShells();
-                if (shells.length > 0)
-                {
-                    holder[0] = shells[0];
-                }
-            }
-        });
+        display.syncExec(() -> holder[0] = activeOrFirstShell(display));
         return holder[0];
+    }
+
+    /**
+     * The shell this class hands out: the active one, or the first one there is. Extracted so the
+     * unbounded and bounded probes cannot drift apart on WHICH shell they mean.
+     * <p>
+     * Must run on the UI thread.
+     * </p>
+     *
+     * @param display the live display
+     * @return a shell, or {@code null} when the workbench has none
+     */
+    private static Shell activeOrFirstShell(Display display)
+    {
+        Shell active = display.getActiveShell();
+        if (active != null)
+        {
+            return active;
+        }
+        Shell[] shells = display.getShells();
+        return shells.length > 0 ? shells[0] : null;
+    }
+
+    /**
+     * How a bounded shell probe ended, so a caller can tell "there is no window" from "the UI
+     * never answered". The two need different words to a human and, before a destructive
+     * operation, they are the difference between "nobody is there" and "somebody is stuck".
+     */
+    public enum ShellProbeOutcome
+    {
+        /** A shell was obtained. */
+        SHELL,
+        /** The UI answered, and there is no shell - or there is no display at all. */
+        NO_SHELL,
+        /** The UI thread did not answer within the budget. */
+        TIMED_OUT
+    }
+
+    /** The result of {@link #grabActiveShellWithin(long)}: how it ended, and the shell if any. */
+    public static final class ShellProbe
+    {
+        private final ShellProbeOutcome outcome;
+        private final Shell shell;
+
+        ShellProbe(ShellProbeOutcome outcome, Shell shell)
+        {
+            this.outcome = outcome;
+            this.shell = shell;
+        }
+
+        /**
+         * @return how the probe ended
+         */
+        public ShellProbeOutcome outcome()
+        {
+            return outcome;
+        }
+
+        /**
+         * @return the shell, or {@code null} unless {@link #outcome()} is
+         *         {@link ShellProbeOutcome#SHELL}
+         */
+        public Shell shell()
+        {
+            return shell;
+        }
+    }
+
+    /**
+     * {@link #grabActiveShell()} with a deadline, for callers that must not wait forever.
+     * <p>
+     * The unbounded form asks the UI thread with {@code syncExec} and waits as long as that thread
+     * takes. On a workbench whose UI thread is wedged that is forever - and a caller holding a
+     * lock goes on holding it, so every later call for the same resource queues behind a wait that
+     * will not end. The destructive-consent gate is exactly such a caller.
+     * </p>
+     * <p>
+     * This form posts the same question with {@code asyncExec} and waits on a latch for at most
+     * {@code timeoutMillis}. A late answer is harmless: the runnable only reads a shell into a
+     * holder nobody is waiting on any more.
+     * </p>
+     * <p>
+     * A timeout is its OWN outcome and is never reported as "no shell". Collapsing the two would
+     * tell a stuck operator they are running headless and send them to the launch bypass, when
+     * what they actually need is to free the UI thread - and inside a gate, "there is no UI" has
+     * to keep meaning precisely that.
+     * </p>
+     *
+     * @param timeoutMillis how long to wait for the UI thread, in milliseconds
+     * @return how the probe ended, and the shell when one was obtained
+     */
+    public static ShellProbe grabActiveShellWithin(long timeoutMillis)
+    {
+        Display display = workbenchDisplayOrNull();
+        if (display == null || display.isDisposed())
+        {
+            return new ShellProbe(ShellProbeOutcome.NO_SHELL, null);
+        }
+        final Shell[] holder = new Shell[1];
+        CountDownLatch answered = new CountDownLatch(1);
+        try
+        {
+            display.asyncExec(() -> {
+                try
+                {
+                    holder[0] = activeOrFirstShell(display);
+                }
+                finally
+                {
+                    answered.countDown();
+                }
+            });
+        }
+        catch (RuntimeException disposedMidCall)
+        {
+            // The display went away between the probe and the post: the same answer as no display.
+            return new ShellProbe(ShellProbeOutcome.NO_SHELL, null);
+        }
+        return awaitShellAnswer(answered, holder, timeoutMillis);
+    }
+
+    /**
+     * Waits for a posted shell question to be answered, and turns the wait into an outcome.
+     * <p>
+     * Package-visible and free of SWT ON PURPOSE: the deadline is the whole point of the bounded
+     * probe, and a UI thread that never answers is precisely what cannot be arranged in a
+     * headless test runtime. Given the latch, it can - a latch that is never counted down IS a
+     * wedged UI thread, as far as this code is concerned.
+     * </p>
+     *
+     * @param answered counted down by the UI thread once it has filled {@code holder}
+     * @param holder receives the shell, or keeps {@code null} when there is none
+     * @param timeoutMillis how long to wait
+     * @return {@link ShellProbeOutcome#TIMED_OUT} when the answer did not arrive in time,
+     *         otherwise what the answer was
+     */
+    static ShellProbe awaitShellAnswer(CountDownLatch answered, Shell[] holder, long timeoutMillis)
+    {
+        try
+        {
+            if (!answered.await(timeoutMillis, TimeUnit.MILLISECONDS))
+            {
+                return new ShellProbe(ShellProbeOutcome.TIMED_OUT, null);
+            }
+        }
+        catch (InterruptedException e)
+        {
+            // An interrupt is not an answer. Restore the flag and report the same "did not
+            // answer" outcome rather than inventing a shell or a headless verdict.
+            Thread.currentThread().interrupt();
+            return new ShellProbe(ShellProbeOutcome.TIMED_OUT, null);
+        }
+        Shell shell = holder[0];
+        return shell != null ? new ShellProbe(ShellProbeOutcome.SHELL, shell)
+            : new ShellProbe(ShellProbeOutcome.NO_SHELL, null);
     }
 
     // ==================================================================================

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGateTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGateTest.java
@@ -431,6 +431,62 @@ public class DestructiveConsentGateTest
             tookMs < 5_000L);
     }
 
+    /**
+     * The branch that keeps the bounded probe usable from the UI thread itself:
+     * rename_metadata_object asks the gate from INSIDE its {@code syncExec} scope, where posting
+     * the question and then waiting on it would block the only thread that could answer - the
+     * probe would spend its whole budget and refuse on a perfectly healthy workbench. An answer
+     * taken inline is therefore never a timeout; with no shell it is NO_SHELL, a different
+     * verdict with a different remedy.
+     */
+    @Test
+    public void anInlineAnswerIsNeverATimeout()
+    {
+        LaunchLifecycleUtils.ShellProbe probe = LaunchLifecycleUtils.inlineShellAnswer(null);
+
+        assertEquals("an inline read with no shell means NO_SHELL, not TIMED_OUT", //$NON-NLS-1$
+            LaunchLifecycleUtils.ShellProbeOutcome.NO_SHELL, probe.outcome());
+        assertNull("and it hands back no shell", probe.shell()); //$NON-NLS-1$
+    }
+
+    /**
+     * The probe timeout and the dialog timeout are DIFFERENT failures and must not share a text:
+     * nothing was ever shown here, the wait was the probe's 5 s and not the prompt's 120 s, and a
+     * Preferences allowance cannot rescue it because the probe runs BEFORE the policy is read.
+     * Telling the operator to answer a dialog promptly sends them after a window that never opened.
+     */
+    @Test
+    public void anUnresponsiveUiIsNotReportedAsAnUnansweredDialog()
+    {
+        String message =
+            DestructiveConsentGate.consentDeniedMessage(ConsentDecision.UI_UNRESPONSIVE, TOOL);
+
+        assertTrue(message, message.contains(TOOL));
+        assertTrue("it must name the probe budget: " + message, //$NON-NLS-1$
+            message.contains(String.valueOf(DestructiveConsentGate.SHELL_PROBE_TIMEOUT_MS)));
+        assertTrue("and say the workbench did not answer: " + message, //$NON-NLS-1$
+            message.contains("wedged") || message.contains("did not answer")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("it must NOT quote the dialog budget: " + message, //$NON-NLS-1$
+            message.contains(DestructiveConsentGate.CONSENT_PROMPT_TIMEOUT_SECONDS + " s")); //$NON-NLS-1$
+        assertFalse("nor send them to a dialog that was never shown: " + message, //$NON-NLS-1$
+            message.contains("answer the confirmation dialog")); //$NON-NLS-1$
+    }
+
+    /**
+     * The mirror direction: the DIALOG timeout keeps its own text, so splitting the two verdicts
+     * did not quietly rewrite the case that really is an unanswered prompt.
+     */
+    @Test
+    public void theDialogTimeoutKeepsItsOwnPromptText()
+    {
+        String message = DestructiveConsentGate.consentDeniedMessage(ConsentDecision.TIMEOUT, TOOL);
+
+        assertTrue("the dialog verdict still names its 120 s budget: " + message, //$NON-NLS-1$
+            message.contains(String.valueOf(DestructiveConsentGate.CONSENT_PROMPT_TIMEOUT_SECONDS)));
+        assertTrue("and still points at the dialog: " + message, //$NON-NLS-1$
+            message.contains("confirmation dialog")); //$NON-NLS-1$
+    }
+
     @Test
     public void consentDeniedMessageKeepsTheOriginalRejectText()
     {

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGateTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGateTest.java
@@ -14,10 +14,12 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
 import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
 import java.util.Collections;
 import java.util.Set;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.swt.widgets.Shell;
 import org.junit.After;
 import org.junit.Test;
 
@@ -360,6 +362,74 @@ public class DestructiveConsentGateTest
     // =====================================================================
     // Issue #277 — consentDeniedMessage: REJECT text unchanged, TIMEOUT text actionable
     // =====================================================================
+
+    // =====================================================================
+    // The shell probe is BOUNDED: a wedged UI thread is refused, not waited on
+    // =====================================================================
+
+    /**
+     * The defect this closes: the gate asked the UI thread for a shell with an unbounded
+     * syncExec, from a worker thread that is holding the caller's lock. On a workbench whose UI
+     * thread is wedged the call never returned, so merge_rules kept its path mutex and every
+     * later call for that path queued behind a wait that could not end.
+     * <p>
+     * A latch that is never counted down IS that wedged UI thread as far as the wait is
+     * concerned, which is what makes the deadline testable with no display in the room.
+     * </p>
+     */
+    @Test
+    public void aUiThreadThatNeverAnswersIsGivenUpOnRatherThanWaitedFor()
+    {
+        CountDownLatch neverAnswered = new CountDownLatch(1);
+
+        long startedAt = System.nanoTime();
+        LaunchLifecycleUtils.ShellProbe probe =
+            LaunchLifecycleUtils.awaitShellAnswer(neverAnswered, new Shell[1], 150L);
+        long tookMs = (System.nanoTime() - startedAt) / 1_000_000L;
+
+        assertEquals("a silent UI thread must end as TIMED_OUT", //$NON-NLS-1$
+            LaunchLifecycleUtils.ShellProbeOutcome.TIMED_OUT, probe.outcome());
+        assertNull("and hand back no shell", probe.shell()); //$NON-NLS-1$
+        assertTrue("it must give up near the budget, not hang: took " + tookMs + "ms", //$NON-NLS-1$ //$NON-NLS-2$
+            tookMs < 10_000L);
+    }
+
+    /**
+     * The other edge, and the one that keeps #566 intact: a UI thread that ANSWERS "there is no
+     * shell" must not be reported as a timeout. The two mean different things to the operator -
+     * one says nobody is there, the other says somebody is stuck - and the gate turns them into
+     * different verdicts with different remedies.
+     */
+    @Test
+    public void aUiThreadThatAnswersNoShellIsNotATimeout()
+    {
+        CountDownLatch answered = new CountDownLatch(1);
+        answered.countDown();
+
+        LaunchLifecycleUtils.ShellProbe probe =
+            LaunchLifecycleUtils.awaitShellAnswer(answered, new Shell[1], 150L);
+
+        assertEquals("an answered probe with no shell is NO_SHELL, not TIMED_OUT", //$NON-NLS-1$
+            LaunchLifecycleUtils.ShellProbeOutcome.NO_SHELL, probe.outcome());
+    }
+
+    /**
+     * The probe must not spend its budget when there is simply no display: a headless runtime is
+     * answered from the workbench check, without ever posting to a UI thread.
+     */
+    @Test
+    public void aHeadlessRuntimeIsAnsweredWithoutSpendingTheBudget()
+    {
+        long startedAt = System.nanoTime();
+        LaunchLifecycleUtils.ShellProbe probe =
+            LaunchLifecycleUtils.grabActiveShellWithin(30_000L);
+        long tookMs = (System.nanoTime() - startedAt) / 1_000_000L;
+
+        assertEquals("no workbench means NO_SHELL", //$NON-NLS-1$
+            LaunchLifecycleUtils.ShellProbeOutcome.NO_SHELL, probe.outcome());
+        assertTrue("and it must answer at once, not wait 30s: took " + tookMs + "ms", //$NON-NLS-1$ //$NON-NLS-2$
+            tookMs < 5_000L);
+    }
 
     @Test
     public void consentDeniedMessageKeepsTheOriginalRejectText()


### PR DESCRIPTION
Находка ревьюера на #560, вынесенная в отдельную работу по решению владельца: **сначала починка, потом #560**.

### Что было

Гейт согласия спрашивал у UI-потока шелл через **неограниченный** `syncExec`. На воркбенче с заклиненным UI-потоком этот вызов не возвращается никогда — а приходят в него из рабочего потока, который держит замок вызывающего. `merge_rules` при этом держит свой `PathMutex`, поэтому все последующие вызовы по тому же пути встают за ожиданием, которое не кончится. Через то же ожидание ходят `delete_project`, `delete_infobase` и `update_database`, поэтому чиню в общем месте, а не в одном инструменте.

### Что изменилось — ожидание, а не порядок

Порядок проверок **намеренно не тронут**. Если читать политику раньше пробы, то на EDT без дисплея `ALLOW_ALL`, поштучное разрешение и разрешение на сессию ответят ALLOW ровно там, где по #566 гейт обязан отказать. Такая перестановка уже делалась (`b1180580`) и была откачена именно за это (`b1d14680`). Здесь чинится ожидание, дыра #566 остаётся закрытой.

`grabActiveShellWithin` задаёт тот же вопрос через `asyncExec` и ждёт на латче не дольше бюджета. Поздний ответ безвреден: рунабл только кладёт шелл в холдер, которого уже никто не ждёт. Обе пробы теперь выбирают шелл одним хелпером, так что разойтись в том, *какой* шелл имеется в виду, они не могут.

**Таймаут — отдельный исход, а не «шелла нет».** Слить их значило бы сказать застрявшему оператору, что он работает без дисплея, и отправить его к launch-обходу, тогда как чинить надо UI-поток. Вердикт — `TIMEOUT`, у которого текст уже называет бюджет и три способа выйти; фраза «нет UI» продолжает означать ровно то, что означает.

### Проверяется без дисплея — в этом и смысл

Ожидание вынесено в `awaitShellAnswer(latch, holder, timeout)`, и латч, который никто не досчитал, — это и есть заклиненный UI-поток с точки зрения этого кода. Закреплены три случая: молчащий поток заканчивается `TIMED_OUT` внутри бюджета; поток, ответивший «шелла нет», даёт `NO_SHELL`, а не таймаут; headless отвечает сразу, не тратя 30 секунд бюджета.

Прогон целевых классов: `DestructiveConsentGateTest` 31/31, `UpdateDatabaseToolTest` 69/69, `LaunchToolTest` 62/62 — оба других инструмента через тот же хелпер целы. Тест на таймаут занимает 0.152 с при бюджете 150 мс, то есть дедлайн действительно срабатывает, а не возвращается мгновенно.

### Что осталось honest

Бюджет 5 секунд **обоснован рассуждением, а не измерен**: здоровый UI-поток отвечает за микросекунды, заклиненный не ответит никогда, поэтому точное значение влияет только на то, как долго вызывающий держит свой замок. Если нужно другое число — скажите.

Полный локальный прогон не делался: машина занята параллельными сборками, тестовая JVM умирает посреди набора с нативным OOM. Прогонялись целевые классы; полный гейт — за CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
