### PR TITLE
ask_workmate снова запускается: адаптер выбирает форму API Workmate, а не версию (#552)

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,8 +371,14 @@ Add to `.claude.json` (in Windows `%USERPROFILE%\.claude.json`):
 
 ## 1C:Workmate in-process bridge
 
-When 1C:Workmate (`com.e1c.edt.ai*` 1.0.5) runs in the same EDT JVM, integration
-works in both directions:
+When 1C:Workmate (`com.e1c.edt.ai*` 1.0.5 or 1.0.7) runs in the same EDT JVM,
+integration works in both directions. The two builds differ in the conversation
+API — 1.0.5 wraps the project in `ProjectId`, 1.0.7 takes the Eclipse `IProject`
+and adds a progress-listener argument — and the adapter picks the layout by
+probing the installed classes, so no version has to be configured. One behaviour
+follows from that difference: on 1.0.7 a conversation is bound to a project, so
+`projectName` is required there and omitting it is refused before the question is
+sent.
 
 - `ask_workmate` starts Workmate's full conversation/tool loop in a bounded
   background job and returns a pollable `jobId`, so the MCP transport request

--- a/docs/tools/ask_workmate.md
+++ b/docs/tools/ask_workmate.md
@@ -6,7 +6,7 @@ Start a background question to the 1C:Workmate plugin and return its jobId. Poll
 | Parameter | Required | Type | Description |
 | --- | --- | --- | --- |
 | question | — | string | Non-empty question or instruction to send to 1C:Workmate. Required unless workmateTool selects direct tool mode. |
-| projectName | — | string | Optional open EDT project name used as Workmate's context. Omit to use Workmate's default project context. |
+| projectName | — | string | Optional open EDT project name used as Workmate's context. It may be omitted only on builds with a default project context; newer builds require it for conversations. |
 | maxToolRounds | — | integer | Optional positive limit for Workmate's internal tool-call rounds; it applies per assistant turn, so a conversation continued to reach a final answer spends it again on each turn. |
 | skillName | — | string | Optional Workmate skill name. Omit to use 'custom', the skill under which Workmate runs its own tool loop; Workmate's plain 'raw' skill answers from the model alone and inspects nothing. |
 | timeoutSeconds | — | integer | Total wall-clock budget for the background job across all get_job_status polls, in seconds; defaults to 300 and accepts 1 to 3600. After this budget the job is failed - unless the request has already reached Workmate, which cannot be taken back: the job then reports Workmate's own outcome rather than a retryable timeout, because a retry would run the same work twice. This is not the per-call waitSeconds budget. |
@@ -23,8 +23,9 @@ Start a background question to the 1C:Workmate plugin and return its jobId. Poll
   non-whitespace text. It is required unless `workmateTool` selects direct tool
   mode.
 - `projectName` applies only when starting. When present, it must name an open
-  EDT project; use `list_projects` to discover valid names. When omitted,
-  Workmate receives its `ProjectId.Default` context.
+  EDT project; use `list_projects` to discover valid names. When omitted, the
+  1.0.5 API uses `ProjectId.Default`; the 1.0.7 API requires a project for
+  conversation modes and refuses the request before dispatch.
 - `maxToolRounds` applies only when starting and optionally limits Workmate's
   internal tool-call rounds. It must be a positive integer. Omit it to use
   Workmate's own default. The limit is **per assistant turn**, which is how the

--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/ask_workmate.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/ask_workmate.md
@@ -4,8 +4,9 @@
   non-whitespace text. It is required unless `workmateTool` selects direct tool
   mode.
 - `projectName` applies only when starting. When present, it must name an open
-  EDT project; use `list_projects` to discover valid names. When omitted,
-  Workmate receives its `ProjectId.Default` context.
+  EDT project; use `list_projects` to discover valid names. When omitted, the
+  1.0.5 API uses `ProjectId.Default`; the 1.0.7 API requires a project for
+  conversation modes and refuses the request before dispatch.
 - `maxToolRounds` applies only when starting and optionally limits Workmate's
   internal tool-call rounds. It must be a positive integer. Omit it to use
   Workmate's own default. The limit is **per assistant turn**, which is how the

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/AskWorkmateTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/AskWorkmateTool.java
@@ -143,7 +143,8 @@ public class AskWorkmateTool implements IMcpTool
                     + "workmateTool selects direct tool mode.") //$NON-NLS-1$
             .stringProperty(KEY_PROJECT_NAME,
                 "Optional open EDT project name used as Workmate's context. " //$NON-NLS-1$
-                    + "Omit to use Workmate's default project context.") //$NON-NLS-1$
+                    + "It may be omitted only on builds with a default project context; " //$NON-NLS-1$
+                    + "newer builds require it for conversations.") //$NON-NLS-1$
             .integerProperty(KEY_MAX_TOOL_ROUNDS,
                 "Optional positive limit for Workmate's internal tool-call " //$NON-NLS-1$
                     + "rounds; it applies per assistant turn, so a conversation continued to " //$NON-NLS-1$
@@ -633,8 +634,12 @@ public class AskWorkmateTool implements IMcpTool
                     + "Preferences > 1C:Workmate > User Token, then retry ask_workmate."; //$NON-NLS-1$
             case INCOMPATIBLE:
                 return "Incompatible 1C:Workmate version or structure: " + error.getDetail() //$NON-NLS-1$
-                    + ". Install a 1C:Workmate build compatible with 1.0.5 or update EDT-MCP's " //$NON-NLS-1$
-                    + "Workmate adapter, then retry ask_workmate."; //$NON-NLS-1$
+                    + ". Install a supported 1C:Workmate build (1.0.5 or 1.0.7) or update " //$NON-NLS-1$
+                    + "EDT-MCP's Workmate adapter, then retry ask_workmate."; //$NON-NLS-1$
+            case PROJECT_REQUIRED:
+                return endSentence(error.getDetail())
+                    + " Set projectName to the name of an open EDT project; use " //$NON-NLS-1$
+                    + "list_projects to discover valid names, then retry ask_workmate."; //$NON-NLS-1$
             case NOT_READY:
                 return "1C:Workmate is installed but not initialized: " + error.getDetail() //$NON-NLS-1$
                     + ". Open Workmate in EDT (or restart EDT), wait for it to initialize, " //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/WorkmateGateway.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -35,7 +36,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 /**
- * Version-localized reflective adapter for 1C:Workmate 1.0.5.
+ * Reflective adapter for the 1C:Workmate 1.0.5 and 1.0.7 API shapes.
  * <p>
  * Workmate is deliberately absent from EDT-MCP's target platform. Every class,
  * constructor, field and method belonging to Workmate is therefore named and
@@ -45,6 +46,12 @@ import org.osgi.framework.FrameworkUtil;
  * point. Since there is no public injector/facade getter, this adapter reads the
  * single private {@code injectorRef} field and asks the live Guice injector for
  * the facade instance.
+ * <p>
+ * Workmate 1.0.5 wraps the EDT project in {@code ProjectId} and exposes a
+ * two-argument {@code ConversationFacade.sendAsync}; 1.0.7 takes {@link IProject}
+ * directly and adds a third progress-listener argument to {@code sendAsync}. The
+ * adapter selects between those layouts by probing the installed public
+ * constructors and methods, never by interpreting a bundle version string.
  */
 public class WorkmateGateway
 {
@@ -58,6 +65,7 @@ public class WorkmateGateway
     private static final String AI_BUNDLE = "com.e1c.edt.ai"; //$NON-NLS-1$
     private static final String UI_COMMON_BUNDLE = "com.e1c.edt.ai.ui.common"; //$NON-NLS-1$
     private static final String UI_BUNDLE = "com.e1c.edt.ai.ui"; //$NON-NLS-1$
+    private static final String CONTEXT_BUNDLE = "com.e1c.edt.ai.context"; //$NON-NLS-1$
 
     private static final String BASE_ACTIVATOR = "com.e1c.edt.ai.ui.BaseActivator"; //$NON-NLS-1$
     private static final String CONVERSATION_FACADE = "com.e1c.edt.ai.ConversationFacade"; //$NON-NLS-1$
@@ -257,6 +265,187 @@ public class WorkmateGateway
         "com.e1c.edt.ai.assistent.model.McpToolCallFunctionCall"; //$NON-NLS-1$
 
     /**
+     * Finds the seven-argument conversation request shared by the supported API layouts.
+     * The first parameter deliberately remains open: it is the part Workmate changed.
+     *
+     * @param requestClass installed request class
+     * @param sessionClass installed conversation-session class
+     * @return the matching public constructor, or {@code null}
+     */
+    static Constructor<?> findConversationRequestConstructor(Class<?> requestClass,
+        Class<?> sessionClass)
+    {
+        try
+        {
+            for (Constructor<?> constructor : requestClass.getConstructors())
+            {
+                Class<?>[] parameters = constructor.getParameterTypes();
+                if (parameters.length == 7
+                    && parameters[1] == String.class
+                    && parameters[2] == sessionClass
+                    && parameters[3] == boolean.class
+                    && parameters[4] == String.class
+                    && parameters[5] == Boolean.class
+                    && parameters[6] == Integer.class)
+                {
+                    return constructor;
+                }
+            }
+        }
+        catch (RuntimeException | LinkageError e) // NOSONAR a failed probe is reported by its caller
+        {
+            return null;
+        }
+        return null;
+    }
+
+    /**
+     * Finds the thirteen-argument AI context shared by the supported API layouts.
+     * The first parameter deliberately remains open: it is the part Workmate changed.
+     *
+     * @param contextClass installed context class
+     * @param documentClass installed document class
+     * @return the matching public constructor, or {@code null}
+     */
+    static Constructor<?> findAiContextConstructor(Class<?> contextClass, Class<?> documentClass)
+    {
+        try
+        {
+            for (Constructor<?> constructor : contextClass.getConstructors())
+            {
+                Class<?>[] parameters = constructor.getParameterTypes();
+                if (parameters.length == 13
+                    && parameters[1] == int.class
+                    && parameters[2] == String.class
+                    && parameters[3] == int.class
+                    && parameters[4] == String.class
+                    && parameters[5] == String.class
+                    && parameters[6] == int.class
+                    && parameters[7] == String.class
+                    && parameters[8] == String.class
+                    && parameters[9] == int.class
+                    && parameters[10] == int.class
+                    && parameters[11] == documentClass
+                    && parameters[12] == Supplier.class)
+                {
+                    return constructor;
+                }
+            }
+        }
+        catch (RuntimeException | LinkageError e) // NOSONAR a failed probe is reported by its caller
+        {
+            return null;
+        }
+        return null;
+    }
+
+    /**
+     * Finds Workmate's conversation send method, preferring the older two-argument shape.
+     *
+     * @param facadeClass installed conversation facade class
+     * @param requestClass installed request class
+     * @param tokenClass installed cancellation-token class
+     * @return the two-argument method, otherwise a matching three-argument method, or {@code null}
+     */
+    static Method findSendAsync(Class<?> facadeClass, Class<?> requestClass, Class<?> tokenClass)
+    {
+        Method threeArgument = null;
+        try
+        {
+            for (Method method : facadeClass.getMethods())
+            {
+                Class<?>[] parameters = method.getParameterTypes();
+                if (!"sendAsync".equals(method.getName()) //$NON-NLS-1$
+                    || parameters.length < 2
+                    || parameters[0] != requestClass
+                    || parameters[1] != tokenClass)
+                {
+                    continue;
+                }
+                if (parameters.length == 2)
+                {
+                    return method;
+                }
+                if (parameters.length == 3 && threeArgument == null)
+                {
+                    threeArgument = method;
+                }
+            }
+        }
+        catch (RuntimeException | LinkageError e) // NOSONAR a failed probe is reported by its caller
+        {
+            return null;
+        }
+        return threeArgument;
+    }
+
+    /**
+     * Builds the arguments for whichever supported {@code sendAsync} overload was found.
+     *
+     * @param sendAsync resolved two- or three-argument method
+     * @param request prepared conversation request
+     * @param cancellationToken Workmate cancellation token
+     * @return arguments matching the resolved method's arity
+     */
+    static Object[] sendAsyncArguments(Method sendAsync, Object request, Object cancellationToken)
+    {
+        return sendAsync.getParameterCount() == 3
+            ? new Object[] {request, cancellationToken, null}
+            : new Object[] {request, cancellationToken};
+    }
+
+    /**
+     * Reports whether the constructor explicitly declares an Eclipse project type.
+     * <p>
+     * The direction is deliberately {@code IProject.class.isAssignableFrom(parameterType)}.
+     * Reversing it would accept supertypes such as {@code Object} or {@code IResource}; those
+     * are unrecognized API shapes and must be refused with a diagnostic rather than guessed.
+     *
+     * @param projectParameterType first parameter of the probed Workmate constructor
+     * @return whether that parameter is {@link IProject} or a more specific project type
+     */
+    static boolean takesEclipseProject(Class<?> projectParameterType)
+    {
+        return projectParameterType != null
+            && IProject.class.isAssignableFrom(projectParameterType);
+    }
+
+    /**
+     * Reports whether a type is Workmate's legacy project wrapper.
+     * <p>
+     * The known FQN is checked first. The exact shape fallback exists because a renamed wrapper
+     * with the same public {@code Default} value and {@code (IProject)} constructor is still that
+     * wrapper; anything else is refused rather than inferred from a looser resemblance.
+     *
+     * @param projectParameterType first parameter of the probed Workmate constructor
+     * @return whether the type is the known wrapper or declares its exact public shape
+     */
+    static boolean isLegacyProjectWrapper(Class<?> projectParameterType)
+    {
+        if (projectParameterType == null)
+        {
+            return false;
+        }
+        if (PROJECT_ID.equals(projectParameterType.getName()))
+        {
+            return true;
+        }
+        try
+        {
+            Field defaultField = projectParameterType.getDeclaredField("Default"); //$NON-NLS-1$
+            int modifiers = defaultField.getModifiers();
+            return Modifier.isPublic(modifiers)
+                && Modifier.isStatic(modifiers)
+                && defaultField.getType() == projectParameterType
+                && projectParameterType.getConstructor(IProject.class) != null;
+        }
+        catch (NoSuchFieldException | NoSuchMethodException | SecurityException | LinkageError e)
+        {
+            return false;
+        }
+    }
+
+    /**
      * How long the hand-off to the SWT thread may take. This bounds only the hand-off - opening
      * the view and posting the question - never Workmate's own work, which continues in its chat.
      */
@@ -292,6 +481,7 @@ public class WorkmateGateway
         DISABLED,
         NO_CLIENT_TOKEN,
         INCOMPATIBLE,
+        PROJECT_REQUIRED,
         NOT_READY,
         TIMED_OUT,
         /**
@@ -358,7 +548,13 @@ public class WorkmateGateway
 
         public static GatewayException incompatible(String detail)
         {
-            return new GatewayException(FailureKind.INCOMPATIBLE, detail);
+            return new GatewayException(FailureKind.INCOMPATIBLE,
+                detail + installedWorkmateBundles());
+        }
+
+        public static GatewayException projectRequired(String detail)
+        {
+            return new GatewayException(FailureKind.PROJECT_REQUIRED, detail);
         }
 
         public static GatewayException notReady(String detail)
@@ -517,7 +713,8 @@ public class WorkmateGateway
     /**
      * Sends one new conversation request through Workmate's own full tool loop.
      *
-     * @param project optional EDT project; {@code null} selects ProjectId.Default
+     * @param project optional EDT project; {@code null} selects {@code ProjectId.Default}
+     *            only on Workmate layouts that provide it
      * @param question user message
      * @param maxToolRounds optional Workmate tool-round limit
      * @param skillName optional Workmate skill name
@@ -537,7 +734,8 @@ public class WorkmateGateway
      * Sends one new conversation request and reports only milestones actually
      * completed by the reflective adapter.
      *
-     * @param project optional EDT project; {@code null} selects ProjectId.Default
+     * @param project optional EDT project; {@code null} selects {@code ProjectId.Default}
+     *            only on Workmate layouts that provide it
      * @param question user message
      * @param maxToolRounds optional Workmate tool-round limit
      * @param skillName optional Workmate skill name
@@ -582,21 +780,33 @@ public class WorkmateGateway
             }
             progress.onProgress("Obtained the Workmate conversation facade."); //$NON-NLS-1$
 
-            Class<?> projectIdClass = requireClass(aiBundle, PROJECT_ID);
-            Object projectId = project == null
-                ? readField(requirePublicField(projectIdClass, "Default"), null) //$NON-NLS-1$
-                : create(requireConstructor(projectIdClass, PROJECT_ID + "(IProject)", //$NON-NLS-1$
-                    IProject.class), project);
-
             Class<?> sessionClass = requireClass(aiBundle, CONVERSATION_SESSION);
             Class<?> requestClass = requireClass(aiBundle, SEND_REQUEST);
-            Constructor<?> requestConstructor = requireConstructor(requestClass,
-                SEND_REQUEST + "(ProjectId,String,ConversationSession,boolean,String,Boolean,Integer)", //$NON-NLS-1$
-                projectIdClass, String.class, sessionClass, boolean.class, String.class,
-                Boolean.class, Integer.class);
+            Constructor<?> requestConstructor =
+                findConversationRequestConstructor(requestClass, sessionClass);
+            if (requestConstructor == null)
+            {
+                throw GatewayException.incompatible("constructor probe for '" //$NON-NLS-1$
+                    + requestClass.getName() + "' looked for public " //$NON-NLS-1$
+                    + "(X,java.lang.String," + sessionClass.getName() //$NON-NLS-1$
+                    + ",boolean,java.lang.String,java.lang.Boolean,java.lang.Integer); " //$NON-NLS-1$
+                    + "selected: none; detected public constructors: " //$NON-NLS-1$
+                    + publicConstructorShapes(requestClass));
+            }
+            Object requestProject = projectArgument(requestConstructor.getParameterTypes()[0],
+                project, "SendUserMessageRequest"); //$NON-NLS-1$
             Class<?> cancellationTokenClass = requireClass(aiBundle, CANCELLATION_TOKEN);
-            Method sendAsync = requireMethod(facadeClass, "sendAsync", requestClass, //$NON-NLS-1$
-                cancellationTokenClass);
+            Method sendAsync = findSendAsync(facadeClass, requestClass, cancellationTokenClass);
+            if (sendAsync == null)
+            {
+                throw GatewayException.incompatible("method probe for '" //$NON-NLS-1$
+                    + facadeClass.getName() + "' looked for public sendAsync(" //$NON-NLS-1$
+                    + requestClass.getName() + ',' + cancellationTokenClass.getName()
+                    + ") and sendAsync(" + requestClass.getName() + ',' //$NON-NLS-1$
+                    + cancellationTokenClass.getName() + ",X), preferring 2 arguments; " //$NON-NLS-1$
+                    + "selected: none; detected public sendAsync methods: " //$NON-NLS-1$
+                    + publicMethodShapes(facadeClass, "sendAsync")); //$NON-NLS-1$
+            }
             Class<?> resultClass = requireClass(aiBundle, SEND_RESULT);
 
             // ONE facade call answers ONE assistant turn: ConversationFacade completes its future
@@ -620,7 +830,7 @@ public class WorkmateGateway
             int continuations = 0;
             while (true)
             {
-                Object request = create(requestConstructor, projectId,
+                Object request = create(requestConstructor, requestProject,
                     message + FINALITY_INSTRUCTION, session,
                     session == null,
                     // chat = FALSE matches Workmate's OWN default (ConversationFacade maps a null
@@ -1084,7 +1294,11 @@ public class WorkmateGateway
         Object futureValue;
         try
         {
-            futureValue = invoke(sendAsync, facade, request, cancellationToken);
+            // Workmate 1.0.7 added a progress listener, but its reporting paths explicitly
+            // accept null. Passing that sentinel keeps this adapter independent of the listener
+            // interface and preserves the two-argument call on 1.0.5.
+            futureValue = invoke(sendAsync, facade,
+                sendAsyncArguments(sendAsync, request, cancellationToken));
         }
         catch (GatewayException e)
         {
@@ -1731,28 +1945,29 @@ public class WorkmateGateway
      * outside an editor: a project, no document, and EMPTY (not null) text fields, because
      * Workmate reads members such as {@code getPrefix()} without a null check.
      *
-     * @param aiBundle the {@code com.e1c.edt.ai} bundle
      * @param contextClass the resolved {@code AIContext} class
      * @param project optional project; {@code null} selects {@code ProjectId.Default}
+     *            only on Workmate layouts that provide it
      * @return a usable empty context
      * @throws GatewayException when the expected constructor is missing
      */
-    private static Object createEmptyContext(Bundle aiBundle, Class<?> contextClass,
-        IProject project) throws GatewayException
+    private static Object createEmptyContext(Class<?> contextClass, IProject project)
+        throws GatewayException
     {
-        Class<?> projectIdClass = requireClass(aiBundle, PROJECT_ID);
-        Object projectId = project == null
-            ? readField(requirePublicField(projectIdClass, "Default"), null) //$NON-NLS-1$
-            : create(requireConstructor(projectIdClass, PROJECT_ID + "(IProject)", //$NON-NLS-1$
-                IProject.class), project);
-        Constructor<?> constructor = requireConstructor(contextClass,
-            AI_CONTEXT + "(ProjectId,int,String,int,String,String,int,String,String,int,int," //$NON-NLS-1$
-                + "IDocument,Supplier)", //$NON-NLS-1$
-            projectIdClass, int.class, String.class, int.class, String.class, String.class,
-            int.class, String.class, String.class, int.class, int.class, IDocument.class,
-            Supplier.class);
+        Constructor<?> constructor = findAiContextConstructor(contextClass, IDocument.class);
+        if (constructor == null)
+        {
+            throw GatewayException.incompatible("constructor probe for '" //$NON-NLS-1$
+                + contextClass.getName() + "' looked for public " //$NON-NLS-1$
+                + "(X,int,java.lang.String,int,java.lang.String,java.lang.String,int," //$NON-NLS-1$
+                + "java.lang.String,java.lang.String,int,int," + IDocument.class.getName() //$NON-NLS-1$
+                + ",java.util.function.Supplier); selected: none; detected public " //$NON-NLS-1$
+                + "constructors: " + publicConstructorShapes(contextClass)); //$NON-NLS-1$
+        }
+        Object contextProject = projectArgument(constructor.getParameterTypes()[0], project,
+            "AIContext"); //$NON-NLS-1$
         Supplier<Boolean> notDisposed = () -> Boolean.FALSE;
-        return create(constructor, projectId, Integer.valueOf(0), "", Integer.valueOf(0), //$NON-NLS-1$
+        return create(constructor, contextProject, Integer.valueOf(0), "", Integer.valueOf(0), //$NON-NLS-1$
             "", "", Integer.valueOf(0), "", "", Integer.valueOf(0), Integer.valueOf(0), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
             null, notDisposed);
     }
@@ -2046,7 +2261,7 @@ public class WorkmateGateway
      * lie). The caller's cancellation - the job deadline - is what ends the wait.
      *
      * @param project optional EDT project the chat should treat as context; {@code null} selects
-     *            Workmate's default project
+     *            Workmate's default project only on layouts that provide one
      * @param question the user question, already validated as non-blank
      * @param progress milestone listener
      * @throws GatewayException categorized runtime/compatibility failure
@@ -2084,7 +2299,7 @@ public class WorkmateGateway
             // question never reached the chat. Build an EMPTY-but-real context instead - no
             // editor, no selection, empty text - which is what "asked from outside an editor"
             // actually means.
-            Object aiContext = createEmptyContext(aiBundle, contextClass, project);
+            Object aiContext = createEmptyContext(contextClass, project);
             progress.onProgress("Obtained the Workmate chat."); //$NON-NLS-1$
 
             // Chat.chat(...) calls IUI.showView(...) before dispatching, so it must start on the
@@ -2228,6 +2443,188 @@ public class WorkmateGateway
                 + "' returned " + typeName(value) + " instead of boolean"); //$NON-NLS-1$ //$NON-NLS-2$
         }
         return ((Boolean)value).booleanValue();
+    }
+
+    /**
+     * Adapts the caller's project only after the constructor itself has revealed which
+     * Workmate layout is installed. A version string would not prove that layout.
+     *
+     * @param projectParameterType first parameter of the selected constructor
+     * @param project caller's optional EDT project
+     * @param apiType selected Workmate API type, for diagnostics
+     * @return direct project or legacy wrapper expected by the constructor
+     * @throws GatewayException when the build requires a project or exposes an unknown shape
+     */
+    static Object projectArgument(Class<?> projectParameterType, IProject project,
+        String apiType) throws GatewayException
+    {
+        if (takesEclipseProject(projectParameterType))
+        {
+            if (project == null)
+            {
+                throw GatewayException.projectRequired(
+                    "This 1C:Workmate build binds every conversation to an EDT project ('" //$NON-NLS-1$
+                        + apiType + "' takes an " + projectParameterType.getName() + ")."); //$NON-NLS-1$ //$NON-NLS-2$
+            }
+            return project;
+        }
+        if (isLegacyProjectWrapper(projectParameterType))
+        {
+            return project == null
+                ? readField(requirePublicField(projectParameterType, "Default"), null) //$NON-NLS-1$
+                // The display name comes from the type actually selected, not from the known
+                // FQN: a shape-matched wrapper under another name would otherwise be reported
+                // as the one class this adapter did NOT find.
+                : create(requireConstructor(projectParameterType,
+                    projectParameterType.getName() + "(IProject)", //$NON-NLS-1$
+                    IProject.class), project);
+        }
+        throw GatewayException.incompatible("selected the public " + apiType //$NON-NLS-1$
+            + " constructor, whose project parameter type is '" //$NON-NLS-1$
+            + projectParameterType.getName() + "'; supported project parameter shapes are '" //$NON-NLS-1$
+            + IProject.class.getName() + "' and the legacy wrapper '" + PROJECT_ID //$NON-NLS-1$
+            + "' (or the same shape: public static Default of its own type plus a public " //$NON-NLS-1$
+            + "constructor taking IProject)"); //$NON-NLS-1$
+    }
+
+    /**
+     * Appends runtime evidence to every structure refusal, including failures outside the
+     * two version probes. Diagnostics must identify the installation that was actually seen.
+     */
+    private static String installedWorkmateBundles()
+    {
+        try
+        {
+            Bundle owner = FrameworkUtil.getBundle(WorkmateGateway.class);
+            if (owner == null)
+            {
+                return " (installed: unavailable; EDT-MCP is not loaded as an OSGi bundle)"; //$NON-NLS-1$
+            }
+            BundleContext context = owner.getBundleContext();
+            if (context == null)
+            {
+                return " (installed: unavailable; EDT-MCP BundleContext is null)"; //$NON-NLS-1$
+            }
+            Bundle[] bundles = context.getBundles();
+            if (bundles == null)
+            {
+                return " (installed: unavailable; BundleContext returned no bundle list)"; //$NON-NLS-1$
+            }
+            String[] workmateBundleNames = {
+                AI_BUNDLE, UI_BUNDLE, UI_COMMON_BUNDLE, CONTEXT_BUNDLE
+            };
+            StringBuilder detected = new StringBuilder();
+            for (String symbolicName : workmateBundleNames)
+            {
+                for (Bundle bundle : bundles)
+                {
+                    if (symbolicName.equals(bundle.getSymbolicName()))
+                    {
+                        if (detected.length() > 0)
+                        {
+                            detected.append(", "); //$NON-NLS-1$
+                        }
+                        // The STATE belongs here as much as the version. "class not found" has
+                        // two very different causes - the build genuinely does not carry that
+                        // class, or the bundle never resolved and can load nothing - and only
+                        // the state tells them apart. Without it the same sentence sends the
+                        // reader to reinstall Workmate in both cases.
+                        detected.append(symbolicName)
+                            .append(' ')
+                            .append(bundle.getVersion())
+                            .append(" [") //$NON-NLS-1$
+                            .append(bundleStateName(bundle.getState()))
+                            .append(']');
+                        break;
+                    }
+                }
+            }
+            return detected.length() == 0
+                ? " (installed: no known 1C:Workmate bundles detected)" //$NON-NLS-1$
+                : " (installed: " + detected + ')'; //$NON-NLS-1$
+        }
+        catch (RuntimeException | LinkageError e) // NOSONAR diagnostics must never hide the refusal
+        {
+            return " (installed: bundle discovery failed with " //$NON-NLS-1$
+                + e.getClass().getSimpleName() + ')';
+        }
+    }
+
+    /**
+     * Names an OSGi bundle state for the diagnostics above.
+     *
+     * @param state the value returned by {@code Bundle.getState()}
+     * @return the OSGi name of that state, or the raw number when it is not a known one
+     */
+    static String bundleStateName(int state)
+    {
+        switch (state)
+        {
+            case Bundle.UNINSTALLED:
+                return "UNINSTALLED"; //$NON-NLS-1$
+            case Bundle.INSTALLED:
+                return "INSTALLED"; //$NON-NLS-1$
+            case Bundle.RESOLVED:
+                return "RESOLVED"; //$NON-NLS-1$
+            case Bundle.STARTING:
+                return "STARTING"; //$NON-NLS-1$
+            case Bundle.STOPPING:
+                return "STOPPING"; //$NON-NLS-1$
+            case Bundle.ACTIVE:
+                return "ACTIVE"; //$NON-NLS-1$
+            default:
+                return "state " + state; //$NON-NLS-1$
+        }
+    }
+
+    private static String publicConstructorShapes(Class<?> type)
+    {
+        try
+        {
+            Constructor<?>[] constructors = type.getConstructors();
+            if (constructors.length == 0)
+            {
+                return "none"; //$NON-NLS-1$
+            }
+            StringBuilder result = new StringBuilder();
+            for (Constructor<?> constructor : constructors)
+            {
+                if (result.length() > 0)
+                {
+                    result.append(" | "); //$NON-NLS-1$
+                }
+                result.append(constructor.toGenericString());
+            }
+            return result.toString();
+        }
+        catch (RuntimeException | LinkageError e) // NOSONAR this text reports why the probe failed
+        {
+            return "unavailable (" + e.getClass().getSimpleName() + ')'; //$NON-NLS-1$
+        }
+    }
+
+    private static String publicMethodShapes(Class<?> type, String methodName)
+    {
+        try
+        {
+            StringBuilder result = new StringBuilder();
+            for (Method method : type.getMethods())
+            {
+                if (methodName.equals(method.getName()))
+                {
+                    if (result.length() > 0)
+                    {
+                        result.append(" | "); //$NON-NLS-1$
+                    }
+                    result.append(method.toGenericString());
+                }
+            }
+            return result.length() == 0 ? "none" : result.toString(); //$NON-NLS-1$
+        }
+        catch (RuntimeException | LinkageError e) // NOSONAR this text reports why the probe failed
+        {
+            return "unavailable (" + e.getClass().getSimpleName() + ')'; //$NON-NLS-1$
+        }
     }
 
     private static Bundle requireBundle(String symbolicName) throws GatewayException

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/AskWorkmateToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/AskWorkmateToolTest.java
@@ -96,6 +96,11 @@ public class AskWorkmateToolTest
         assertTrue(properties.has("shareMcpTools")); //$NON-NLS-1$
         assertEquals(10, properties.size());
 
+        String projectDescription = properties.getAsJsonObject("projectName") //$NON-NLS-1$
+            .get("description").getAsString(); //$NON-NLS-1$
+        assertTrue(projectDescription.contains("default project context")); //$NON-NLS-1$
+        assertTrue(projectDescription.contains("newer builds require it")); //$NON-NLS-1$
+
         // The mode description must warn that chat answers never come back through
         // MCP, otherwise a caller picks 'chat' expecting a returned answer.
         String modeDescription = properties.getAsJsonObject("mode") //$NON-NLS-1$
@@ -305,7 +310,20 @@ public class AskWorkmateToolTest
         String missing = "field 'com.e1c.edt.ai.ui.BaseActivator.injectorRef' was not found"; //$NON-NLS-1$
         String result = executeWithFailure(GatewayException.incompatible(missing));
         assertJobFailedContains(result, "Incompatible 1C:Workmate version or structure", //$NON-NLS-1$
-            missing, "compatible with 1.0.5", "update EDT-MCP's Workmate adapter"); //$NON-NLS-1$ //$NON-NLS-2$
+            missing, "1.0.5 or 1.0.7", "update EDT-MCP's Workmate adapter", //$NON-NLS-1$ //$NON-NLS-2$
+            "retry ask_workmate"); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testProjectRequiredNamesDiscoveryAndDoesNotAdviseReinstallingWorkmate()
+    {
+        String detail = "This 1C:Workmate build binds every conversation to an EDT project " //$NON-NLS-1$
+            + "('SendUserMessageRequest' takes an org.eclipse.core.resources.IProject)."; //$NON-NLS-1$
+        String result = executeWithFailure(GatewayException.projectRequired(detail));
+        assertJobFailedContains(result, "binds every conversation to an EDT project", //$NON-NLS-1$
+            "projectName", "open EDT project", "list_projects", "retry ask_workmate"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        assertFalse("a missing project is fixed by naming one, not by reinstalling Workmate", //$NON-NLS-1$
+            result.contains("Install New Software") || result.contains("Install a supported")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/WorkmateVersionCompatTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/WorkmateVersionCompatTest.java
@@ -1,0 +1,312 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.function.Supplier;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.jface.text.IDocument;
+import org.junit.Test;
+
+import com.ditrix.edt.mcp.server.utils.WorkmateGateway.FailureKind;
+import com.ditrix.edt.mcp.server.utils.WorkmateGateway.GatewayException;
+
+/** Pure shape-probe tests; no 1C:Workmate class is present on the test classpath. */
+public class WorkmateVersionCompatTest
+{
+    @Test
+    public void testLegacyRequestAndAiContextSelectProjectIdLikeParameter()
+    {
+        Constructor<?> request = WorkmateGateway.findConversationRequestConstructor(
+            LegacyRequest.class, FakeSession.class);
+        assertNotNull(request);
+        assertSame(FakeProjectId.class, request.getParameterTypes()[0]);
+        assertFalse(WorkmateGateway.takesEclipseProject(request.getParameterTypes()[0]));
+
+        Constructor<?> context =
+            WorkmateGateway.findAiContextConstructor(LegacyAiContext.class, IDocument.class);
+        assertNotNull(context);
+        assertSame(FakeProjectId.class, context.getParameterTypes()[0]);
+        assertSame(IDocument.class, context.getParameterTypes()[11]);
+        assertSame(Supplier.class, context.getParameterTypes()[12]);
+    }
+
+    @Test
+    public void testModernRequestAndAiContextSelectEclipseProjectParameter()
+    {
+        Constructor<?> request = WorkmateGateway.findConversationRequestConstructor(
+            ModernRequest.class, FakeSession.class);
+        assertNotNull(request);
+        assertSame(IProject.class, request.getParameterTypes()[0]);
+        assertTrue(WorkmateGateway.takesEclipseProject(request.getParameterTypes()[0]));
+        assertFalse(WorkmateGateway.takesEclipseProject(IResource.class));
+        assertFalse(WorkmateGateway.takesEclipseProject(Object.class));
+
+        Constructor<?> context =
+            WorkmateGateway.findAiContextConstructor(ModernAiContext.class, IDocument.class);
+        assertNotNull(context);
+        assertSame(IProject.class, context.getParameterTypes()[0]);
+        assertSame(IDocument.class, context.getParameterTypes()[11]);
+        assertSame(Supplier.class, context.getParameterTypes()[12]);
+    }
+
+    @Test
+    public void testSendAsyncSelectsOldAndNewArities()
+    {
+        Method legacy = WorkmateGateway.findSendAsync(LegacyFacade.class,
+            LegacyRequest.class, FakeToken.class);
+        assertNotNull(legacy);
+        assertEquals(2, legacy.getParameterCount());
+        assertSame(LegacyRequest.class, legacy.getParameterTypes()[0]);
+        assertSame(FakeToken.class, legacy.getParameterTypes()[1]);
+
+        Method modern = WorkmateGateway.findSendAsync(ModernFacade.class,
+            ModernRequest.class, FakeToken.class);
+        assertNotNull(modern);
+        assertEquals(3, modern.getParameterCount());
+        assertSame(ModernRequest.class, modern.getParameterTypes()[0]);
+        assertSame(FakeToken.class, modern.getParameterTypes()[1]);
+        assertSame(FakeProgressListener.class, modern.getParameterTypes()[2]);
+
+        Method preferred = WorkmateGateway.findSendAsync(BothFacade.class,
+            ModernRequest.class, FakeToken.class);
+        assertNotNull(preferred);
+        assertEquals("the two-argument overload must win when both are public", //$NON-NLS-1$
+            2, preferred.getParameterCount());
+    }
+
+    @Test
+    public void testSendAsyncArgumentsMatchBothResolvedArities()
+    {
+        Object request = new Object();
+        Object token = new Object();
+        Method legacy = WorkmateGateway.findSendAsync(LegacyFacade.class,
+            LegacyRequest.class, FakeToken.class);
+        Object[] legacyArguments = WorkmateGateway.sendAsyncArguments(legacy, request, token);
+        assertEquals(2, legacyArguments.length);
+        assertSame(request, legacyArguments[0]);
+        assertSame(token, legacyArguments[1]);
+
+        Method modern = WorkmateGateway.findSendAsync(ModernFacade.class,
+            ModernRequest.class, FakeToken.class);
+        Object[] modernArguments = WorkmateGateway.sendAsyncArguments(modern, request, token);
+        assertEquals(3, modernArguments.length);
+        assertSame(request, modernArguments[0]);
+        assertSame(token, modernArguments[1]);
+        assertNull(modernArguments[2]);
+    }
+
+    @Test
+    public void testModernProjectArgumentRequiresOrPassesThroughProject() throws Exception
+    {
+        try
+        {
+            WorkmateGateway.projectArgument(IProject.class, null, "SendUserMessageRequest"); //$NON-NLS-1$
+            fail("a modern conversation without a project must be refused"); //$NON-NLS-1$
+        }
+        catch (GatewayException e)
+        {
+            assertSame(FailureKind.PROJECT_REQUIRED, e.getKind());
+            assertTrue(e.getDetail().contains("'SendUserMessageRequest'")); //$NON-NLS-1$
+        }
+
+        IProject project = projectProxy();
+        assertSame(project, WorkmateGateway.projectArgument(IProject.class, project,
+            "SendUserMessageRequest")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testLegacyProjectArgumentUsesDefaultOrCreatesWrapper() throws Exception
+    {
+        assertTrue(WorkmateGateway.isLegacyProjectWrapper(FakeProjectId.class));
+        assertSame(FakeProjectId.Default, WorkmateGateway.projectArgument(
+            FakeProjectId.class, null, "SendUserMessageRequest")); //$NON-NLS-1$
+
+        Object wrapped = WorkmateGateway.projectArgument(
+            FakeProjectId.class, projectProxy(), "SendUserMessageRequest"); //$NON-NLS-1$
+        assertTrue(wrapped instanceof FakeProjectId);
+        assertNotSame(FakeProjectId.Default, wrapped);
+    }
+
+    @Test
+    public void testUnsupportedProjectArgumentNamesBothSupportedShapes() throws Exception
+    {
+        assertFalse(WorkmateGateway.isLegacyProjectWrapper(String.class));
+        try
+        {
+            WorkmateGateway.projectArgument(String.class, projectProxy(), "AIContext"); //$NON-NLS-1$
+            fail("an unsupported project parameter must be refused"); //$NON-NLS-1$
+        }
+        catch (GatewayException e)
+        {
+            assertSame(FailureKind.INCOMPATIBLE, e.getKind());
+            assertTrue(e.getDetail().contains("java.lang.String")); //$NON-NLS-1$
+            assertTrue(e.getDetail().contains(IProject.class.getName()));
+            assertTrue(e.getDetail().contains("com.e1c.edt.ai.assistent.model.ProjectId")); //$NON-NLS-1$
+            assertTrue(e.getDetail().contains("public static Default")); //$NON-NLS-1$
+            assertTrue(e.getDetail().contains("constructor taking IProject")); //$NON-NLS-1$
+        }
+    }
+
+    @Test
+    public void testMissingShapesReturnNullWithoutThrowing()
+    {
+        assertNull(WorkmateGateway.findConversationRequestConstructor(
+            NeitherShape.class, FakeSession.class));
+        assertNull(WorkmateGateway.findAiContextConstructor(
+            NeitherShape.class, IDocument.class));
+        assertNull(WorkmateGateway.findSendAsync(
+            NeitherShape.class, ModernRequest.class, FakeToken.class));
+    }
+
+    /**
+     * "Class not found" has two causes - the build does not carry it, or the bundle never
+     * resolved - and the diagnostics tell them apart only if the state is spelled out. The
+     * numbers are the OSGi ones, so they are pinned here rather than read back from the
+     * constants the production code already uses.
+     */
+    @Test
+    public void testBundleStateIsNamedSoAnUnresolvedBundleIsNotReadAsAMissingClass()
+    {
+        assertEquals("UNINSTALLED", WorkmateGateway.bundleStateName(1)); //$NON-NLS-1$
+        assertEquals("INSTALLED", WorkmateGateway.bundleStateName(2)); //$NON-NLS-1$
+        assertEquals("RESOLVED", WorkmateGateway.bundleStateName(4)); //$NON-NLS-1$
+        assertEquals("STARTING", WorkmateGateway.bundleStateName(8)); //$NON-NLS-1$
+        assertEquals("STOPPING", WorkmateGateway.bundleStateName(16)); //$NON-NLS-1$
+        assertEquals("ACTIVE", WorkmateGateway.bundleStateName(32)); //$NON-NLS-1$
+        assertEquals("an unknown state must still be reported, not swallowed", //$NON-NLS-1$
+            "state 7", WorkmateGateway.bundleStateName(7)); //$NON-NLS-1$
+    }
+
+    public static final class FakeProjectId
+    {
+        public static final FakeProjectId Default = new FakeProjectId(null);
+
+        public FakeProjectId(IProject project)
+        {
+            // Project wrapper shape only.
+        }
+    }
+
+    public static final class FakeSession
+    {
+        // Shape marker only.
+    }
+
+    public interface FakeToken
+    {
+        // Shape marker only.
+    }
+
+    public interface FakeProgressListener
+    {
+        // Shape marker only.
+    }
+
+    public static final class LegacyRequest
+    {
+        public LegacyRequest(FakeProjectId project, String message, FakeSession session,
+            boolean firstTurn, String skill, Boolean chat, Integer maxToolRounds)
+        {
+            // Constructor shape only.
+        }
+    }
+
+    public static final class ModernRequest
+    {
+        public ModernRequest(IProject project, String message, FakeSession session,
+            boolean firstTurn, String skill, Boolean chat, Integer maxToolRounds)
+        {
+            // Constructor shape only.
+        }
+    }
+
+    public static final class LegacyFacade
+    {
+        public void sendAsync(LegacyRequest request, FakeToken token)
+        {
+            // Method shape only.
+        }
+    }
+
+    public static final class ModernFacade
+    {
+        public void sendAsync(ModernRequest request, FakeToken token,
+            FakeProgressListener progressListener)
+        {
+            // Method shape only.
+        }
+    }
+
+    public static final class BothFacade
+    {
+        public void sendAsync(ModernRequest request, FakeToken token)
+        {
+            // Preferred method shape only.
+        }
+
+        public void sendAsync(ModernRequest request, FakeToken token,
+            FakeProgressListener progressListener)
+        {
+            // Fallback method shape only.
+        }
+    }
+
+    public static final class LegacyAiContext
+    {
+        public LegacyAiContext(FakeProjectId project, int selectionOffset, String prefix,
+            int selectionLength, String selection, String suffix, int line, String module,
+            String metadata, int column, int tabWidth, IDocument document,
+            Supplier<Boolean> notDisposed)
+        {
+            // Constructor shape only.
+        }
+    }
+
+    public static final class ModernAiContext
+    {
+        public ModernAiContext(IProject project, int selectionOffset, String prefix,
+            int selectionLength, String selection, String suffix, int line, String module,
+            String metadata, int column, int tabWidth, IDocument document,
+            Supplier<Boolean> notDisposed)
+        {
+            // Constructor shape only.
+        }
+    }
+
+    public static final class NeitherShape
+    {
+        public NeitherShape()
+        {
+            // Deliberately carries none of the supported shapes.
+        }
+
+        public void sendAsync(String request)
+        {
+            // Deliberately carries neither supported arity/signature.
+        }
+    }
+
+    private static IProject projectProxy()
+    {
+        return (IProject)Proxy.newProxyInstance(IProject.class.getClassLoader(),
+            new Class<?>[] {IProject.class}, (proxy, method, arguments) -> null);
+    }
+}

--- a/tests/e2e/tools/test_ask_workmate.py
+++ b/tests/e2e/tools/test_ask_workmate.py
@@ -137,8 +137,18 @@ def test_ask_workmate_real_answer_or_actionable_environment_error():
             assert_error_quality(
                 error,
                 names=["1C:Workmate"],
-                suggests=["compatible with 1.0.5", "update EDT-MCP", "retry"],
+                suggests=["1.0.5", "1.0.7", "update EDT-MCP", "retry ask_workmate"],
             )
+        elif "binds every conversation to an EDT project" in error:
+            assert_error_quality(
+                error,
+                names=["projectName", "open EDT project"],
+                suggests=["list_projects", "retry ask_workmate"],
+            )
+            if "Install New Software" in error or "Install a supported" in error:
+                raise AssertionError(
+                    "PROJECT_REQUIRED must not advise reinstalling Workmate: " + error
+                )
         elif "installed but not initialized" in error:
             assert_error_quality(
                 error,


### PR DESCRIPTION
Закрывает #552.

## Что происходило

`ask_workmate` падал до отправки вопроса:

```
Incompatible 1C:Workmate version or structure:
class 'com.e1c.edt.ai.assistent.model.ProjectId' was not found.
```

## Причина — проверено по самим сборкам, а не по гипотезе

В комментарии к задаче версия «класс исчез в новой сборке» не подтверждалась по сборкам 1.0.2…1.0.5, которые идут в комплекте с EDT. Она подтверждается по сборке **с code.1c.ai**: сейчас там опубликована **1.0.7.v202608311234**, и в ней `ProjectId` нет.

Отличий, которые ломают адаптер, ровно два:

| | 1.0.5 | 1.0.7 |
|---|---|---|
| проект в запросе | `SendUserMessageRequest(ProjectId, …)` | `SendUserMessageRequest(IProject, …)` |
| `ConversationFacade.sendAsync` | `(request, token)` | `(request, token, IConversationProgressListener)` |

То же смещение — в `AIContext` (13-аргументный конструктор, первым параметром `IProject` вместо `ProjectId`). Всё остальное, чего касается адаптер (`SendMessageResult`, `IMcpTools.callTools`, `McpToolCall*`, `McpCallToolsResult`, `IJShellSessionManager` с приватным `cache`, `BaseActivator.injectorRef`, `IChat.askQuestion`, `ISettings`), в 1.0.7 не изменилось.

И одно следствие, которое нельзя обойти кодом: в 1.0.7 `SessionService.getSessionAsync(IProject)` начинается с `Preconditions.checkNotNull(project)`, конструктор `AIContext` — тоже. В 1.0.5 «без проекта» выражалось непустым `ProjectId.Default` (внутри `project == null`). **Значит на 1.0.7 разговор без `projectName` невозможен в принципе** — не «мы не умеем», а платформа не принимает.

## Что сделано

- Адаптер **определяет форму API, а не версию**: ищет публичный конструктор запроса формы `(X, String, ConversationSession, boolean, String, Boolean, Integer)` и берёт `X` как параметр проекта; так же для `AIContext`; для `sendAsync` берёт двухаргументную перегрузку, иначе трёхаргументную. Никакой строки версии в решении не участвует.
- Третьим аргументом `sendAsync` передаётся `null`: все три места, где 1.0.7 использует слушатель (`ConversationFacade.reportProgress`, `Conversations.reportToolCallStart/End`), явно проверяют его на `null`. Прокси не нужен.
- Отсутствие `projectName` на «новой» форме API — отдельный отказ `PROJECT_REQUIRED` **до отправки**: он говорит назвать открытый проект и не советует переустанавливать Напарника.
- Диагностика (пункты 4 и 8 задачи): любой отказ по структуре теперь называет **наблюдаемое** — версии И состояния установленных бандлов `com.e1c.edt.ai*`, какие формы искались, какая выбрана, а при промахе — полный список публичных конструкторов/методов, которые реально есть. Состояние бандла и различает две причины «класс не найден»: его нет в сборке или бандл не разрешён — вторая гипотеза из комментария к задаче.

## Чем это доказано

- Сигнатуры сняты с самих jar-ов обеих сборок (`javap` по 1.0.5 и по 1.0.7 с code.1c.ai), а не восстановлены по памяти; заглушки в `WorkmateVersionCompatTest` повторяют ровно эти формы.
- Новые unit-тесты закрывают обе формы запроса и `AIContext`, обе арности `sendAsync`, дополнение аргументов `null`, и все четыре ветки выбора проекта — включая `PROJECT_REQUIRED` и отказ по неизвестному типу параметра.
- e2e-ветка ask_workmate для несовместимости обновлена и дополнена веткой PROJECT_REQUIRED; ни одна существующая проверка не ослаблена. Важно: на CI все e2e ask_workmate ПРОПУСКАЮТСЯ (инструмент выключен по умолчанию, нужен EDT_MCP_WORKMATE_E2E=1), поэтому зелёный CI их не исполняет — исполнил живой прогон на стенде ниже.
- Полная локальная сборка: 7329 тестов, 0 падений.

## Проверено вживую на настоящей 1.0.7

Стенд EDT 2026.2 переставлен с идущей в комплекте 1.0.5 на `1.0.7.v202608311234` с code.1c.ai, собран этот бранч, вызовы сделаны через живой MCP:

| Сборка | Вызов | Результат |
|---|---|---|
| 1.0.7 | без `projectName` | отказ `PROJECT_REQUIRED` **до отправки**, уже после «Obtained the Workmate conversation facade» — то есть `ProjectId` больше не ищется |
| 1.0.7 | `projectName=TestConfiguration` | `status: done`, `assistantMessages: 1`, ответ облака за 2.2 с |
| 1.0.5 | без `projectName` | `status: done`, ответ за 1.1 с — ветка `ProjectId.Default` не сломана |
| 1.0.5 | `projectName=TestConfiguration` | `status: done`, ответ за 0.7 с — ветка `new ProjectId(project)` не сломана |

Это закрывает пункты 1, 2, 3, 5 и 7 критериев готовности; пункт 4 закрыт честным отказом, потому что платформа 1.0.7 режим без проекта не принимает. Стенд возвращён в исходное состояние (1.0.5, `ask_workmate` снова выключен).

## Чего этот PR НЕ доказывает

Что у автора задачи именно 1.0.7: у него может быть 1.0.6, которую p2-репозиторий уже не отдаёт. Решение это не ломает — адаптер смотрит на форму, а не на номер, — но подтвердить может только прогон на его установке.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
