### PR TITLE
Инвариант гейта согласия описывает то, что делает код (#585)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGate.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGate.java
@@ -74,14 +74,15 @@ import com.ditrix.edt.mcp.server.ui.DestructiveConsentDialog;
  *       shell is closed (best-effort) so it does not linger.</li>
  * </ol>
  *
- * <p><b>Invariant:</b> every path is bounded. Two return without
- * waiting for anything: the env bypass (step 1) and a display-less EDT (the probe answers
- * NO_SHELL immediately when there is no display). On a live workbench EVERY remaining path
- * first waits on the shell probe for at most {@link #SHELL_PROBE_TIMEOUT_MS} ms — the non-ASK
- * ones (level-2 / session / per-tool-allowed) included, because the probe deliberately precedes
- * the policy (see step 2). Beyond it the dialog paths wait at most
- * {@link #CONSENT_PROMPT_TIMEOUT_SECONDS} (issue #277). It does not deadlock when already on
- * the UI thread (the probe reads the shell inline there); and a non-
+ * <p><b>Invariant:</b> every path is bounded, and the shell probe is what any of them can wait
+ * on. Two never wait, whichever thread asks: the env bypass (step 1) and a display-less EDT (the
+ * probe answers NO_SHELL at once when there is no display). On a live workbench the probe comes
+ * first, and its cost depends on the CALLER's thread. Asked ON the UI thread it reads the shell
+ * inline and waits for nothing — so a non-ASK path (level-2 / session / per-tool-allowed)
+ * returns immediately, and nothing can deadlock. Asked from a worker it posts the question and
+ * waits at most {@link #SHELL_PROBE_TIMEOUT_MS} ms — the non-ASK paths included, because the
+ * probe deliberately precedes the policy (see step 2). Beyond the probe the dialog paths wait at
+ * most {@link #CONSENT_PROMPT_TIMEOUT_SECONDS} (issue #277); and a non-
  * {@link ConsentDecision#ALLOW} verdict ({@link ConsentDecision#REJECT},
  * {@link ConsentDecision#TIMEOUT}, {@link ConsentDecision#UNATTENDED} or
  * {@link ConsentDecision#UI_UNRESPONSIVE}) mutates nothing

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGate.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/DestructiveConsentGate.java
@@ -74,12 +74,17 @@ import com.ditrix.edt.mcp.server.ui.DestructiveConsentDialog;
  *       shell is closed (best-effort) so it does not linger.</li>
  * </ol>
  *
- * <p><b>Invariant:</b> the gate NEVER blocks indefinitely in EITHER dialog path — it
- * waits at most {@link #CONSENT_PROMPT_TIMEOUT_SECONDS} (issue #277); it NEVER blocks
- * at all in a headless / env-bypass / non-ASK (level-2/session/per-tool-allowed)
- * path; it does not deadlock when already on the UI thread; and a non-
+ * <p><b>Invariant:</b> every path is bounded. Two return without
+ * waiting for anything: the env bypass (step 1) and a display-less EDT (the probe answers
+ * NO_SHELL immediately when there is no display). On a live workbench EVERY remaining path
+ * first waits on the shell probe for at most {@link #SHELL_PROBE_TIMEOUT_MS} ms — the non-ASK
+ * ones (level-2 / session / per-tool-allowed) included, because the probe deliberately precedes
+ * the policy (see step 2). Beyond it the dialog paths wait at most
+ * {@link #CONSENT_PROMPT_TIMEOUT_SECONDS} (issue #277). It does not deadlock when already on
+ * the UI thread (the probe reads the shell inline there); and a non-
  * {@link ConsentDecision#ALLOW} verdict ({@link ConsentDecision#REJECT},
- * {@link ConsentDecision#TIMEOUT} or {@link ConsentDecision#UNATTENDED}) mutates nothing
+ * {@link ConsentDecision#TIMEOUT}, {@link ConsentDecision#UNATTENDED} or
+ * {@link ConsentDecision#UI_UNRESPONSIVE}) mutates nothing
  * (it only returns the decision, and the caller turns it into an error via
  * {@link #consentDeniedMessage(ConsentDecision, String)}).
  */


### PR DESCRIPTION
Остаток по #585 — единственный, который владелец оставил открытым после #586.

Абзац «Invariant» в javadoc `DestructiveConsentGate` обещал, что в non-ASK пути
(`ALLOW_ALL`, разрешение конкретного инструмента в Preferences, session-allow)
гейт «NEVER blocks at all». После #586 это неверно: проба активного shell стоит
**до** чтения политики — намеренно, иначе на EDT без дисплея вернулся бы `ALLOW`
ровно там, где #566 требует отказа (перестановку пробовали в #560 и откатили), —
поэтому такой путь ждёт до `SHELL_PROBE_TIMEOUT_MS`.

Абзац переписан по фактическому порядку шагов:

- без ожидания возвращаются ровно два пути — обход через
  `EDT_MCP_DESTRUCTIVE_CONSENT=allow` (шаг 1) и EDT без дисплея (проба сразу
  отвечает `NO_SHELL`, см. `grabActiveShellWithin`);
- на живом воркбенче **любой** оставшийся путь сначала ждёт пробу, не дольше
  `SHELL_PROBE_TIMEOUT_MS`;
- дальше диалоговые пути ждут не дольше `CONSENT_PROMPT_TIMEOUT_SECONDS`;
- на UI-потоке дедлока нет — проба читает shell inline.

Заодно в перечень не-`ALLOW` вердиктов добавлен `UI_UNRESPONSIVE`, появившийся
в #586: он там отсутствовал, хотя ведёт себя так же (ничего не мутирует).

Только документация — поведение не менялось.

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)
