### PR TITLE
Формы: корневой extInfo создаётся, и обработчики в нём видны (#591, #592)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -2423,6 +2423,28 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
      * @return the value the list leaves in {@code main}, or {@code null} when it writes none (or
      *         writes something that is not a boolean at all, which the write itself refuses)
      */
+    /**
+     * Whether the batch flags this member main AT ANY POINT. The demotion of the OTHER attributes
+     * follows from that, not from the flag the batch is left with: applied in order,
+     * {@code [main=true, main=false]} promotes and takes it back, and the previous main is demoted
+     * on the way through - which is what the platform's two calls would do.
+     *
+     * @param properties the requested property changes
+     * @return {@code true} when any {@code main} write in the list is true
+     */
+    static boolean mainPromotedIn(List<JsonObject> properties)
+    {
+        for (JsonObject prop : properties)
+        {
+            if (PROP_MAIN.equalsIgnoreCase(asString(prop.get("name"))) //$NON-NLS-1$
+                && Boolean.TRUE.equals(parseBoolean(asString(prop.get("value"))))) //$NON-NLS-1$
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     static Boolean mainFlagIn(List<JsonObject> properties)
     {
         Boolean last = null;
@@ -2487,7 +2509,8 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 // flag it LEAVES would take the root ext-info and the handlers bound in it. WHICH
                 // of the two it is decides what the dialog says, so it is reported back.
                 extInfoLossOut[0] = mainFlag != null && FormElementWriter.clearsBoundFormExtInfo(
-                    formModel, member, mainFlag.booleanValue(), categoryAfter(prepared, member));
+                    formModel, member, mainFlag.booleanValue(), categoryAfter(prepared, member),
+                    mainPromotedIn(properties));
                 return retype || extInfoLossOut[0] ? null : ""; //$NON-NLS-1$
             });
     }
@@ -3371,8 +3394,13 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 // the batch (per change it would depend on the order the properties arrived in).
                 if (mainFlagWritten)
                 {
-                    demotedMains.addAll(
-                        FormElementWriter.demoteOtherMainAttributes(formModel, target));
+                    // Demoted by the PROMOTION the batch performed, even when a later write in the
+                    // same batch takes the flag back off this one.
+                    if (mainPromotedIn(properties))
+                    {
+                        demotedMains.addAll(
+                            FormElementWriter.demoteOtherMainAttributes(formModel, target));
+                    }
                     if (FormElementWriter.syncFormExtInfo(formModel) != null
                         && !applied.contains("extInfo")) //$NON-NLS-1$
                     {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -3236,10 +3236,9 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 // which properties the batch carried: a change object names the KIND of property,
                 // so a re-write of the same type looks identical to a retype.
                 String mainCategoryAfter = FormElementWriter.mainAttributeCategory(formModel);
-                boolean mainCategoryChanged = mainCategoryBefore == null
-                    ? mainCategoryAfter != null : !mainCategoryBefore.equals(mainCategoryAfter);
                 if (mainAttributeTouched
-                    && FormElementWriter.syncFormExtInfo(formModel, mainCategoryChanged) != null
+                    && FormElementWriter.syncFormExtInfo(formModel,
+                        mainCategoryReplaced(mainCategoryBefore, mainCategoryAfter)) != null
                     && !applied.contains("extInfo")) //$NON-NLS-1$
                 {
                     applied.add("extInfo"); //$NON-NLS-1$
@@ -3708,6 +3707,24 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             return FormElementWriter.syncItemExtInfo(formModel, member) != null;
         }
         return false;
+    }
+
+    /**
+     * Whether the batch REPLACED the category the form root's ext-info is keyed on - the only
+     * transition that may leave the form without a node.
+     *
+     * <p>Gaining a FIRST main attribute ({@code null} before) is not a replacement: nothing was
+     * keyed on anything, so there is nothing to invalidate, and a bare {@code main} write does not
+     * pass the destructive-consent gate ({@code isFormRetypeRequest} looks for {@code type} /
+     * {@code valueType}). Re-writing the same category is not one either.</p>
+     *
+     * @param before the main attribute's category before the batch, may be {@code null}
+     * @param after the same after it, may be {@code null}
+     * @return {@code true} only when a category that WAS there became something else
+     */
+    static boolean mainCategoryReplaced(String before, String after)
+    {
+        return before != null && !before.equals(after);
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -3200,7 +3200,8 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 List<EObject> localizedHolders = new ArrayList<>();
                 List<PreparedChange> localizedChanges = new ArrayList<>();
                 boolean mainAttributeTouched = false;
-                boolean mainAttributeRetyped = false;
+                // Read BEFORE anything is applied: what the form's ext-info is keyed on.
+                String mainCategoryBefore = FormElementWriter.mainAttributeCategory(formModel);
                 for (HolderChange hc : changes)
                 {
                     // A direct feature lands on the target; a property on the nested <extInfo> lands
@@ -3218,8 +3219,6 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                         applied.add("extInfo"); //$NON-NLS-1$
                     }
                     mainAttributeTouched = mainAttributeTouched || decidesFormExtInfo(hc);
-                    mainAttributeRetyped =
-                        mainAttributeRetyped || (!hc.onExtInfo && hc.change.isTypeChange());
                     if (hc.change.isLocalized())
                     {
                         // Remember the receiver the change actually landed on: a title on the
@@ -3232,13 +3231,15 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 // decided once the whole batch is applied. Per change it would depend on the
                 // order the properties arrived in: [main=false, valueType=X] and the reverse pair
                 // describe the same end state and must not leave two different ext-infos.
-                // ... and only when the retype was of the MAIN attribute itself. Every change in
-                // this batch lands on ONE member, so a retype of some other attribute or column
-                // says nothing about the node the main attribute decides.
-                boolean mainRetyped =
-                    mainAttributeRetyped && FormElementWriter.isMainAttribute(target);
+                // ... and the node may be REMOVED only when the thing it is keyed on actually
+                // became something else. Asked of the model before and after, not inferred from
+                // which properties the batch carried: a change object names the KIND of property,
+                // so a re-write of the same type looks identical to a retype.
+                String mainCategoryAfter = FormElementWriter.mainAttributeCategory(formModel);
+                boolean mainCategoryChanged = mainCategoryBefore == null
+                    ? mainCategoryAfter != null : !mainCategoryBefore.equals(mainCategoryAfter);
                 if (mainAttributeTouched
-                    && FormElementWriter.syncFormExtInfo(formModel, mainRetyped) != null
+                    && FormElementWriter.syncFormExtInfo(formModel, mainCategoryChanged) != null
                     && !applied.contains("extInfo")) //$NON-NLS-1$
                 {
                     applied.add("extInfo"); //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -3200,6 +3200,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 List<EObject> localizedHolders = new ArrayList<>();
                 List<PreparedChange> localizedChanges = new ArrayList<>();
                 boolean mainAttributeTouched = false;
+                boolean mainAttributeRetyped = false;
                 for (HolderChange hc : changes)
                 {
                     // A direct feature lands on the target; a property on the nested <extInfo> lands
@@ -3217,6 +3218,8 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                         applied.add("extInfo"); //$NON-NLS-1$
                     }
                     mainAttributeTouched = mainAttributeTouched || decidesFormExtInfo(hc);
+                    mainAttributeRetyped =
+                        mainAttributeRetyped || (!hc.onExtInfo && hc.change.isTypeChange());
                     if (hc.change.isLocalized())
                     {
                         // Remember the receiver the change actually landed on: a title on the
@@ -3229,7 +3232,8 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 // decided once the whole batch is applied. Per change it would depend on the
                 // order the properties arrived in: [main=false, valueType=X] and the reverse pair
                 // describe the same end state and must not leave two different ext-infos.
-                if (mainAttributeTouched && FormElementWriter.syncFormExtInfo(formModel) != null
+                if (mainAttributeTouched
+                    && FormElementWriter.syncFormExtInfo(formModel, mainAttributeRetyped) != null
                     && !applied.contains("extInfo")) //$NON-NLS-1$
                 {
                     applied.add("extInfo"); //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -166,15 +166,17 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
      * raise a destructive dialog, because a denial or a timeout would come back INSTEAD of the
      * actionable validation error (issue #295 review).
      *
-     * @param preview what the user is being asked to authorize
+     * @param preview what the user is being asked to authorize, built AFTER the pre-check ran: the
+     *            request alone cannot say which of the two losses is actually at stake, and a
+     *            dialog that names a loss that will not happen teaches the reader to ignore it
      * @param preflight the deterministic pre-check, run BEFORE any prompt: a ready JSON error refuses
      *            the write with no prompt at all, {@code ""} means nothing destructive happens (write
      *            without asking), {@code null} means a real retype - ask
      * @param write the mutation, invoked only when the pre-check passed and consent was granted
      * @return the mutation's result, the pre-check's refusal, or the consent refusal
      */
-    String gateFormRetype(ConsentPreview preview, java.util.function.Supplier<String> preflight,
-        java.util.function.Supplier<String> write)
+    String gateFormRetype(java.util.function.Supplier<ConsentPreview> preview,
+        java.util.function.Supplier<String> preflight, java.util.function.Supplier<String> write)
     {
         String verdict = preflight.get();
         if (verdict != null && !verdict.isEmpty())
@@ -184,7 +186,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         }
         if (verdict == null)
         {
-            ConsentDecision decision = consentRequester.request(NAME, preview);
+            ConsentDecision decision = consentRequester.request(NAME, preview.get());
             if (decision != ConsentDecision.ALLOW)
             {
                 return ToolResult.error(
@@ -2361,22 +2363,21 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
 
     /** What the user authorizes when a form attribute (or column) changes its data type. */
     static ConsentPreview formRetypePreview(String normFqn,
-        FormElementWriter.FormMemberRef ref, List<JsonObject> properties)
+        FormElementWriter.FormMemberRef ref, List<JsonObject> properties, boolean extInfoLoss)
     {
         boolean retype = isFormRetypeRequest(ref, properties);
-        boolean mainWrite = requestedMainFlag(ref, properties) != null;
-        if (retype && mainWrite)
+        if (retype && extInfoLoss)
         {
             // One batch, two different losses - the dialog has to name both, or the answer
             // authorizes something the question never mentioned.
             return new ConsentPreview(
                 "Change the data type of " + normFqn + " and rewrite its main flag", //$NON-NLS-1$ //$NON-NLS-2$
                 "Retyping a form attribute can drop stored values on the next database update, " //$NON-NLS-1$
-                    + "and the main flag can leave the form without its root ext-info, deleting " //$NON-NLS-1$
-                    + "the event handlers bound inside it.", //$NON-NLS-1$
+                    + "and the main flag leaves the form without its root ext-info, deleting the " //$NON-NLS-1$
+                    + "event handlers bound inside it.", //$NON-NLS-1$
                 2, List.of(PROP_VALUE_TYPE, PROP_MAIN));
         }
-        if (mainWrite)
+        if (extInfoLoss)
         {
             // The only other thing this gate authorizes: a main-flag write that leaves the form
             // root without its ext-info, and the event handlers bound inside it with it.
@@ -2386,6 +2387,8 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                     + "event handlers bound inside it.", //$NON-NLS-1$
                 1, java.util.Collections.singletonList(PROP_MAIN));
         }
+        // Only the retype is at stake: the main flag either was not written, or writing it takes
+        // nothing with it (an empty node, or a kind change that carries its handlers over).
         return new ConsentPreview(
             "Change the data type of " + normFqn, //$NON-NLS-1$
             "Retyping a form attribute can drop stored values on the next database update.", //$NON-NLS-1$
@@ -2457,7 +2460,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
      */
     private String formRetypePreflight(ProjectContext ctx, Version version, // NOSONAR signature is inherent / public-or-test-contract; a parameter-object would not improve clarity
         FormElementWriter.FormEditContext fctx, FormElementWriter.FormMemberRef ref,
-        List<JsonObject> properties, MdNameNormalizer.Report normReport)
+        List<JsonObject> properties, MdNameNormalizer.Report normReport, boolean[] extInfoLossOut)
     {
         boolean retype = isFormRetypeRequest(ref, properties);
         Boolean mainFlag = requestedMainFlag(ref, properties);
@@ -2480,9 +2483,11 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                     return refusal;
                 }
                 // Prepared cleanly: ask when the request retypes stored data, or when the main
-                // flag it LEAVES would take the root ext-info and the handlers bound in it.
-                return retype || (mainFlag != null && FormElementWriter.clearsBoundFormExtInfo(
-                    formModel, member, mainFlag.booleanValue())) ? null : ""; //$NON-NLS-1$
+                // flag it LEAVES would take the root ext-info and the handlers bound in it. WHICH
+                // of the two it is decides what the dialog says, so it is reported back.
+                extInfoLossOut[0] = mainFlag != null && FormElementWriter.clearsBoundFormExtInfo(
+                    formModel, member, mainFlag.booleanValue());
+                return retype || extInfoLossOut[0] ? null : ""; //$NON-NLS-1$
             });
     }
 
@@ -3187,8 +3192,12 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             // The version the type payload is built for: resolved BEFORE the gate, because the
             // pre-check validates that payload (it is the same one the write then uses).
             final Version version = platformVersionOf(ctx);
-            return gateFormRetype(formRetypePreview(normFqn, ref, properties),
-                () -> formRetypePreflight(ctx, version, fctx, ref, properties, normReport),
+            // Written by the pre-check, read by the preview - in that order, which is the order
+            // gateFormRetype runs them in.
+            final boolean[] extInfoLoss = new boolean[1];
+            return gateFormRetype(() -> formRetypePreview(normFqn, ref, properties, extInfoLoss[0]),
+                () -> formRetypePreflight(ctx, version, fctx, ref, properties, normReport,
+                    extInfoLoss),
                 () -> applyFormMemberProperties(ctx, normFqn, ref, properties, normReport, fctx,
                     version));
         }
@@ -3447,7 +3456,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             // Resolved BEFORE the gate: the conversion needs the DynamicList value type for this
             // version, and failing to build it refuses the write whatever the user answers.
             final Version version = platformVersionOf(ctx);
-            return gateFormRetype(dynamicListRetypePreview(normFqn),
+            return gateFormRetype(() -> dynamicListRetypePreview(normFqn),
                 () -> dynamicListRetypePreflight(fctx, ctx.config, version, ref, qt, mt),
                 () -> applyDynamicListQuery(ctx, normFqn, ref, qt, cq, mt, normReport, fctx, version));
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -2475,8 +2475,9 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 // The WHOLE batch is prepared first, whichever of the two brought us here: every
                 // refusal that pass can produce belongs above the gate, or a denial comes back
                 // instead of the actionable error (issue #295).
-                String refusal =
-                    formRetypeVerdict(ctx.scope, version, member, properties, normReport);
+                List<HolderChange> prepared = new ArrayList<>();
+                String refusal = formRetypeVerdict(ctx.scope, version, member, properties,
+                    normReport, prepared);
                 if (refusal != null)
                 {
                     // A refusal, or "" for a member the write path answers "not found" for.
@@ -2486,7 +2487,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 // flag it LEAVES would take the root ext-info and the handlers bound in it. WHICH
                 // of the two it is decides what the dialog says, so it is reported back.
                 extInfoLossOut[0] = mainFlag != null && FormElementWriter.clearsBoundFormExtInfo(
-                    formModel, member, mainFlag.booleanValue());
+                    formModel, member, mainFlag.booleanValue(), categoryAfter(prepared, member));
                 return retype || extInfoLossOut[0] ? null : ""; //$NON-NLS-1$
             });
     }
@@ -2517,19 +2518,53 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
     String formRetypeVerdict(MetadataScope scope, Version version, EObject member,
         List<JsonObject> properties, MdNameNormalizer.Report normReport)
     {
+        return formRetypeVerdict(scope, version, member, properties, normReport, new ArrayList<>());
+    }
+
+    /**
+     * {@link #formRetypeVerdict(MetadataScope, Version, EObject, List, MdNameNormalizer.Report)}
+     * that also hands the PREPARED batch back. The pre-check has to know what the batch will leave
+     * behind - a retype in the same call changes the very category the ext-info decision keys on -
+     * and preparing it twice would report every normalized name twice.
+     *
+     * @param preparedOut filled with the prepared changes when the preparation succeeded
+     */
+    String formRetypeVerdict(MetadataScope scope, Version version, EObject member, // NOSONAR signature is inherent / public-or-test-contract; a parameter-object would not improve clarity
+        List<JsonObject> properties, MdNameNormalizer.Report normReport,
+        List<HolderChange> preparedOut)
+    {
         if (member == null)
         {
             return ""; //$NON-NLS-1$
         }
         try
         {
-            prepareFormMemberChanges(scope, version, member, properties, normReport.emptyCopy());
+            preparedOut.addAll(
+                prepareFormMemberChanges(scope, version, member, properties, normReport.emptyCopy()));
         }
         catch (FormValidationException e)
         {
             return FormValidationException.jsonOf(e);
         }
         return null;
+    }
+
+    /**
+     * The type category the member is left with: the one the batch WRITES when it retypes it,
+     * otherwise the one it already carries. Read from the prepared change rather than from the
+     * model, because the model still holds the old type when the pre-check runs.
+     */
+    private static String categoryAfter(List<HolderChange> prepared, EObject member)
+    {
+        for (HolderChange hc : prepared)
+        {
+            if (!hc.onExtInfo && hc.change.isTypeChange()
+                && PROP_VALUE_TYPE.equalsIgnoreCase(hc.change.featureName()))
+            {
+                return FormElementWriter.typeCategoryOf(hc.change.value());
+            }
+        }
+        return FormElementWriter.valueTypeCategoryOf(member);
     }
 
     /**
@@ -6097,6 +6132,12 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         boolean isTypeChange()
         {
             return typeChange;
+        }
+
+        /** The value this change would write - for a type change, the built {@code TypeDescription}. */
+        Object value()
+        {
+            return scalarValue;
         }
 
         boolean isLocalized()

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -2554,17 +2554,23 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
      * otherwise the one it already carries. Read from the prepared change rather than from the
      * model, because the model still holds the old type when the pre-check runs.
      */
-    private static String categoryAfter(List<HolderChange> prepared, EObject member)
+    static String categoryAfter(List<HolderChange> prepared, EObject member)
     {
+        Object lastType = null;
+        boolean retyped = false;
         for (HolderChange hc : prepared)
         {
             if (!hc.onExtInfo && hc.change.isTypeChange()
                 && PROP_VALUE_TYPE.equalsIgnoreCase(hc.change.featureName()))
             {
-                return FormElementWriter.typeCategoryOf(hc.change.value());
+                // The batch is applied in ORDER, so a repeated property is decided by its LAST
+                // write - the same rule mainFlagIn follows for the main flag.
+                lastType = hc.change.value();
+                retyped = true;
             }
         }
-        return FormElementWriter.valueTypeCategoryOf(member);
+        return retyped ? FormElementWriter.typeCategoryOf(lastType)
+            : FormElementWriter.valueTypeCategoryOf(member);
     }
 
     /**
@@ -5832,7 +5838,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
      * ... live under {@code <extInfo>}). Threading the receiver per property lets a mixed direct +
      * extInfo batch apply each change to the correct EObject inside the one form write transaction.
      */
-    private static final class HolderChange
+    static final class HolderChange
     {
         private final boolean onExtInfo;
         private final PreparedChange change;
@@ -5998,7 +6004,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
     }
 
     /** A validated, coerced change ready to apply to the re-fetched target inside the write tx. */
-    private static final class PreparedChange
+    static final class PreparedChange
     {
         private enum Kind
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -3199,6 +3199,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 // a LATER change in the same call fills in.
                 List<EObject> localizedHolders = new ArrayList<>();
                 List<PreparedChange> localizedChanges = new ArrayList<>();
+                boolean mainAttributeTouched = false;
                 for (HolderChange hc : changes)
                 {
                     // A direct feature lands on the target; a property on the nested <extInfo> lands
@@ -3215,6 +3216,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                     {
                         applied.add("extInfo"); //$NON-NLS-1$
                     }
+                    mainAttributeTouched = mainAttributeTouched || decidesFormExtInfo(hc);
                     if (hc.change.isLocalized())
                     {
                         // Remember the receiver the change actually landed on: a title on the
@@ -3222,6 +3224,15 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                         localizedHolders.add(holder);
                         localizedChanges.add(hc.change);
                     }
+                }
+                // The form ROOT's ext-info follows the MAIN attribute's FINAL state, so it is
+                // decided once the whole batch is applied. Per change it would depend on the
+                // order the properties arrived in: [main=false, valueType=X] and the reverse pair
+                // describe the same end state and must not leave two different ext-infos.
+                if (mainAttributeTouched && FormElementWriter.syncFormExtInfo(formModel) != null
+                    && !applied.contains("extInfo")) //$NON-NLS-1$
+                {
+                    applied.add("extInfo"); //$NON-NLS-1$
                 }
                 for (int i = 0; i < localizedChanges.size(); i++)
                 {
@@ -3680,21 +3691,23 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         }
         if (hc.change.isTypeChange())
         {
-            boolean onMember = FormElementWriter.syncAttributeExtInfo(formModel, member) != null;
-            // The MAIN attribute's type also decides the FORM root's ext-info - the node that
-            // publishes a record/object form's write and read events (#591).
-            boolean onForm = FormElementWriter.syncFormExtInfo(formModel) != null;
-            return onMember || onForm;
-        }
-        if (PROP_MAIN.equalsIgnoreCase(hc.change.featureName()))
-        {
-            return FormElementWriter.syncFormExtInfo(formModel) != null;
+            return FormElementWriter.syncAttributeExtInfo(formModel, member) != null;
         }
         if ("type".equalsIgnoreCase(hc.change.featureName())) //$NON-NLS-1$
         {
             return FormElementWriter.syncItemExtInfo(formModel, member) != null;
         }
         return false;
+    }
+
+    /**
+     * Whether this change can move the FORM ROOT's ext-info: the main attribute's type, or the
+     * flag that decides which attribute is main. Asked per change, answered once per batch.
+     */
+    private static boolean decidesFormExtInfo(HolderChange hc)
+    {
+        return !hc.onExtInfo
+            && (hc.change.isTypeChange() || PROP_MAIN.equalsIgnoreCase(hc.change.featureName()));
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -2360,12 +2360,45 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
     }
 
     /** What the user authorizes when a form attribute (or column) changes its data type. */
-    private static ConsentPreview formRetypePreview(String normFqn)
+    private static ConsentPreview formRetypePreview(String normFqn,
+        FormElementWriter.FormMemberRef ref, List<JsonObject> properties)
     {
+        if (!isFormRetypeRequest(ref, properties))
+        {
+            // The only other thing this gate authorizes: a main-flag write that leaves the form
+            // root without its ext-info, and the event handlers bound inside it with it.
+            return new ConsentPreview(
+                "Remove the root ext-info of " + ref.formPath, //$NON-NLS-1$
+                "Writing the main flag leaves this form without a root ext-info, deleting the " //$NON-NLS-1$
+                    + "event handlers bound inside it.", //$NON-NLS-1$
+                1, java.util.Collections.singletonList(PROP_MAIN));
+        }
         return new ConsentPreview(
             "Change the data type of " + normFqn, //$NON-NLS-1$
             "Retyping a form attribute can drop stored values on the next database update.", //$NON-NLS-1$
             1, java.util.Collections.singletonList(PROP_VALUE_TYPE));
+    }
+
+    /**
+     * The {@code main} value this request writes on an ATTRIBUTE, or {@code null} when it writes
+     * none. Reads only the request; whether that write actually destroys anything is a question
+     * for the model, answered in {@link #formRetypePreflight}.
+     */
+    private static Boolean requestedMainFlag(FormElementWriter.FormMemberRef ref,
+        List<JsonObject> properties)
+    {
+        if (FormElementWriter.kindForToken(ref.kindToken) != FormElementWriter.Kind.ATTRIBUTE)
+        {
+            return null; // NOSONAR tri-state: null means "this request writes no main flag"
+        }
+        for (JsonObject prop : properties)
+        {
+            if (PROP_MAIN.equalsIgnoreCase(asString(prop.get("name")))) //$NON-NLS-1$
+            {
+                return parseBooleanFlag(prop.get("value")); //$NON-NLS-1$
+            }
+        }
+        return null; // NOSONAR tri-state: see above
     }
 
     /**
@@ -2376,6 +2409,11 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
      * not exist (the write path answers "not found"), or ANY of the requested property changes fails
      * to validate - a retype that would strand the attribute's columns, an unbuildable {@code type}
      * payload, an unknown property, an out-of-range value. Issue #295 review.
+     *
+     * <p>TWO requests can reach the gate: a retype, and a {@code main} write that would leave the
+     * form root without its ext-info AND take bound event handlers with it. The second is asked
+     * about only in that exact shape - an empty node, or one that merely changes kind (its data is
+     * carried over), loses nothing and is written without a prompt.</p>
      *
      * @param ctx the resolved project context (the configuration references resolve against)
      * @param version the platform version the type payload is built for
@@ -2389,13 +2427,30 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         FormElementWriter.FormEditContext fctx, FormElementWriter.FormMemberRef ref,
         List<JsonObject> properties, MdNameNormalizer.Report normReport)
     {
-        if (!isFormRetypeRequest(ref, properties))
+        boolean retype = isFormRetypeRequest(ref, properties);
+        Boolean mainFlag = requestedMainFlag(ref, properties);
+        if (!retype && mainFlag == null)
         {
             return ""; //$NON-NLS-1$
         }
         return FormElementWriter.readEditableForm(fctx, "FormRetypePreflight", //$NON-NLS-1$
-            (formModel, tx) -> formRetypeVerdict(ctx.scope, version,
-                FormElementWriter.resolveFormMember(formModel, ref), properties, normReport));
+            (formModel, tx) ->
+            {
+                EObject member = FormElementWriter.resolveFormMember(formModel, ref);
+                String verdict = retype
+                    ? formRetypeVerdict(ctx.scope, version, member, properties, normReport)
+                    : ""; //$NON-NLS-1$
+                if (verdict == null || !verdict.isEmpty())
+                {
+                    // A refusal, or a retype that must be asked about - either way it decides.
+                    return verdict;
+                }
+                // Nothing destructive about the types; the main flag can still delete the form
+                // root ext-info together with the handlers bound in it.
+                return member != null && mainFlag != null
+                    && FormElementWriter.clearsBoundFormExtInfo(formModel, member,
+                        mainFlag.booleanValue()) ? null : ""; //$NON-NLS-1$
+            });
     }
 
     /**
@@ -3099,7 +3154,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             // The version the type payload is built for: resolved BEFORE the gate, because the
             // pre-check validates that payload (it is the same one the write then uses).
             final Version version = platformVersionOf(ctx);
-            return gateFormRetype(formRetypePreview(normFqn),
+            return gateFormRetype(formRetypePreview(normFqn, ref, properties),
                 () -> formRetypePreflight(ctx, version, fctx, ref, properties, normReport),
                 () -> applyFormMemberProperties(ctx, normFqn, ref, properties, normReport, fctx,
                     version));

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -251,6 +251,8 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
 
     /** The form attribute's value-type feature / property alias. */
     private static final String PROP_VALUE_TYPE = "valueType"; //$NON-NLS-1$
+    /** The form-attribute flag that names the form's main data source. */
+    private static final String PROP_MAIN = "main"; //$NON-NLS-1$
 
     /** A ScheduledJob's method-reference property (guarded by {@link MethodReferenceValidator}). */
     private static final String PROP_METHOD_NAME = "methodName"; //$NON-NLS-1$
@@ -3678,7 +3680,15 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         }
         if (hc.change.isTypeChange())
         {
-            return FormElementWriter.syncAttributeExtInfo(formModel, member) != null;
+            boolean onMember = FormElementWriter.syncAttributeExtInfo(formModel, member) != null;
+            // The MAIN attribute's type also decides the FORM root's ext-info - the node that
+            // publishes a record/object form's write and read events (#591).
+            boolean onForm = FormElementWriter.syncFormExtInfo(formModel) != null;
+            return onMember || onForm;
+        }
+        if (PROP_MAIN.equalsIgnoreCase(hc.change.featureName()))
+        {
+            return FormElementWriter.syncFormExtInfo(formModel) != null;
         }
         if ("type".equalsIgnoreCase(hc.change.featureName())) //$NON-NLS-1$
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -3232,8 +3232,13 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 // decided once the whole batch is applied. Per change it would depend on the
                 // order the properties arrived in: [main=false, valueType=X] and the reverse pair
                 // describe the same end state and must not leave two different ext-infos.
+                // ... and only when the retype was of the MAIN attribute itself. Every change in
+                // this batch lands on ONE member, so a retype of some other attribute or column
+                // says nothing about the node the main attribute decides.
+                boolean mainRetyped =
+                    mainAttributeRetyped && FormElementWriter.isMainAttribute(target);
                 if (mainAttributeTouched
-                    && FormElementWriter.syncFormExtInfo(formModel, mainAttributeRetyped) != null
+                    && FormElementWriter.syncFormExtInfo(formModel, mainRetyped) != null
                     && !applied.contains("extInfo")) //$NON-NLS-1$
                 {
                     applied.add("extInfo"); //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -3181,6 +3181,9 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         // gives (issue #298). The declared codes are read OUTSIDE the write transaction.
         final List<String> declaredCodes = ctx.scope.declaredLanguageCodes();
         final LocalizedWriteReport localizedReport = new LocalizedWriteReport();
+        // Attributes this call took the main flag AWAY from - a change to a member the caller did
+        // not address, so it is reported rather than left to be discovered.
+        final List<String> demotedMains = new ArrayList<>();
 
         // Validate + apply inside ONE BM write transaction: resolve the target, validate every
         // property (a failure throws FormValidationException carrying the JSON error BEFORE any eSet,
@@ -3199,7 +3202,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 // a LATER change in the same call fills in.
                 List<EObject> localizedHolders = new ArrayList<>();
                 List<PreparedChange> localizedChanges = new ArrayList<>();
-                boolean mainAttributeTouched = false;
+                boolean mainFlagWritten = false;
                 for (HolderChange hc : changes)
                 {
                     // A direct feature lands on the target; a property on the nested <extInfo> lands
@@ -3216,7 +3219,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                     {
                         applied.add("extInfo"); //$NON-NLS-1$
                     }
-                    mainAttributeTouched = mainAttributeTouched || decidesFormExtInfo(hc);
+                    mainFlagWritten = mainFlagWritten || decidesFormExtInfo(hc);
                     if (hc.change.isLocalized())
                     {
                         // Remember the receiver the change actually landed on: a title on the
@@ -3225,14 +3228,18 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                         localizedChanges.add(hc.change);
                     }
                 }
-                // The form ROOT's ext-info follows the MAIN attribute's FINAL state, so it is
-                // decided once the whole batch is applied. Per change it would depend on the
-                // order the properties arrived in: [main=false, valueType=X] and the reverse pair
-                // describe the same end state and must not leave two different ext-infos.
-                if (mainAttributeTouched && FormElementWriter.syncFormExtInfo(formModel) != null
-                    && !applied.contains("extInfo")) //$NON-NLS-1$
+                // A main-attribute promotion is the platform's setMainAttribute: it demotes the
+                // previous main first, then re-derives the root ext-info from the FINAL state of
+                // the batch (per change it would depend on the order the properties arrived in).
+                if (mainFlagWritten)
                 {
-                    applied.add("extInfo"); //$NON-NLS-1$
+                    demotedMains.addAll(
+                        FormElementWriter.demoteOtherMainAttributes(formModel, target));
+                    if (FormElementWriter.syncFormExtInfo(formModel) != null
+                        && !applied.contains("extInfo")) //$NON-NLS-1$
+                    {
+                        applied.add("extInfo"); //$NON-NLS-1$
+                    }
                 }
                 for (int i = 0; i < localizedChanges.size(); i++)
                 {
@@ -3248,6 +3255,10 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             .put(KEY_PERSISTED, persisted);
         localizedReport.addTo(result);
         normReport.addTo(result);
+        if (!demotedMains.isEmpty())
+        {
+            result.put("demotedMainAttributes", demotedMains); //$NON-NLS-1$
+        }
         return result
             .put(McpKeys.MESSAGE, MSG_MODIFIED_PREFIX + normFqn + " (" + String.join(", ", applied) + ")") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             .toJson();
@@ -3701,13 +3712,14 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
     }
 
     /**
-     * Whether this change can move the FORM ROOT's ext-info: the main attribute's type, or the
-     * flag that decides which attribute is main. Asked per change, answered once per batch.
+     * Whether this change decides the FORM ROOT's ext-info - a write of the {@code main} flag, and
+     * nothing else. The platform re-derives that node from one place only
+     * ({@code FormAttributeService.setMainAttribute}); a retype of the main attribute goes to
+     * {@code setTypeDescription}, which never touches the root node.
      */
     private static boolean decidesFormExtInfo(HolderChange hc)
     {
-        return !hc.onExtInfo
-            && (hc.change.isTypeChange() || PROP_MAIN.equalsIgnoreCase(hc.change.featureName()));
+        return !hc.onExtInfo && PROP_MAIN.equalsIgnoreCase(hc.change.featureName());
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -2391,11 +2391,26 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
         {
             return null; // NOSONAR tri-state: null means "this request writes no main flag"
         }
+        return mainFlagIn(properties);
+    }
+
+    /**
+     * The {@code main} value a property list carries, read with the SAME parser the write uses -
+     * {@link #parseBoolean} also takes {@code 1}/{@code 0}/{@code yes}/{@code no}, and a gate that
+     * recognized a narrower set would miss exactly the writes it exists to catch. Package-private
+     * so a test can pin that equivalence.
+     *
+     * @param properties the requested property changes
+     * @return the value written into {@code main}, or {@code null} when the list writes none (or
+     *         writes something that is not a boolean at all, which the write itself refuses)
+     */
+    static Boolean mainFlagIn(List<JsonObject> properties)
+    {
         for (JsonObject prop : properties)
         {
             if (PROP_MAIN.equalsIgnoreCase(asString(prop.get("name")))) //$NON-NLS-1$
             {
-                return parseBooleanFlag(prop.get("value")); //$NON-NLS-1$
+                return parseBoolean(asString(prop.get("value"))); //$NON-NLS-1$
             }
         }
         return null; // NOSONAR tri-state: see above

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -2360,10 +2360,23 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
     }
 
     /** What the user authorizes when a form attribute (or column) changes its data type. */
-    private static ConsentPreview formRetypePreview(String normFqn,
+    static ConsentPreview formRetypePreview(String normFqn,
         FormElementWriter.FormMemberRef ref, List<JsonObject> properties)
     {
-        if (!isFormRetypeRequest(ref, properties))
+        boolean retype = isFormRetypeRequest(ref, properties);
+        boolean mainWrite = requestedMainFlag(ref, properties) != null;
+        if (retype && mainWrite)
+        {
+            // One batch, two different losses - the dialog has to name both, or the answer
+            // authorizes something the question never mentioned.
+            return new ConsentPreview(
+                "Change the data type of " + normFqn + " and rewrite its main flag", //$NON-NLS-1$ //$NON-NLS-2$
+                "Retyping a form attribute can drop stored values on the next database update, " //$NON-NLS-1$
+                    + "and the main flag can leave the form without its root ext-info, deleting " //$NON-NLS-1$
+                    + "the event handlers bound inside it.", //$NON-NLS-1$
+                2, List.of(PROP_VALUE_TYPE, PROP_MAIN));
+        }
+        if (mainWrite)
         {
             // The only other thing this gate authorizes: a main-flag write that leaves the form
             // root without its ext-info, and the event handlers bound inside it with it.
@@ -2395,25 +2408,29 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
     }
 
     /**
-     * The {@code main} value a property list carries, read with the SAME parser the write uses -
-     * {@link #parseBoolean} also takes {@code 1}/{@code 0}/{@code yes}/{@code no}, and a gate that
-     * recognized a narrower set would miss exactly the writes it exists to catch. Package-private
-     * so a test can pin that equivalence.
+     * The {@code main} value a property list LEAVES on the member: the batch is applied in order,
+     * so a repeated property is decided by its last write, and the gate has to judge the state the
+     * model actually ends up in.
+     *
+     * <p>Read with the SAME parser the write uses - {@link #parseBoolean} also takes
+     * {@code 1}/{@code 0}/{@code yes}/{@code no}, and a gate that recognized a narrower set would
+     * miss exactly the writes it exists to catch. Package-private so a test can pin both.</p>
      *
      * @param properties the requested property changes
-     * @return the value written into {@code main}, or {@code null} when the list writes none (or
+     * @return the value the list leaves in {@code main}, or {@code null} when it writes none (or
      *         writes something that is not a boolean at all, which the write itself refuses)
      */
     static Boolean mainFlagIn(List<JsonObject> properties)
     {
+        Boolean last = null;
         for (JsonObject prop : properties)
         {
             if (PROP_MAIN.equalsIgnoreCase(asString(prop.get("name")))) //$NON-NLS-1$
             {
-                return parseBoolean(asString(prop.get("value"))); //$NON-NLS-1$
+                last = parseBoolean(asString(prop.get("value"))); //$NON-NLS-1$
             }
         }
-        return null; // NOSONAR tri-state: see above
+        return last; // NOSONAR tri-state: see above
     }
 
     /**
@@ -2452,19 +2469,20 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             (formModel, tx) ->
             {
                 EObject member = FormElementWriter.resolveFormMember(formModel, ref);
-                String verdict = retype
-                    ? formRetypeVerdict(ctx.scope, version, member, properties, normReport)
-                    : ""; //$NON-NLS-1$
-                if (verdict == null || !verdict.isEmpty())
+                // The WHOLE batch is prepared first, whichever of the two brought us here: every
+                // refusal that pass can produce belongs above the gate, or a denial comes back
+                // instead of the actionable error (issue #295).
+                String refusal =
+                    formRetypeVerdict(ctx.scope, version, member, properties, normReport);
+                if (refusal != null)
                 {
-                    // A refusal, or a retype that must be asked about - either way it decides.
-                    return verdict;
+                    // A refusal, or "" for a member the write path answers "not found" for.
+                    return refusal;
                 }
-                // Nothing destructive about the types; the main flag can still delete the form
-                // root ext-info together with the handlers bound in it.
-                return member != null && mainFlag != null
-                    && FormElementWriter.clearsBoundFormExtInfo(formModel, member,
-                        mainFlag.booleanValue()) ? null : ""; //$NON-NLS-1$
+                // Prepared cleanly: ask when the request retypes stored data, or when the main
+                // flag it LEAVES would take the root ext-info and the handlers bound in it.
+                return retype || (mainFlag != null && FormElementWriter.clearsBoundFormExtInfo(
+                    formModel, member, mainFlag.booleanValue())) ? null : ""; //$NON-NLS-1$
             });
     }
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataTool.java
@@ -3200,8 +3200,6 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 List<EObject> localizedHolders = new ArrayList<>();
                 List<PreparedChange> localizedChanges = new ArrayList<>();
                 boolean mainAttributeTouched = false;
-                // Read BEFORE anything is applied: what the form's ext-info is keyed on.
-                String mainCategoryBefore = FormElementWriter.mainAttributeCategory(formModel);
                 for (HolderChange hc : changes)
                 {
                     // A direct feature lands on the target; a property on the nested <extInfo> lands
@@ -3231,14 +3229,7 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
                 // decided once the whole batch is applied. Per change it would depend on the
                 // order the properties arrived in: [main=false, valueType=X] and the reverse pair
                 // describe the same end state and must not leave two different ext-infos.
-                // ... and the node may be REMOVED only when the thing it is keyed on actually
-                // became something else. Asked of the model before and after, not inferred from
-                // which properties the batch carried: a change object names the KIND of property,
-                // so a re-write of the same type looks identical to a retype.
-                String mainCategoryAfter = FormElementWriter.mainAttributeCategory(formModel);
-                if (mainAttributeTouched
-                    && FormElementWriter.syncFormExtInfo(formModel,
-                        mainCategoryReplaced(mainCategoryBefore, mainCategoryAfter)) != null
+                if (mainAttributeTouched && FormElementWriter.syncFormExtInfo(formModel) != null
                     && !applied.contains("extInfo")) //$NON-NLS-1$
                 {
                     applied.add("extInfo"); //$NON-NLS-1$
@@ -3707,24 +3698,6 @@ public class ModifyMetadataTool extends AbstractMetadataWriteTool
             return FormElementWriter.syncItemExtInfo(formModel, member) != null;
         }
         return false;
-    }
-
-    /**
-     * Whether the batch REPLACED the category the form root's ext-info is keyed on - the only
-     * transition that may leave the form without a node.
-     *
-     * <p>Gaining a FIRST main attribute ({@code null} before) is not a replacement: nothing was
-     * keyed on anything, so there is nothing to invalidate, and a bare {@code main} write does not
-     * pass the destructive-consent gate ({@code isFormRetypeRequest} looks for {@code type} /
-     * {@code valueType}). Re-writing the same category is not one either.</p>
-     *
-     * @param before the main attribute's category before the batch, may be {@code null}
-     * @param after the same after it, may be {@code null}
-     * @return {@code true} only when a category that WAS there became something else
-     */
-    static boolean mainCategoryReplaced(String before, String after)
-    {
-        return before != null && !before.equals(after);
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -2979,8 +2979,16 @@ public final class FormElementWriter
 
     /**
      * The MAIN attribute's value-type CATEGORY &rarr; the concrete {@code FormExtInfo} classifier the
-     * platform pairs with the form ROOT, copied from {@code ExtInfoManagementService.createFormExtInfo}.
-     * A category not listed here leaves the form without a root ext-info, exactly as the platform does.
+     * platform pairs with the form ROOT. A category not listed here leaves the form without a root
+     * ext-info, which is what the platform writes for it.
+     *
+     * <p>The platform decides this in THREE places that do not agree:
+     * {@code ExtInfoManagementService.createFormExtInfo} (the main-attribute checkbox), the form
+     * generators ({@code ItemFormContainGenerator} and its siblings, at form creation) and
+     * {@code FormExtInfoXmlPartReader} (designer-XML import). This map is their UNION, because a
+     * form on disk carries whichever of them wrote it - the DT load path re-derives nothing - and a
+     * narrower map would delete a node a different writer legitimately produced. Chart-of-accounts
+     * object forms are the case that proves it: only the generator and the importer map them.</p>
      */
     private static final Map<String, String> FORM_EXT_INFO_BY_TYPE_CATEGORY = buildFormExtInfoMap();
 
@@ -3011,6 +3019,18 @@ public final class FormElementWriter
         m.put("ExternalDataSourceTableObject", "TableObjectFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
         m.put("ExternalDataSourceTableRecordManager", "TableRecordFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
         m.put("ExternalDataSourceCubeRecordManager", "CubeRecordFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
+        // Kinds only the GENERATORS and the designer-XML importer produce; createFormExtInfo has no
+        // case for them and would clear a correct node.
+        m.put("ChartOfAccountsObject", ECLASS_OBJECT_FORM_EXT_INFO); //$NON-NLS-1$
+        m.put("ChartOfCalculationTypesObject", ECLASS_OBJECT_FORM_EXT_INFO); //$NON-NLS-1$
+        m.put("ExternalDataProcessor", ECLASS_OBJECT_FORM_EXT_INFO); //$NON-NLS-1$
+        m.put("ExternalDataProcessorObject", ECLASS_OBJECT_FORM_EXT_INFO); //$NON-NLS-1$
+        m.put("ExternalReport", "ReportFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.put("ExternalReportObject", "ReportFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
+        // ... and one only the record-set generator produces, for a cube.
+        m.put("ExternalDataSourceCubeRecordSet", "CubeRecordSetFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
+        // Deliberately absent: SpreadsheetDocument, whose importer branch casts a FormAttributeExtInfo
+        // to FormExtInfo, and InformationRegisterManager, which no writer pairs with a kind at all.
         return Collections.unmodifiableMap(m);
     }
 
@@ -3018,14 +3038,16 @@ public final class FormElementWriter
     private static final String ECLASS_RECORD_SET_FORM_EXT_INFO = "RecordSetFormExtInfo"; //$NON-NLS-1$
 
     /**
-     * Gives the form ROOT the ext-info its MAIN attribute's type calls for, mirroring
-     * {@code ExtInfoManagementService.setExtInfo(Form, FormAttribute, Version)}.
+     * Gives the form ROOT the ext-info its MAIN attribute calls for, mirroring the platform pair
+     * {@code ExtInfoManagementService.setExtInfo(Form, FormAttribute, Version)} and
+     * {@code resetExtInfo(Form, Version)}.
      *
      * <p>That node is what publishes a form's write and read events: without it a record form
      * refuses {@code BeforeWriteAtServer} outright, and no MCP property can supply it (issue #591).
-     * A MAIN attribute whose category maps to nothing clears a stale ext-info this mapping produced,
-     * as the platform does; a form with NO main attribute is left untouched, because the platform
-     * never asks the question that way ({@code setExtInfo} asserts {@code isMain}).</p>
+     * The platform reaches the question from exactly ONE place - a write of the main-attribute flag
+     * ({@code FormAttributeService.setMainAttribute}) - and answers it from the model alone: no main
+     * attribute, or a category that maps to no kind, and the node is cleared, because
+     * {@code isNeedUpdateExtInfo} returns true precisely when the new kind is {@code null}.</p>
      *
      * @param formModel the editable content form, re-fetched inside the tx
      * @return the EClass name of the ext-info now on the form root, or {@code null} when it carries none
@@ -3038,32 +3060,17 @@ public final class FormElementWriter
             return null;
         }
         EObject current = singleReference(formModel, FEATURE_EXT_INFO);
-        if (!hasMainAttribute(formModel))
-        {
-            // Having NO main attribute is not an instruction to clear. The platform only ever asks
-            // this question about a main attribute - setExtInfo asserts isMain - so a form without
-            // one is left as it is; clearing here would delete the events bound inside the node on
-            // a plain main=false.
-            return current == null ? null : current.eClass().getName();
-        }
-        String classifier = FORM_EXT_INFO_BY_TYPE_CATEGORY.get(mainAttributeCategory(formModel));
+        // The kind the main attribute calls for: none when the form has no main attribute at all
+        // (the platform's resetExtInfo) or when its category maps to nothing.
+        String classifier = hasMainAttribute(formModel)
+            ? FORM_EXT_INFO_BY_TYPE_CATEGORY.get(mainAttributeCategory(formModel)) : null;
         if (classifier == null)
         {
-            if (current == null)
-            {
-                return null;
-            }
-            // The main attribute pairs with nothing, so a node THIS mapping produced is stale by
-            // construction: it was keyed to a category that no longer applies, and leaving it would
-            // go on publishing that kind's events for a form that is not one.
-            if (FORM_EXT_INFO_BY_TYPE_CATEGORY.containsValue(current.eClass().getName()))
+            if (current != null)
             {
                 formModel.eSet(extInfoFeature, null);
-                return null;
             }
-            // A node the platform GENERATOR wrote - a cube record set's - is left alone: this
-            // mapping never keyed it, so it cannot say whether it is stale.
-            return current.eClass().getName();
+            return null;
         }
         if (current != null && classifier.equals(current.eClass().getName()))
         {
@@ -3085,10 +3092,10 @@ public final class FormElementWriter
      * The type CATEGORY of the form's MAIN attribute, or {@code null} when the form has no main
      * attribute or its type is not single.
      *
-     * <p>This is the one value {@link #syncFormExtInfo(EObject, boolean)} keys on, so a caller can
-     * read it BEFORE a batch and again AFTER and tell an actual retype from a re-write of the same
-     * value. A property-shaped signal cannot: a change object says which KIND of property it
-     * carries, not whether the value in it differs from the one already there.</p>
+     * <p>This is the one value {@link #syncFormExtInfo(EObject)} keys on. It is the FIRST main
+     * attribute in list order, exactly what {@code FormUtil.getMainAttribute} answers; a form
+     * carrying TWO of them is a state the platform reports as an error rather than resolves, so
+     * {@link #demoteOtherMainAttributes(EObject, EObject)} keeps it from arising.</p>
      *
      * @param formModel the editable content form, on the tx-bound model
      * @return the category, or {@code null}
@@ -3103,6 +3110,38 @@ public final class FormElementWriter
             }
         }
         return null;
+    }
+
+    /**
+     * Clears {@code main} on every OTHER attribute of the form, mirroring
+     * {@code FormAttributeService.setMainAttribute}, which demotes the previous main before it
+     * flags the new one. A form may hold one main attribute or none - the platform reports two as
+     * an error ({@code FormValidator.isMainFormAttributeOneOrNone}).
+     *
+     * @param formModel the editable content form, on the tx-bound model
+     * @param promoted the attribute just flagged main; nothing is demoted unless it actually is
+     * @return the names of the demoted attributes in list order, empty when there were none
+     */
+    public static List<String> demoteOtherMainAttributes(EObject formModel, EObject promoted)
+    {
+        List<EObject> attributes = referenceList(formModel, FEATURE_ATTRIBUTES);
+        // Only a member of the form's OWN attribute list can be its main one: that is the list
+        // FormUtil.getMainAttribute reads, so a flag on a nested column decides nothing.
+        if (promoted == null || !isMainAttribute(promoted) || !attributes.contains(promoted))
+        {
+            return List.of();
+        }
+        List<String> demoted = new ArrayList<>();
+        for (EObject attr : attributes)
+        {
+            if (attr == promoted || !isMainAttribute(attr))
+            {
+                continue;
+            }
+            setBooleanFeature(attr, FEATURE_MAIN, false);
+            demoted.add(stringFeature(attr, FEATURE_NAME));
+        }
+        return demoted;
     }
 
     /** The features {@code ExtInfoManagementService} refuses to carry over. */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -3058,12 +3058,10 @@ public final class FormElementWriter
         String classifier = FORM_EXT_INFO_BY_TYPE_CATEGORY.get(singleValueTypeCategory(main));
         if (classifier == null)
         {
-            // Clear only a kind THIS mapping could have produced. The platform generator writes
-            // kinds createFormExtInfo never makes - a cube record-set form gets its
-            // CubeRecordSetFormExtInfo from RecordSetFormContainGenerator - and dropping one of
-            // those would delete the handlers bound inside it.
-            if (current != null
-                && FORM_EXT_INFO_BY_TYPE_CATEGORY.containsValue(current.eClass().getName()))
+            // A main attribute whose category pairs with nothing takes the node with it, whatever
+            // kind it was: createFormExtInfo answers null here, and isNeedUpdateExtInfo(null, old)
+            // makes the platform set it to null.
+            if (current != null)
             {
                 formModel.eSet(extInfoFeature, null);
             }
@@ -3075,7 +3073,49 @@ public final class FormElementWriter
         }
         EObject created =
             replaceExtInfoClassifier(formModel, formModel, extInfoFeature, classifier);
-        return created == null ? null : created.eClass().getName();
+        if (created == null)
+        {
+            return null;
+        }
+        // A CHANGE of kind is not a reason to lose what the old node held - above all the event
+        // handlers bound inside it.
+        copySameFeatures(current, created);
+        return created.eClass().getName();
+    }
+
+    /** The features {@code ExtInfoManagementService} refuses to carry over. */
+    private static final Set<String> EXT_INFO_FEATURES_NOT_CARRIED_OVER =
+        Set.of("orientation"); //$NON-NLS-1$
+
+    /**
+     * Carries the old ext-info's data over to the new one, mirroring
+     * {@code ExtInfoManagementService.copyDataOfSameFeatures}: every feature the two kinds share by
+     * NAME and TYPE, that the old one actually set, minus the ones the platform skips.
+     *
+     * <p>For a form ROOT that is what keeps the event handlers bound inside the node when its KIND
+     * changes - promoting a different main attribute must not silently discard them.</p>
+     */
+    private static void copySameFeatures(EObject source, EObject destination)
+    {
+        if (source == null || destination == null)
+        {
+            return;
+        }
+        EClass destinationClass = destination.eClass();
+        for (EStructuralFeature feature : source.eClass().getEAllStructuralFeatures())
+        {
+            EStructuralFeature target = destinationClass.getEStructuralFeature(feature.getName());
+            if (target == null || !feature.getEType().equals(target.getEType())
+                || !source.eIsSet(feature)
+                || EXT_INFO_FEATURES_NOT_CARRIED_OVER.contains(feature.getName()))
+            {
+                continue;
+            }
+            Object value = source.eGet(feature);
+            // A containment list is COPIED before it is handed over: setting it moves the elements
+            // out of the source, and the source list is what is being read.
+            destination.eSet(target, value instanceof List<?> ? new ArrayList<>((List<?>)value) : value);
+        }
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -3043,7 +3043,12 @@ public final class FormElementWriter
         EObject current = singleReference(formModel, FEATURE_EXT_INFO);
         if (classifier == null)
         {
-            if (current != null)
+            // Clear only a kind THIS mapping could have produced. The platform generator writes
+            // kinds createFormExtInfo never makes - a cube record-set form gets its
+            // CubeRecordSetFormExtInfo from RecordSetFormContainGenerator - and dropping one of
+            // those would delete the handlers bound inside it.
+            if (current != null
+                && FORM_EXT_INFO_BY_TYPE_CATEGORY.containsValue(current.eClass().getName()))
             {
                 formModel.eSet(extInfoFeature, null);
             }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -3132,10 +3132,12 @@ public final class FormElementWriter
      * @param mainAfter the value the request writes into that flag
      * @param categoryAfter the attribute's type category AFTER the batch - the same batch may
      *            retype it, and the model still holds the old one when this is asked
+     * @param demotesOthers whether the batch takes the flag off every OTHER attribute, which it
+     *            does as soon as it flags this one main at any point
      * @return {@code true} when the write would take bound handlers with the node
      */
-    public static boolean clearsBoundFormExtInfo(EObject formModel, EObject attribute,
-        boolean mainAfter, String categoryAfter)
+    public static boolean clearsBoundFormExtInfo(EObject formModel, EObject attribute, // NOSONAR the decision needs all four; a parameter object would not make it clearer
+        boolean mainAfter, String categoryAfter, boolean demotesOthers)
     {
         EObject current = singleReference(formModel, FEATURE_EXT_INFO);
         if (current == null || referenceList(current, KEY_HANDLERS).isEmpty())
@@ -3144,11 +3146,25 @@ public final class FormElementWriter
         }
         if (mainAfter)
         {
-            return FORM_EXT_INFO_BY_TYPE_CATEGORY.get(categoryAfter) == null;
+            return !pairsWithACreatableKind(formModel, categoryAfter);
         }
-        EObject deciding = otherMainAttribute(formModel, attribute);
+        // With the others demoted the form is left with no main attribute at all, whatever it
+        // carried before the batch.
+        EObject deciding = demotesOthers ? null : otherMainAttribute(formModel, attribute);
         return deciding == null
-            || FORM_EXT_INFO_BY_TYPE_CATEGORY.get(singleValueTypeCategory(deciding)) == null;
+            || !pairsWithACreatableKind(formModel, singleValueTypeCategory(deciding));
+    }
+
+    /**
+     * Whether a category pairs with an ext-info kind THIS form model can actually create. The map
+     * alone is not enough: on a platform whose form EPackage has no such EClass,
+     * {@code replaceExtInfoClassifier} clears the slot rather than leave a stale node, so the
+     * handlers go the same way as for a category that pairs with nothing.
+     */
+    private static boolean pairsWithACreatableKind(EObject formModel, String category)
+    {
+        String classifier = FORM_EXT_INFO_BY_TYPE_CATEGORY.get(category);
+        return classifier != null && formEClass(formModel, classifier) != null;
     }
 
     /** The form's main attribute other than the given one, or {@code null} when there is none. */
@@ -3170,8 +3186,12 @@ public final class FormElementWriter
      * flags the new one. A form may hold one main attribute or none - the platform reports two as
      * an error ({@code FormValidator.isMainFormAttributeOneOrNone}).
      *
+     * <p>Called when the batch flags the attribute main AT ANY POINT, not when it is left main: a
+     * batch of {@code [main=true, main=false]} promotes it and takes it back, and the platform's
+     * two calls would have demoted the previous main on the way through.</p>
+     *
      * @param formModel the editable content form, on the tx-bound model
-     * @param promoted the attribute just flagged main; nothing is demoted unless it actually is
+     * @param promoted the attribute the batch flagged main
      * @return the names of the demoted attributes in list order, empty when there were none
      */
     public static List<String> demoteOtherMainAttributes(EObject formModel, EObject promoted)
@@ -3179,7 +3199,7 @@ public final class FormElementWriter
         List<EObject> attributes = referenceList(formModel, FEATURE_ATTRIBUTES);
         // Only a member of the form's OWN attribute list can be its main one: that is the list
         // FormUtil.getMainAttribute reads, so a flag on a nested column decides nothing.
-        if (promoted == null || !isMainAttribute(promoted) || !attributes.contains(promoted))
+        if (promoted == null || !attributes.contains(promoted))
         {
             return List.of();
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -3032,22 +3032,6 @@ public final class FormElementWriter
      */
     public static String syncFormExtInfo(EObject formModel)
     {
-        return syncFormExtInfo(formModel, false);
-    }
-
-    /**
-     * {@link #syncFormExtInfo(EObject)} with the CLEAR allowed.
-     *
-     * <p>Only a change of the main attribute's TYPE may clear the node, because only that request
-     * passes the destructive-consent gate ({@code isFormRetypeRequest} looks for {@code type} /
-     * {@code valueType}). A bare {@code main} write must not turn destructive: re-writing an
-     * already-true flag on a form whose kind this mapping cannot produce would otherwise delete the
-     * node and every handler inside it, un-gated and for no change at all.</p>
-     *
-     * @param retypeMayClear whether this call may leave the form without an ext-info
-     */
-    public static String syncFormExtInfo(EObject formModel, boolean retypeMayClear)
-    {
         EStructuralFeature extInfoFeature = formModel.eClass().getEStructuralFeature(FEATURE_EXT_INFO);
         if (!(extInfoFeature instanceof EReference) || extInfoFeature.isMany())
         {
@@ -3065,18 +3049,21 @@ public final class FormElementWriter
         String classifier = FORM_EXT_INFO_BY_TYPE_CATEGORY.get(mainAttributeCategory(formModel));
         if (classifier == null)
         {
-            // A main attribute whose category pairs with nothing takes the node with it, whatever
-            // kind it was: createFormExtInfo answers null here, and isNeedUpdateExtInfo(null, old)
-            // makes the platform set it to null. Only a RETYPE gets to do that (see the overload).
-            if (!retypeMayClear)
+            if (current == null)
             {
-                return current == null ? null : current.eClass().getName();
+                return null;
             }
-            if (current != null)
+            // The main attribute pairs with nothing, so a node THIS mapping produced is stale by
+            // construction: it was keyed to a category that no longer applies, and leaving it would
+            // go on publishing that kind's events for a form that is not one.
+            if (FORM_EXT_INFO_BY_TYPE_CATEGORY.containsValue(current.eClass().getName()))
             {
                 formModel.eSet(extInfoFeature, null);
+                return null;
             }
-            return null;
+            // A node the platform GENERATOR wrote - a cube record set's - is left alone: this
+            // mapping never keyed it, so it cannot say whether it is stale.
+            return current.eClass().getName();
         }
         if (current != null && classifier.equals(current.eClass().getName()))
         {

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -2833,6 +2833,10 @@ public final class FormElementWriter
         {
             applyMainTable(extInfo, config, mainTableFqn, applied);
         }
+        // This branch sets valueType (and main) itself, outside the property loop that syncs the
+        // form root - so it has to ask for the root ext-info here, or a main dynamic list leaves
+        // the form without its DynamicListFormExtInfo.
+        syncFormExtInfo(formModel);
         return applied;
     }
 
@@ -3019,7 +3023,9 @@ public final class FormElementWriter
      *
      * <p>That node is what publishes a form's write and read events: without it a record form
      * refuses {@code BeforeWriteAtServer} outright, and no MCP property can supply it (issue #591).
-     * A main attribute whose category maps to nothing CLEARS a stale ext-info, as the platform does.</p>
+     * A MAIN attribute whose category maps to nothing clears a stale ext-info this mapping produced,
+     * as the platform does; a form with NO main attribute is left untouched, because the platform
+     * never asks the question that way ({@code setExtInfo} asserts {@code isMain}).</p>
      *
      * @param formModel the editable content form, re-fetched inside the tx
      * @return the EClass name of the ext-info now on the form root, or {@code null} when it carries none
@@ -3031,16 +3037,25 @@ public final class FormElementWriter
         {
             return null;
         }
-        String classifier = null;
+        EObject main = null;
         for (EObject attr : referenceList(formModel, FEATURE_ATTRIBUTES))
         {
             if (isMainAttribute(attr))
             {
-                classifier = FORM_EXT_INFO_BY_TYPE_CATEGORY.get(singleValueTypeCategory(attr));
+                main = attr;
                 break;
             }
         }
         EObject current = singleReference(formModel, FEATURE_EXT_INFO);
+        if (main == null)
+        {
+            // Having NO main attribute is not an instruction to clear. The platform only ever asks
+            // this question about a main attribute - setExtInfo asserts isMain - so a form without
+            // one is left as it is; clearing here would delete the events bound inside the node on
+            // a plain main=false.
+            return current == null ? null : current.eClass().getName();
+        }
+        String classifier = FORM_EXT_INFO_BY_TYPE_CATEGORY.get(singleValueTypeCategory(main));
         if (classifier == null)
         {
             // Clear only a kind THIS mapping could have produced. The platform generator writes

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -3130,17 +3130,23 @@ public final class FormElementWriter
      * @param formModel the editable content form, on the tx-bound model
      * @param attribute the attribute whose main flag the request writes
      * @param mainAfter the value the request writes into that flag
+     * @param categoryAfter the attribute's type category AFTER the batch - the same batch may
+     *            retype it, and the model still holds the old one when this is asked
      * @return {@code true} when the write would take bound handlers with the node
      */
     public static boolean clearsBoundFormExtInfo(EObject formModel, EObject attribute,
-        boolean mainAfter)
+        boolean mainAfter, String categoryAfter)
     {
         EObject current = singleReference(formModel, FEATURE_EXT_INFO);
         if (current == null || referenceList(current, KEY_HANDLERS).isEmpty())
         {
             return false;
         }
-        EObject deciding = mainAfter ? attribute : otherMainAttribute(formModel, attribute);
+        if (mainAfter)
+        {
+            return FORM_EXT_INFO_BY_TYPE_CATEGORY.get(categoryAfter) == null;
+        }
+        EObject deciding = otherMainAttribute(formModel, attribute);
         return deciding == null
             || FORM_EXT_INFO_BY_TYPE_CATEGORY.get(singleValueTypeCategory(deciding)) == null;
     }
@@ -3234,14 +3240,42 @@ public final class FormElementWriter
      * platform PROXY as well as for a resolved type - so an attribute typed with the Russian spelling
      * classifies identically.
      */
+    /**
+     * The type CATEGORY a form member is typed with, or {@code null} when its type is not single.
+     * The read-only counterpart of {@link #typeCategoryOf(Object)} for a member that already
+     * carries its type.
+     *
+     * @param member the form member, on the tx-bound model
+     * @return the category, or {@code null}
+     */
+    public static String valueTypeCategoryOf(EObject member)
+    {
+        return member == null ? null : singleValueTypeCategory(member);
+    }
+
     private static String singleValueTypeCategory(EObject member)
     {
         EStructuralFeature feature = member.eClass().getEStructuralFeature(FEATURE_VALUE_TYPE);
-        if (feature == null || !(member.eGet(feature) instanceof EObject))
+        return feature == null ? null : typeCategoryOf(member.eGet(feature));
+    }
+
+    /**
+     * The type CATEGORY a value-type description names - the part before the first dot - or
+     * {@code null} when it does not name exactly one type.
+     *
+     * <p>Asked of the DESCRIPTION rather than of the member on purpose: a caller deciding what a
+     * batch will leave behind holds the type it is about to write, not a model that has it yet.</p>
+     *
+     * @param valueType the {@code TypeDescription}, or anything else (answered {@code null})
+     * @return the category, or {@code null}
+     */
+    public static String typeCategoryOf(Object valueType)
+    {
+        if (!(valueType instanceof EObject))
         {
             return null;
         }
-        List<EObject> types = referenceList((EObject)member.eGet(feature), "types"); //$NON-NLS-1$
+        List<EObject> types = referenceList((EObject)valueType, "types"); //$NON-NLS-1$
         if (types.size() != 1 || !(types.get(0) instanceof TypeItem))
         {
             return null;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -2807,9 +2807,12 @@ public final class FormElementWriter
                 + "Catalog.Products'}. 'customQuery' alone only toggles an attribute that is already a " //$NON-NLS-1$
                 + "dynamic list.").toJson()); //$NON-NLS-1$
         }
+        boolean promotedToMain = false;
         if (!alreadyDynamicList)
         {
+            boolean hadMainAttribute = hasMainAttribute(formModel);
             extInfo = convertPlainAttributeToDynamicList(formModel, attribute, version, applied);
+            promotedToMain = !hadMainAttribute && isMainAttribute(attribute);
         }
 
         boolean effectiveCustomQuery = customQuery != null ? customQuery.booleanValue() : queryText != null;
@@ -2833,10 +2836,13 @@ public final class FormElementWriter
         {
             applyMainTable(extInfo, config, mainTableFqn, applied);
         }
-        // This branch sets valueType (and main) itself, outside the property loop that syncs the
-        // form root - so it has to ask for the root ext-info here, or a main dynamic list leaves
-        // the form without its DynamicListFormExtInfo.
-        syncFormExtInfo(formModel);
+        // This branch sets main itself, outside the property loop that syncs the form root - so it
+        // asks here, but ONLY when it actually promoted the attribute. A query edit on a list that
+        // was already dynamic writes no main flag, and the root node is not its business.
+        if (promotedToMain)
+        {
+            syncFormExtInfo(formModel);
+        }
         return applied;
     }
 
@@ -3107,6 +3113,46 @@ public final class FormElementWriter
             if (isMainAttribute(attr))
             {
                 return singleValueTypeCategory(attr);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Whether writing {@code main} on this attribute would DELETE event handlers: the form root
+     * carries an ext-info with bindings inside, and the kind it would be left with is none.
+     *
+     * <p>Following the platform ({@code resetExtInfo} clears the node unconditionally) costs
+     * nothing when the node is empty or merely changes kind - a kind change carries the handlers
+     * over. This is the one shape where it destroys something the caller did not name, so it is
+     * the one the consent gate is asked about.</p>
+     *
+     * @param formModel the editable content form, on the tx-bound model
+     * @param attribute the attribute whose main flag the request writes
+     * @param mainAfter the value the request writes into that flag
+     * @return {@code true} when the write would take bound handlers with the node
+     */
+    public static boolean clearsBoundFormExtInfo(EObject formModel, EObject attribute,
+        boolean mainAfter)
+    {
+        EObject current = singleReference(formModel, FEATURE_EXT_INFO);
+        if (current == null || referenceList(current, KEY_HANDLERS).isEmpty())
+        {
+            return false;
+        }
+        EObject deciding = mainAfter ? attribute : otherMainAttribute(formModel, attribute);
+        return deciding == null
+            || FORM_EXT_INFO_BY_TYPE_CATEGORY.get(singleValueTypeCategory(deciding)) == null;
+    }
+
+    /** The form's main attribute other than the given one, or {@code null} when there is none. */
+    private static EObject otherMainAttribute(EObject formModel, EObject excluded)
+    {
+        for (EObject attr : referenceList(formModel, FEATURE_ATTRIBUTES))
+        {
+            if (attr != excluded && isMainAttribute(attr))
+            {
+                return attr;
             }
         }
         return null;

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -3032,6 +3032,22 @@ public final class FormElementWriter
      */
     public static String syncFormExtInfo(EObject formModel)
     {
+        return syncFormExtInfo(formModel, false);
+    }
+
+    /**
+     * {@link #syncFormExtInfo(EObject)} with the CLEAR allowed.
+     *
+     * <p>Only a change of the main attribute's TYPE may clear the node, because only that request
+     * passes the destructive-consent gate ({@code isFormRetypeRequest} looks for {@code type} /
+     * {@code valueType}). A bare {@code main} write must not turn destructive: re-writing an
+     * already-true flag on a form whose kind this mapping cannot produce would otherwise delete the
+     * node and every handler inside it, un-gated and for no change at all.</p>
+     *
+     * @param retypeMayClear whether this call may leave the form without an ext-info
+     */
+    public static String syncFormExtInfo(EObject formModel, boolean retypeMayClear)
+    {
         EStructuralFeature extInfoFeature = formModel.eClass().getEStructuralFeature(FEATURE_EXT_INFO);
         if (!(extInfoFeature instanceof EReference) || extInfoFeature.isMany())
         {
@@ -3060,7 +3076,11 @@ public final class FormElementWriter
         {
             // A main attribute whose category pairs with nothing takes the node with it, whatever
             // kind it was: createFormExtInfo answers null here, and isNeedUpdateExtInfo(null, old)
-            // makes the platform set it to null.
+            // makes the platform set it to null. Only a RETYPE gets to do that (see the overload).
+            if (!retypeMayClear)
+            {
+                return current == null ? null : current.eClass().getName();
+            }
             if (current != null)
             {
                 formModel.eSet(extInfoFeature, null);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -1973,6 +1973,8 @@ public final class FormElementWriter
         // one shared helper rather than a copy that can drift out of step (issue #382).
         applyFormAttributeDefaults(attr);
         addToList(content, FEATURE_ATTRIBUTES, attr);
+        // The designer pairs a root ext-info with the main attribute it just seeded (#591).
+        syncFormExtInfo(content);
     }
 
     /**
@@ -2969,6 +2971,91 @@ public final class FormElementWriter
             ensureEmptyTypeDescription(created);
         }
         return created.eClass().getName();
+    }
+
+    /**
+     * The MAIN attribute's value-type CATEGORY &rarr; the concrete {@code FormExtInfo} classifier the
+     * platform pairs with the form ROOT, copied from {@code ExtInfoManagementService.createFormExtInfo}.
+     * A category not listed here leaves the form without a root ext-info, exactly as the platform does.
+     */
+    private static final Map<String, String> FORM_EXT_INFO_BY_TYPE_CATEGORY = buildFormExtInfoMap();
+
+    private static Map<String, String> buildFormExtInfoMap()
+    {
+        Map<String, String> m = new HashMap<>();
+        m.put("BusinessProcessObject", "BusinessProcesFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.put("CatalogObject", "CatalogFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.put("ChartOfCharacteristicTypesObject", //$NON-NLS-1$
+            "ChartOfCharacteristicTypesFormExtInfo"); //$NON-NLS-1$
+        m.put("ConstantsSet", "ConstantsFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.put("DocumentObject", "DocumentFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.put("ExternalDataSourceCubeDimensionTableObject", ECLASS_OBJECT_FORM_EXT_INFO); //$NON-NLS-1$
+        m.put("ExchangePlanObject", ECLASS_OBJECT_FORM_EXT_INFO); //$NON-NLS-1$
+        m.put("DataProcessorObject", ECLASS_OBJECT_FORM_EXT_INFO); //$NON-NLS-1$
+        m.put("DynamicList", "DynamicListFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.put("InformationRegisterRecordManager", //$NON-NLS-1$
+            "InformationRegisterManagerFormExtInfo"); //$NON-NLS-1$
+        m.put("RecalculationRecordSet", ECLASS_RECORD_SET_FORM_EXT_INFO); //$NON-NLS-1$
+        m.put("CalculationRegisterRecordSet", ECLASS_RECORD_SET_FORM_EXT_INFO); //$NON-NLS-1$
+        m.put("InformationRegisterRecordSet", ECLASS_RECORD_SET_FORM_EXT_INFO); //$NON-NLS-1$
+        m.put("AccountingRegisterRecordSet", ECLASS_RECORD_SET_FORM_EXT_INFO); //$NON-NLS-1$
+        m.put("SequenceRecordSet", ECLASS_RECORD_SET_FORM_EXT_INFO); //$NON-NLS-1$
+        m.put("AccumulationRegisterRecordSet", ECLASS_RECORD_SET_FORM_EXT_INFO); //$NON-NLS-1$
+        m.put("ReportObject", "ReportFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.put("DataCompositionSettingsComposer", "SettingsComposerFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.put("TaskObject", "TaskFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.put("ExternalDataSourceTableObject", "TableObjectFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.put("ExternalDataSourceTableRecordManager", "TableRecordFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.put("ExternalDataSourceCubeRecordManager", "CubeRecordFormExtInfo"); //$NON-NLS-1$ //$NON-NLS-2$
+        return Collections.unmodifiableMap(m);
+    }
+
+    private static final String ECLASS_OBJECT_FORM_EXT_INFO = "ObjectFormExtInfo"; //$NON-NLS-1$
+    private static final String ECLASS_RECORD_SET_FORM_EXT_INFO = "RecordSetFormExtInfo"; //$NON-NLS-1$
+
+    /**
+     * Gives the form ROOT the ext-info its MAIN attribute's type calls for, mirroring
+     * {@code ExtInfoManagementService.setExtInfo(Form, FormAttribute, Version)}.
+     *
+     * <p>That node is what publishes a form's write and read events: without it a record form
+     * refuses {@code BeforeWriteAtServer} outright, and no MCP property can supply it (issue #591).
+     * A main attribute whose category maps to nothing CLEARS a stale ext-info, as the platform does.</p>
+     *
+     * @param formModel the editable content form, re-fetched inside the tx
+     * @return the EClass name of the ext-info now on the form root, or {@code null} when it carries none
+     */
+    public static String syncFormExtInfo(EObject formModel)
+    {
+        EStructuralFeature extInfoFeature = formModel.eClass().getEStructuralFeature(FEATURE_EXT_INFO);
+        if (!(extInfoFeature instanceof EReference) || extInfoFeature.isMany())
+        {
+            return null;
+        }
+        String classifier = null;
+        for (EObject attr : referenceList(formModel, FEATURE_ATTRIBUTES))
+        {
+            if (isMainAttribute(attr))
+            {
+                classifier = FORM_EXT_INFO_BY_TYPE_CATEGORY.get(singleValueTypeCategory(attr));
+                break;
+            }
+        }
+        EObject current = singleReference(formModel, FEATURE_EXT_INFO);
+        if (classifier == null)
+        {
+            if (current != null)
+            {
+                formModel.eSet(extInfoFeature, null);
+            }
+            return null;
+        }
+        if (current != null && classifier.equals(current.eClass().getName()))
+        {
+            return classifier;
+        }
+        EObject created =
+            replaceExtInfoClassifier(formModel, formModel, extInfoFeature, classifier);
+        return created == null ? null : created.eClass().getName();
     }
 
     /**
@@ -4918,18 +5005,18 @@ public final class FormElementWriter
             return "The form element '" + container.eClass().getName() //$NON-NLS-1$
                 + "' cannot hold event handlers."; //$NON-NLS-1$
         }
-        List<EObject> events = availableEvents(container, version);
+        List<AvailableEvent> events = availableEvents(container, version);
         if (events.isEmpty())
         {
             return "Could not resolve the available events for this form element."; //$NON-NLS-1$
         }
-        EObject matched = null;
-        for (EObject ev : events)
+        AvailableEvent matched = null;
+        for (AvailableEvent candidate : events)
         {
-            if (eventName.equalsIgnoreCase(eventNameOf(ev, false))
-                || eventName.equalsIgnoreCase(eventNameOf(ev, true)))
+            if (eventName.equalsIgnoreCase(eventNameOf(candidate.event, false))
+                || eventName.equalsIgnoreCase(eventNameOf(candidate.event, true)))
             {
-                matched = ev;
+                matched = candidate;
                 break;
             }
         }
@@ -4937,8 +5024,9 @@ public final class FormElementWriter
         {
             boolean ru = "ru".equals(langCode); //$NON-NLS-1$
             StringBuilder sb = new StringBuilder();
-            for (EObject ev : events)
+            for (AvailableEvent candidate : events)
             {
+                EObject ev = candidate.event;
                 String n = eventNameOf(ev, ru);
                 if (n == null || n.isEmpty())
                 {
@@ -4956,8 +5044,12 @@ public final class FormElementWriter
             return ERR_EVENT_PREFIX + eventName + "' is not valid for " + container.eClass().getName() //$NON-NLS-1$
                 + ". Available events: " + sb; //$NON-NLS-1$
         }
-        return bindEventHandler(container, handlersFeat, matched, eventName, procName, callType,
-            createdKind);
+        // The binding goes where the event is published from: the element, or its extInfo when that
+        // is the handler container (a record form's write/read events, #592).
+        EStructuralFeature ownerHandlersFeat =
+            matched.owner.eClass().getEStructuralFeature(KEY_HANDLERS);
+        return bindEventHandler(matched.owner, ownerHandlersFeat, matched.event, eventName, procName,
+            callType, createdKind);
     }
 
     /**
@@ -5007,7 +5099,7 @@ public final class FormElementWriter
         // the extension handler COEXIST with the base handler and with other-call-type extension handlers; // NOSONAR explanatory comment, not commented-out code
         // only a same-(event, callType) EventHandlerExtension is a real duplicate.
         EStructuralFeature evFeat = handlerEventFeature(handlersFeat);
-        for (EObject existing : referenceList(container, KEY_HANDLERS))
+        for (EObject existing : handlersAroundContainer(container))
         {
             if (evFeat == null || existing.eGet(evFeat) != matched)
             {
@@ -5198,8 +5290,14 @@ public final class FormElementWriter
      * <p>Unioning the ext-info type matters for items: e.g. an input field's {@code OnChange} lives on
      * {@code FormFieldExtensionForATextBox} (its {@code InputFieldExtInfo}), not on the bare
      * {@code FormField} base type.</p>
+     *
+     * <p>Each event is paired with the object that OWNS its handler list. For an item that is the
+     * item itself, but a form root's {@code extInfo} is an {@code EventHandlerContainer} of its own
+     * and the events it publishes bind INSIDE it - that is where EDT puts a record form's
+     * {@code BeforeWriteAtServer} (issue #592, and {@code EventHandlerCollectionModel} does the same
+     * split). Item ext-infos hold no handler list, so they keep answering with the item.</p>
      */
-    private static List<EObject> availableEvents(EObject element, Version version)
+    private static List<AvailableEvent> availableEvents(EObject element, Version version)
     {
         if (version == null)
         {
@@ -5211,19 +5309,82 @@ public final class FormElementWriter
         {
             return Collections.emptyList();
         }
-        List<EObject> events = new ArrayList<>();
-        addTypeEvents(provider, element, PLATFORM_TYPE_BY_ECLASS.get(element.eClass().getName()), events);
-        EStructuralFeature extInfoFeat = element.eClass().getEStructuralFeature(FEATURE_EXT_INFO);
-        if (extInfoFeat instanceof EReference)
+        List<EObject> base = new ArrayList<>();
+        addTypeEvents(provider, element, PLATFORM_TYPE_BY_ECLASS.get(element.eClass().getName()), base);
+        List<AvailableEvent> events = new ArrayList<>();
+        for (EObject event : base)
         {
-            Object ext = element.eGet(extInfoFeat);
-            if (ext instanceof EObject)
-            {
-                addTypeEvents(provider, element,
-                    PLATFORM_TYPE_BY_ECLASS.get(((EObject)ext).eClass().getName()), events);
-            }
+            events.add(new AvailableEvent(event, element));
+        }
+        EObject ext = singleReference(element, FEATURE_EXT_INFO);
+        if (ext == null)
+        {
+            return events;
+        }
+        List<EObject> extEvents = new ArrayList<>();
+        addTypeEvents(provider, element, PLATFORM_TYPE_BY_ECLASS.get(ext.eClass().getName()), extEvents);
+        EObject extOwner = holdsHandlerList(ext) ? ext : element;
+        for (EObject event : extEvents)
+        {
+            events.add(new AvailableEvent(event, extOwner));
         }
         return events;
+    }
+
+    /** An available form event and the object whose {@code handlers} list its binding belongs in. */
+    private static final class AvailableEvent
+    {
+        final EObject event;
+        final EObject owner;
+
+        AvailableEvent(EObject event, EObject owner)
+        {
+            this.event = event;
+            this.owner = owner;
+        }
+    }
+
+    /** Whether the object carries a {@code handlers} COLLECTION of its own. */
+    private static boolean holdsHandlerList(EObject object)
+    {
+        EStructuralFeature feature = object.eClass().getEStructuralFeature(KEY_HANDLERS);
+        return feature instanceof EReference && feature.isMany();
+    }
+
+    /**
+     * Every handler bound around {@code container}: its own list plus the other half of the
+     * root/{@code extInfo} pair, whichever side was handed in.
+     *
+     * <p>One event has ONE binding, but the two lists are separate objects, so a lookup or a
+     * duplicate check that reads only one of them answers about half the form. That is how a second
+     * handler was appended to the root for an event already bound inside the extInfo (issue #592),
+     * and why a binding EDT wrote there could not be addressed at all.</p>
+     */
+    private static List<EObject> handlersAroundContainer(EObject container)
+    {
+        List<EObject> own = referenceList(container, KEY_HANDLERS);
+        EObject sibling = null;
+        EObject ext = singleReference(container, FEATURE_EXT_INFO);
+        if (ext != null && holdsHandlerList(ext))
+        {
+            sibling = ext;
+        }
+        else
+        {
+            EObject parent = container.eContainer();
+            if (parent != null && singleReference(parent, FEATURE_EXT_INFO) == container
+                && holdsHandlerList(parent))
+            {
+                sibling = parent;
+            }
+        }
+        if (sibling == null)
+        {
+            return own;
+        }
+        List<EObject> all = new ArrayList<>(own);
+        all.addAll(referenceList(sibling, KEY_HANDLERS));
+        return all;
     }
 
     /** Resolves {@code typeName} to a platform {@code Type} and appends its {@code events} to the list. */
@@ -6564,8 +6725,9 @@ public final class FormElementWriter
         {
             return owner.eClass().getEStructuralFeature(FEATURE_ACTION) != null && isActionToken(leaf);
         }
-        for (EObject event : availableEvents(owner, version))
+        for (AvailableEvent candidate : availableEvents(owner, version))
         {
+            EObject event = candidate.event;
             if (leaf.equalsIgnoreCase(eventNameOf(event, false))
                 || leaf.equalsIgnoreCase(eventNameOf(event, true)))
             {
@@ -6737,7 +6899,7 @@ public final class FormElementWriter
         }
         EClass ehType = ((EReference)handlersFeat).getEReferenceType();
         EStructuralFeature evFeat = ehType != null ? ehType.getEStructuralFeature(FEATURE_EVENT) : null;
-        for (EObject handler : referenceList(container, KEY_HANDLERS))
+        for (EObject handler : handlersAroundContainer(container))
         {
             Object ev = evFeat != null ? handler.eGet(evFeat) : null;
             if (ev instanceof EObject

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -3053,17 +3053,8 @@ public final class FormElementWriter
         {
             return null;
         }
-        EObject main = null;
-        for (EObject attr : referenceList(formModel, FEATURE_ATTRIBUTES))
-        {
-            if (isMainAttribute(attr))
-            {
-                main = attr;
-                break;
-            }
-        }
         EObject current = singleReference(formModel, FEATURE_EXT_INFO);
-        if (main == null)
+        if (!hasMainAttribute(formModel))
         {
             // Having NO main attribute is not an instruction to clear. The platform only ever asks
             // this question about a main attribute - setExtInfo asserts isMain - so a form without
@@ -3071,7 +3062,7 @@ public final class FormElementWriter
             // a plain main=false.
             return current == null ? null : current.eClass().getName();
         }
-        String classifier = FORM_EXT_INFO_BY_TYPE_CATEGORY.get(singleValueTypeCategory(main));
+        String classifier = FORM_EXT_INFO_BY_TYPE_CATEGORY.get(mainAttributeCategory(formModel));
         if (classifier == null)
         {
             // A main attribute whose category pairs with nothing takes the node with it, whatever
@@ -3101,6 +3092,30 @@ public final class FormElementWriter
         // handlers bound inside it.
         copySameFeatures(current, created);
         return created.eClass().getName();
+    }
+
+    /**
+     * The type CATEGORY of the form's MAIN attribute, or {@code null} when the form has no main
+     * attribute or its type is not single.
+     *
+     * <p>This is the one value {@link #syncFormExtInfo(EObject, boolean)} keys on, so a caller can
+     * read it BEFORE a batch and again AFTER and tell an actual retype from a re-write of the same
+     * value. A property-shaped signal cannot: a change object says which KIND of property it
+     * carries, not whether the value in it differs from the one already there.</p>
+     *
+     * @param formModel the editable content form, on the tx-bound model
+     * @return the category, or {@code null}
+     */
+    public static String mainAttributeCategory(EObject formModel)
+    {
+        for (EObject attr : referenceList(formModel, FEATURE_ATTRIBUTES))
+        {
+            if (isMainAttribute(attr))
+            {
+                return singleValueTypeCategory(attr);
+            }
+        }
+        return null;
     }
 
     /** The features {@code ExtInfoManagementService} refuses to carry over. */

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -5271,10 +5271,10 @@ public final class FormElementWriter
         // Duplicate guard. Base path keeps the original "one BASE handler per event" rule. Extension
         // path lets the extension handler COEXIST with the base handler and with other-call-type // NOSONAR explanatory comment, not commented-out code
         // extension handlers; only a same-(event, callType) EventHandlerExtension is a real duplicate.
-        EStructuralFeature evFeat = handlerEventFeature(handlersFeat);
+        List<String> matchedSpellings = eventSpellings(matched);
         for (EObject existing : handlersAroundContainer(container))
         {
-            if (evFeat == null || existing.eGet(evFeat) != matched)
+            if (!boundToSameEvent(existing, matched, matchedSpellings))
             {
                 continue;
             }
@@ -5298,9 +5298,10 @@ public final class FormElementWriter
         }
         EObject handler = ehType.getEPackage().getEFactoryInstance().create(ehType);
         setStringFeature(handler, FEATURE_NAME, (procName == null || procName.isEmpty()) ? eventName : procName);
-        if (evFeat != null)
+        EStructuralFeature eventFeat = ehType.getEStructuralFeature(FEATURE_EVENT);
+        if (eventFeat != null)
         {
-            handler.eSet(evFeat, matched);
+            handler.eSet(eventFeat, matched);
         }
         if (extension)
         {
@@ -5448,12 +5449,6 @@ public final class FormElementWriter
         return matchesKindToken(item, ref.itemKindToken) ? item : null;
     }
 
-    /** The {@code event} EReference on the EventHandler EClass held by the {@code handlers} feature. */
-    private static EStructuralFeature handlerEventFeature(EStructuralFeature handlersFeat)
-    {
-        EClass ehType = ((EReference)handlersFeat).getEReferenceType();
-        return ehType != null ? ehType.getEStructuralFeature(FEATURE_EVENT) : null;
-    }
 
     private static String eventNameOf(EObject event, boolean russian)
     {
@@ -7110,20 +7105,55 @@ public final class FormElementWriter
      */
     public static List<String> eventNameSpellings(EObject handler)
     {
-        List<String> names = new ArrayList<>(2);
         if (handler == null)
         {
-            return names;
+            return new ArrayList<>(2);
         }
         EStructuralFeature eventFeat = handler.eClass().getEStructuralFeature(FEATURE_EVENT);
         Object event = eventFeat instanceof EReference ? handler.eGet(eventFeat) : null;
-        if (!(event instanceof EObject))
+        return event instanceof EObject ? eventSpellings((EObject)event) : new ArrayList<>(2);
+    }
+
+    /**
+     * Whether an existing handler is bound to the SAME event as the one being written. Object
+     * identity is not enough: a change of ext-info kind carries the handlers over to the new node
+     * ({@code copyDataOfSameFeatures}), and they keep pointing at the PREVIOUS platform type's event
+     * object while a fresh resolution answers with the new type's - two objects, one event, and a
+     * duplicate the identity test would wave through.
+     */
+    private static boolean boundToSameEvent(EObject handler, EObject event, List<String> spellings)
+    {
+        EStructuralFeature eventFeat = handler.eClass().getEStructuralFeature(FEATURE_EVENT);
+        Object bound = eventFeat instanceof EReference ? handler.eGet(eventFeat) : null;
+        if (bound == event)
+        {
+            return true;
+        }
+        if (!(bound instanceof EObject) || spellings.isEmpty())
+        {
+            return false;
+        }
+        for (String spelling : eventSpellings((EObject)bound))
+        {
+            if (spellings.contains(spelling))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Both spellings an event answers to, English first; empty when it names itself neither way. */
+    private static List<String> eventSpellings(EObject event)
+    {
+        List<String> names = new ArrayList<>(2);
+        if (event == null)
         {
             return names;
         }
         for (String feature : new String[] {FEATURE_NAME, FEATURE_NAME_RU})
         {
-            String name = stringFeature((EObject)event, feature);
+            String name = stringFeature(event, feature);
             if (name != null && !name.isEmpty() && !names.contains(name))
             {
                 names.add(name);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -3299,8 +3299,14 @@ public final class FormElementWriter
         return extInfo != null && ECLASS_DYNAMIC_LIST_EXT_INFO.equals(extInfo.eClass().getName());
     }
 
-    /** Whether a form attribute is flagged as the form's main data source ({@code main = true}). */
-    private static boolean isMainAttribute(EObject attribute)
+    /**
+     * Whether a form member is flagged as the form's main data source ({@code main = true}).
+     * Answers {@code false} for anything without that flag, an item or a column included.
+     *
+     * @param attribute the form member to inspect, on the tx-bound model
+     * @return {@code true} only for the attribute the form reads its data through
+     */
+    public static boolean isMainAttribute(EObject attribute)
     {
         EStructuralFeature mainFeature = attribute.eClass().getEStructuralFeature(FEATURE_MAIN);
         return mainFeature != null && Boolean.TRUE.equals(attribute.eGet(mainFeature));

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormElementWriter.java
@@ -5268,9 +5268,9 @@ public final class FormElementWriter
                     + "Instead (ChangeAndValidate is for method interception, not events)."; //$NON-NLS-1$
             }
         }
-        // Duplicate guard. Base path keeps the original "one handler per event" rule. Extension path lets
-        // the extension handler COEXIST with the base handler and with other-call-type extension handlers; // NOSONAR explanatory comment, not commented-out code
-        // only a same-(event, callType) EventHandlerExtension is a real duplicate.
+        // Duplicate guard. Base path keeps the original "one BASE handler per event" rule. Extension
+        // path lets the extension handler COEXIST with the base handler and with other-call-type // NOSONAR explanatory comment, not commented-out code
+        // extension handlers; only a same-(event, callType) EventHandlerExtension is a real duplicate.
         EStructuralFeature evFeat = handlerEventFeature(handlersFeat);
         for (EObject existing : handlersAroundContainer(container))
         {
@@ -5278,12 +5278,19 @@ public final class FormElementWriter
             {
                 continue;
             }
+            boolean existingIsExtension =
+                ECLASS_EVENT_HANDLER_EXTENSION.equals(existing.eClass().getName());
             if (!extension)
             {
+                // Coexistence works in BOTH orders: an extension handler intercepts the base one,
+                // so finding it says nothing about whether the base handler is already there.
+                if (existingIsExtension)
+                {
+                    continue;
+                }
                 return "An event handler for '" + eventName + "' already exists on this element."; //$NON-NLS-1$ //$NON-NLS-2$
             }
-            if (ECLASS_EVENT_HANDLER_EXTENSION.equals(existing.eClass().getName())
-                && callTypeLiteral.getName().equals(callTypeNameOf(existing)))
+            if (existingIsExtension && callTypeLiteral.getName().equals(callTypeNameOf(existing)))
             {
                 return "An extension event handler for '" + eventName + "' with call type '" //$NON-NLS-1$ //$NON-NLS-2$
                     + callType + "' already exists on this element."; //$NON-NLS-1$

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormStructureReader.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormStructureReader.java
@@ -1465,28 +1465,16 @@ public final class FormStructureReader
                 continue;
             }
             budget[0]--;
-            for (EObject handler : handlersOf(current.element))
+            // Both lists this element binds through, walked in place and in order. The extInfo's
+            // list is consulted only while the cap is still taking rows.
+            EObject extInfo = getSingleReference(current.element, FEATURE_EXT_INFO);
+            boolean declined = collectBoundHandlers(
+                getReferenceList(current.element, FEATURE_HANDLERS), current.ownerLabel, language,
+                rows);
+            if (!declined && extInfo != null)
             {
-                if (handler == null)
-                {
-                    // Never a row, and never counted as one: the cap decides between handlers
-                    // this element HAS, and the model's list may legally hold a null.
-                    continue;
-                }
-                // Asked BEFORE the row is built: past the cap the strings would be read off the
-                // model only to be dropped, and the whole point of the cap is that nothing past it
-                // is retained. Leaving the loop still RECORDS the decline - there is a handler in
-                // hand, so "there were more rows than are shown" is established - and it leaves
-                // only this element's remaining handlers; the WALK carries on, because the element
-                // budget is a separate statement (see this method's own doc).
-                if (rows.full())
-                {
-                    rows.decline();
-                    break;
-                }
-                String procName = stringValue(getValue(handler, FEATURE_NAME));
-                String eventName = eventNameOf(getSingleReference(handler, FEATURE_EVENT), language);
-                rows.add(current.ownerLabel, eventName, procName);
+                collectBoundHandlers(getReferenceList(extInfo, FEATURE_HANDLERS),
+                    current.ownerLabel, language, rows);
             }
             pushHandlerChildren(current.element, pending, budget, cutShort);
         }
@@ -1624,28 +1612,42 @@ public final class FormStructureReader
      *         them
      */
     /**
-     * The element's own bound handlers plus the ones its {@code extInfo} holds, under the SAME
-     * owner label.
+     * Adds one bound-handler list to {@code rows} under {@code ownerLabel}.
      *
-     * <p>A form root's ext-info is an event-handler container in its own right, and EDT binds a
-     * record form's write and read events inside it. Reading only the element's own list reported
-     * "no event handlers" for a form that has one (issue #592). Item ext-infos carry no handler
-     * list, so nothing else changes.</p>
+     * <p>An element binds through TWO lists: its own, and the one its {@code extInfo} holds when
+     * that ext-info is an event-handler container - a form root's is, which is where EDT keeps a
+     * record form's write and read events (issue #592). They are walked separately rather than
+     * merged so the row cap is consulted before anything is built, exactly as it was with one.</p>
+     *
+     * @return {@code true} when the cap DECLINED a row, so the caller stops offering more
      */
-    private static List<EObject> handlersOf(EObject element)
+    private static boolean collectBoundHandlers(List<EObject> handlers, String ownerLabel,
+        String language, HandlerRows rows)
     {
-        List<EObject> own = getReferenceList(element, FEATURE_HANDLERS);
-        EObject extInfo = getSingleReference(element, FEATURE_EXT_INFO);
-        List<EObject> inExtInfo =
-            extInfo == null ? List.of() : getReferenceList(extInfo, FEATURE_HANDLERS);
-        if (inExtInfo.isEmpty())
+        for (EObject handler : handlers)
         {
-            return own;
+            if (handler == null)
+            {
+                // Never a row, and never counted as one: the cap decides between handlers
+                // this element HAS, and the model's list may legally hold a null.
+                continue;
+            }
+            // Asked BEFORE the row is built: past the cap the strings would be read off the
+            // model only to be dropped, and the whole point of the cap is that nothing past it
+            // is retained. Leaving the loop still RECORDS the decline - there is a handler in
+            // hand, so "there were more rows than are shown" is established - and it leaves
+            // only this element's remaining handlers; the WALK carries on, because the element
+            // budget is a separate statement (see collectHandlers' own doc).
+            if (rows.full())
+            {
+                rows.decline();
+                return true;
+            }
+            String procName = stringValue(getValue(handler, FEATURE_NAME));
+            String eventName = eventNameOf(getSingleReference(handler, FEATURE_EVENT), language);
+            rows.add(ownerLabel, eventName, procName);
         }
-        List<EObject> all = new ArrayList<>(own.size() + inExtInfo.size());
-        all.addAll(own);
-        all.addAll(inExtInfo);
-        return all;
+        return false;
     }
 
     private static List<EObject> handlerSingularChildren(EObject element)

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormStructureReader.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/FormStructureReader.java
@@ -1465,7 +1465,7 @@ public final class FormStructureReader
                 continue;
             }
             budget[0]--;
-            for (EObject handler : getReferenceList(current.element, FEATURE_HANDLERS))
+            for (EObject handler : handlersOf(current.element))
             {
                 if (handler == null)
                 {
@@ -1623,6 +1623,31 @@ public final class FormStructureReader
      * @return the children present, at most {@link #SINGULAR_ITEM_CONTAINMENTS}{@code .length} of
      *         them
      */
+    /**
+     * The element's own bound handlers plus the ones its {@code extInfo} holds, under the SAME
+     * owner label.
+     *
+     * <p>A form root's ext-info is an event-handler container in its own right, and EDT binds a
+     * record form's write and read events inside it. Reading only the element's own list reported
+     * "no event handlers" for a form that has one (issue #592). Item ext-infos carry no handler
+     * list, so nothing else changes.</p>
+     */
+    private static List<EObject> handlersOf(EObject element)
+    {
+        List<EObject> own = getReferenceList(element, FEATURE_HANDLERS);
+        EObject extInfo = getSingleReference(element, FEATURE_EXT_INFO);
+        List<EObject> inExtInfo =
+            extInfo == null ? List.of() : getReferenceList(extInfo, FEATURE_HANDLERS);
+        if (inExtInfo.isEmpty())
+        {
+            return own;
+        }
+        List<EObject> all = new ArrayList<>(own.size() + inExtInfo.size());
+        all.addAll(own);
+        all.addAll(inExtInfo);
+        return all;
+    }
+
     private static List<EObject> handlerSingularChildren(EObject element)
     {
         List<EObject> present = new ArrayList<>(SINGULAR_ITEM_CONTAINMENTS.length);

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
@@ -2690,6 +2690,55 @@ public class ModifyMetadataToolTest
             ModifyMetadataTool.mainFlagIn(props("main", "maybe"))); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
+    /**
+     * A batch is applied in ORDER, so a repeated property is decided by its last write. The gate
+     * judges the state the model is left in: reading the first {@code main} would wave
+     * {@code [main=true, main=false]} through and prompt for {@code [main=false, main=true]},
+     * which deletes nothing.
+     */
+    @Test
+    public void testARepeatedMainWriteIsJudgedByItsLastValue()
+    {
+        assertEquals("the LAST write is what the model ends up with", //$NON-NLS-1$
+            Boolean.FALSE,
+            ModifyMetadataTool.mainFlagIn(List.of(boolProp("main", true), //$NON-NLS-1$
+                boolProp("main", false)))); //$NON-NLS-1$
+        assertEquals("and the other way round", Boolean.TRUE, //$NON-NLS-1$
+            ModifyMetadataTool.mainFlagIn(List.of(boolProp("main", false), //$NON-NLS-1$
+                boolProp("main", true)))); //$NON-NLS-1$
+    }
+
+    /**
+     * One batch can carry two different destructions - a retype and a main flag that empties the
+     * form root. The dialog has to name both, or a single answer authorizes a loss the question
+     * never mentioned.
+     */
+    @Test
+    public void testTheConsentPreviewNamesEveryLossTheBatchCarries()
+    {
+        FormElementWriter.FormMemberRef ref = FormElementWriter.parse(
+            "InformationRegister.Reg.Form.RecordForm.Attribute.Record"); //$NON-NLS-1$
+        String fqn = "InformationRegister.Reg.Form.RecordForm.Attribute.Record"; //$NON-NLS-1$
+
+        ConsentPreview retypeOnly =
+            ModifyMetadataTool.formRetypePreview(fqn, ref, props("valueType", "String")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(List.of("valueType"), retypeOnly.getTopNames()); //$NON-NLS-1$
+
+        ConsentPreview mainOnly =
+            ModifyMetadataTool.formRetypePreview(fqn, ref, props("main", "false")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals(List.of("main"), mainOnly.getTopNames()); //$NON-NLS-1$
+        assertTrue("a main-only prompt is about the ext-info, not about stored values: " //$NON-NLS-1$
+            + mainOnly.getSubtitle(),
+            mainOnly.getSubtitle().contains("ext-info")); //$NON-NLS-1$
+
+        ConsentPreview both = ModifyMetadataTool.formRetypePreview(fqn, ref,
+            List.of(props("valueType", "String").get(0), props("main", "false").get(0))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        assertEquals("both losses are named", List.of("valueType", "main"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            both.getTopNames());
+        assertTrue("and the subtitle spells out the second one: " + both.getSubtitle(), //$NON-NLS-1$
+            both.getSubtitle().contains("ext-info")); //$NON-NLS-1$
+    }
+
     /** One property list carrying a single string-valued property. */
     private static List<JsonObject> props(String name, String value)
     {

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
@@ -1824,7 +1824,7 @@ public class ModifyMetadataToolTest
         RecordingConsent consent = new RecordingConsent(ConsentDecision.REJECT);
         RecordingWrite write = new RecordingWrite();
 
-        String result = new ModifyMetadataTool(consent).gateFormRetype(retypePreview(),
+        String result = new ModifyMetadataTool(consent).gateFormRetype(() -> retypePreview(),
             () -> REFUSAL, write);
 
         assertEquals("a refused retype must never raise the destructive prompt", 0, consent.asked); //$NON-NLS-1$
@@ -1842,7 +1842,7 @@ public class ModifyMetadataToolTest
         RecordingConsent consent = new RecordingConsent(ConsentDecision.REJECT);
         RecordingWrite write = new RecordingWrite();
 
-        String result = new ModifyMetadataTool(consent).gateFormRetype(retypePreview(), () -> "", write); //$NON-NLS-1$
+        String result = new ModifyMetadataTool(consent).gateFormRetype(() -> retypePreview(), () -> "", write); //$NON-NLS-1$
 
         assertEquals("a benign change must not prompt", 0, consent.asked); //$NON-NLS-1$
         assertEquals("a benign change is written exactly once", 1, write.calls); //$NON-NLS-1$
@@ -1858,7 +1858,7 @@ public class ModifyMetadataToolTest
             RecordingConsent consent = new RecordingConsent(refused);
             RecordingWrite write = new RecordingWrite();
             String result =
-                new ModifyMetadataTool(consent).gateFormRetype(retypePreview(), () -> null, write);
+                new ModifyMetadataTool(consent).gateFormRetype(() -> retypePreview(), () -> null, write);
             assertEquals("a real retype must be authorized (" + refused + ")", 1, consent.asked); //$NON-NLS-1$ //$NON-NLS-2$
             assertEquals("a refused retype must not write (" + refused + ")", 0, write.calls); //$NON-NLS-1$ //$NON-NLS-2$
             assertTrue(result.contains("error")); //$NON-NLS-1$
@@ -1866,7 +1866,7 @@ public class ModifyMetadataToolTest
 
         RecordingConsent allowed = new RecordingConsent(ConsentDecision.ALLOW);
         RecordingWrite write = new RecordingWrite();
-        String ok = new ModifyMetadataTool(allowed).gateFormRetype(retypePreview(), () -> null, write);
+        String ok = new ModifyMetadataTool(allowed).gateFormRetype(() -> retypePreview(), () -> null, write);
         assertEquals("an allowed retype is written exactly once", 1, write.calls); //$NON-NLS-1$
         assertEquals(WRITTEN, ok);
     }
@@ -2721,22 +2721,43 @@ public class ModifyMetadataToolTest
         String fqn = "InformationRegister.Reg.Form.RecordForm.Attribute.Record"; //$NON-NLS-1$
 
         ConsentPreview retypeOnly =
-            ModifyMetadataTool.formRetypePreview(fqn, ref, props("valueType", "String")); //$NON-NLS-1$ //$NON-NLS-2$
+            ModifyMetadataTool.formRetypePreview(fqn, ref, props("valueType", "String"), false); //$NON-NLS-1$ //$NON-NLS-2$
         assertEquals(List.of("valueType"), retypeOnly.getTopNames()); //$NON-NLS-1$
 
         ConsentPreview mainOnly =
-            ModifyMetadataTool.formRetypePreview(fqn, ref, props("main", "false")); //$NON-NLS-1$ //$NON-NLS-2$
+            ModifyMetadataTool.formRetypePreview(fqn, ref, props("main", "false"), true); //$NON-NLS-1$ //$NON-NLS-2$
         assertEquals(List.of("main"), mainOnly.getTopNames()); //$NON-NLS-1$
         assertTrue("a main-only prompt is about the ext-info, not about stored values: " //$NON-NLS-1$
             + mainOnly.getSubtitle(),
             mainOnly.getSubtitle().contains("ext-info")); //$NON-NLS-1$
 
         ConsentPreview both = ModifyMetadataTool.formRetypePreview(fqn, ref,
-            List.of(props("valueType", "String").get(0), props("main", "false").get(0))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            List.of(props("valueType", "String").get(0), props("main", "false").get(0)), true); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
         assertEquals("both losses are named", List.of("valueType", "main"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             both.getTopNames());
         assertTrue("and the subtitle spells out the second one: " + both.getSubtitle(), //$NON-NLS-1$
             both.getSubtitle().contains("ext-info")); //$NON-NLS-1$
+    }
+
+    /**
+     * The other edge of the same rule. A batch may carry BOTH a retype and a main write and still
+     * lose no handler - the node merely changes kind, and its data is carried over. The dialog is
+     * therefore built from what the pre-check FOUND, not from what the request could have carried:
+     * a prompt that promises a deletion which will not happen teaches the reader to ignore it.
+     */
+    @Test
+    public void testThePreviewDoesNotClaimALossThePreCheckDidNotFind()
+    {
+        FormElementWriter.FormMemberRef ref = FormElementWriter.parse(
+            "InformationRegister.Reg.Form.RecordForm.Attribute.Record"); //$NON-NLS-1$
+        String fqn = "InformationRegister.Reg.Form.RecordForm.Attribute.Record"; //$NON-NLS-1$
+
+        ConsentPreview harmlessMain = ModifyMetadataTool.formRetypePreview(fqn, ref,
+            List.of(props("valueType", "String").get(0), props("main", "true").get(0)), false); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        assertEquals("only the retype is at stake", List.of("valueType"), //$NON-NLS-1$ //$NON-NLS-2$
+            harmlessMain.getTopNames());
+        assertFalse("so the dialog must not promise a deletion that will not happen: " //$NON-NLS-1$
+            + harmlessMain.getSubtitle(), harmlessMain.getSubtitle().contains("ext-info")); //$NON-NLS-1$
     }
 
     /** One property list carrying a single string-valued property. */

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
@@ -2664,4 +2664,47 @@ public class ModifyMetadataToolTest
         return valueType;
     }
 
+
+    /**
+     * The consent gate for a main-flag write reads the value with the same parser the WRITE uses.
+     * {@code prepareBoolean} accepts {@code 1}/{@code 0}/{@code yes}/{@code no} as well as
+     * {@code true}/{@code false}, so a gate that only knew the last pair would let
+     * {@code {"main":"no"}} delete a form root ext-info - handlers and all - with no prompt.
+     */
+    @Test
+    public void testTheMainFlagGateReadsEverySpellingTheWriteAccepts()
+    {
+        for (String yes : new String[]{"true", "1", "yes", "YES"}) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        {
+            assertEquals(yes, Boolean.TRUE, ModifyMetadataTool.mainFlagIn(props("main", yes))); //$NON-NLS-1$
+        }
+        for (String no : new String[]{"false", "0", "no", "No"}) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        {
+            assertEquals(no, Boolean.FALSE, ModifyMetadataTool.mainFlagIn(props("main", no))); //$NON-NLS-1$
+        }
+        assertEquals("a JSON boolean is the ordinary form", //$NON-NLS-1$
+            Boolean.TRUE, ModifyMetadataTool.mainFlagIn(List.of(boolProp("main", true)))); //$NON-NLS-1$
+        assertNull("a list that writes no main flag asks for no consent", //$NON-NLS-1$
+            ModifyMetadataTool.mainFlagIn(props("savedData", "true"))); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNull("a value the write itself refuses is not a main write either", //$NON-NLS-1$
+            ModifyMetadataTool.mainFlagIn(props("main", "maybe"))); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /** One property list carrying a single string-valued property. */
+    private static List<JsonObject> props(String name, String value)
+    {
+        JsonObject prop = new JsonObject();
+        prop.addProperty("name", name); //$NON-NLS-1$
+        prop.addProperty("value", value); //$NON-NLS-1$
+        return List.of(prop);
+    }
+
+    /** One property carrying a JSON boolean, the shape a schema-driven client sends. */
+    private static JsonObject boolProp(String name, boolean value)
+    {
+        JsonObject prop = new JsonObject();
+        prop.addProperty("name", name); //$NON-NLS-1$
+        prop.addProperty("value", Boolean.valueOf(value)); //$NON-NLS-1$
+        return prop;
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
@@ -38,8 +38,11 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com._1c.g5.v8.bm.core.IBmObject;
+import com._1c.g5.v8.dt.mcore.McoreFactory;
 import com._1c.g5.v8.dt.mcore.McorePackage;
 import com._1c.g5.v8.dt.mcore.QName;
+import com._1c.g5.v8.dt.mcore.Type;
+import com._1c.g5.v8.dt.mcore.TypeDescription;
 import com._1c.g5.v8.dt.metadata.mdclass.BasicTemplate;
 import com._1c.g5.v8.dt.metadata.mdclass.Catalog;
 import com._1c.g5.v8.dt.metadata.mdclass.CatalogAttribute;
@@ -2758,6 +2761,41 @@ public class ModifyMetadataToolTest
             harmlessMain.getTopNames());
         assertFalse("so the dialog must not promise a deletion that will not happen: " //$NON-NLS-1$
             + harmlessMain.getSubtitle(), harmlessMain.getSubtitle().contains("ext-info")); //$NON-NLS-1$
+    }
+
+    /**
+     * The same ordering rule as {@code mainFlagIn}, on the other property the ext-info decision
+     * keys on: a batch is applied in order, so a repeated {@code valueType} leaves the LAST one.
+     * Judged by the first, {@code [valueType=CatalogObject, valueType=String, main=true]} would
+     * promise no loss and then delete the node with its handlers.
+     */
+    @Test
+    public void testARepeatedRetypeIsJudgedByItsLastWrite()
+    {
+        EAttribute valueTypeFeature = EcoreFactory.eINSTANCE.createEAttribute();
+        valueTypeFeature.setName("valueType"); //$NON-NLS-1$
+        List<ModifyMetadataTool.HolderChange> prepared = List.of(
+            new ModifyMetadataTool.HolderChange(false,
+                ModifyMetadataTool.PreparedChange.typeDescription(valueTypeFeature,
+                    singleType("CatalogObject.Goods"))), //$NON-NLS-1$
+            new ModifyMetadataTool.HolderChange(false,
+                ModifyMetadataTool.PreparedChange.typeDescription(valueTypeFeature,
+                    singleType("String")))); //$NON-NLS-1$
+
+        assertEquals("the LAST write is what the model ends up with", //$NON-NLS-1$
+            "String", ModifyMetadataTool.categoryAfter(prepared, null)); //$NON-NLS-1$
+        assertNull("a batch that retypes nothing falls back to the member", //$NON-NLS-1$
+            ModifyMetadataTool.categoryAfter(List.of(), null));
+    }
+
+    /** A {@code TypeDescription} naming exactly one type, the shape a retype prepares. */
+    private static TypeDescription singleType(String typeName)
+    {
+        TypeDescription description = McoreFactory.eINSTANCE.createTypeDescription();
+        Type type = McoreFactory.eINSTANCE.createType();
+        type.setName(typeName);
+        description.getTypes().add(type);
+        return description;
     }
 
     /** One property list carrying a single string-valued property. */

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
@@ -2664,27 +2664,4 @@ public class ModifyMetadataToolTest
         return valueType;
     }
 
-    /**
-     * The one transition that may leave a form without its root ext-info (issues #591 / #592).
-     *
-     * <p>Four review rounds landed on this boundary, each time because the right to CLEAR was
-     * inferred from the shape of the request instead of from what actually changed. The rule is
-     * pure, so every transition is pinned here rather than argued about.</p>
-     */
-    @Test
-    public void testOnlyAReplacedMainCategoryMayClearTheFormExtInfo()
-    {
-        assertTrue("one category became another - that is the retype the gate consented to", //$NON-NLS-1$
-            ModifyMetadataTool.mainCategoryReplaced("CatalogObject", "DocumentObject")); //$NON-NLS-1$ //$NON-NLS-2$
-        assertTrue("a category that became nothing was replaced too", //$NON-NLS-1$
-            ModifyMetadataTool.mainCategoryReplaced("CatalogObject", null)); //$NON-NLS-1$
-
-        assertFalse("gaining a FIRST main attribute invalidates nothing", //$NON-NLS-1$
-            ModifyMetadataTool.mainCategoryReplaced(null, "String")); //$NON-NLS-1$
-        assertFalse("a form that had no main attribute and still has none", //$NON-NLS-1$
-            ModifyMetadataTool.mainCategoryReplaced(null, null));
-        assertFalse("re-writing the SAME category is not a retype", //$NON-NLS-1$
-            ModifyMetadataTool.mainCategoryReplaced("ExternalDataSourceCubeRecordSet", //$NON-NLS-1$
-                "ExternalDataSourceCubeRecordSet")); //$NON-NLS-1$
-    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/ModifyMetadataToolTest.java
@@ -2663,4 +2663,28 @@ public class ModifyMetadataToolTest
         valueType.setContainment(true);
         return valueType;
     }
+
+    /**
+     * The one transition that may leave a form without its root ext-info (issues #591 / #592).
+     *
+     * <p>Four review rounds landed on this boundary, each time because the right to CLEAR was
+     * inferred from the shape of the request instead of from what actually changed. The rule is
+     * pure, so every transition is pinned here rather than argued about.</p>
+     */
+    @Test
+    public void testOnlyAReplacedMainCategoryMayClearTheFormExtInfo()
+    {
+        assertTrue("one category became another - that is the retype the gate consented to", //$NON-NLS-1$
+            ModifyMetadataTool.mainCategoryReplaced("CatalogObject", "DocumentObject")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("a category that became nothing was replaced too", //$NON-NLS-1$
+            ModifyMetadataTool.mainCategoryReplaced("CatalogObject", null)); //$NON-NLS-1$
+
+        assertFalse("gaining a FIRST main attribute invalidates nothing", //$NON-NLS-1$
+            ModifyMetadataTool.mainCategoryReplaced(null, "String")); //$NON-NLS-1$
+        assertFalse("a form that had no main attribute and still has none", //$NON-NLS-1$
+            ModifyMetadataTool.mainCategoryReplaced(null, null));
+        assertFalse("re-writing the SAME category is not a retype", //$NON-NLS-1$
+            ModifyMetadataTool.mainCategoryReplaced("ExternalDataSourceCubeRecordSet", //$NON-NLS-1$
+                "ExternalDataSourceCubeRecordSet")); //$NON-NLS-1$
+    }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -6534,6 +6534,23 @@ public class FormElementWriterTest
         assertEquals("CubeRecordSetFormExtInfo", m.extInfo().eClass().getName()); //$NON-NLS-1$
     }
 
+    /**
+     * Setting {@code main=false} is an ordinary boolean change, and it must not take the node that
+     * holds the form's write and read bindings with it. The platform never asks this question
+     * without a main attribute at all - {@code setExtInfo} asserts {@code isMain}.
+     */
+    @Test
+    public void testSyncFormExtInfoLeavesAFormWithNoMainAttributeAlone()
+    {
+        FormRootModel m = newFormRootModel("InformationRegisterRecordManager.MyRegister", false); //$NON-NLS-1$
+        m.giveExtInfo("InformationRegisterManagerFormExtInfo"); //$NON-NLS-1$
+
+        assertEquals("InformationRegisterManagerFormExtInfo", //$NON-NLS-1$
+            FormElementWriter.syncFormExtInfo(m.form));
+        assertNotNull("main=false must not destroy the ext-info nor the handlers inside it", //$NON-NLS-1$
+            m.extInfo());
+    }
+
     @Test
     public void testSyncFormExtInfoIgnoresAnAttributeThatIsNotMain()
     {

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -6518,20 +6518,42 @@ public class FormElementWriterTest
     }
 
     /**
-     * The other side of the CLEAR: {@code createFormExtInfo} has no case for a cube record set,
-     * but {@code RecordSetFormContainGenerator} writes {@code CubeRecordSetFormExtInfo} for one.
-     * Clearing a kind this mapping never produces would delete the handlers bound inside it.
+     * A MAIN attribute whose category pairs with nothing takes the node with it, whatever kind it
+     * was - {@code CubeRecordSetFormExtInfo} comes from the form GENERATOR and
+     * {@code createFormExtInfo} cannot produce it, but the platform still answers {@code null} for
+     * that category and {@code isNeedUpdateExtInfo(null, old)} clears the node.
      */
     @Test
-    public void testSyncFormExtInfoKeepsAKindItCouldNotHaveProduced()
+    public void testSyncFormExtInfoClearsEvenAKindItCouldNotHaveProduced()
     {
         FormRootModel m = newFormRootModel("ExternalDataSourceCubeRecordSet.Sales", true); //$NON-NLS-1$
         m.giveExtInfo("CubeRecordSetFormExtInfo"); //$NON-NLS-1$
 
         assertNull("this mapping produces no ext-info for that category", //$NON-NLS-1$
             FormElementWriter.syncFormExtInfo(m.form));
-        assertNotNull("a generator-authored ext-info must survive the sync", m.extInfo()); //$NON-NLS-1$
-        assertEquals("CubeRecordSetFormExtInfo", m.extInfo().eClass().getName()); //$NON-NLS-1$
+        assertNull("a main attribute that pairs with nothing leaves no node behind", //$NON-NLS-1$
+            m.extInfo());
+    }
+
+    /**
+     * Promoting a different main attribute CHANGES the ext-info kind, and the platform carries the
+     * old node's data across ({@code copyDataOfSameFeatures}) rather than dropping it. For a form
+     * root the data that matters is the event handlers bound inside.
+     */
+    @Test
+    public void testAKindChangeCarriesTheBoundHandlersOver()
+    {
+        FormRootModel m = newFormRootModel("CatalogObject.Goods", true); //$NON-NLS-1$
+        assertEquals("CatalogFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
+        assertNull(FormElementWriter.bindEventHandler(m.extInfo(), m.extInfoHandlers(), m.event,
+            "BeforeWriteAtServer", "BeforeWriteAtServer", null, new String[1])); //$NON-NLS-1$ //$NON-NLS-2$
+
+        m.retypeMainAttribute("InformationRegisterRecordManager.MyRegister"); //$NON-NLS-1$
+        assertEquals("InformationRegisterManagerFormExtInfo", //$NON-NLS-1$
+            FormElementWriter.syncFormExtInfo(m.form));
+
+        assertEquals("the handlers bound in the old ext-info must survive the kind change", //$NON-NLS-1$
+            1, ((List<?>)m.extInfo().eGet(m.extInfoHandlers())).size());
     }
 
     /**

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -6513,7 +6513,7 @@ public class FormElementWriterTest
 
         // Retyped to a category the platform pairs with nothing: the stale node is CLEARED, not kept.
         m.retypeMainAttribute("String"); //$NON-NLS-1$
-        assertNull(FormElementWriter.syncFormExtInfo(m.form));
+        assertNull(FormElementWriter.syncFormExtInfo(m.form, true));
         assertNull("a form whose main type maps to no ext-info must carry none", m.extInfo()); //$NON-NLS-1$
     }
 
@@ -6530,9 +6530,25 @@ public class FormElementWriterTest
         m.giveExtInfo("CubeRecordSetFormExtInfo"); //$NON-NLS-1$
 
         assertNull("this mapping produces no ext-info for that category", //$NON-NLS-1$
-            FormElementWriter.syncFormExtInfo(m.form));
+            FormElementWriter.syncFormExtInfo(m.form, true));
         assertNull("a main attribute that pairs with nothing leaves no node behind", //$NON-NLS-1$
             m.extInfo());
+    }
+
+    /**
+     * The same form, the same unmapped category - but reached by a bare {@code main} write instead
+     * of a retype. Only a retype passes the destructive-consent gate, so only a retype may clear;
+     * otherwise re-writing an already-true flag would destroy the node for no change at all.
+     */
+    @Test
+    public void testAMainOnlyWriteNeverClearsTheExtInfo()
+    {
+        FormRootModel m = newFormRootModel("ExternalDataSourceCubeRecordSet.Sales", true); //$NON-NLS-1$
+        m.giveExtInfo("CubeRecordSetFormExtInfo"); //$NON-NLS-1$
+
+        assertEquals("the node stays, and the sync reports the kind it found", //$NON-NLS-1$
+            "CubeRecordSetFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
+        assertNotNull("a main-only write must not destroy the node", m.extInfo()); //$NON-NLS-1$
     }
 
     /**

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -6668,6 +6668,51 @@ public class FormElementWriterTest
     }
 
     /**
+     * The consent gate is asked about exactly one shape: the node holds handlers AND the form is
+     * left with no kind at all. Everything else - an empty node, or a kind CHANGE, whose data is
+     * carried over - loses nothing and must be written without a prompt.
+     */
+    @Test
+    public void testOnlyALossOfBoundHandlersCountsAsDestructive()
+    {
+        FormRootModel m = newFormRootModel("CatalogObject.Goods", true); //$NON-NLS-1$
+        assertEquals("CatalogFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
+
+        assertFalse("an EMPTY node carries nothing to lose", //$NON-NLS-1$
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, false));
+        assertNull(FormElementWriter.bindEventHandler(m.extInfo(), m.extInfoHandlers(), m.event,
+            "BeforeWriteAtServer", "BeforeWriteAtServer", null, new String[1])); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertTrue("main=false leaves no main attribute, so the bound handlers go with the node", //$NON-NLS-1$
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, false));
+        assertFalse("re-writing main=true keeps the kind, so nothing is lost", //$NON-NLS-1$
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, true));
+
+        // Another attribute takes over: the kind CHANGES, and copySameFeatures carries the
+        // handlers across - a change of kind is not a loss.
+        EObject register = m.addMainAttribute("Register", //$NON-NLS-1$
+            "InformationRegisterRecordManager.MyRegister"); //$NON-NLS-1$
+        assertFalse("a kind change carries the handlers over", //$NON-NLS-1$
+            FormElementWriter.clearsBoundFormExtInfo(m.form, register, true));
+        assertFalse("and demoting THIS one leaves the other main deciding", //$NON-NLS-1$
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, false));
+    }
+
+    @Test
+    public void testAPromotionToAnUnpairedCategoryIsDestructiveToo()
+    {
+        FormRootModel m = newFormRootModel("CatalogObject.Goods", true); //$NON-NLS-1$
+        assertEquals("CatalogFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
+        assertNull(FormElementWriter.bindEventHandler(m.extInfo(), m.extInfoHandlers(), m.event,
+            "BeforeWriteAtServer", "BeforeWriteAtServer", null, new String[1])); //$NON-NLS-1$ //$NON-NLS-2$
+        EObject unpaired = m.addMainAttribute("Manager", //$NON-NLS-1$
+            "InformationRegisterManager.MyRegister"); //$NON-NLS-1$
+
+        assertTrue("promoting an attribute no writer pairs with a kind empties the node", //$NON-NLS-1$
+            FormElementWriter.clearsBoundFormExtInfo(m.form, unpaired, true));
+    }
+
+    /**
      * Taking the main flag off is the platform's {@code resetExtInfo}: {@code form.setExtInfo(null)},
      * unconditional, whatever kind the node was and whatever it held. The handlers bound inside go
      * with it, exactly as {@code copyDataOfSameFeatures} no-ops on a null destination.

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -6683,17 +6683,60 @@ public class FormElementWriterTest
             "InformationRegisterManagerFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
     }
 
+    /**
+     * A batch of {@code [main=true, main=false]} promotes the attribute and takes it back, and the
+     * platform's two calls would have demoted the previous main on the way through. The demotion
+     * therefore follows the PROMOTION the batch performed, not the flag it is left with - so the
+     * form is left with no main attribute at all, and its root ext-info goes with it.
+     */
     @Test
-    public void testDemotingIsRefusedForAnAttributeThatIsNotItselfMain()
+    public void testAPromotionTakenBackInTheSameBatchStillDemotesThePrevious()
     {
         FormRootModel m = newFormRootModel("CatalogObject.Goods", true); //$NON-NLS-1$
-        EObject other = m.addMainAttribute("Other", "String"); //$NON-NLS-1$ //$NON-NLS-2$
-        other.eSet(other.eClass().getEStructuralFeature("main"), Boolean.FALSE); //$NON-NLS-1$
+        assertEquals("CatalogFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
+        EObject promoted = m.addMainAttribute("Register", //$NON-NLS-1$
+            "InformationRegisterRecordManager.MyRegister"); //$NON-NLS-1$
+        // ... and the batch takes the flag back off it.
+        promoted.eSet(promoted.eClass().getEStructuralFeature("main"), Boolean.FALSE); //$NON-NLS-1$
 
-        assertEquals("nothing is demoted on behalf of an attribute that was not promoted", //$NON-NLS-1$
-            List.of(), FormElementWriter.demoteOtherMainAttributes(m.form, other));
-        assertTrue("the real main attribute keeps its flag", //$NON-NLS-1$
+        assertEquals("the previous main was demoted on the way through", //$NON-NLS-1$
+            List.of("Record"), FormElementWriter.demoteOtherMainAttributes(m.form, promoted)); //$NON-NLS-1$
+        assertNull("with no main attribute left, the root node goes", //$NON-NLS-1$
+            FormElementWriter.syncFormExtInfo(m.form));
+        assertNull(m.extInfo());
+    }
+
+    @Test
+    public void testAMainFlagOutsideTheFormsAttributeListDemotesNothingEvenWhenPromoted()
+    {
+        FormRootModel m = newFormRootModel("CatalogObject.Goods", true); //$NON-NLS-1$
+        EObject nested = m.addMainAttribute("Column", "String"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.detach(nested);
+
+        assertEquals("a flag outside the form's attribute list decides nothing", //$NON-NLS-1$
+            List.of(), FormElementWriter.demoteOtherMainAttributes(m.form, nested));
+        assertTrue("the form's real main attribute keeps its flag", //$NON-NLS-1$
             FormElementWriter.isMainAttribute(m.attribute));
+    }
+
+    /**
+     * The map says the category pairs with a kind; THIS form model may still not have that EClass.
+     * {@code replaceExtInfoClassifier} then clears the slot rather than leave a stale node, so the
+     * handlers are lost - and the consent gate has to know that before it decides not to ask.
+     */
+    @Test
+    public void testAKindThisModelCannotCreateCountsAsALoss()
+    {
+        FormRootModel m = newFormRootModel("CatalogObject.Goods", true); //$NON-NLS-1$
+        assertEquals("CatalogFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
+        assertNull(FormElementWriter.bindEventHandler(m.extInfo(), m.extInfoHandlers(), m.event,
+            "BeforeWriteAtServer", "BeforeWriteAtServer", null, new String[1])); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertFalse("this package HAS the catalog kind", //$NON-NLS-1$
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, true, CATALOG, false));
+        // TaskObject is in the mapping, and this test package declares no TaskFormExtInfo.
+        assertTrue("a kind this model cannot create loses the node just the same", //$NON-NLS-1$
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, true, "TaskObject", false)); //$NON-NLS-1$
     }
 
     /**
@@ -6754,9 +6797,9 @@ public class FormElementWriterTest
 
         // The model still says CatalogObject; the batch is about to write String.
         assertTrue("a retype to an unpaired category in the SAME batch loses the handlers", //$NON-NLS-1$
-            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, true, "String")); //$NON-NLS-1$
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, true, "String", false)); //$NON-NLS-1$
         assertFalse("a retype to another PAIRED category only changes the kind", //$NON-NLS-1$
-            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, true, REGISTER));
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, true, REGISTER, false));
     }
 
     /**
@@ -6771,23 +6814,23 @@ public class FormElementWriterTest
         assertEquals("CatalogFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
 
         assertFalse("an EMPTY node carries nothing to lose", //$NON-NLS-1$
-            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, false, CATALOG));
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, false, CATALOG, false));
         assertNull(FormElementWriter.bindEventHandler(m.extInfo(), m.extInfoHandlers(), m.event,
             "BeforeWriteAtServer", "BeforeWriteAtServer", null, new String[1])); //$NON-NLS-1$ //$NON-NLS-2$
 
         assertTrue("main=false leaves no main attribute, so the bound handlers go with the node", //$NON-NLS-1$
-            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, false, CATALOG));
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, false, CATALOG, false));
         assertFalse("re-writing main=true keeps the kind, so nothing is lost", //$NON-NLS-1$
-            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, true, CATALOG));
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, true, CATALOG, false));
 
         // Another attribute takes over: the kind CHANGES, and copySameFeatures carries the
         // handlers across - a change of kind is not a loss.
         EObject register = m.addMainAttribute("Register", //$NON-NLS-1$
             "InformationRegisterRecordManager.MyRegister"); //$NON-NLS-1$
         assertFalse("a kind change carries the handlers over", //$NON-NLS-1$
-            FormElementWriter.clearsBoundFormExtInfo(m.form, register, true, REGISTER));
+            FormElementWriter.clearsBoundFormExtInfo(m.form, register, true, REGISTER, false));
         assertFalse("and demoting THIS one leaves the other main deciding", //$NON-NLS-1$
-            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, false, CATALOG));
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, false, CATALOG, false));
     }
 
     @Test
@@ -6801,7 +6844,7 @@ public class FormElementWriterTest
             "InformationRegisterManager.MyRegister"); //$NON-NLS-1$
 
         assertTrue("promoting an attribute no writer pairs with a kind empties the node", //$NON-NLS-1$
-            FormElementWriter.clearsBoundFormExtInfo(m.form, unpaired, true, "InformationRegisterManager")); //$NON-NLS-1$
+            FormElementWriter.clearsBoundFormExtInfo(m.form, unpaired, true, "InformationRegisterManager", false)); //$NON-NLS-1$
     }
 
     /**

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -1275,6 +1275,33 @@ public class FormElementWriterTest
         assertEquals("After", handlerCallTypeName((EObject)handlers.get(1))); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
+    /**
+     * Coexistence has to work in BOTH orders. The extension handler intercepts the base one, so an
+     * extension found on the event says nothing about whether the BASE handler is already there -
+     * and the platform stores the two next to each other whichever was written first.
+     */
+    @Test
+    public void testBindEventHandlerBaseIsAllowedAfterAnExtension()
+    {
+        HandlerModel m = newHandlerModel(true);
+        assertNull(FormElementWriter.bindEventHandler(m.container, m.handlersFeat, m.event,
+            "OnChange", "ext_OnChangeAfter", "After", new String[1])); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+        String[] baseKind = new String[1];
+        assertNull("the base handler must not be refused because an extension came first", //$NON-NLS-1$
+            FormElementWriter.bindEventHandler(m.container, m.handlersFeat, m.event, "OnChange", //$NON-NLS-1$
+                "OnChange", null, baseKind)); //$NON-NLS-1$
+        assertEquals("EventHandler", baseKind[0]); //$NON-NLS-1$
+        assertEquals("extension + base handler must coexist", 2, //$NON-NLS-1$
+            ((List<?>)m.container.eGet(m.handlersFeat)).size());
+
+        // ... and the base rule itself still holds: a SECOND base handler is a duplicate.
+        String dup = FormElementWriter.bindEventHandler(m.container, m.handlersFeat, m.event,
+            "OnChange", "another", null, new String[1]); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNotNull(dup);
+        assertTrue(dup.contains("already exists")); //$NON-NLS-1$
+    }
+
     @Test
     public void testBindEventHandlerDuplicateCallTypeRejectedOtherwiseCoexists()
     {

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -6381,6 +6381,14 @@ public class FormElementWriterTest
             return extInfo().eClass().getEStructuralFeature("handlers"); //$NON-NLS-1$
         }
 
+        void giveExtInfo(String kind)
+        {
+            EPackage pkg = form.eClass().getEPackage();
+            EClass kindClass = (EClass)pkg.getEClassifier(kind);
+            form.eSet(form.eClass().getEStructuralFeature("extInfo"), //$NON-NLS-1$
+                pkg.getEFactoryInstance().create(kindClass));
+        }
+
         void retypeMainAttribute(String typeName)
         {
             TypeDescription description = McoreFactory.eINSTANCE.createTypeDescription();
@@ -6437,8 +6445,10 @@ public class FormElementWriterTest
         extInfoBase.setAbstract(true);
         pkg.getEClassifiers().add(extInfoBase);
 
-        // Two concrete kinds, so a test can watch the sync REPLACE one with the other.
-        for (String kind : new String[]{"InformationRegisterManagerFormExtInfo", "CatalogFormExtInfo"}) //$NON-NLS-1$ //$NON-NLS-2$
+        // Two kinds the mapping produces, so a test can watch the sync REPLACE one with the
+        // other, and one it never produces (the platform form GENERATOR writes that one).
+        for (String kind : new String[]{"InformationRegisterManagerFormExtInfo", //$NON-NLS-1$
+            "CatalogFormExtInfo", "CubeRecordSetFormExtInfo"}) //$NON-NLS-1$ //$NON-NLS-2$
         {
             EClass formExtInfo = f.createEClass();
             formExtInfo.setName(kind);
@@ -6505,6 +6515,23 @@ public class FormElementWriterTest
         m.retypeMainAttribute("String"); //$NON-NLS-1$
         assertNull(FormElementWriter.syncFormExtInfo(m.form));
         assertNull("a form whose main type maps to no ext-info must carry none", m.extInfo()); //$NON-NLS-1$
+    }
+
+    /**
+     * The other side of the CLEAR: {@code createFormExtInfo} has no case for a cube record set,
+     * but {@code RecordSetFormContainGenerator} writes {@code CubeRecordSetFormExtInfo} for one.
+     * Clearing a kind this mapping never produces would delete the handlers bound inside it.
+     */
+    @Test
+    public void testSyncFormExtInfoKeepsAKindItCouldNotHaveProduced()
+    {
+        FormRootModel m = newFormRootModel("ExternalDataSourceCubeRecordSet.Sales", true); //$NON-NLS-1$
+        m.giveExtInfo("CubeRecordSetFormExtInfo"); //$NON-NLS-1$
+
+        assertNull("this mapping produces no ext-info for that category", //$NON-NLS-1$
+            FormElementWriter.syncFormExtInfo(m.form));
+        assertNotNull("a generator-authored ext-info must survive the sync", m.extInfo()); //$NON-NLS-1$
+        assertEquals("CubeRecordSetFormExtInfo", m.extInfo().eClass().getName()); //$NON-NLS-1$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -6735,6 +6735,30 @@ public class FormElementWriterTest
             1, ((List<?>)m.extInfo().eGet(m.extInfoHandlers())).size());
     }
 
+    /** The two categories these tests move between, spelled once. */
+    private static final String CATALOG = "CatalogObject"; //$NON-NLS-1$
+    private static final String REGISTER = "InformationRegisterRecordManager"; //$NON-NLS-1$
+
+    /**
+     * The category the BATCH leaves decides the loss, not the one the model still carries. A batch
+     * that retypes the main attribute and re-writes its main flag in one call would otherwise be
+     * judged against the type it is replacing - and would promise no loss while deleting the node.
+     */
+    @Test
+    public void testTheLossIsJudgedByTheCategoryTheBatchLeaves()
+    {
+        FormRootModel m = newFormRootModel("CatalogObject.Goods", true); //$NON-NLS-1$
+        assertEquals("CatalogFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
+        assertNull(FormElementWriter.bindEventHandler(m.extInfo(), m.extInfoHandlers(), m.event,
+            "BeforeWriteAtServer", "BeforeWriteAtServer", null, new String[1])); //$NON-NLS-1$ //$NON-NLS-2$
+
+        // The model still says CatalogObject; the batch is about to write String.
+        assertTrue("a retype to an unpaired category in the SAME batch loses the handlers", //$NON-NLS-1$
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, true, "String")); //$NON-NLS-1$
+        assertFalse("a retype to another PAIRED category only changes the kind", //$NON-NLS-1$
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, true, REGISTER));
+    }
+
     /**
      * The consent gate is asked about exactly one shape: the node holds handlers AND the form is
      * left with no kind at all. Everything else - an empty node, or a kind CHANGE, whose data is
@@ -6747,23 +6771,23 @@ public class FormElementWriterTest
         assertEquals("CatalogFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
 
         assertFalse("an EMPTY node carries nothing to lose", //$NON-NLS-1$
-            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, false));
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, false, CATALOG));
         assertNull(FormElementWriter.bindEventHandler(m.extInfo(), m.extInfoHandlers(), m.event,
             "BeforeWriteAtServer", "BeforeWriteAtServer", null, new String[1])); //$NON-NLS-1$ //$NON-NLS-2$
 
         assertTrue("main=false leaves no main attribute, so the bound handlers go with the node", //$NON-NLS-1$
-            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, false));
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, false, CATALOG));
         assertFalse("re-writing main=true keeps the kind, so nothing is lost", //$NON-NLS-1$
-            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, true));
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, true, CATALOG));
 
         // Another attribute takes over: the kind CHANGES, and copySameFeatures carries the
         // handlers across - a change of kind is not a loss.
         EObject register = m.addMainAttribute("Register", //$NON-NLS-1$
             "InformationRegisterRecordManager.MyRegister"); //$NON-NLS-1$
         assertFalse("a kind change carries the handlers over", //$NON-NLS-1$
-            FormElementWriter.clearsBoundFormExtInfo(m.form, register, true));
+            FormElementWriter.clearsBoundFormExtInfo(m.form, register, true, REGISTER));
         assertFalse("and demoting THIS one leaves the other main deciding", //$NON-NLS-1$
-            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, false));
+            FormElementWriter.clearsBoundFormExtInfo(m.form, m.attribute, false, CATALOG));
     }
 
     @Test
@@ -6777,7 +6801,7 @@ public class FormElementWriterTest
             "InformationRegisterManager.MyRegister"); //$NON-NLS-1$
 
         assertTrue("promoting an attribute no writer pairs with a kind empties the node", //$NON-NLS-1$
-            FormElementWriter.clearsBoundFormExtInfo(m.form, unpaired, true));
+            FormElementWriter.clearsBoundFormExtInfo(m.form, unpaired, true, "InformationRegisterManager")); //$NON-NLS-1$
     }
 
     /**

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -28,6 +28,7 @@ import org.eclipse.emf.common.util.Enumerator;
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EEnum;
 import org.eclipse.emf.ecore.EEnumLiteral;
 import org.eclipse.emf.ecore.EObject;
@@ -6354,5 +6355,216 @@ public class FormElementWriterTest
             reference.setUpperBound(many ? -1 : 1);
             return reference;
         }
+    }
+
+    // ---- the form ROOT extInfo: where a record/object form keeps its write and read events -----
+    //
+    // FormExtInfo is an EventHandlerContainer of its own (item ext-infos are not), so a record
+    // form binds BeforeWriteAtServer INSIDE <extInfo> while OnCreateAtServer sits on the root.
+    // Issue #591 is the missing node; #592 is the two lists being read as if they were one.
+
+    /** A dynamic model shaped like a form ROOT whose extInfo is itself a handler container. */
+    private static final class FormRootModel
+    {
+        EObject form;
+        EStructuralFeature rootHandlers;
+        EObject event;
+        EObject attribute;
+
+        EObject extInfo()
+        {
+            return (EObject)form.eGet(form.eClass().getEStructuralFeature("extInfo")); //$NON-NLS-1$
+        }
+
+        EStructuralFeature extInfoHandlers()
+        {
+            return extInfo().eClass().getEStructuralFeature("handlers"); //$NON-NLS-1$
+        }
+
+        void retypeMainAttribute(String typeName)
+        {
+            TypeDescription description = McoreFactory.eINSTANCE.createTypeDescription();
+            Type type = McoreFactory.eINSTANCE.createType();
+            type.setName(typeName);
+            description.getTypes().add(type);
+            attribute.eSet(attribute.eClass().getEStructuralFeature("valueType"), description); //$NON-NLS-1$
+        }
+    }
+
+    private static EAttribute dynAttribute(String name, EClassifier type)
+    {
+        EAttribute attribute = EcoreFactory.eINSTANCE.createEAttribute();
+        attribute.setName(name);
+        attribute.setEType(type);
+        return attribute;
+    }
+
+    private static EReference dynContainment(String name, EClassifier type, boolean many)
+    {
+        EReference reference = EcoreFactory.eINSTANCE.createEReference();
+        reference.setName(name);
+        reference.setEType(type);
+        reference.setContainment(true);
+        reference.setUpperBound(many ? -1 : 1);
+        return reference;
+    }
+
+    private static FormRootModel newFormRootModel(String mainTypeName, boolean mainFlag)
+    {
+        EcoreFactory f = EcoreFactory.eINSTANCE;
+        EPackage pkg = f.createEPackage();
+        pkg.setName("form"); //$NON-NLS-1$
+        pkg.setNsURI("http://g5.1c.ru/v8/dt/form/rootextinfotest"); //$NON-NLS-1$
+        pkg.setNsPrefix("form"); //$NON-NLS-1$
+
+        EClass eventType = f.createEClass();
+        eventType.setName("Event"); //$NON-NLS-1$
+        eventType.getEStructuralFeatures().add(dynAttribute("name", EcorePackage.Literals.ESTRING)); //$NON-NLS-1$
+        eventType.getEStructuralFeatures().add(dynAttribute("nameRu", EcorePackage.Literals.ESTRING)); //$NON-NLS-1$
+        pkg.getEClassifiers().add(eventType);
+
+        EClass eventHandler = f.createEClass();
+        eventHandler.setName("EventHandler"); //$NON-NLS-1$
+        EReference eventRef = f.createEReference();
+        eventRef.setName("event"); //$NON-NLS-1$
+        eventRef.setEType(eventType);
+        eventHandler.getEStructuralFeatures().add(eventRef);
+        eventHandler.getEStructuralFeatures().add(dynAttribute("name", EcorePackage.Literals.ESTRING)); //$NON-NLS-1$
+        pkg.getEClassifiers().add(eventHandler);
+
+        EClass extInfoBase = f.createEClass();
+        extInfoBase.setName("ExtInfo"); //$NON-NLS-1$
+        extInfoBase.setAbstract(true);
+        pkg.getEClassifiers().add(extInfoBase);
+
+        // Two concrete kinds, so a test can watch the sync REPLACE one with the other.
+        for (String kind : new String[]{"InformationRegisterManagerFormExtInfo", "CatalogFormExtInfo"}) //$NON-NLS-1$ //$NON-NLS-2$
+        {
+            EClass formExtInfo = f.createEClass();
+            formExtInfo.setName(kind);
+            formExtInfo.getESuperTypes().add(extInfoBase);
+            formExtInfo.getEStructuralFeatures().add(dynContainment("handlers", eventHandler, true)); //$NON-NLS-1$
+            pkg.getEClassifiers().add(formExtInfo);
+        }
+
+        EClass attributeType = f.createEClass();
+        attributeType.setName("FormAttribute"); //$NON-NLS-1$
+        attributeType.getEStructuralFeatures().add(dynAttribute("name", EcorePackage.Literals.ESTRING)); //$NON-NLS-1$
+        attributeType.getEStructuralFeatures()
+            .add(dynAttribute("main", EcorePackage.Literals.EBOOLEAN)); //$NON-NLS-1$
+        attributeType.getEStructuralFeatures().add(dynContainment("valueType", //$NON-NLS-1$
+            McoreFactory.eINSTANCE.createTypeDescription().eClass(), false));
+        pkg.getEClassifiers().add(attributeType);
+
+        EClass formType = f.createEClass();
+        formType.setName("Form"); //$NON-NLS-1$
+        formType.getEStructuralFeatures().add(dynContainment("handlers", eventHandler, true)); //$NON-NLS-1$
+        formType.getEStructuralFeatures().add(dynContainment("attributes", attributeType, true)); //$NON-NLS-1$
+        formType.getEStructuralFeatures().add(dynContainment("extInfo", extInfoBase, false)); //$NON-NLS-1$
+        pkg.getEClassifiers().add(formType);
+
+        FormRootModel m = new FormRootModel();
+        m.form = pkg.getEFactoryInstance().create(formType);
+        m.rootHandlers = formType.getEStructuralFeature("handlers"); //$NON-NLS-1$
+        m.event = pkg.getEFactoryInstance().create(eventType);
+        m.event.eSet(eventType.getEStructuralFeature("name"), "BeforeWriteAtServer"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.attribute = pkg.getEFactoryInstance().create(attributeType);
+        m.attribute.eSet(attributeType.getEStructuralFeature("name"), "Record"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.attribute.eSet(attributeType.getEStructuralFeature("main"), Boolean.valueOf(mainFlag)); //$NON-NLS-1$
+        @SuppressWarnings("unchecked")
+        List<EObject> attributes =
+            (List<EObject>)m.form.eGet(formType.getEStructuralFeature("attributes")); //$NON-NLS-1$
+        attributes.add(m.attribute);
+        m.retypeMainAttribute(mainTypeName);
+        return m;
+    }
+
+    @Test
+    public void testSyncFormExtInfoFollowsTheMainAttributeType()
+    {
+        FormRootModel m = newFormRootModel("InformationRegisterRecordManager.MyRegister", true); //$NON-NLS-1$
+
+        assertEquals("a record-manager main attribute pairs with the register form ext-info", //$NON-NLS-1$
+            "InformationRegisterManagerFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
+        assertNotNull("the ext-info node itself must exist on the form root", m.extInfo()); //$NON-NLS-1$
+        assertEquals("InformationRegisterManagerFormExtInfo", m.extInfo().eClass().getName()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSyncFormExtInfoReplacesAStaleKindAndClearsAnUnmappedOne()
+    {
+        FormRootModel m = newFormRootModel("CatalogObject.Goods", true); //$NON-NLS-1$
+        assertEquals("CatalogFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
+
+        // Retyped to another mapped category: the ext-info follows.
+        m.retypeMainAttribute("InformationRegisterRecordManager.MyRegister"); //$NON-NLS-1$
+        assertEquals("InformationRegisterManagerFormExtInfo", //$NON-NLS-1$
+            FormElementWriter.syncFormExtInfo(m.form));
+
+        // Retyped to a category the platform pairs with nothing: the stale node is CLEARED, not kept.
+        m.retypeMainAttribute("String"); //$NON-NLS-1$
+        assertNull(FormElementWriter.syncFormExtInfo(m.form));
+        assertNull("a form whose main type maps to no ext-info must carry none", m.extInfo()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testSyncFormExtInfoIgnoresAnAttributeThatIsNotMain()
+    {
+        FormRootModel m = newFormRootModel("InformationRegisterRecordManager.MyRegister", false); //$NON-NLS-1$
+
+        assertNull("only the MAIN attribute decides the form ext-info", //$NON-NLS-1$
+            FormElementWriter.syncFormExtInfo(m.form));
+        assertNull(m.extInfo());
+    }
+
+    @Test
+    public void testDuplicateGuardSpansTheRootAndItsExtInfo()
+    {
+        FormRootModel m = newFormRootModel("InformationRegisterRecordManager.MyRegister", true); //$NON-NLS-1$
+        FormElementWriter.syncFormExtInfo(m.form);
+
+        // Bound where EDT puts it: inside the extInfo.
+        assertNull(FormElementWriter.bindEventHandler(m.extInfo(), m.extInfoHandlers(), m.event,
+            "BeforeWriteAtServer", "BeforeWriteAtServer", null, new String[1])); //$NON-NLS-1$ //$NON-NLS-2$
+
+        // The ROOT must now refuse the same event: one binding, two lists.
+        String duplicate = FormElementWriter.bindEventHandler(m.form, m.rootHandlers, m.event,
+            "BeforeWriteAtServer", "BeforeWriteAtServer", null, new String[1]); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNotNull("a binding inside the extInfo is still a binding", duplicate); //$NON-NLS-1$
+        assertTrue(duplicate.contains("already exists")); //$NON-NLS-1$
+        assertEquals("nothing may be appended to the root", //$NON-NLS-1$
+            0, ((List<?>)m.form.eGet(m.rootHandlers)).size());
+    }
+
+    @Test
+    public void testDuplicateGuardSpansTheExtInfoAndItsRoot()
+    {
+        FormRootModel m = newFormRootModel("InformationRegisterRecordManager.MyRegister", true); //$NON-NLS-1$
+        FormElementWriter.syncFormExtInfo(m.form);
+
+        // The other direction: bound at the root first (how an older build of this tool left forms).
+        assertNull(FormElementWriter.bindEventHandler(m.form, m.rootHandlers, m.event,
+            "BeforeWriteAtServer", "BeforeWriteAtServer", null, new String[1])); //$NON-NLS-1$ //$NON-NLS-2$
+
+        String duplicate = FormElementWriter.bindEventHandler(m.extInfo(), m.extInfoHandlers(),
+            m.event, "BeforeWriteAtServer", "BeforeWriteAtServer", null, new String[1]); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNotNull(duplicate);
+        assertEquals("nothing may be appended to the extInfo", //$NON-NLS-1$
+            0, ((List<?>)m.extInfo().eGet(m.extInfoHandlers())).size());
+    }
+
+    @Test
+    public void testFindFormHandlerReachesABindingInsideTheExtInfo()
+    {
+        FormRootModel m = newFormRootModel("InformationRegisterRecordManager.MyRegister", true); //$NON-NLS-1$
+        FormElementWriter.syncFormExtInfo(m.form);
+        assertNull(FormElementWriter.bindEventHandler(m.extInfo(), m.extInfoHandlers(), m.event,
+            "BeforeWriteAtServer", "BeforeWriteAtServer", null, new String[1])); //$NON-NLS-1$ //$NON-NLS-2$
+        EObject bound = (EObject)((List<?>)m.extInfo().eGet(m.extInfoHandlers())).get(0);
+
+        assertSame("delete_metadata and the rebind path address a handler through this lookup", //$NON-NLS-1$
+            bound, FormElementWriter.findFormHandler(m.form, "BeforeWriteAtServer")); //$NON-NLS-1$
+        assertNull("an event nothing is bound to still answers null", //$NON-NLS-1$
+            FormElementWriter.findFormHandler(m.form, "OnReadAtServer")); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -6381,6 +6381,12 @@ public class FormElementWriterTest
             return extInfo().eClass().getEStructuralFeature("handlers"); //$NON-NLS-1$
         }
 
+        void setMain(boolean main)
+        {
+            attribute.eSet(attribute.eClass().getEStructuralFeature("main"), //$NON-NLS-1$
+                Boolean.valueOf(main));
+        }
+
         void giveExtInfo(String kind)
         {
             EPackage pkg = form.eClass().getEPackage();
@@ -6513,42 +6519,48 @@ public class FormElementWriterTest
 
         // Retyped to a category the platform pairs with nothing: the stale node is CLEARED, not kept.
         m.retypeMainAttribute("String"); //$NON-NLS-1$
-        assertNull(FormElementWriter.syncFormExtInfo(m.form, true));
+        assertNull(FormElementWriter.syncFormExtInfo(m.form));
         assertNull("a form whose main type maps to no ext-info must carry none", m.extInfo()); //$NON-NLS-1$
     }
 
     /**
-     * A MAIN attribute whose category pairs with nothing takes the node with it, whatever kind it
-     * was - {@code CubeRecordSetFormExtInfo} comes from the form GENERATOR and
-     * {@code createFormExtInfo} cannot produce it, but the platform still answers {@code null} for
-     * that category and {@code isNeedUpdateExtInfo(null, old)} clears the node.
+     * A kind this mapping never produced cannot be judged stale BY it:
+     * {@code CubeRecordSetFormExtInfo} comes from the platform form generator, and
+     * {@code createFormExtInfo} has no case that makes one. Clearing it would delete a node and
+     * its handlers on a guess.
      */
     @Test
-    public void testSyncFormExtInfoClearsEvenAKindItCouldNotHaveProduced()
-    {
-        FormRootModel m = newFormRootModel("ExternalDataSourceCubeRecordSet.Sales", true); //$NON-NLS-1$
-        m.giveExtInfo("CubeRecordSetFormExtInfo"); //$NON-NLS-1$
-
-        assertNull("this mapping produces no ext-info for that category", //$NON-NLS-1$
-            FormElementWriter.syncFormExtInfo(m.form, true));
-        assertNull("a main attribute that pairs with nothing leaves no node behind", //$NON-NLS-1$
-            m.extInfo());
-    }
-
-    /**
-     * The same form, the same unmapped category - but reached by a bare {@code main} write instead
-     * of a retype. Only a retype passes the destructive-consent gate, so only a retype may clear;
-     * otherwise re-writing an already-true flag would destroy the node for no change at all.
-     */
-    @Test
-    public void testAMainOnlyWriteNeverClearsTheExtInfo()
+    public void testSyncFormExtInfoKeepsAKindItCouldNotHaveProduced()
     {
         FormRootModel m = newFormRootModel("ExternalDataSourceCubeRecordSet.Sales", true); //$NON-NLS-1$
         m.giveExtInfo("CubeRecordSetFormExtInfo"); //$NON-NLS-1$
 
         assertEquals("the node stays, and the sync reports the kind it found", //$NON-NLS-1$
             "CubeRecordSetFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
-        assertNotNull("a main-only write must not destroy the node", m.extInfo()); //$NON-NLS-1$
+        assertNotNull("a generator-authored node must not be removed on a guess", m.extInfo()); //$NON-NLS-1$
+    }
+
+    /**
+     * A node this mapping DID produce, on a form whose main attribute now pairs with nothing, is
+     * stale by construction - however the form got there. The route that matters in practice is
+     * demote, retype the demoted attribute, promote it again: the node is left keyed to the old
+     * category, and keeping it would publish catalog events for a String-backed form.
+     */
+    @Test
+    public void testSyncFormExtInfoClearsAKindItProducedOnceItsCategoryIsGone()
+    {
+        FormRootModel m = newFormRootModel("CatalogObject.Goods", true); //$NON-NLS-1$
+        assertEquals("CatalogFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
+
+        // demote - retype - promote, the sequence that leaves a node keyed to nothing
+        m.setMain(false);
+        m.retypeMainAttribute("String"); //$NON-NLS-1$
+        assertEquals("with no main attribute the node is left as it is", //$NON-NLS-1$
+            "CatalogFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
+        m.setMain(true);
+
+        assertNull(FormElementWriter.syncFormExtInfo(m.form));
+        assertNull("a node keyed to a category that no longer applies must go", m.extInfo()); //$NON-NLS-1$
     }
 
     /**

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -1199,6 +1199,12 @@ public class FormElementWriterTest
 
         EClass eventType = EcoreFactory.eINSTANCE.createEClass();
         eventType.setName("Event"); //$NON-NLS-1$
+        // The platform's Event carries its own name, and the duplicate guard keys on it: two
+        // resolutions of one event are two EObjects, and only the name says they are the same.
+        EAttribute eventName = EcoreFactory.eINSTANCE.createEAttribute();
+        eventName.setName("name"); //$NON-NLS-1$
+        eventName.setEType(EcorePackage.Literals.ESTRING);
+        eventType.getEStructuralFeatures().add(eventName);
         pkg.getEClassifiers().add(eventType);
 
         EClass eventHandler = EcoreFactory.eINSTANCE.createEClass();
@@ -1246,6 +1252,7 @@ public class FormElementWriterTest
         m.container = pkg.getEFactoryInstance().create(field);
         m.handlersFeat = field.getEStructuralFeature("handlers"); //$NON-NLS-1$
         m.event = pkg.getEFactoryInstance().create(eventType);
+        m.event.eSet(eventType.getEStructuralFeature("name"), "OnChange"); //$NON-NLS-1$ //$NON-NLS-2$
         return m;
     }
 
@@ -1300,6 +1307,40 @@ public class FormElementWriterTest
             "OnChange", "another", null, new String[1]); //$NON-NLS-1$ //$NON-NLS-2$
         assertNotNull(dup);
         assertTrue(dup.contains("already exists")); //$NON-NLS-1$
+    }
+
+    /**
+     * The duplicate guard compares events by NAME, not by object identity. A change of ext-info
+     * kind carries the handlers over to the new node, and they keep pointing at the PREVIOUS
+     * platform type's event object while a fresh resolution answers with the new type's - two
+     * objects, one event. Compared by identity, the existing handler is invisible and a second
+     * base handler for the same event lands next to it.
+     */
+    @Test
+    public void testADuplicateIsCaughtEvenWhenTheEventObjectIsADifferentInstance()
+    {
+        HandlerModel m = newHandlerModel(true);
+        assertNull(FormElementWriter.bindEventHandler(m.container, m.handlersFeat, m.event,
+            "OnChange", "OnChange", null, new String[1])); //$NON-NLS-1$ //$NON-NLS-2$
+
+        // The same event, resolved from another type: a different EObject carrying the same name.
+        EObject sameEventOtherInstance = m.event.eClass().getEPackage().getEFactoryInstance()
+            .create(m.event.eClass());
+        sameEventOtherInstance.eSet(m.event.eClass().getEStructuralFeature("name"), "OnChange"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        String dup = FormElementWriter.bindEventHandler(m.container, m.handlersFeat,
+            sameEventOtherInstance, "OnChange", "second", null, new String[1]); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNotNull("a second base handler for the same event must be refused", dup); //$NON-NLS-1$
+        assertTrue(dup.contains("already exists")); //$NON-NLS-1$
+        assertEquals("and nothing must have been added", 1, //$NON-NLS-1$
+            ((List<?>)m.container.eGet(m.handlersFeat)).size());
+
+        // A DIFFERENT event still binds - the name is the key, not a blanket refusal.
+        EObject otherEvent = m.event.eClass().getEPackage().getEFactoryInstance()
+            .create(m.event.eClass());
+        otherEvent.eSet(m.event.eClass().getEStructuralFeature("name"), "OnOpen"); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNull(FormElementWriter.bindEventHandler(m.container, m.handlersFeat, otherEvent,
+            "OnOpen", "OnOpen", null, new String[1])); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormElementWriterTest.java
@@ -6387,6 +6387,28 @@ public class FormElementWriterTest
                 Boolean.valueOf(main));
         }
 
+        @SuppressWarnings("unchecked")
+        EObject addMainAttribute(String name, String typeName)
+        {
+            EClass attributeType = attribute.eClass();
+            EObject added = attributeType.getEPackage().getEFactoryInstance().create(attributeType);
+            added.eSet(attributeType.getEStructuralFeature("name"), name); //$NON-NLS-1$
+            added.eSet(attributeType.getEStructuralFeature("main"), Boolean.TRUE); //$NON-NLS-1$
+            TypeDescription description = McoreFactory.eINSTANCE.createTypeDescription();
+            Type type = McoreFactory.eINSTANCE.createType();
+            type.setName(typeName);
+            description.getTypes().add(type);
+            added.eSet(attributeType.getEStructuralFeature("valueType"), description); //$NON-NLS-1$
+            ((List<EObject>)form.eGet(form.eClass().getEStructuralFeature("attributes"))).add(added); //$NON-NLS-1$
+            return added;
+        }
+
+        @SuppressWarnings("unchecked")
+        void detach(EObject attr)
+        {
+            ((List<EObject>)form.eGet(form.eClass().getEStructuralFeature("attributes"))).remove(attr); //$NON-NLS-1$
+        }
+
         void giveExtInfo(String kind)
         {
             EPackage pkg = form.eClass().getEPackage();
@@ -6451,10 +6473,10 @@ public class FormElementWriterTest
         extInfoBase.setAbstract(true);
         pkg.getEClassifiers().add(extInfoBase);
 
-        // Two kinds the mapping produces, so a test can watch the sync REPLACE one with the
-        // other, and one it never produces (the platform form GENERATOR writes that one).
+        // The kinds the tests move between: two the service maps, one only the form GENERATOR
+        // writes, and the one only the generator and the designer-XML importer map.
         for (String kind : new String[]{"InformationRegisterManagerFormExtInfo", //$NON-NLS-1$
-            "CatalogFormExtInfo", "CubeRecordSetFormExtInfo"}) //$NON-NLS-1$ //$NON-NLS-2$
+            "CatalogFormExtInfo", "CubeRecordSetFormExtInfo", "ObjectFormExtInfo"}) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         {
             EClass formExtInfo = f.createEClass();
             formExtInfo.setName(kind);
@@ -6524,43 +6546,104 @@ public class FormElementWriterTest
     }
 
     /**
-     * A kind this mapping never produced cannot be judged stale BY it:
-     * {@code CubeRecordSetFormExtInfo} comes from the platform form generator, and
-     * {@code createFormExtInfo} has no case that makes one. Clearing it would delete a node and
-     * its handlers on a guess.
+     * {@code CubeRecordSetFormExtInfo} is written by {@code RecordSetFormContainGenerator} and by
+     * nothing else - {@code createFormExtInfo} has no case for that category. The mapping carries
+     * the generator's pairing too, so the node is KEPT because it is the right one, not by an
+     * exception for kinds we cannot produce.
      */
     @Test
-    public void testSyncFormExtInfoKeepsAKindItCouldNotHaveProduced()
+    public void testSyncFormExtInfoKeepsAKindOnlyTheGeneratorWrites()
     {
         FormRootModel m = newFormRootModel("ExternalDataSourceCubeRecordSet.Sales", true); //$NON-NLS-1$
         m.giveExtInfo("CubeRecordSetFormExtInfo"); //$NON-NLS-1$
 
-        assertEquals("the node stays, and the sync reports the kind it found", //$NON-NLS-1$
+        assertEquals("the cube record set pairs with the kind the generator writes", //$NON-NLS-1$
             "CubeRecordSetFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
-        assertNotNull("a generator-authored node must not be removed on a guess", m.extInfo()); //$NON-NLS-1$
+        assertNotNull(m.extInfo());
     }
 
     /**
-     * A node this mapping DID produce, on a form whose main attribute now pairs with nothing, is
-     * stale by construction - however the form got there. The route that matters in practice is
-     * demote, retype the demoted attribute, promote it again: the node is left keyed to the old
-     * category, and keeping it would publish catalog events for a String-backed form.
+     * A chart-of-accounts object form is the case that decides WHICH platform mapping to mirror:
+     * the generator and the designer-XML importer both pair it with {@code ObjectFormExtInfo},
+     * while {@code createFormExtInfo} has no case for it and would clear the node. Every such form
+     * in a real configuration carries the node, so the narrow mapping is the wrong one to copy.
      */
     @Test
-    public void testSyncFormExtInfoClearsAKindItProducedOnceItsCategoryIsGone()
+    public void testSyncFormExtInfoPairsAChartOfAccountsFormWithTheObjectKind()
+    {
+        FormRootModel m = newFormRootModel("ChartOfAccountsObject.Main", true); //$NON-NLS-1$
+
+        assertEquals("ObjectFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
+        assertNotNull(m.extInfo());
+    }
+
+    /**
+     * {@code InformationRegisterManager} is admitted as a main attribute type by the platform
+     * ({@code FormAttributeService.MAIN_ATRRIBUTE_TYPE_PREFIX}) and paired with no kind by any of
+     * its three writers - so the node goes, handlers and all.
+     */
+    @Test
+    public void testSyncFormExtInfoClearsWhenNoWriterPairsTheCategory()
+    {
+        FormRootModel m = newFormRootModel("InformationRegisterManager.MyRegister", true); //$NON-NLS-1$
+        m.giveExtInfo("CatalogFormExtInfo"); //$NON-NLS-1$
+
+        assertNull("no writer pairs that category with a kind", //$NON-NLS-1$
+            FormElementWriter.syncFormExtInfo(m.form));
+        assertNull("a category that maps to nothing leaves no node behind", m.extInfo()); //$NON-NLS-1$
+    }
+
+    /**
+     * Promoting an attribute takes the flag off the previous main, mirroring
+     * {@code FormAttributeService.setMainAttribute}: the platform demotes first, then re-derives
+     * the node. Left undone, the form would carry two main attributes - which the platform reports
+     * as an error - and the root node would follow whichever came first in the list.
+     */
+    @Test
+    public void testPromotingAnAttributeDemotesThePreviousMain()
     {
         FormRootModel m = newFormRootModel("CatalogObject.Goods", true); //$NON-NLS-1$
         assertEquals("CatalogFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
+        EObject promoted = m.addMainAttribute("Register", //$NON-NLS-1$
+            "InformationRegisterRecordManager.MyRegister"); //$NON-NLS-1$
 
-        // demote - retype - promote, the sequence that leaves a node keyed to nothing
-        m.setMain(false);
-        m.retypeMainAttribute("String"); //$NON-NLS-1$
-        assertEquals("with no main attribute the node is left as it is", //$NON-NLS-1$
-            "CatalogFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
-        m.setMain(true);
+        assertEquals("the attribute that lost the flag is named back to the caller", //$NON-NLS-1$
+            List.of("Record"), FormElementWriter.demoteOtherMainAttributes(m.form, promoted)); //$NON-NLS-1$
+        assertFalse("the previous main must not keep the flag", //$NON-NLS-1$
+            FormElementWriter.isMainAttribute(m.attribute));
+        assertEquals("with one main attribute left, the node follows THAT one", //$NON-NLS-1$
+            "InformationRegisterManagerFormExtInfo", FormElementWriter.syncFormExtInfo(m.form)); //$NON-NLS-1$
+    }
 
-        assertNull(FormElementWriter.syncFormExtInfo(m.form));
-        assertNull("a node keyed to a category that no longer applies must go", m.extInfo()); //$NON-NLS-1$
+    @Test
+    public void testDemotingIsRefusedForAnAttributeThatIsNotItselfMain()
+    {
+        FormRootModel m = newFormRootModel("CatalogObject.Goods", true); //$NON-NLS-1$
+        EObject other = m.addMainAttribute("Other", "String"); //$NON-NLS-1$ //$NON-NLS-2$
+        other.eSet(other.eClass().getEStructuralFeature("main"), Boolean.FALSE); //$NON-NLS-1$
+
+        assertEquals("nothing is demoted on behalf of an attribute that was not promoted", //$NON-NLS-1$
+            List.of(), FormElementWriter.demoteOtherMainAttributes(m.form, other));
+        assertTrue("the real main attribute keeps its flag", //$NON-NLS-1$
+            FormElementWriter.isMainAttribute(m.attribute));
+    }
+
+    /**
+     * The flag only means anything on the form's OWN attribute list - the list
+     * {@code FormUtil.getMainAttribute} reads. A {@code main} on a nested attribute (a table
+     * column) names no main attribute, so it must not demote the one the form actually has.
+     */
+    @Test
+    public void testAMainFlagOutsideTheFormsAttributeListDemotesNothing()
+    {
+        FormRootModel m = newFormRootModel("CatalogObject.Goods", true); //$NON-NLS-1$
+        EObject nested = m.addMainAttribute("Column", "String"); //$NON-NLS-1$ //$NON-NLS-2$
+        m.detach(nested);
+
+        assertEquals("a flag outside the form's attribute list decides nothing", //$NON-NLS-1$
+            List.of(), FormElementWriter.demoteOtherMainAttributes(m.form, nested));
+        assertTrue("the form's real main attribute keeps its flag", //$NON-NLS-1$
+            FormElementWriter.isMainAttribute(m.attribute));
     }
 
     /**
@@ -6585,20 +6668,18 @@ public class FormElementWriterTest
     }
 
     /**
-     * Setting {@code main=false} is an ordinary boolean change, and it must not take the node that
-     * holds the form's write and read bindings with it. The platform never asks this question
-     * without a main attribute at all - {@code setExtInfo} asserts {@code isMain}.
+     * Taking the main flag off is the platform's {@code resetExtInfo}: {@code form.setExtInfo(null)},
+     * unconditional, whatever kind the node was and whatever it held. The handlers bound inside go
+     * with it, exactly as {@code copyDataOfSameFeatures} no-ops on a null destination.
      */
     @Test
-    public void testSyncFormExtInfoLeavesAFormWithNoMainAttributeAlone()
+    public void testSyncFormExtInfoClearsTheNodeWhenNoAttributeIsMain()
     {
         FormRootModel m = newFormRootModel("InformationRegisterRecordManager.MyRegister", false); //$NON-NLS-1$
         m.giveExtInfo("InformationRegisterManagerFormExtInfo"); //$NON-NLS-1$
 
-        assertEquals("InformationRegisterManagerFormExtInfo", //$NON-NLS-1$
-            FormElementWriter.syncFormExtInfo(m.form));
-        assertNotNull("main=false must not destroy the ext-info nor the handlers inside it", //$NON-NLS-1$
-            m.extInfo());
+        assertNull(FormElementWriter.syncFormExtInfo(m.form));
+        assertNull("a form with no main attribute carries no root ext-info", m.extInfo()); //$NON-NLS-1$
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormStructureReaderTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/FormStructureReaderTest.java
@@ -628,6 +628,108 @@ public class FormStructureReaderTest
         return names;
     }
 
+    /**
+     * A form root's {@code extInfo} is an event-handler container of its own, and EDT binds a record
+     * form's write and read events inside it. The walk has to read that list too: reading only the
+     * root's own reported "no event handlers" for a form that has one (issue #592).
+     */
+    @Test
+    public void testTheHandlerWalkReportsBindingsThatLiveInTheExtInfo()
+    {
+        EObject root = rootWithExtInfoBinding();
+        FormStructureReader.HandlerRows rows = new FormStructureReader.HandlerRows(10);
+
+        FormStructureReader.collectHandlers(root, "Form", "en", rows, //$NON-NLS-1$ //$NON-NLS-2$
+            new int[] {MAX_NODES}, new boolean[] {false}, new ArrayDeque<>());
+
+        assertEquals("the binding inside the extInfo is a handler of this form", //$NON-NLS-1$
+            List.of("OnCreateAtServer", "BeforeWriteAtServer"), keptHandlerNames(rows)); //$NON-NLS-1$ //$NON-NLS-2$
+        for (String[] row : rows.kept())
+        {
+            assertEquals("both belong to the FORM, not to a node called extInfo", //$NON-NLS-1$
+                "Form", row[0]); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * A form root carrying {@code OnCreateAtServer} on itself and {@code BeforeWriteAtServer} inside
+     * its {@code extInfo} - the shape EDT's wizard writes for an information-register record form.
+     */
+    private static EObject rootWithExtInfoBinding()
+    {
+        EcoreFactory f = EcoreFactory.eINSTANCE;
+        EPackage pkg = f.createEPackage();
+        pkg.setName("form"); //$NON-NLS-1$
+        pkg.setNsURI("http://g5.1c.ru/v8/dt/form/extinfohandlerstest"); //$NON-NLS-1$
+        pkg.setNsPrefix("form"); //$NON-NLS-1$
+
+        EClass eventType = f.createEClass();
+        eventType.setName("Event"); //$NON-NLS-1$
+        EAttribute eventName = f.createEAttribute();
+        eventName.setName("name"); //$NON-NLS-1$
+        eventName.setEType(EcorePackage.Literals.ESTRING);
+        eventType.getEStructuralFeatures().add(eventName);
+        pkg.getEClassifiers().add(eventType);
+
+        EClass handlerType = f.createEClass();
+        handlerType.setName("EventHandler"); //$NON-NLS-1$
+        EAttribute handlerName = f.createEAttribute();
+        handlerName.setName("name"); //$NON-NLS-1$
+        handlerName.setEType(EcorePackage.Literals.ESTRING);
+        handlerType.getEStructuralFeatures().add(handlerName);
+        EReference handlerEvent = f.createEReference();
+        handlerEvent.setName("event"); //$NON-NLS-1$
+        handlerEvent.setEType(eventType);
+        handlerEvent.setContainment(true);
+        handlerType.getEStructuralFeatures().add(handlerEvent);
+        pkg.getEClassifiers().add(handlerType);
+
+        EClass extInfoType = f.createEClass();
+        extInfoType.setName("InformationRegisterManagerFormExtInfo"); //$NON-NLS-1$
+        extInfoType.getEStructuralFeatures().add(handlerList(f, handlerType));
+        pkg.getEClassifiers().add(extInfoType);
+
+        EClass formType = f.createEClass();
+        formType.setName("Form"); //$NON-NLS-1$
+        formType.getEStructuralFeatures().add(handlerList(f, handlerType));
+        EReference extInfo = f.createEReference();
+        extInfo.setName("extInfo"); //$NON-NLS-1$
+        extInfo.setEType(extInfoType);
+        extInfo.setContainment(true);
+        formType.getEStructuralFeatures().add(extInfo);
+        pkg.getEClassifiers().add(formType);
+
+        EObject form = pkg.getEFactoryInstance().create(formType);
+        EObject extInfoObject = pkg.getEFactoryInstance().create(extInfoType);
+        form.eSet(extInfo, extInfoObject);
+        bindTestHandler(pkg, handlerType, eventType, form, "OnCreateAtServer"); //$NON-NLS-1$
+        bindTestHandler(pkg, handlerType, eventType, extInfoObject, "BeforeWriteAtServer"); //$NON-NLS-1$
+        return form;
+    }
+
+    private static EReference handlerList(EcoreFactory f, EClass handlerType)
+    {
+        EReference handlers = f.createEReference();
+        handlers.setName("handlers"); //$NON-NLS-1$
+        handlers.setEType(handlerType);
+        handlers.setContainment(true);
+        handlers.setUpperBound(-1);
+        return handlers;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void bindTestHandler(EPackage pkg, EClass handlerType, EClass eventType,
+        EObject container, String eventName)
+    {
+        EObject event = pkg.getEFactoryInstance().create(eventType);
+        event.eSet(eventType.getEStructuralFeature("name"), eventName); //$NON-NLS-1$
+        EObject handler = pkg.getEFactoryInstance().create(handlerType);
+        handler.eSet(handlerType.getEStructuralFeature("name"), eventName); //$NON-NLS-1$
+        handler.eSet(handlerType.getEStructuralFeature("event"), event); //$NON-NLS-1$
+        ((List<EObject>)container.eGet(container.eClass().getEStructuralFeature("handlers"))) //$NON-NLS-1$
+            .add(handler);
+    }
+
     @Test
     public void testTheHandlerWalkKeepsNoMoreRowsThanTheCapAllows()
     {

--- a/tests/e2e/tools/test_form_root_ext_info.py
+++ b/tests/e2e/tools/test_form_root_ext_info.py
@@ -212,3 +212,36 @@ def test_a_binding_inside_the_ext_info_can_be_deleted():
     poll_diff_contains("<extInfo", ctx="the form file must be rewritten after the delete")
     assert "DelBeforeWrite" not in _form_xml(reg), \
         "the binding must be gone from the file, wherever it lived"
+
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_promoting_a_second_attribute_demotes_the_first():
+    """A form holds ONE main attribute or none: the platform's setMainAttribute clears the flag on
+    the previous main before it sets the new one, and FormValidator reports two as an error. Left
+    undone, the root ext-info would follow whichever main came first in the attribute list."""
+    reg, form = _seed_record_form("Demote")
+    second = form + ".Attribute.Goods"
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": second}),
+              "seed a second form attribute")
+    wait_for_project_ready()
+    assert_ok(call("modify_metadata", {
+        "projectName": PROJECT, "fqn": second,
+        "properties": [{"name": "valueType", "value": {
+            "types": [{"kind": "CatalogObject", "ref": "Catalog"}]}}],
+    }), "type the second attribute as a catalog object")
+
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": second,
+        "properties": [{"name": "main", "value": True}],
+    })
+    assert_ok(r, "promote the second attribute to main")
+    demoted = (r.structured or {}).get("demotedMainAttributes")
+    assert demoted == ["Record"], \
+        "the attribute that lost the flag must be named back to the caller: %r" % (demoted,)
+
+    poll_diff_contains('xsi:type="form:CatalogFormExtInfo"',
+                       ctx="the root ext-info must follow the newly promoted main attribute")
+    xml = _form_xml(reg)
+    assert xml.count("<main>true</main>") == 1, \
+        "exactly one main attribute may remain, found %d" % (xml.count("<main>true</main>"),)
+    assert EXT_INFO_TYPE not in xml, "the previous main's ext-info kind must be gone"

--- a/tests/e2e/tools/test_form_root_ext_info.py
+++ b/tests/e2e/tools/test_form_root_ext_info.py
@@ -245,3 +245,35 @@ def test_promoting_a_second_attribute_demotes_the_first():
     assert xml.count("<main>true</main>") == 1, \
         "exactly one main attribute may remain, found %d" % (xml.count("<main>true</main>"),)
     assert EXT_INFO_TYPE not in xml, "the previous main's ext-info kind must be gone"
+
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_a_retype_and_a_later_list_conversion_leave_the_root_node_alone():
+    """Only a `main` write moves the form root's ext-info. In the platform the node is reached from
+    exactly one place — FormAttributeService.setMainAttribute; a retype goes to setTypeDescription,
+    which never touches it, and a query edit on some other attribute is not its business either."""
+    reg, form = _seed_record_form("Keep")
+    poll_diff_contains(EXT_INFO_TYPE, ctx="the seeded form must carry the register-manager ext-info")
+
+    assert_ok(call("modify_metadata", {
+        "projectName": PROJECT, "fqn": form + ".Attribute.Record",
+        "properties": [{"name": "valueType", "value": {
+            "types": [{"kind": "CatalogObject", "ref": "Catalog"}]}}],
+    }), "retype the main attribute")
+    assert EXT_INFO_TYPE in _form_xml(reg), \
+        "a retype of the main attribute must not move the form root's ext-info"
+
+    second = form + ".Attribute.List"
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": second}),
+              "seed a second form attribute")
+    wait_for_project_ready()
+    assert_ok(call("modify_metadata", {
+        "projectName": PROJECT, "fqn": second,
+        "properties": [{"name": "queryText", "value": "SELECT Ref FROM Catalog.Catalog"}],
+    }), "turn the second attribute into a dynamic list")
+
+    xml = _form_xml(reg)
+    assert EXT_INFO_TYPE in xml, \
+        "a list conversion that promoted nothing must leave the root ext-info as it is"
+    assert xml.count("<main>true</main>") == 1, \
+        "and it must not hand the main flag to the new list either: %d" % (xml.count("<main>true</main>"),)

--- a/tests/e2e/tools/test_form_root_ext_info.py
+++ b/tests/e2e/tools/test_form_root_ext_info.py
@@ -1,0 +1,155 @@
+"""
+e2e for the form ROOT extInfo - the node that publishes a form's write and read events.
+
+A record/object form carries `<extInfo xsi:type="form:...FormExtInfo">` at its root, and that node
+is an event-handler container of its own: EDT's wizard writes `BeforeWriteAtServer` INSIDE it while
+`OnCreateAtServer` sits on the root's own `<handlers>`. Two defects came out of that one structure:
+
+- #591 - `create_metadata` built the form without the root extInfo, so every write/read event was
+  refused as "not valid for Form" and no MCP property could supply the missing node;
+- #592 - on a form that HAD the node, the tool read only the root's list, so it saw no existing
+  binding, appended a SECOND one, and `get_metadata_details` reported neither.
+
+The kind of extInfo follows the MAIN attribute's type, exactly as the platform's
+`ExtInfoManagementService.setExtInfo(Form, FormAttribute, Version)` decides it - so the tests set
+the main attribute's type and then read the file back.
+
+reset: kind="write-metadata" -> reset_model() after each test; each test seeds a UNIQUE register.
+"""
+
+from harness import (
+    call,
+    assert_ok,
+    assert_error,
+    assert_error_quality,
+    assert_contains,
+    read_disk,
+    poll_diff_contains,
+    wait_for_project_ready,
+    e2e_test,
+    PROJECT,
+)
+
+EXT_INFO_TYPE = 'xsi:type="form:InformationRegisterManagerFormExtInfo"'
+
+
+def _seed_record_form(suffix):
+    """Register + record form + a typed MAIN attribute. Returns (register name, form fqn)."""
+    reg = "E2ERecForm" + suffix
+    reg_fqn = "InformationRegister." + reg
+    form_fqn = reg_fqn + ".Form.RecordForm"
+    attr_fqn = form_fqn + ".Attribute.Record"
+
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": reg_fqn}),
+              "seed InformationRegister " + reg)
+    wait_for_project_ready()
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": form_fqn}),
+              "seed the record form")
+    wait_for_project_ready()
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": attr_fqn}),
+              "seed the main form attribute")
+    wait_for_project_ready()
+    assert_ok(call("modify_metadata", {
+        "projectName": PROJECT, "fqn": attr_fqn,
+        "properties": [{"name": "valueType", "value": {
+            "types": [{"kind": "InformationRegisterRecordManager", "ref": reg}]}}],
+    }), "type the main attribute as the register's record manager")
+    assert_ok(call("modify_metadata", {
+        "projectName": PROJECT, "fqn": attr_fqn,
+        "properties": [{"name": "main", "value": True}, {"name": "savedData", "value": True}],
+    }), "flag the attribute as the form's main data source")
+    wait_for_project_ready()
+    return reg, form_fqn
+
+
+def _form_xml(reg):
+    return read_disk("src/InformationRegisters/%s/Forms/RecordForm/Form.form" % reg)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# #591 — the node itself
+# ──────────────────────────────────────────────────────────────────────────────
+
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_record_form_gets_its_root_ext_info():
+    reg, _form = _seed_record_form("Node")
+
+    poll_diff_contains(EXT_INFO_TYPE,
+                       ctx="the form root must carry the register-manager ext-info on disk")
+    xml = _form_xml(reg)
+    assert xml.count(EXT_INFO_TYPE) == 1, \
+        "exactly one root ext-info, not one per write: %d" % (xml.count(EXT_INFO_TYPE),)
+
+
+@e2e_test(tool="create_metadata", kind="write-metadata")
+def test_write_event_binds_and_lands_inside_the_ext_info():
+    reg, form = _seed_record_form("Bind")
+
+    r = call("create_metadata", {
+        "projectName": PROJECT, "fqn": form + ".Handler.BeforeWriteAtServer",
+        "properties": [{"name": "procedure", "value": "RecBeforeWriteAtServer"}]})
+    assert_ok(r, "bind BeforeWriteAtServer on a record form")
+    assert r.structured.get("action") == "created", "must report created: %r" % (r.structured,)
+    poll_diff_contains("RecBeforeWriteAtServer",
+                       ctx="the bound handler must land in the form file on disk")
+
+    # WHERE it landed is the point: inside <extInfo>, the way EDT's own wizard writes it.
+    xml = _form_xml(reg)
+    ext_at = xml.find("<extInfo")
+    assert ext_at != -1, "the root ext-info must exist: %s" % (xml[:400],)
+    assert xml.find("RecBeforeWriteAtServer") > ext_at, \
+        "a write event belongs INSIDE the root ext-info, not in the root's own handlers: %s" % (xml,)
+
+
+@e2e_test(tool="get_metadata_details", kind="write-metadata")
+def test_details_lists_a_binding_that_lives_in_the_ext_info():
+    _reg, form = _seed_record_form("Read")
+    assert_ok(call("create_metadata", {
+        "projectName": PROJECT, "fqn": form + ".Handler.BeforeWriteAtServer",
+        "properties": [{"name": "procedure", "value": "ReadBackBeforeWrite"}]}), "bind the event")
+
+    r = call("get_metadata_details", {"projectName": PROJECT, "objectFqns": [form], "full": True})
+    assert_ok(r, "read the form back in full")
+    assert_contains(r.text, "ReadBackBeforeWrite",
+                    "the handler table must list a binding that lives in the extInfo")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# #592 — one event, one binding, across both lists
+# ──────────────────────────────────────────────────────────────────────────────
+
+@e2e_test(tool="create_metadata", kind="write-metadata")
+def test_second_binding_of_the_same_write_event_is_refused():
+    reg, form = _seed_record_form("Dup")
+    handler_fqn = form + ".Handler.BeforeWriteAtServer"
+    assert_ok(call("create_metadata", {
+        "projectName": PROJECT, "fqn": handler_fqn,
+        "properties": [{"name": "procedure", "value": "DupBeforeWrite"}]}), "bind the event once")
+    wait_for_project_ready()
+
+    r = call("create_metadata", {"projectName": PROJECT, "fqn": handler_fqn,
+                                 "properties": [{"name": "procedure", "value": "DupBeforeWrite2"}]})
+    e = assert_error(r, "the same write event bound twice")
+    assert_error_quality(e, names=["BeforeWriteAtServer"], suggests=["already exists"],
+                         ctx="the second binding must be refused, naming the event")
+
+    xml = _form_xml(reg)
+    assert "DupBeforeWrite2" not in xml, "the refused binding must not be written: %s" % (xml,)
+    assert xml.count("<event>BeforeWriteAtServer</event>") == 1, \
+        "exactly one binding for the event: %d" % (xml.count("<event>BeforeWriteAtServer</event>"),)
+
+
+@e2e_test(tool="delete_metadata", kind="write-metadata")
+def test_a_binding_inside_the_ext_info_can_be_deleted():
+    reg, form = _seed_record_form("Del")
+    handler_fqn = form + ".Handler.BeforeWriteAtServer"
+    assert_ok(call("create_metadata", {
+        "projectName": PROJECT, "fqn": handler_fqn,
+        "properties": [{"name": "procedure", "value": "DelBeforeWrite"}]}), "bind the event")
+    wait_for_project_ready()
+
+    assert_ok(call("delete_metadata", {"projectName": PROJECT, "fqn": handler_fqn, "confirm": True}),
+              "delete a handler that lives inside the root ext-info")
+    poll_diff_contains("<extInfo", ctx="the form file must be rewritten after the delete")
+    assert "DelBeforeWrite" not in _form_xml(reg), \
+        "the binding must be gone from the file, wherever it lived"

--- a/tests/e2e/tools/test_form_root_ext_info.py
+++ b/tests/e2e/tools/test_form_root_ext_info.py
@@ -81,6 +81,35 @@ def test_record_form_gets_its_root_ext_info():
         "exactly one root ext-info, not one per write: %d" % (xml.count(EXT_INFO_TYPE),)
 
 
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_type_and_main_in_one_batch_still_decide_the_ext_info():
+    """The root ext-info is decided ONCE, after the whole batch: per property it would depend on
+    the order the properties arrived in ([main, valueType] vs the reverse describe one end state)."""
+    reg = "E2ERecFormBatch"
+    reg_fqn = "InformationRegister." + reg
+    attr_fqn = reg_fqn + ".Form.RecordForm.Attribute.Record"
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": reg_fqn}), "seed register")
+    wait_for_project_ready()
+    assert_ok(call("create_metadata", {"projectName": PROJECT,
+                                       "fqn": reg_fqn + ".Form.RecordForm"}), "seed record form")
+    wait_for_project_ready()
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": attr_fqn}), "seed attribute")
+    wait_for_project_ready()
+
+    # main FIRST, then the type - the order that used to leave the root ext-info behind.
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": attr_fqn,
+        "properties": [
+            {"name": "main", "value": True},
+            {"name": "valueType", "value": {
+                "types": [{"kind": "InformationRegisterRecordManager", "ref": reg}]}},
+        ],
+    })
+    assert_ok(r, "set main and the type in ONE batch")
+    poll_diff_contains(EXT_INFO_TYPE,
+                       ctx="the batch decides the root ext-info whatever order it arrived in")
+
+
 @e2e_test(tool="create_metadata", kind="write-metadata")
 def test_write_event_binds_and_lands_inside_the_ext_info():
     reg, form = _seed_record_form("Bind")

--- a/tests/e2e/tools/test_form_root_ext_info.py
+++ b/tests/e2e/tools/test_form_root_ext_info.py
@@ -139,6 +139,36 @@ def test_second_binding_of_the_same_write_event_is_refused():
         "exactly one binding for the event: %d" % (xml.count("<event>BeforeWriteAtServer</event>"),)
 
 
+@e2e_test(tool="modify_metadata", kind="write-metadata")
+def test_a_main_dynamic_list_gets_the_list_form_ext_info():
+    """The dynamic-list branch writes valueType and main itself, outside the property loop that
+    syncs the form root - so it has to ask for the root ext-info on its own."""
+    base = "Catalog.E2ERootExtDynList"
+    list_form = base + ".Form.ListForm"
+    list_attr = list_form + ".Attribute.List"
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": base}), "seed catalog")
+    wait_for_project_ready()
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": list_form}), "seed list form")
+    wait_for_project_ready()
+    assert_ok(call("create_metadata", {"projectName": PROJECT, "fqn": list_attr}), "seed attribute")
+    wait_for_project_ready()
+
+    r = call("modify_metadata", {
+        "projectName": PROJECT, "fqn": list_attr,
+        "properties": [
+            {"name": "queryText",
+             "value": "SELECT Ref, Description AS Description FROM " + base},
+            {"name": "customQuery", "value": True},
+        ],
+    })
+    assert_ok(r, "convert the attribute into a dynamic list")
+    assert "dynamicList" in (r.structured.get("applied") or []), \
+        "the attribute must really be converted: %r" % (r.structured,)
+
+    poll_diff_contains('xsi:type="form:DynamicListFormExtInfo"',
+                       ctx="a MAIN dynamic list must give the form root its list ext-info")
+
+
 @e2e_test(tool="delete_metadata", kind="write-metadata")
 def test_a_binding_inside_the_ext_info_can_be_deleted():
     reg, form = _seed_record_form("Del")


### PR DESCRIPTION
Две половины одного дефекта, поэтому один PR.

Корень формы записи/объекта несёт `<extInfo xsi:type="form:...FormExtInfo">`, и
этот узел — **сам по себе контейнер обработчиков**: `FormExtInfo extends ExtInfo,
EventHandlerContainer`, тогда как ext-info элементов (`FieldExtInfo`,
`InputFieldExtInfo`) списка `handlers` не имеют вовсе. Поэтому мастер EDT кладёт
`ПередЗаписьюНаСервере` внутрь `<extInfo>`, а `ПриСозданииНаСервере` оставляет в
`<handlers>` корня. Это же деление делает и сама EDT в
`EventHandlerCollectionModel.createHandlerModels`: сначала модели для событий
самого объекта, потом отдельно — для событий его `extInfo`.

## #591 — узла не было вовсе

`create_metadata` строил форму без корневого `extInfo`, поэтому события записи и
чтения не попадали в состав доступных и отклонялись как «not valid for Form», а
задать вид узла было нечем — среди assignable его нет.

Вид корневого `extInfo` теперь следует типу **главного** реквизита. Правило
взято из исходников платформы и проверено на реальных конфигурациях:

- решает его **только запись флага `main`**: перегрузка
  `setExtInfo(Form, FormAttribute, Version)` достижима ровно из одного места во
  всей платформе — `FormAttributeService.setMainAttribute:195`. Ретайп главного
  реквизита уходит в `setTypeDescription:131-146` и корневой узел не трогает;
- снятие флага — `resetExtInfo` → `form.setExtInfo(null)`, безусловно. Категория,
  которую не отображает ни один писатель, тоже очищает узел:
  `isNeedUpdateExtInfo(null, old)` истинно для любого старого узла;
- продвижение реквизита снимает `main` с прежнего главного, как
  `setMainAttribute:185-188`; имена снятых возвращаются в ответе как
  `demotedMainAttributes`. Два главных реквизита платформа считает ошибкой
  (`FormValidator.isMainFormAttributeOneOrNone`, код 5);
- карта категорий — **объединение трёх несогласованных писателей платформы**
  (`createFormExtInfo`, генераторы форм, импортёр XML конфигуратора). Только у
  первого нет `ChartOfAccountsObject`, `ChartOfCalculationTypesObject`,
  `ExternalReport*`, `ExternalDataProcessor*` — по узкой карте инструмент удалил
  бы законный `ObjectFormExtInfo` на форме плана счетов.

## #592 — узел был, но списков два, а читался один

`availableEvents` уже объединял события базового типа и `extInfo`. А вот привязка,
проверка дубля и поиск смотрели только в `handlers` **корня**:

- второй обработчик на то же событие писался молча (диагностика
  `form-items-single-event-handler` появлялась ТОЛЬКО после записи);
- привязку, сделанную мастером EDT, нельзя было ни увидеть в
  `get_metadata_details`, ни удалить, ни перепривязать.

Теперь событие связывается с тем контейнером, который его публикует, а проверка
дубля и `findFormHandler` смотрят **обе** половины пары корень/`extInfo` — в обе
стороны, потому что формы, испорченные прежней версией инструмента, несут дубль
именно в корне. `FormStructureReader` читает обе, но под меткой самой формы, а не
узла `extInfo`.

## Проверено

- `mvn verify -Dtest=FormElementWriterTest,FormStructureReaderTest` — **301 тест,
  0 падений**, сборка бандла зелёная.
- 7 новых unit-тестов на динамической EMF-модели: обе стороны карты extInfo
  (нужный вид, замена устаревшего, очистка при неотображаемой категории,
  неглавный реквизит игнорируется), дубль в обе стороны и `findFormHandler`
  внутрь `extInfo`, плюс чтение обоих списков в `collectHandlers`.
- Новый e2e `tests/e2e/tools/test_form_root_ext_info.py` — на живой форме записи:
  узел на диске в единственном экземпляре, обработчик записан **внутрь** него,
  вторая привязка отклонена и ничего не дописала, `get_metadata_details` его
  показывает, `delete_metadata` его достаёт.

Основание для карты — перепись **10 742 форм, которые писал сам EDT** (полная
ERP в формате EDT плюс вторая конфигурация, 6299 из них с корневым `extInfo`).
Инвариант без исключений: узел есть ровно тогда, когда есть один главный
реквизит отображаемой категории — 0 форм с узлом и без главного реквизита,
0 форм с двумя главными. Все 16 наблюдённых пар «категория → вид» новая карта
воспроизводит; прежняя удалила бы узел на пяти из них.

Границы: на живом стенде проверено, что EDT НЕ считает ошибкой ни форму с
узлом без главного реквизита, ни узел, не соответствующий типу главного —
платформенная проверка `checkCorrectExtInfoType` захардкожена в «всё верно».
Поэтому правило опирается на то, что платформа ПИШЕТ, а не на то, что она
проверяет.

Closes #591
Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)

