### PR TITLE
Виртуальные группы больше не попадают в деревья редакторов EDT (#587)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupContentProvider.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/groups/ui/GroupContentProvider.java
@@ -15,6 +15,7 @@ import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IMemento;
+import org.eclipse.ui.navigator.CommonViewer;
 import org.eclipse.ui.navigator.ICommonContentExtensionSite;
 import org.eclipse.ui.navigator.ICommonContentProvider;
 
@@ -42,6 +43,8 @@ public class GroupContentProvider implements ICommonContentProvider, IGroupChang
     private StructuredViewer viewer;
     private GroupSelectionHelper selectionHelper;
     private volatile boolean listenerRegistered = false;
+    /** Set from {@link #servesNavigatorView(Viewer)}; false until the viewer is known. */
+    private volatile boolean servesNavigatorView = false;
     
     public GroupContentProvider() {
         Activator.logDebug("GroupContentProvider: constructor called");
@@ -78,6 +81,10 @@ public class GroupContentProvider implements ICommonContentProvider, IGroupChang
     
     @Override
     public Object[] getChildren(Object parentElement) {
+        if (!servesNavigatorView) {
+            return NO_CHILDREN;
+        }
+
         if (GroupVisibilityManager.getInstance().areGroupsHidden()) {
             return NO_CHILDREN;
         }
@@ -150,6 +157,10 @@ public class GroupContentProvider implements ICommonContentProvider, IGroupChang
     
     @Override
     public boolean hasChildren(Object element) {
+        if (!servesNavigatorView) {
+            return false;
+        }
+
         if (GroupVisibilityManager.getInstance().areGroupsHidden()) {
             return false;
         }
@@ -187,6 +198,12 @@ public class GroupContentProvider implements ICommonContentProvider, IGroupChang
         Activator.logDebug("GroupContentProvider.inputChanged called, viewer type: " 
             + (viewer != null ? viewer.getClass().getName() : "null"));
         
+        servesNavigatorView = servesNavigatorView(viewer);
+        if (!servesNavigatorView) {
+            this.viewer = null;
+            return;
+        }
+
         if (viewer instanceof StructuredViewer sv) {
             this.viewer = sv;
             // Note: Filter is added via commonFilter in plugin.xml with activeByDefault="true"
@@ -199,6 +216,26 @@ public class GroupContentProvider implements ICommonContentProvider, IGroupChang
                 Activator.logDebug("GroupContentProvider: attached GroupSelectionHelper");
             }
         }
+    }
+    
+    /**
+     * Answers whether {@code viewer} is the Navigator view itself.
+     *
+     * <p>EDT creates content services for the Navigator viewer id from metadata-editor pages and
+     * picker dialogs as well, driving them with a UI-less viewer instead of the view. Our viewer
+     * binding matches those, and a group node reaching them hits platform tree filters that cast
+     * every child to a metadata type (issue #587). Only the view gets nodes.</p>
+     */
+    static boolean servesNavigatorView(Viewer viewer) {
+        return viewer != null && isNavigatorViewer(viewer.getClass());
+    }
+    
+    /**
+     * The viewer-class half of {@link #servesNavigatorView(Viewer)}. Split out so a test can ask
+     * the question of a class: mocking a JFace viewer costs minutes of build time.
+     */
+    static boolean isNavigatorViewer(Class<?> viewerType) {
+        return CommonViewer.class.isAssignableFrom(viewerType);
     }
     
     @Override

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/groups/ui/GroupContentProviderViewerScopeTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/groups/ui/GroupContentProviderViewerScopeTest.java
@@ -1,0 +1,122 @@
+/**
+ * MCP Server for EDT - Tests
+ * Copyright (C) 2025 DitriX (https://github.com/DitriXNew)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.groups.ui;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.jface.viewers.AbstractTreeViewer;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.ui.navigator.CommonViewer;
+import org.junit.Test;
+
+/**
+ * Pins WHICH viewer gets virtual group nodes (issue #587).
+ *
+ * <p>The viewer binding in {@code plugin.xml} names the Navigator's viewer id, but EDT builds
+ * metadata-editor pages and picker dialogs from a content service created for that SAME id, driving
+ * it with a UI-less viewer instead of the view. A group node delivered into one of those trees
+ * reaches platform tree filters that cast every child to a metadata type - the register editor's
+ * Recorders tab casts to {@code Document} and threw {@code ClassCastException} in the SWT event
+ * loop. The viewer id therefore cannot tell the two apart; the viewer can.</p>
+ */
+public class GroupContentProviderViewerScopeTest
+{
+    /** A viewer that is not the Navigator's - the shape EDT's UI-less stand-in has. */
+    private static final class ForeignViewer
+        extends Viewer
+    {
+        @Override
+        public Control getControl()
+        {
+            return null;
+        }
+
+        @Override
+        public Object getInput()
+        {
+            return null;
+        }
+
+        @Override
+        public ISelection getSelection()
+        {
+            return StructuredSelection.EMPTY;
+        }
+
+        @Override
+        public void refresh()
+        {
+            // nothing to show
+        }
+
+        @Override
+        public void setInput(Object input)
+        {
+            // nothing to show
+        }
+
+        @Override
+        public void setSelection(ISelection selection, boolean reveal)
+        {
+            // nothing to select
+        }
+    }
+
+    @Test
+    public void testNavigatorViewerIsServed()
+    {
+        assertTrue("The Navigator view's own viewer is the one place group nodes belong", //$NON-NLS-1$
+            GroupContentProvider.isNavigatorViewer(CommonViewer.class));
+    }
+
+    @Test
+    public void testOtherViewersAreNotServed()
+    {
+        assertFalse("A plain TreeViewer is a dialog or an editor page, not the Navigator view", //$NON-NLS-1$
+            GroupContentProvider.isNavigatorViewer(TreeViewer.class));
+        assertFalse("EDT drives its editor-page trees with an AbstractTreeViewer stand-in", //$NON-NLS-1$
+            GroupContentProvider.isNavigatorViewer(AbstractTreeViewer.class));
+        assertFalse("A StructuredViewer alone says nothing about being the Navigator", //$NON-NLS-1$
+            GroupContentProvider.isNavigatorViewer(StructuredViewer.class));
+        assertFalse("No viewer at all is not the Navigator view either", //$NON-NLS-1$
+            GroupContentProvider.servesNavigatorView(null));
+    }
+
+    /**
+     * The gate is closed until {@code inputChanged} names the viewer, so a provider asked for
+     * children before it knows where it is contributes nothing.
+     */
+    @Test
+    public void testProviderYieldsUntilItsViewerIsKnown()
+    {
+        GroupContentProvider provider = new GroupContentProvider();
+
+        assertEquals("No children before the viewer is known", //$NON-NLS-1$
+            0, provider.getChildren(new Object()).length);
+        assertFalse("No children before the viewer is known", //$NON-NLS-1$
+            provider.hasChildren(new Object()));
+    }
+
+    @Test
+    public void testForeignViewerClosesTheGate()
+    {
+        GroupContentProvider provider = new GroupContentProvider();
+        provider.inputChanged(new ForeignViewer(), null, new Object());
+
+        assertEquals("An editor-page tree must not receive group nodes", //$NON-NLS-1$
+            0, provider.getChildren(new Object()).length);
+        assertFalse("An editor-page tree must not receive group nodes", //$NON-NLS-1$
+            provider.hasChildren(new Object()));
+    }
+}


### PR DESCRIPTION
Вкладка «Регистраторы» в редакторе любого регистра падала с
`ClassCastException`: платформенный `PredicateTreeFilter` приводит каждого
ребёнка к `Document`, а туда приходил наш `GroupNavigatorAdapter`.

## Причина оказалась не та, что в задаче

В задаче предполагалось, что расширение навигатора объявлено слишком широко.
Это не так — привязка и сейчас объявлена ровно на `viewerId` навигатора
(`com._1c.g5.v8.dt.ui2.navigator`).

Дело в том, что EDT строит этим же id деревья **страниц редакторов и диалогов
выбора**: `NavigatorTreeModel` создаёт content service через
`NavigatorContentServiceFactory.createContentService("com._1c.g5.v8.dt.ui2.navigator",
UiLessTreeViewer.INSTANCE)` и берёт у него `createCommonContentProvider()`.
То есть по id эти два случая **неразличимы**, и декларативно вопрос не решается.
Различает их только сам viewer: у вида это `CommonViewer`, у страницы редактора —
UI-less заглушка без контрола.

## Что сделано

`GroupContentProvider` отдаёт узлы групп, только когда viewer — `CommonViewer`.
Гейт закрыт до `inputChanged`, то есть по умолчанию провайдер молчит; CNF
вызывает `inputChanged` при создании провайдера в обоих путях, так что вид своё
получает, а редактор — нет.

Решение вынесено в `isNavigatorViewer(Class)`: первая версия теста мокала
JFace-вьюеров и стоила **163 секунды** на прогон (57 с только на
`mock(CommonViewer.class)`); вопрос к классу отвечает за доли секунды.

## Проверено

- `bash source/compile.sh` — BUILD SUCCESS, весь unit-набор зелёный.
- `GroupContentProviderViewerScopeTest` — 4 теста, 0.68 с: вид обслуживается,
  `TreeViewer` / `AbstractTreeViewer` / `StructuredViewer` / `null` — нет, и
  провайдер молчит и до `inputChanged`, и после чужого viewer'а.

Живьём в EDT не воспроизводил: падение приходит из платформенного фильтра, а
не из нашего кода, и доказательство здесь — что узел туда больше не попадает.

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)
