### PR TITLE
create_metadata для роли сразу создаёт её модель прав (#605)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/guides/create_metadata.md
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/guides/create_metadata.md
@@ -87,6 +87,12 @@ The kind + modifiers map to ONE canonical 8-flag combination; an illegal mix (e.
 ### XDTOPackage namespace (top-object `XDTOPackage` only; create-time-only)
 - `targetNamespace`: the package URI namespace. A non-empty namespace is required for the package to be valid; defaults to `http://example.org/<Name>` when omitted. The success payload echoes the written `targetNamespace`.
 
+### Role rights model (top-object `Role` only)
+A `Role` is created together with its own rights model, exported beside the role as
+`src/Roles/<Name>/Rights.rights` and carrying the three role properties at their defaults. That
+file is what makes the role valid for the configurator: without it an incremental configuration
+load fails on the whole configuration, not just on the role. No follow-up call is needed to make
+a created role usable - `modify_metadata` is only for granting rights or changing the properties.
 ### Edition-gated top types
 `Bot`, `WebSocketClient` and `IntegrationService` are created only when the loaded platform version exposes their Configuration collection. On a build that lacks the collection feature the create returns a clear "Could not resolve configuration collection" error rather than crashing (the feature is probed on the live `Configuration` EClass, never assumed). On the 2026.1 target platform all three resolve and create.
 

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
@@ -34,6 +34,7 @@ import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
 import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
 import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
 import com._1c.g5.v8.dt.metadata.mdclass.ReturnValuesReuse;
+import com._1c.g5.v8.dt.metadata.mdclass.Role;
 import com._1c.g5.v8.dt.metadata.mdclass.ScriptVariant;
 import com._1c.g5.v8.dt.metadata.mdclass.Subsystem;
 import com._1c.g5.v8.dt.metadata.mdclass.TemplateType;
@@ -61,6 +62,7 @@ import com.ditrix.edt.mcp.server.utils.MetadataScope;
 import com.ditrix.edt.mcp.server.utils.MetadataTypeBuilder;
 import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils;
 import com.ditrix.edt.mcp.server.utils.PredefinedWriter;
+import com.ditrix.edt.mcp.server.utils.RoleRightsWriter;
 import com.ditrix.edt.mcp.server.utils.SubsystemUtils;
 import com.ditrix.edt.mcp.server.utils.XdtoWriteException;
 import com.ditrix.edt.mcp.server.utils.XdtoWriter;
@@ -1088,9 +1090,9 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         final String configFeatureName = req.target.configFeatureName;
         final IModelObjectFactory factory = bm.factory;
         final Version version = bm.version;
-        // Needed to name the external-property content of a CommonForm and of an XDTOPackage
-        // (both below); resolved up front like the rest of the BM services this method uses, not
-        // inside the transaction.
+        // Needed to name the external-property content of a CommonForm, of an XDTOPackage and the
+        // rights model of a Role (all below); resolved up front like the rest of the BM services
+        // this method uses, not inside the transaction.
         final ITopObjectFqnGenerator fqnGenerator = Activator.getDefault().getTopObjectFqnGenerator();
         // The FORM factory + script variant build that content form the same way the owned-form path
         // does (issue #297).
@@ -1099,15 +1101,17 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         // For a FORM the generator is mandatory, exactly as on the owned-form path: a form whose
         // content could not be attached under its canonical FQN is precisely the half-created object
         // issue #297 is about, so refuse rather than report success for a form nothing can be added
-        // to. Every other top type still creates without it (the XDTOPackage content below is
-        // best-effort by design), so the check is scoped to forms.
-        if (fqnGenerator == null && MdClassPackage.Literals.BASIC_FORM.isSuperTypeOf(eClass))
+        // to. A ROLE is the same case for a harder reason (below). The XDTOPackage content stays
+        // best-effort by design, so the check covers these two types only.
+        if (fqnGenerator == null && (MdClassPackage.Literals.BASIC_FORM.isSuperTypeOf(eClass)
+            || MdClassPackage.Literals.ROLE.isSuperTypeOf(eClass)))
         {
             return ToolResult.error(ERR_NO_FQN_GENERATOR).toJson();
         }
 
         final String[] xdtoContentFqnHolder = { null };
         final String[] formContentFqnHolder = { null };
+        final String[] rightsFqnHolder = { null };
         final EClass createdKind;
         try
         {
@@ -1149,6 +1153,14 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
                 {
                     FormElementWriter.enforceContentFormCommandBarId((BasicForm)newObject);
                 }
+                // A role without its rights model is not merely incomplete: the configurator then
+                // refuses to load the WHOLE configuration, and re-saving the role in EDT does not
+                // bring the file back. Attached in the CREATING transaction, like the content below.
+                if (newObject instanceof Role)
+                {
+                    rightsFqnHolder[0] =
+                        RoleRightsWriter.attachRoleDescription(tx, (Role)newObject, fqnGenerator);
+                }
                 // An XDTOPackage's content (Package.xdto) is a lazy @ExternalProperty; a live-stand
                 // finding showed the platform does NOT durably serialize it when it is first
                 // materialized in a LATER, separate transaction (the first member-edit call) - each
@@ -1171,6 +1183,10 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
                 return newObject.eClass();
             });
         }
+        catch (RoleRightsWriter.RoleWriteException e)
+        {
+            return e.getErrorJson();
+        }
         catch (Exception e)
         {
             Activator.logError("Error creating metadata object", e); //$NON-NLS-1$
@@ -1182,6 +1198,11 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         if (formContentFqn != null && !exportFqns.contains(formContentFqn))
         {
             exportFqns.add(formContentFqn);
+        }
+        String rightsFqn = rightsFqnHolder[0];
+        if (rightsFqn != null && !exportFqns.contains(rightsFqn))
+        {
+            exportFqns.add(rightsFqn);
         }
         String xdtoContentFqn = xdtoContentFqnHolder[0];
         if (xdtoContentFqn != null && !exportFqns.contains(xdtoContentFqn))

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataTool.java
@@ -142,6 +142,13 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         "ITopObjectFqnGenerator not available (needed to attach the content form under its " //$NON-NLS-1$
             + "canonical FQN)"; //$NON-NLS-1$
 
+    /** Error: the service that registers a role's rights model is unavailable. */
+    private static final String ERR_NO_ROLE_FQN_GENERATOR =
+        "The role was not created because ITopObjectFqnGenerator is not available. The generator " //$NON-NLS-1$
+            + "is needed to register the role's rights model under its canonical FQN; without that " //$NON-NLS-1$
+            + "model, the role would be invalid for the configurator and an incremental " //$NON-NLS-1$
+            + "configuration load would fail for the whole configuration."; //$NON-NLS-1$
+
     /** Error prefix: could not resolve the V8 project. */
     private static final String ERR_NO_V8_PROJECT = "Could not resolve V8 project for: "; //$NON-NLS-1$
 
@@ -1102,9 +1109,12 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         // content could not be attached under its canonical FQN is precisely the half-created object
         // issue #297 is about, so refuse rather than report success for a form nothing can be added
         // to. A ROLE is the same case for a harder reason (below). The XDTOPackage content stays
-        // best-effort by design, so the check covers these two types only.
-        if (fqnGenerator == null && (MdClassPackage.Literals.BASIC_FORM.isSuperTypeOf(eClass)
-            || MdClassPackage.Literals.ROLE.isSuperTypeOf(eClass)))
+        // best-effort by design, so the checks cover these two types only.
+        if (fqnGenerator == null && MdClassPackage.Literals.ROLE.isSuperTypeOf(eClass))
+        {
+            return ToolResult.error(ERR_NO_ROLE_FQN_GENERATOR).toJson();
+        }
+        if (fqnGenerator == null && MdClassPackage.Literals.BASIC_FORM.isSuperTypeOf(eClass))
         {
             return ToolResult.error(ERR_NO_FQN_GENERATOR).toJson();
         }
@@ -1185,7 +1195,7 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         }
         catch (RoleRightsWriter.RoleWriteException e)
         {
-            return e.getErrorJson();
+            return roleCreationFailure(name, RoleRightsWriter.extractErrorMessage(e));
         }
         catch (Exception e)
         {
@@ -1213,6 +1223,12 @@ public class CreateMetadataTool extends AbstractMetadataWriteTool
         return success(new SuccessInfo(req.normFqn, createdKind, name, persisted, req.props,
             req.synonymLanguage, req.localesMissing, req.localeUnused, req.typeSpecific,
             req.normReport));
+    }
+
+    /** Adds the rolled-back create context without nesting the writer's error JSON. */
+    static String roleCreationFailure(String roleName, String writerMessage)
+    {
+        return ToolResult.error("Role '" + roleName + "' was not created. " + writerMessage).toJson(); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     /**

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/RoleRightsWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/RoleRightsWriter.java
@@ -838,8 +838,10 @@ public final class RoleRightsWriter
      *     (nothing was mutated on that branch, so the write stands and only the rights-resource export
      *     is lost); a FRESH description that cannot be given an FQN is refused instead, because there
      *     the reference has already been repointed and leaving it is the unpersistable #452 state
+     * @throws RoleWriteException when a fresh description cannot be safely registered
      */
-    static String attachRoleDescription(IBmTransaction tx, Role inTx, ITopObjectFqnGenerator fqnGenerator)
+    public static String attachRoleDescription(IBmTransaction tx, Role inTx,
+        ITopObjectFqnGenerator fqnGenerator)
     {
         AbstractRoleDescription current = inTx.getRights();
         if (current instanceof RoleDescription && current instanceof IBmObject
@@ -1531,7 +1533,7 @@ public final class RoleRightsWriter
      * top-level {@link #apply} returns it verbatim. Unchecked so it crosses the BM task boundary; the
      * message is a validated {@link ToolResult#error} JSON string.
      */
-    static final class RoleWriteException extends RuntimeException
+    public static final class RoleWriteException extends RuntimeException
     {
         private static final long serialVersionUID = 1L;
         private final transient String errorJson;
@@ -1542,7 +1544,7 @@ public final class RoleRightsWriter
             this.errorJson = errorJson;
         }
 
-        String getErrorJson()
+        public String getErrorJson()
         {
             return errorJson;
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/RoleRightsWriter.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/utils/RoleRightsWriter.java
@@ -910,8 +910,8 @@ public final class RoleRightsWriter
                 + "this project's model, so this role's rights model cannot be attached under it. " //$NON-NLS-1$
                 + "This call did not determine why that FQN is taken: if the " //$NON-NLS-1$
                 + "registration is stale (a rights model whose role no longer exists on disk), run " //$NON-NLS-1$
-                + "clean_project on the project and retry the same call; otherwise re-read the role " //$NON-NLS-1$
-                + "with get_metadata_details first.").toJson()); //$NON-NLS-1$
+                + "clean_project on the project and retry the same call; otherwise resolve the " //$NON-NLS-1$
+                + "conflicting registration before retrying.").toJson()); //$NON-NLS-1$
         }
 
         // (3) ...and only now register it. A role whose reference was set but whose attach did not
@@ -932,8 +932,36 @@ public final class RoleRightsWriter
             : PlatformFailures.withoutObjectIdentity(PlatformFailures.describe(cause));
         return ToolResult.error("Could not generate the rights model FQN for role '" + inTx.getName() //$NON-NLS-1$
             + "' (" + detail + "), so its rights model was not created and nothing was written. The " //$NON-NLS-1$ //$NON-NLS-2$
-            + "role is most likely not resolvable in the configuration tree: re-read it with " //$NON-NLS-1$
-            + "get_metadata_details, then retry.").toJson(); //$NON-NLS-1$
+            + "role is most likely not resolvable in the configuration tree. Run clean_project on " //$NON-NLS-1$
+            + "the project, then retry the same call.").toJson(); //$NON-NLS-1$
+    }
+
+    /** Extracts the error text; unexpected payloads pass through so error handling cannot fail again. */
+    public static String extractErrorMessage(RoleWriteException failure)
+    {
+        if (failure == null)
+        {
+            return null;
+        }
+        String errorJson = failure.getErrorJson();
+        try
+        {
+            JsonElement parsed = JsonParser.parseString(errorJson);
+            if (parsed.isJsonObject())
+            {
+                JsonElement error = parsed.getAsJsonObject().get(McpKeys.ERROR);
+                if (error != null && error.isJsonPrimitive()
+                    && error.getAsJsonPrimitive().isString())
+                {
+                    return error.getAsString();
+                }
+            }
+        }
+        catch (RuntimeException e)
+        {
+            // Error handling must preserve the original payload instead of failing again.
+        }
+        return errorJson;
     }
 
     /**

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/CreateMetadataToolTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,6 +25,8 @@ import com.ditrix.edt.mcp.server.tools.impl.CreateMetadataTool.CommonModuleFlags
 import com.ditrix.edt.mcp.server.tools.impl.CreateMetadataTool.CommonModuleKind;
 import com.ditrix.edt.mcp.server.utils.MetadataLanguageUtils;
 import com.ditrix.edt.mcp.server.utils.PredefinedWriter;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 /**
  * Lightweight contract tests for {@link CreateMetadataTool}: tool metadata and JSON schema,
@@ -53,6 +56,46 @@ public class CreateMetadataToolTest
         assertFalse(desc.isEmpty());
         assertTrue("description should point to get_tool_guide", //$NON-NLS-1$
             desc.contains("get_tool_guide('create_metadata')")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testMissingFqnGeneratorHasADistinctRoleCreationRefusal() throws Exception
+    {
+        String formMessage = privateStringConstant("ERR_NO_FQN_GENERATOR"); //$NON-NLS-1$
+        String roleMessage = privateStringConstant("ERR_NO_ROLE_FQN_GENERATOR"); //$NON-NLS-1$
+
+        assertEquals("ITopObjectFqnGenerator not available (needed to attach the content form under " //$NON-NLS-1$
+            + "its canonical FQN)", formMessage); //$NON-NLS-1$
+        assertFalse("the role guard must not reuse the form-specific refusal", //$NON-NLS-1$
+            roleMessage.equals(formMessage));
+        assertTrue("the role refusal must say that the role was not created", //$NON-NLS-1$
+            roleMessage.contains("The role was not created")); //$NON-NLS-1$
+        assertTrue("the role refusal must name the missing rights-model registration", //$NON-NLS-1$
+            roleMessage.contains("register the role's rights model under its canonical FQN")); //$NON-NLS-1$
+        assertTrue("the role refusal must explain the configurator-wide consequence", //$NON-NLS-1$
+            roleMessage.contains("incremental configuration load would fail for the " //$NON-NLS-1$
+                + "whole configuration")); //$NON-NLS-1$
+        assertFalse("the role refusal must not name a content form", //$NON-NLS-1$
+            roleMessage.contains("content form")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testRoleCreationFailureAddsCreateContextWithoutNestingJson()
+    {
+        String writerMessage = "The registration is stale; run clean_project and retry the same call."; //$NON-NLS-1$
+
+        JsonObject result = JsonParser.parseString(
+            CreateMetadataTool.roleCreationFailure("Reader", writerMessage)).getAsJsonObject(); //$NON-NLS-1$
+
+        assertEquals("Role 'Reader' was not created. " + writerMessage, //$NON-NLS-1$
+            result.get("error").getAsString()); //$NON-NLS-1$
+    }
+
+    private static String privateStringConstant(String name) throws Exception
+    {
+        Field field = CreateMetadataTool.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return (String)field.get(null);
     }
 
     @Test

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/RoleRightsWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/RoleRightsWriterTest.java
@@ -417,8 +417,8 @@ public class RoleRightsWriterTest
     @Test
     public void testAttachRoleDescriptionRegistersTheFreshDescriptionUnderTheGeneratedFqn()
     {
-        // The whole of issue #452: a role created through create_metadata has no rights model, and a
-        // description that is merely REFERENCED is not persistable - the next commit dies with
+        // The missing-model branch behind issue #452: a merely REFERENCED description is not
+        // persistable - the next commit dies with
         // "Failed to persist reference value ...RoleDescriptionImpl@<hash>". The bootstrap must
         // register it as a BM top object in the SAME transaction that sets the reference.
         Role role = mockRole("Reader"); //$NON-NLS-1$
@@ -789,9 +789,8 @@ public class RoleRightsWriterTest
     @Test
     public void testAnUnresolvableRightsEntryIsRefusedBeforeTheBootstrapWrites()
     {
-        // The whole rights payload must resolve before the bootstrap commits. An unresolvable entry
-        // on a fresh role must therefore leave NO Rights.rights model behind - and, above all, must
-        // not leave a right granted while the caller sees only a refusal.
+        // The whole payload resolves before bootstrap. For a legacy role with no description, an
+        // unresolvable entry must leave no Rights.rights model or silently granted right behind.
         Role role = mockRole("Reader"); //$NON-NLS-1$
         JsonObject missing = rightsEntry("DefinitelyNotAnObjectFqn", "Read", "set"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         RoleRightsWriter.Result result = applyThroughMockedModel(role, null,

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/RoleRightsWriterTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/RoleRightsWriterTest.java
@@ -667,6 +667,9 @@ public class RoleRightsWriterTest
         {
             assertErrorMentions(e.getErrorJson(), "Role.Reader.Rights"); //$NON-NLS-1$
             assertErrorMentions(e.getErrorJson(), "clean_project"); //$NON-NLS-1$
+            assertErrorMentions(e.getErrorJson(), "retry the same call"); //$NON-NLS-1$
+            assertFalse("the refusal must not tell a create caller to re-read a rolled-back role", //$NON-NLS-1$
+                e.getErrorJson().contains("re-read the role")); //$NON-NLS-1$
             // ...but the refusal may claim only what it OBSERVED: that the name is taken. Declaring
             // the registration stale sends the caller to run clean_project - a rebuild - on a premise
             // this call never checked, and a LIVE registration the role's reference has not resolved
@@ -997,6 +1000,38 @@ public class RoleRightsWriterTest
     }
 
     @Test
+    public void testExtractErrorMessageReturnsTheHumanReadableError()
+    {
+        String message = "The rights model could not be registered."; //$NON-NLS-1$
+        RoleRightsWriter.RoleWriteException failure = new RoleRightsWriter.RoleWriteException(
+            ToolResult.error(message).toJson());
+
+        assertEquals(message, RoleRightsWriter.extractErrorMessage(failure));
+    }
+
+    @Test
+    public void testExtractErrorMessageFallsBackToMalformedPayload()
+    {
+        String malformed = "{definitely not json"; //$NON-NLS-1$
+        RoleRightsWriter.RoleWriteException failure =
+            new RoleRightsWriter.RoleWriteException(malformed);
+
+        assertSame("a malformed refusal must pass through byte-for-byte", malformed, //$NON-NLS-1$
+            RoleRightsWriter.extractErrorMessage(failure));
+    }
+
+    @Test
+    public void testExtractErrorMessageFallsBackToUnexpectedPayloadShape()
+    {
+        String unexpected = "{\"success\":false,\"error\":42}"; //$NON-NLS-1$
+        RoleRightsWriter.RoleWriteException failure =
+            new RoleRightsWriter.RoleWriteException(unexpected);
+
+        assertSame("a non-string error must pass through byte-for-byte", unexpected, //$NON-NLS-1$
+            RoleRightsWriter.extractErrorMessage(failure));
+    }
+
+    @Test
     public void testApplyFailureCarriesNoEmfObjectIdentity()
     {
         // The catch-all of apply() is the one place the #452 commit failure reaches a caller, and the
@@ -1055,6 +1090,8 @@ public class RoleRightsWriterTest
         catch (RoleRightsWriter.RoleWriteException e)
         {
             assertErrorMentions(e.getErrorJson(), roleName);
+            assertErrorMentions(e.getErrorJson(), "clean_project"); //$NON-NLS-1$
+            assertErrorMentions(e.getErrorJson(), "retry the same call"); //$NON-NLS-1$
         }
 
         assertNull("the role must not keep a reference to a description that was never attached", //$NON-NLS-1$
@@ -1080,6 +1117,8 @@ public class RoleRightsWriterTest
         catch (RoleRightsWriter.RoleWriteException e)
         {
             assertErrorMentions(e.getErrorJson(), "Reader"); //$NON-NLS-1$
+            assertErrorMentions(e.getErrorJson(), "clean_project"); //$NON-NLS-1$
+            assertErrorMentions(e.getErrorJson(), "retry the same call"); //$NON-NLS-1$
         }
 
         assertSame("the previous reference must be restored, not cleared", previous, //$NON-NLS-1$

--- a/tests/e2e/tools/test_create_metadata.py
+++ b/tests/e2e/tools/test_create_metadata.py
@@ -69,6 +69,11 @@ def _objects_text(metadata_type):
     return r.text
 
 
+def _role_rights_file(role_name):
+    """The separate rights resource create_metadata must export for a Role top object."""
+    return "src/Roles/%s/Rights.rights" % role_name
+
+
 def _xml_local(tag):
     return tag.rsplit("}", 1)[-1]
 
@@ -119,6 +124,37 @@ def test_create_top_level_catalog_appears_in_readback():
 
     assert_contains(_objects_text("catalogs"), name,
                     "the new catalog must appear in the model read-back")
+
+
+@e2e_test(tool="create_metadata", kind="write-metadata")
+def test_created_role_gets_its_rights_model():
+    """A created role must immediately own its separate Rights.rights resource.
+
+    Without that file the 1C configurator refuses to load the WHOLE configuration, while the failure
+    surfaces far from the create_metadata call that caused it. This pins the resource and its three
+    default properties at creation time, before any later modify_metadata call can materialize it."""
+    name = "E2ECreatedRoleRights"
+    fqn = "Role." + name
+    rights_file = _role_rights_file(name)
+
+    r = call("create_metadata", {"projectName": PROJECT, "fqn": fqn})
+    assert_ok(r, "create %s with its rights model" % fqn)
+    assert (r.structured or {}).get("persisted") is True, (
+        "role creation must report persisted=true after exporting Role.mdo and Rights.rights: %r"
+        % (r.structured,))
+
+    poll_disk_contains(rights_file, "<setForNewObjects>",
+                       ctx="create_metadata must export the role's Rights.rights resource")
+    rights_xml = read_disk(rights_file)
+    for prop in ("setForNewObjects", "setForAttributesByDefault",
+                 "independentRightsOfChildObjects"):
+        assert_contains(rights_xml, "<%s>" % prop,
+                        "the created rights resource must carry its %s default" % prop)
+    assert_not_contains(rights_xml, "<object>",
+                        "the created rights model must be empty before any rights write")
+
+    assert_contains(_objects_text("roles"), name,
+                    "MODEL read-back: the role with the exported rights model must resolve")
 
 
 @e2e_test(tool="create_metadata", kind="write-metadata")

--- a/tests/e2e/tools/test_get_metadata_details_role.py
+++ b/tests/e2e/tools/test_get_metadata_details_role.py
@@ -10,8 +10,8 @@ to RoleRightsReader, which renders one document - `# Role Rights: <fqn>`, then `
 
 This file covers the five things only the wire can prove about that reader:
 
-  * the empty state - a role created by create_metadata carries no editable rights model, and the
-    note is what a caller sees (the stable read-side pin the #452 fix is measured against);
+  * the created empty state - a role created by create_metadata already carries a concrete rights
+    model, so the caller sees the full document with an empty matrix and the default properties;
   * the VALUE labels - `allowed` (RightValue.SET) and `denied` (RightValue.UNSET) for two
     authored objects;
   * the TRI-STATE - `provided` is a third value, NOT a synonym for "denied": it is dropped from
@@ -76,8 +76,8 @@ from harness import (
 )
 
 
-# The note RoleRightsReader.render emits INSTEAD of the whole document when Role.getRights() is not
-# a concrete RoleDescription. Asserted literally: it is what a caller reads.
+# The note RoleRightsReader.render reserves for a genuinely missing RoleDescription. A role created
+# through the tools must never render it.
 _NO_MATRIX_NOTE = "_(this role has no editable rights model)_"
 
 _MATRIX_HEADING = "## Rights matrix"
@@ -104,13 +104,8 @@ def _rights_file_text(role_name):
     """The role's Rights.rights exactly as it is on disk right now, or None when the file does not
     exist at all.
 
-    Deliberately a plain read rather than one of the export-ordered disk helpers: the "no rights
-    model yet" assertion is made after a READ call that touched no file and submitted no export,
-    so assert_disk_path_gone's precondition (the same call removed the path or queued the export
-    that removes it) does not hold and its failure text would blame an export race that is not the
-    defect. poll_disk_lacks / assert_disk_lacks are wrong for the opposite reasons - one would only
-    burn the polling budget on a file nothing is going to create, the other requires the file to
-    exist. The sibling write-side file keeps the same helper for the same reason."""
+    The created-role test polls for the resource first, then uses this plain read to pin every
+    default property in that one file rather than accepting a match from another changed file."""
     full = os.path.join(PROJECT_DIR, *_rights_file(role_name).split("/"))
     if not os.path.isfile(full):
         return None
@@ -123,7 +118,7 @@ def _rights_file_text(role_name):
 # ---------------------------------------------------------------------------
 
 def _seed_role(name):
-    """Creates Role.<name> and returns its FQN. A role created this way has NO rights model."""
+    """Creates Role.<name> and returns its FQN. The role already has an empty rights model."""
     r = call("create_metadata", {"projectName": PROJECT, "fqn": "Role." + name})
     assert_ok(r, "seed Role.%s" % name)
     wait_for_project_ready()
@@ -222,40 +217,44 @@ def _cell(rows, obj, right):
 
 
 # ---------------------------------------------------------------------------
-# The empty state
+# The created empty model
 # ---------------------------------------------------------------------------
 
 @e2e_test(tool="get_metadata_details", kind="write-metadata")
-def test_role_rights_read_note_when_role_has_no_rights_model():
-    """A role created through create_metadata has no rights model, and the reader says exactly
-    that - it does not fabricate an empty matrix and it does not fail the object.
+def test_role_rights_read_created_role_already_has_its_rights_model():
+    """A role created through create_metadata has a concrete, empty rights model immediately, so
+    the reader renders the full document and the three default properties exist on disk.
 
-    This is the read-side pin the #452 flip is measured against: the same call renders this note
-    before the first rights write and the full document after it (see
-    test_role_rights_read_matrix_renders_allowed_and_denied). Both halves are asserted - the MODEL
-    (the note, and the absence of every section the note replaces) and the DISK (no Rights.rights
-    resource exists yet) - so a build that quietly created a rights model at object-creation time,
-    or a reader that rendered the note over a model that does have one, both fail here."""
-    name = "E2ERoleNoMatrix"
+    RoleRightsReader still has a note path for a legacy role whose rights model is genuinely absent.
+    No tool can produce that state now, so the note path is covered by unit tests only. This e2e pins
+    both reachable halves of the new contract: the MODEL renders an empty matrix, and the DISK carries
+    the separate Rights.rights resource that makes the role valid for the configurator."""
+    name = "E2ERoleEmptyMatrix"
     role_fqn = _seed_role(name)
+
+    poll_disk_contains(_rights_file(name), "<setForNewObjects>",
+                       ctx="create_metadata must export the role's own rights resource")
+    rights_text = _rights_file_text(name)
+    assert rights_text is not None, "%s must exist after role creation" % _rights_file(name)
+    for prop in ("setForNewObjects", "setForAttributesByDefault",
+                 "independentRightsOfChildObjects"):
+        assert_contains(rights_text, "<%s>" % prop,
+                        "the empty rights resource must carry its %s default" % prop)
 
     text = _read_role(role_fqn)
     assert_contains(text, "# Role Rights: " + role_fqn,
                     "a Role FQN renders the rights document, headed by the normalized FQN")
-    assert_contains(text, _NO_MATRIX_NOTE,
-                    "a role with no editable rights model renders the note verbatim")
-    assert_not_contains(text, "## Properties",
-                        "the note REPLACES the document: no role-property table may be rendered")
-    assert_not_contains(text, _MATRIX_HEADING,
-                        "the note REPLACES the document: no matrix section may be rendered")
+    assert_contains(text, "## Properties",
+                    "the fresh role's concrete rights model renders its properties")
+    assert_contains(text, _MATRIX_HEADING,
+                    "the fresh role's concrete rights model renders an empty matrix section")
+    assert _matrix_rows(text) == [], "a fresh role must have no authored rights rows:\n%s" % text
+    assert_not_contains(text, _NO_MATRIX_NOTE,
+                        "the missing-model note must not replace a concrete empty rights model")
     assert_contains(text, "**Origin:** core",
                     "the role still resolved as a base object, so the origin footer is rendered")
     assert_not_contains(text, "## Errors",
-                        "a role without a rights model is NOT a per-object resolution failure")
-
-    assert _rights_file_text(name) is None, (
-        "a role created with no rights write must carry no Rights.rights resource - that absence "
-        "is the on-disk half of the note above; %s exists" % _rights_file(name))
+                        "the created rights model must not produce a per-object resolution failure")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/tools/test_modify_metadata_role_rights.py
+++ b/tests/e2e/tools/test_modify_metadata_role_rights.py
@@ -1,16 +1,14 @@
 """
 e2e tests for modify_metadata WRITING a role's access rights - the `rights` / `roleProperties`
-payload on a `Role.<Name>` FQN (#454), and the regression proof for #452.
+payload on a `Role.<Name>` FQN (#454), including the first write on a freshly created role.
 
-#452: a role created through create_metadata carries NO editable rights model. The writer
-materialised a RoleDescription with RightsFactory and set it on the role, but never registered that
-description as a BM top object, so the transaction could not build a persistable reference to it and
-the commit died with `Failed to persist reference value ...RoleDescriptionImpl@<hash>` - every FIRST
-rights write on a freshly created role failed, and the failure text leaked the EMF implementation's
-identity to the caller. These tests drive that exact path over the wire: seed a role, write one
-right, and require the cell to land in the role's own `Rights.rights` resource on disk AND to read
-back through get_metadata_details. On the pre-fix build the write returns isError and
-`Rights.rights` is never created, so no assertion here can be satisfied by substring accident.
+#452: the writer once materialised a RoleDescription without registering it as a BM top object, so
+the first rights write on a role with no model died with `Failed to persist reference value
+...RoleDescriptionImpl@<hash>`. A role created through create_metadata now already owns a registered,
+empty rights model. These tests therefore prove the reachable first-write path without relying on
+file creation: before the write, both the rendered matrix and the existing `Rights.rights` resource
+are required to carry NO row for the guarded object; afterwards, both must carry the authored cell.
+No assertion can be satisfied merely because create_metadata produced the empty resource first.
 
 WHAT THE PLATFORM DOES WITH A RIGHT VALUE (measured in RightsModelUtil, EDT 2026.2 - not assumed).
 AddRightValuesTask calls `changeObjectRight(newValue, defaultValue, ...)`, and
@@ -27,8 +25,8 @@ reset: kind="write-metadata" -> reset_fixture()+reset_model() after each test.
 
 FIXTURE TRUTH (TestConfiguration, English Names)
   - TestConfiguration ships NO `src/Roles/` folder at all. There is no role to reuse and no rights
-    matrix to read, so every test here SEEDS ITS OWN role with create_metadata - which is also
-    exactly the #452 path. The seeded role is reverted by the write-metadata reset.
+    matrix to read, so every test here SEEDS ITS OWN role with create_metadata. The seeded role and
+    its empty rights resource are reverted by the write-metadata reset.
   - The only role that exists anywhere in the fixtures (`tests_DefaultRole`) lives in the `tests`
     EXTENSION project, which the per-test reset_fixture does NOT cover and which the PROJECT_DIR-
     scoped disk helpers cannot address. Nothing here may write into it.
@@ -36,9 +34,9 @@ FIXTURE TRUTH (TestConfiguration, English Names)
     default right value comes from `setForNewObjects` (see above), not from
     `setForAttributesByDefault`.
   - A role's rights live in their OWN resource beside the role's .mdo, at
-    `src/Roles/<Name>/Rights.rights` - not inside `<Name>.mdo`. Every disk assertion names that one
-    file and goes through poll_disk_contains; poll_diff_contains is never used here, because it is
-    satisfied by the substring appearing in ANY changed file and a role write touches two.
+    `src/Roles/<Name>/Rights.rights` - not inside `<Name>.mdo`. Positive disk assertions poll that
+    exact file; refusal/setup assertions read it directly and require the guarded object to be absent.
+    poll_diff_contains is never used because a role write touches more than one file.
   - The on-disk shape is the v8 roles XML (`http://v8.1c.ru/8.2/roles`), where the object node is
     `<object><name>FQN</name><right><name>Read</name><value>true</value></right></object>` and the
     RightValue enum literals serialize as `true` (Set) / `false` (Unset) / `provided` (Provided).
@@ -69,10 +67,6 @@ from harness import (
 # object (so its default right value follows setForNewObjects - see the module docstring).
 GUARDED_OBJECT = "Catalog.Catalog"
 
-# The literal note get_metadata_details renders for a role that has NO editable rights model. This
-# is the #452 precondition; it must be present before the first write and gone after it.
-NO_MATRIX_NOTE = "_(this role has no editable rights model)_"
-
 # "Read" written in Russian, spelled from code points so this source file stays pure ASCII:
 # U+0427 U+0442 U+0435 U+043D U+0438 U+0435. The `right` name is bilingual on the way IN
 # (RoleRightsWriter matches Right.getName() OR Right.getNameRu()), which one test drives directly.
@@ -85,11 +79,12 @@ _MATRIX_HEADER = ["Object", "Right", "Value"]
 def _seed_role(name):
     """create_metadata a fresh Role and return its FQN.
 
-    A role created this way has no rights model whatsoever - that is the #452 precondition, and it
-    is asserted explicitly in the test that depends on it rather than assumed everywhere."""
+    A role created this way already has an empty rights model and its own Rights.rights resource."""
     fqn = "Role." + name
     r = call("create_metadata", {"projectName": PROJECT, "fqn": fqn})
     assert_ok(r, "seed role " + fqn)
+    poll_disk_contains(_rights_file(name), "<setForNewObjects>",
+                       ctx="create_metadata must export the seeded role's empty rights resource")
     wait_for_project_ready()
     return fqn
 
@@ -101,15 +96,13 @@ def _rights_file(name):
 
 
 def _rights_file_text(name):
-    """The role's Rights.rights exactly as it is on disk right now, or None when the file does not
-    exist yet.
+    """The role's existing Rights.rights exactly as it is on disk right now.
 
-    Deliberately NOT poll_disk_lacks / assert_disk_lacks: this is used for the "it is not there
-    AT ALL" precondition and for a refused call's "nothing was created", where polling would only
-    burn the budget and assert_disk_lacks would fail on the missing file it is meant to accept."""
+    Failing when the file is missing prevents an absent resource from satisfying a guarded-object
+    absence assertion by accident."""
     full = os.path.join(PROJECT_DIR, *_rights_file(name).split("/"))
     if not os.path.isfile(full):
-        return None
+        raise AssertionError("the seeded role's rights resource does not exist: %s" % _rights_file(name))
     with open(full, encoding="utf-8", errors="replace") as f:
         return f.read()
 
@@ -149,38 +142,37 @@ def _matrix_rows(text):
 
 
 # ──────────────────────────────────────────────────────────────────────────────
-# THE #452 CASE — the first rights write on a role created through create_metadata
+# FIRST WRITE — the empty rights resource created with the role gains its first cell
 # ──────────────────────────────────────────────────────────────────────────────
 
 @e2e_test(tool="modify_metadata", kind="write-metadata")
 def test_role_rights_first_write_on_a_freshly_created_role_lands_on_disk():
-    """#452: a role created by create_metadata must accept a rights write end to end.
+    """A role created by create_metadata must accept its first rights write end to end.
 
-    The steps are ordered so that a failure cannot be misread. The role is first PROVEN to have no
-    rights model (the note) and no rights resource on disk, so "the write created it" is a real
-    claim rather than an observation of something that was already there. Then the call must report
-    success AND `persisted` - the rights matrix is its own BM resource with its own FQN, so a write
-    that reached the model but not the disk would otherwise pass. Only then is the file required to
-    carry the cell, and the same read required to have changed its answer.
-
-    On the pre-fix build the write returns isError and no Rights.rights is ever written, so every
-    assertion from the modify_metadata call onwards is unreachable there."""
+    The steps are ordered so that a failure cannot be misread. The role is first PROVEN to have a
+    rendered empty matrix and an existing rights resource that neither carries the guarded object.
+    Then the call must report success AND `persisted` - the matrix is its own BM resource with its own
+    FQN, so a write that reached the model but not the disk would otherwise pass. Only then must the
+    file and the reader both carry the new cell. A create that omitted the resource fails setup; a
+    modify that did not author the cell fails the postconditions."""
     name = "E2ERoleRightsFresh"
     fqn = _seed_role(name)
 
     before = _details(fqn)
-    assert_contains(before, NO_MATRIX_NOTE,
-                    "a freshly created role must have NO editable rights model yet - that is the "
-                    "#452 precondition this test exists for")
-    assert _rights_file_text(name) is None, (
-        "setup: %s must not exist before the first rights write, otherwise the disk assertions "
-        "below would be satisfied by a file this call never wrote" % _rights_file(name))
+    assert_contains(before, "## Rights matrix",
+                    "a freshly created role must render its concrete empty rights model")
+    before_rows = _matrix_rows(before)
+    assert all(obj != GUARDED_OBJECT for obj, _right, _value in before_rows), (
+        "setup: the guarded object must have no pre-existing matrix row; rows were %r" % before_rows)
+    assert_not_contains(_rights_file_text(name), GUARDED_OBJECT,
+                        "setup: the existing rights resource must not already carry the guarded "
+                        "object this call is meant to add")
 
     r = call("modify_metadata", {
         "projectName": PROJECT, "fqn": fqn,
         "rights": [{"object": GUARDED_OBJECT, "right": "Read", "value": "set"}],
     })
-    assert_ok(r, "the FIRST rights write on a freshly created role (#452)")
+    assert_ok(r, "the FIRST rights write on a freshly created role")
     structured = r.structured or {}
     assert structured.get("persisted") is True, (
         "the rights write must report persisted=true: the matrix lives in its own resource and is "
@@ -195,9 +187,6 @@ def test_role_rights_first_write_on_a_freshly_created_role_lands_on_disk():
                        ctx="a granted right serializes as the 'true' RightValue literal")
 
     after = _details(fqn)
-    assert_not_contains(after, NO_MATRIX_NOTE,
-                        "the role now HAS an editable rights model, so the degraded note must be "
-                        "gone from the read")
     assert_contains(after, "## Properties",
                     "a role with a rights model renders its three role-property booleans")
     assert (GUARDED_OBJECT, "Read", "allowed") in _matrix_rows(after), \
@@ -237,16 +226,16 @@ def test_role_rights_bad_rls_field_refuses_without_granting_the_right():
                          ctx="the refusal must name the bad field and explain how to request a "
                              "whole-object restriction instead")
 
-    assert _rights_file_text(name) is None, (
-        "the refusal must not bootstrap or export %s when rights resolution failed before the first "
-        "commit" % _rights_file(name))
+    assert_not_contains(_rights_file_text(name), GUARDED_OBJECT,
+                        "the refusal must not add the guarded object's cell to the existing rights "
+                        "resource")
     after = _details(fqn)
-    assert (GUARDED_OBJECT, "Read", "allowed") not in _matrix_rows(after), (
-        "the refused call must NOT leave Read granted on %s; get_metadata_details is the semantic "
-        "truth the caller relies on:\n%s" % (GUARDED_OBJECT, after))
-    assert_contains(after, NO_MATRIX_NOTE,
-                    "a rights-resolution refusal on a fresh role must not even bootstrap an empty "
-                    "rights model")
+    assert_contains(after, "## Rights matrix",
+                    "the refusal must leave the fresh role's empty rights model readable")
+    after_rows = _matrix_rows(after)
+    assert all(obj != GUARDED_OBJECT for obj, _right, _value in after_rows), (
+        "the refused call must leave NO row for %s; matrix rows were %r"
+        % (GUARDED_OBJECT, after_rows))
     assert_tree_unchanged(before,
                           "the RLS-field refusal must leave the seeded role byte-for-byte unchanged")
 
@@ -355,8 +344,8 @@ def test_role_rights_combined_with_properties_is_refused_and_writes_nothing():
     The "changed nothing" claim is measured from a snapshot taken AFTER the seed, not from HEAD:
     seeding the role legitimately dirties the tree, so plain assert_no_diff here would fail on the
     setup instead of on the operation under test (harness.tree_snapshot exists for exactly this
-    shape). The rights resource is additionally required to be absent, which is the specific thing
-    a half-applied call would have created."""
+    shape). The existing rights resource is additionally required to carry no guarded-object cell,
+    which is the specific thing a half-applied call would have added."""
     name = "E2ERoleRightsMixed"
     fqn = _seed_role(name)
 
@@ -371,9 +360,9 @@ def test_role_rights_combined_with_properties_is_refused_and_writes_nothing():
                          ctx="the refusal must name the payload that cannot be mixed and say what "
                              "to do instead (set the role's own properties in a separate call)")
 
-    assert _rights_file_text(name) is None, (
-        "a refused call must not have created %s - nothing may be applied when the payload is "
-        "rejected" % _rights_file(name))
+    assert_not_contains(_rights_file_text(name), GUARDED_OBJECT,
+                        "a refused mixed payload must not add the guarded object's cell to the "
+                        "existing rights resource")
     assert_tree_unchanged(before,
                           "a refused role rights write must leave the project byte-for-byte as the "
                           "seed left it")


### PR DESCRIPTION
Closes #605

`create_metadata` для роли создавал только `.mdo`, без модели прав. Роль без `Rights.rights` невалидна для конфигуратора: инкрементальная загрузка встаёт на ВСЕЙ конфигурации, а не на этой роли, и пересохранение роли в редакторе файл не возвращает. При этом вызов отвечал `persisted: true`, `get_project_errors` был чист, а падало потом — у другого человека и на другом шаге.

## Что сделано

Механизм записи уже был: `RoleRightsWriter.attachRoleDescription` — он рассчитан на выполнение ВНУТРИ транзакции вызывающего, трогает только переданную роль и возвращает FQN модели прав. Он и вызывается теперь из транзакции, которая создаёт роль, рядом с двумя такими же хуками (содержимое `CommonForm` и `Package.xdto`), а полученный FQN добавляется в список принудительного экспорта. Новой машинерии не появилось — расширена видимость существующей.

Это НЕ best-effort, в отличие от содержимого `XDTOPackage`: там пропуск лишь откладывает материализацию, а роль без модели прав сломана, и ломается далеко от места вызова. Поэтому `RoleWriteException` отказывает всему созданию (транзакция откатывается, полуобъекта не остаётся), а обязательная проверка наличия генератора FQN, которая раньше касалась только форм, теперь распространяется и на роли.

## Проверено на живом стенде

До: `create_metadata {"fqn":"Role.LiveBefore605"}` → `persisted: true`, на диске только `LiveBefore605.mdo`.
После: рядом с .mdo появился `Rights.rights` (350 байт) с тремя свойствами по умолчанию в пространстве имён `http://v8.1c.ru/8.2/roles` — ровно тот файл, который issue называет обязательным:

```xml
<Rights xmlns="http://v8.1c.ru/8.2/roles" xsi:type="Rights">
	<setForNewObjects>false</setForNewObjects>
	<setForAttributesByDefault>false</setForAttributesByDefault>
	<independentRightsOfChildObjects>false</independentRightsOfChildObjects>
</Rights>
```

И `get_metadata_details` на этой роли теперь рендерит полный документ (`## Properties` + пустая матрица), а не заметку — это измеренное подтверждение того контракта, который правится в e2e ниже, а не предположение. Развёрнутый класс проверен внутри установленного jar (`attachRoleDescription` присутствует), в журнале EDT после прогона ноль записей severity-4 от плагина и ни одного упоминания `RoleDescription` / `Failed to persist reference`.

## Контракт, который пришлось изменить

Три e2e-файла закрепляли прежнее поведение как контракт — «созданная роль не имеет модели прав» — и один из них прямо ловил «сборку, которая втихую создала модель прав при создании объекта». Это ровно то поведение, которое issue объявляет дефектом, поэтому контракт обновлён вместе с кодом:

- `test_get_metadata_details_role.py` — «пустое состояние» перевёрнуто: свежая роль рендерит полный документ с пустой матрицей, а не заметку. Заметка в читателе осталась и по-прежнему верна для роли, у которой модели прав действительно нет, но воспроизвести это состояние инструментами больше нельзя — покрытие осталось юнит-тестам, о чём сказано в докстринге.
- `test_modify_metadata_role_rights.py` — там, где «ничего не записано» доказывалось ОТСУТСТВИЕМ файла, теперь доказывается отсутствием ячейки охраняемого объекта в существующем файле; `assert_tree_unchanged` на месте. `_rights_file_text` теперь падает, если файла нет, чтобы отсутствие ресурса не удовлетворяло проверку «объекта там нет» случайно.
- `test_create_metadata.py` — новый regression-тест. Он и есть настоящая защита: исчерпывающий `test_create_every_top_type` уже создаёт роль и проверяет только чтение обратно — именно так дефект и уехал в релиз.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
