### PR TITLE
Релиз берёт версию tycho из pom, а не из прибитой в workflow

### DIFF
--- a/.github/actions/setup-edt/action.yml
+++ b/.github/actions/setup-edt/action.yml
@@ -71,10 +71,8 @@ runs:
       shell: bash
       run: |
         set -x
-        # Same reason as the inlined copy in e2e-tests.yml: the runner image ships third-party
-        # apt lists we do not use, and a bad index in one of them makes `apt-get update` exit 100
-        # and kill the job before anything of ours has run. The STRICT xvfb install below is the
-        # real gate; the refresh is not.
+        # A bad index in a third-party list we do not use makes apt-get update exit 100 and
+        # kill the job; the strict xvfb install below is the real gate.
         sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
                    /etc/apt/sources.list.d/microsoft-prod.list || true
         sudo apt-get update || sudo apt-get update || true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -201,12 +201,8 @@ jobs:
         shell: bash
         run: |
           set -x
-          # The runner image ships third-party apt lists we do not use (Google Chrome, Microsoft
-          # prod). When one of them serves a bad index, `apt-get update` exits 100 and kills the
-          # job 25 seconds in - it took the whole master matrix down twice on 2026-09-09, with
-          # "Hash Sum mismatch" on dl.google.com and nothing wrong on our side. Drop those lists,
-          # and do not let the refresh itself be fatal: everything we need is in the Ubuntu
-          # archives, and the STRICT xvfb install at the end of this step is the real gate.
+          # A bad index in a third-party list we do not use makes apt-get update exit 100 and
+          # kill the job; the strict xvfb install at the end of this step is the real gate.
           sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
                      /etc/apt/sources.list.d/microsoft-prod.list || true
           sudo apt-get update || sudo apt-get update || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,12 @@ jobs:
       - name: Set version from tag
         working-directory: mcp
         run: |
-          mvn org.eclipse.tycho:tycho-versions-plugin:4.0.5:set-version \
+          set -euo pipefail
+          # From the pom, not pinned here: a hardcoded 4.0.5 stopped loading on the move to Tycho 5.
+          TYCHO=$(sed -n 's|.*<tycho\.version>\(.*\)</tycho\.version>.*|\1|p' bom/pom.xml)
+          test -n "$TYCHO"
+          echo "tycho-versions-plugin: $TYCHO"
+          mvn "org.eclipse.tycho:tycho-versions-plugin:$TYCHO:set-version" \
             -DnewVersion=${{ steps.version.outputs.version }} \
             --batch-mode --no-transfer-progress
 


### PR DESCRIPTION
Тег `v2.16.1` не дал релиза: шаг «Set version from tag» звал `tycho-versions-plugin:4.0.5`, а сборка переехала на Tycho 5 вместе с переходом на EDT 2026.2. Плагин 4.0.5 не инстанцируется под текущим Maven (`Guice CreationException` / `NoSuchElementException`), workflow умирает на шестом шаге — до сборки и до публикации, поэтому релиза нет вовсе, а тег висит пустой.

Версия теперь читается из `mcp/bom/pom.xml` — оттуда же, откуда её берёт сборка. Разъехаться нечему.

**Проверено локально**, а не по логике: та же команда с 5.0.4 на этом дереве отрабатывает `BUILD SUCCESS`.

Заодно сокращены комментарии из #594 — история инцидента место в коммите и PR, в файле остаётся одна строка «почему».

После вливания: удаляю пустой тег `v2.16.1` и ставлю заново на новый master, чтобы Release пошёл уже с исправленным workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)