### PR TITLE
get_project_errors: objectFqns резолвит внешние объекты и не выдаёт «чисто» за неразрешённый адрес (#604)

### DIFF
--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -472,8 +472,8 @@ public class GetProjectErrorsTool implements IMcpTool
 
     /**
      * What ONE project could decide about the requested addresses: the spellings that resolved
-     * HERE, the addresses this project could not decide at all, and whether its resolve pass ran to
-     * the end.
+     * HERE, the addresses this project could not decide at all, and whether it contributed any
+     * completed decision.
      *
      * <p>The undecided set is per ADDRESS on purpose. A single "was anything inspected" flag cannot
      * separate "inspected and absent" from "nobody could look": with no {@code projectName} one
@@ -490,7 +490,7 @@ public class GetProjectErrorsTool implements IMcpTool
         final Map<String, Set<String>> resolved = new LinkedHashMap<>();
         /** Requested addresses this project could not decide (infrastructure failure, never absence). */
         final Set<String> undecided = new LinkedHashSet<>();
-        /** Whether the read pass ran to the end; {@code false} when it threw and decided nothing. */
+        /** Whether this project contributed any completed decision. */
         boolean passCompleted;
 
         ProjectResolution(String projectName)
@@ -888,11 +888,9 @@ public class GetProjectErrorsTool implements IMcpTool
      *   <li><b>An EXTERNAL OBJECTS project whose root cannot be read</b>. Configuration-only
      *       families are structurally ABSENT there, while addresses rooted in a standalone external
      *       object stay UNDECIDED because the project's own roots were never inspected.</li>
-     *   <li><b>An EDT project that DOES hold a configuration but is not readable now</b> - still
-     *       indexing, or closed. It could perfectly well hold the address, so it answers UNDECIDED:
-     *       skipping it lets another project's completed pass stand in as the inspection, and the
-     *       address is then reported in {@code objectsNotFound} - absence "proved" by a project
-     *       nobody looked at.</li>
+     *   <li><b>A configuration / extension project that is not readable now</b> - still indexing,
+     *       or closed. Its configuration families stay UNDECIDED, while standalone external-object
+     *       families are structurally ABSENT there.</li>
      * </ul>
      *
      * <p>Natures that cannot be determined at all fall into the LAST bucket: unknowable is never
@@ -915,31 +913,25 @@ public class GetProjectErrorsTool implements IMcpTool
         }
         if (externalObjects)
         {
-            ProjectResolution decided = new ProjectResolution(project.getName());
-            decided.passCompleted = true;
-            for (String candidate : candidates)
-            {
-                if (isExternalObjectAddress(candidate))
-                {
-                    // Its own root was unavailable, so absence of an external object is unknown.
-                    decided.undecided.add(candidate);
-                }
-            }
-            return decided;
+            return unreadableKnownProjectKindDecision(project, candidates, true);
         }
-        if (natures != null && !containsAny(natures, V8_CONFIGURATION_NATURES))
+        if (natures != null && containsAny(natures, V8_CONFIGURATION_NATURES))
+        {
+            return unreadableKnownProjectKindDecision(project, candidates, false);
+        }
+        if (natures != null)
         {
             // Not a 1C:EDT project at all.
             return null;
         }
-        // Holds a configuration but could not be read now, or its natures are unknowable.
+        // Its project kind is unknowable, so no family can be excluded safely.
         ProjectResolution unreadable = new ProjectResolution(project.getName());
         unreadable.undecided.addAll(candidates);
         return unreadable;
     }
 
     /** Whether the address is rooted in a standalone external-object family. */
-    private static boolean isExternalObjectAddress(String fqn)
+    private static boolean isStandaloneAddress(String fqn)
     {
         String canonical = canonicalAddress(fqn);
         if (canonical == null)
@@ -950,6 +942,31 @@ public class GetProjectErrorsTool implements IMcpTool
         String typeToken = dot < 0 ? canonical : canonical.substring(0, dot);
         MetadataTypeUtils.MetadataTypeInfo info = MetadataTypeUtils.resolve(typeToken);
         return info != null && info.isStandalone();
+    }
+
+    /** Decides incompatible families before an unreadable project root can obscure them. */
+    private static ProjectResolution unreadableKnownProjectKindDecision(IProject project,
+        List<String> candidates, boolean externalObjects)
+    {
+        ProjectResolution decided = new ProjectResolution(project.getName());
+        for (String candidate : candidates)
+        {
+            if (isStandaloneAddress(candidate) == externalObjects)
+            {
+                decided.undecided.add(candidate);
+            }
+            else
+            {
+                decided.passCompleted = true;
+            }
+        }
+        return decided;
+    }
+
+    /** Whether this project kind can own the address family. */
+    private static boolean belongsToProjectKind(MetadataScope metadataScope, String fqn)
+    {
+        return metadataScope.isExternalObjects() == isStandaloneAddress(fqn);
     }
 
     /** Whether {@code natures} carries any of {@code wanted}. */
@@ -1073,9 +1090,7 @@ public class GetProjectErrorsTool implements IMcpTool
         boolean inspectedAny = false;
         for (ProjectResolution decided : perProject)
         {
-            // Counted as inspected only when the pass really COMPLETED: a pass that threw decided
-            // nothing, so treating it as an inspection would turn its undecided addresses into
-            // "not found" (see resolveInProject).
+            // Structural absence is completed before a model read; a total read failure is not.
             inspectedAny |= decided.passCompleted;
             for (String fqn : candidates)
             {
@@ -1123,7 +1138,7 @@ public class GetProjectErrorsTool implements IMcpTool
      * @param resolution the resolution being filled
      * @param candidates the addresses that need resolution, in request order
      * @param knowledge what is known about each address across the whole universe
-     * @param inspectedAny whether ANY project completed a resolve pass
+     * @param inspectedAny whether ANY project contributed a completed decision
      */
     private static void applyWireContract(AddressResolution resolution, List<String> candidates,
         Map<String, AddressKnowledge> knowledge, boolean inspectedAny)
@@ -1217,17 +1232,34 @@ public class GetProjectErrorsTool implements IMcpTool
      * @param candidates the addresses to decide
      * @return what this project decided: the spellings that resolved HERE, the addresses it could
      *     not decide at all (the pass threw, or a form's content model could not be read - never a
-     *     "does not exist"), and whether the pass ran to the end
+     *     "does not exist"), and whether any decision completed
      */
     static ProjectResolution resolveInProject(IProject project, IBmModel bmModel,
         MetadataScope metadataScope, List<String> candidates)
     {
         ProjectResolution decided = new ProjectResolution(project.getName());
+        List<String> ownedCandidates = new ArrayList<>();
+        for (String candidate : candidates)
+        {
+            if (belongsToProjectKind(metadataScope, candidate))
+            {
+                ownedCandidates.add(candidate);
+            }
+            else
+            {
+                // This absence is structural, so a later model failure cannot erase it.
+                decided.passCompleted = true;
+            }
+        }
+        if (ownedCandidates.isEmpty())
+        {
+            return decided;
+        }
         List<DeferredMember> deferred = new ArrayList<>();
         try
         {
             BmTransactions.<Void>read(bmModel, "ResolveErrorObjectAddresses", (tx, pm) -> { //$NON-NLS-1$
-                for (String fqn : candidates)
+                for (String fqn : ownedCandidates)
                 {
                     resolveCandidate(metadataScope, fqn, decided.resolved, deferred);
                 }
@@ -1236,13 +1268,11 @@ public class GetProjectErrorsTool implements IMcpTool
         }
         catch (Exception e)
         {
-            // A failure here is a failure to DECIDE, never a "does not exist": every address this
-            // project was asked about stays undecided, so another project in scope can still answer
-            // for it and a lone failure refuses the call instead of answering it.
+            // Only families this project can own become unknown; the others are already absent.
             Activator.logError("Failed to resolve " + PARAM_OBJECT_FQNS + " in project " //$NON-NLS-1$ //$NON-NLS-2$
                 + project.getName(), e);
             decided.resolved.clear();
-            decided.undecided.addAll(candidates);
+            decided.undecided.addAll(ownedCandidates);
             return decided;
         }
 
@@ -1907,6 +1937,11 @@ public class GetProjectErrorsTool implements IMcpTool
      */
     static Set<String> resolvedSpellings(MetadataScope metadataScope, String normFqn)
     {
+        if (!belongsToProjectKind(metadataScope, normFqn))
+        {
+            // A linked base configuration belongs to another project, never to this scope.
+            return Collections.emptySet();
+        }
         // A Subsystem chain nests the same kind token repeatedly, which the generic child-feature
         // navigation does not model - SubsystemUtils owns that grammar. It is also the only family
         // whose depth is UNBOUNDED, so its yo fallback is applied level by level (linear, and it

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -54,6 +54,7 @@ import com.ditrix.edt.mcp.server.utils.FormElementWriter;
 import com.ditrix.edt.mcp.server.utils.FormStructureReader;
 import com.ditrix.edt.mcp.server.utils.FormValidationException;
 import com.ditrix.edt.mcp.server.utils.MetadataNodeResolver;
+import com.ditrix.edt.mcp.server.utils.MetadataScope;
 import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils;
 import com.ditrix.edt.mcp.server.utils.Pagination;
 import com.ditrix.edt.mcp.server.utils.PredefinedWriter;
@@ -139,10 +140,11 @@ public class GetProjectErrorsTool implements IMcpTool
     }
 
     /**
-     * The exact-address call returns a machine-readable payload (the Markdown report plus the
-     * {@code objectsResolved} / {@code objectsNotFound} / {@code objectsUnsupported} verdicts) in
-     * {@code structuredContent}; every other call keeps the historical Markdown response byte for
-     * byte. Mirrors {@code list_projects}' per-call format switch.
+     * A successful exact-address call returns a machine-readable payload (the Markdown report plus
+     * the {@code objectsResolved} / {@code objectsNotFound} / {@code objectsUnsupported} verdicts)
+     * in {@code structuredContent}; an all-miss exact call is refused, and every other call keeps
+     * the historical Markdown response byte for byte. Mirrors {@code list_projects}' per-call
+     * format switch.
      */
     @Override
     public ResponseType getResponseType(Map<String, String> params)
@@ -464,7 +466,7 @@ public class GetProjectErrorsTool implements IMcpTool
          * a partial answer must not read as a full one.
          */
         final Map<String, Set<String>> incompleteFor = new LinkedHashMap<>();
-        /** A ready JSON error payload when no verdict could be reached at all; {@code null} otherwise. */
+        /** A ready JSON refusal when resolution or the resulting scan could not support an answer. */
         String error;
     }
 
@@ -558,9 +560,13 @@ public class GetProjectErrorsTool implements IMcpTool
                     bmModelManager, collectContext);
             }
 
-            return addressPayload(assembleAddressReport(errors, projectName, severity, objectFqns,
-                limit, detailed, resolution, unresolvedShown, unresolvedFilteredOut),
-                errors.size(), resolution);
+            String report = assembleAddressReport(errors, projectName, severity, objectFqns,
+                limit, detailed, resolution, unresolvedShown, unresolvedFilteredOut);
+            if (resolution.error != null)
+            {
+                return resolution.error;
+            }
+            return addressPayload(report, errors.size(), resolution);
         }
         catch (Exception e)
         {
@@ -589,8 +595,8 @@ public class GetProjectErrorsTool implements IMcpTool
 
 
     /**
-     * Assembles the Markdown an {@code objectFqns} call returns: the table or the empty-report
-     * banner, then EVERY caveat that applies.
+     * Assembles the result body an {@code objectFqns} call returns: a refusal when nothing resolved,
+     * or the Markdown table / empty-report banner followed by EVERY applicable caveat.
      *
      * <p>Extracted so a test can pin that each warning is really EMITTED, not merely that its
      * renderer works when called by hand. A revert sweep found this gap the hard way: dropping the
@@ -606,12 +612,24 @@ public class GetProjectErrorsTool implements IMcpTool
      * @param resolution the per-address verdicts, including the partial-answer map
      * @param unresolvedShown out-counter of markers shown with a placeholder location
      * @param unresolvedFilteredOut out-counter of markers excluded because their location was unknown
-     * @return the assembled Markdown
+     * @return the assembled Markdown, or a {@link ToolResult#error(String)} JSON refusal
      */
     static String assembleAddressReport(List<ErrorInfo> errors, String projectName, String severity,
         List<String> objectFqns, int limit, boolean detailed, AddressResolution resolution,
         int[] unresolvedShown, int[] unresolvedFilteredOut)
     {
+        if (resolution.resolved.isEmpty()
+            && (!resolution.notFound.isEmpty() || !resolution.unsupported.isEmpty()))
+        {
+            // No resolved scope means no marker was scanned, so an all-clear would be invented.
+            resolution.error = ToolResult.error("Cannot scan " + PARAM_OBJECT_FQNS //$NON-NLS-1$
+                + " because none of the requested addresses resolved: " //$NON-NLS-1$
+                + String.join(", ", objectFqns) //$NON-NLS-1$
+                + ". Use the loose '" + PARAM_OBJECTS //$NON-NLS-1$
+                + "' filter to match reported locations, or call get_metadata_objects to find valid FQNs.") //$NON-NLS-1$
+                .toJson();
+            return resolution.error;
+        }
         StringBuilder md = new StringBuilder();
         if (errors.isEmpty())
         {
@@ -728,17 +746,23 @@ public class GetProjectErrorsTool implements IMcpTool
         for (IProject project : scope)
         {
             IBmModel bmModel = null;
-            Configuration config = null;
+            MetadataScope metadataScope = null;
             if (project.isOpen())
             {
                 // Only an OPEN project can be asked; a closed one goes straight to the unreadable
                 // branch instead of being probed (and instead of being silently dropped).
                 bmModel = bmModelManager != null ? bmModelManager.getModel(project) : null;
-                ProjectContext.ConfigurationResult configResult =
-                    ProjectContext.of(project.getName()).resolveConfiguration();
-                config = configResult.ok() ? configResult.configuration() : null;
+                ProjectContext.ConfigurationResult rootResult =
+                    ProjectContext.of(project.getName()).resolveMetadataRoot();
+                metadataScope = rootResult.scope();
+                if (metadataScope == null)
+                {
+                    // Preserve the project kind when root resolution failed, because it decides
+                    // whether an external-object address is absent or merely unreadable.
+                    metadataScope = MetadataScope.of(project, rootResult.configuration());
+                }
             }
-            ProjectResolution decided = projectDecision(project, bmModel, config, resolvable);
+            ProjectResolution decided = projectDecision(project, bmModel, metadataScope, resolvable);
             if (decided != null)
             {
                 perProject.add(decided);
@@ -818,11 +842,9 @@ public class GetProjectErrorsTool implements IMcpTool
     /**
      * The EDT nature of a project that holds EXTERNAL objects (external reports / data processors).
      *
-     * <p>It is a 1C:EDT project, but it has no {@link Configuration} BY DESIGN - not "not yet". So a
-     * missing configuration here is knowledge, not a failure to look: such a project can never own an
-     * mdclass / form / Subsystem / Predefined address, which is exactly what {@code objectFqns}
-     * addresses. Classifying it as unreadable (its nature IS a V8 one) turned ordinary misses into
-     * {@code Cannot decide} across a workspace-wide scan.</p>
+     * <p>It is a 1C:EDT project, but its addressable roots are standalone external data processors
+     * and reports rather than a {@link Configuration}. Configuration-only families are absent there;
+     * its own external-object families require the project's root set to be readable.</p>
      */
     private static final List<String> V8_EXTERNAL_OBJECTS_NATURE = Collections.singletonList(
         "com._1c.g5.v8.dt.core.V8ExternalObjectsNature"); //$NON-NLS-1$
@@ -837,23 +859,24 @@ public class GetProjectErrorsTool implements IMcpTool
      *
      * @param project the project in scope
      * @param bmModel its BM model, or {@code null} when it could not be obtained
-     * @param config its configuration, or {@code null} when it could not be resolved
+     * @param metadataScope its metadata root, or {@code null} when it could not be resolved
      * @param candidates the addresses this request is asking about
      * @return this project's decision, or {@code null} when it contributes nothing at all
      */
-    static ProjectResolution projectDecision(IProject project, IBmModel bmModel, Configuration config,
-        List<String> candidates)
+    static ProjectResolution projectDecision(IProject project, IBmModel bmModel,
+        MetadataScope metadataScope, List<String> candidates)
     {
-        if (bmModel == null || config == null)
+        if (bmModel == null || metadataScope == null || metadataScope.externalRootUnavailable()
+            || (!metadataScope.isExternalObjects() && metadataScope.configuration() == null))
         {
             // It cannot answer - but WHY decides everything (see unreadableProjectDecision).
-            return unreadableProjectDecision(project, candidates);
+            return unreadableProjectDecision(project, metadataScope, candidates);
         }
-        return resolveInProject(project, bmModel, config, candidates);
+        return resolveInProject(project, bmModel, metadataScope, candidates);
     }
 
     /**
-     * What a project whose configuration could NOT be read contributes to the request.
+     * What a project whose metadata root could NOT be read contributes to the request.
      *
      * <p>"No configuration" has THREE causes and they are three different facts. Collapsing any two
      * of them is what produced this defect twice:</p>
@@ -862,11 +885,9 @@ public class GetProjectErrorsTool implements IMcpTool
      *       DEFINITION and cannot hold 1C metadata. It leaves the universe ({@code null}) - treating
      *       it as undecidable would let ONE such project mute the missing-address report for the
      *       whole workspace.</li>
-     *   <li><b>An EDT project that holds NO configuration by design</b> - an EXTERNAL OBJECTS
-     *       project. Its nature is a V8 one, but it structurally cannot own an mdclass / form /
-     *       Subsystem / Predefined address, and that is KNOWLEDGE, not a failure to look. It answers
-     *       ABSENT: a completed pass that resolves nothing. Calling it unreadable (its nature is
-     *       V8!) turned ordinary misses into {@code Cannot decide} on every workspace-wide scan.</li>
+     *   <li><b>An EXTERNAL OBJECTS project whose root cannot be read</b>. Configuration-only
+     *       families are structurally ABSENT there, while addresses rooted in a standalone external
+     *       object stay UNDECIDED because the project's own roots were never inspected.</li>
      *   <li><b>An EDT project that DOES hold a configuration but is not readable now</b> - still
      *       indexing, or closed. It could perfectly well hold the address, so it answers UNDECIDED:
      *       skipping it lets another project's completed pass stand in as the inspection, and the
@@ -878,30 +899,57 @@ public class GetProjectErrorsTool implements IMcpTool
      * evidence that a project holds nothing.</p>
      *
      * @param project the in-scope project whose configuration could not be read
+     * @param metadataScope the project's metadata scope, when its kind could be resolved
      * @param candidates the addresses this request is asking about
      * @return an UNDECIDED resolution, an ABSENT (completed, empty) one, or {@code null} to leave
      *     the universe entirely
      */
-    static ProjectResolution unreadableProjectDecision(IProject project, List<String> candidates)
+    static ProjectResolution unreadableProjectDecision(IProject project, MetadataScope metadataScope,
+        List<String> candidates)
     {
         Set<String> natures = ProjectContext.naturesOf(project);
+        boolean externalObjects = metadataScope != null && metadataScope.isExternalObjects();
+        if (!externalObjects && natures != null)
+        {
+            externalObjects = containsAny(natures, V8_EXTERNAL_OBJECTS_NATURE);
+        }
+        if (externalObjects)
+        {
+            ProjectResolution decided = new ProjectResolution(project.getName());
+            decided.passCompleted = true;
+            for (String candidate : candidates)
+            {
+                if (isExternalObjectAddress(candidate))
+                {
+                    // Its own root was unavailable, so absence of an external object is unknown.
+                    decided.undecided.add(candidate);
+                }
+            }
+            return decided;
+        }
         if (natures != null && !containsAny(natures, V8_CONFIGURATION_NATURES))
         {
-            if (!containsAny(natures, V8_EXTERNAL_OBJECTS_NATURE))
-            {
-                // Not a 1C:EDT project at all.
-                return null;
-            }
-            // An external-objects project: KNOWN to hold no addressable metadata, so this is a
-            // decided ABSENCE - a completed pass that resolves nothing - not an inability to look.
-            ProjectResolution absent = new ProjectResolution(project.getName());
-            absent.passCompleted = true;
-            return absent;
+            // Not a 1C:EDT project at all.
+            return null;
         }
         // Holds a configuration but could not be read now, or its natures are unknowable.
         ProjectResolution unreadable = new ProjectResolution(project.getName());
         unreadable.undecided.addAll(candidates);
         return unreadable;
+    }
+
+    /** Whether the address is rooted in a standalone external-object family. */
+    private static boolean isExternalObjectAddress(String fqn)
+    {
+        String canonical = canonicalAddress(fqn);
+        if (canonical == null)
+        {
+            return false;
+        }
+        int dot = canonical.indexOf('.');
+        String typeToken = dot < 0 ? canonical : canonical.substring(0, dot);
+        MetadataTypeUtils.MetadataTypeInfo info = MetadataTypeUtils.resolve(typeToken);
+        return info != null && info.isStandalone();
     }
 
     /** Whether {@code natures} carries any of {@code wanted}. */
@@ -1165,14 +1213,14 @@ public class GetProjectErrorsTool implements IMcpTool
      *
      * @param project the project being inspected
      * @param bmModel its BM model
-     * @param config its configuration
+     * @param metadataScope its metadata resolution root
      * @param candidates the addresses to decide
      * @return what this project decided: the spellings that resolved HERE, the addresses it could
      *     not decide at all (the pass threw, or a form's content model could not be read - never a
      *     "does not exist"), and whether the pass ran to the end
      */
     static ProjectResolution resolveInProject(IProject project, IBmModel bmModel,
-        Configuration config, List<String> candidates)
+        MetadataScope metadataScope, List<String> candidates)
     {
         ProjectResolution decided = new ProjectResolution(project.getName());
         List<DeferredMember> deferred = new ArrayList<>();
@@ -1181,7 +1229,7 @@ public class GetProjectErrorsTool implements IMcpTool
             BmTransactions.<Void>read(bmModel, "ResolveErrorObjectAddresses", (tx, pm) -> { //$NON-NLS-1$
                 for (String fqn : candidates)
                 {
-                    resolveCandidate(config, fqn, decided.resolved, deferred);
+                    resolveCandidate(metadataScope, fqn, decided.resolved, deferred);
                 }
                 return null;
             });
@@ -1201,7 +1249,7 @@ public class GetProjectErrorsTool implements IMcpTool
         // Addresses whose ONLY attempt failed to read the form content model. They are undecided,
         // exactly like the addresses of a pass that threw - never "not found".
         resolveDeferredMembers(deferred, decided,
-            member -> formMemberScopeSpellings(project, config, member));
+            member -> formMemberScopeSpellings(project, metadataScope, member));
         decided.passCompleted = true;
         return decided;
     }
@@ -1289,12 +1337,12 @@ public class GetProjectErrorsTool implements IMcpTool
      * resolves wins, and a form-MEMBER probe is deferred out of the transaction instead (see
      * {@link #resolveInProject}).
      *
-     * @param config the configuration to resolve against
+     * @param metadataScope the metadata root to resolve against
      * @param fqn the requested address, as the caller wrote it
      * @param found this project's accumulator: requested address -&gt; the spellings that resolved
      * @param deferred the accumulator of form-member probes to decide after the transaction
      */
-    private static void resolveCandidate(Configuration config, String fqn,
+    private static void resolveCandidate(MetadataScope metadataScope, String fqn,
         Map<String, Set<String>> found, List<DeferredMember> deferred)
     {
         if (found.containsKey(fqn))
@@ -1324,7 +1372,7 @@ public class GetProjectErrorsTool implements IMcpTool
             }
             else
             {
-                Set<String> storedSet = resolvedSpellings(config, probe);
+                Set<String> storedSet = resolvedSpellings(metadataScope, probe);
                 if (!storedSet.isEmpty())
                 {
                     if (asTyped)
@@ -1836,7 +1884,7 @@ public class GetProjectErrorsTool implements IMcpTool
     }
 
     /**
-     * The spelling {@code normFqn} really resolved to in {@code config}, dispatching to the
+     * The spelling {@code normFqn} really resolved to in {@code metadataScope}, dispatching to the
      * specialized resolver of the address family it belongs to, or {@code null} when it resolves to
      * nothing. Form MEMBERS are NOT decided here (see {@link #formMemberScopeSpellings}); every
      * other supported family is.
@@ -1851,13 +1899,13 @@ public class GetProjectErrorsTool implements IMcpTool
      * differently spelled node; the caller would stop enumerating on that hit, scope the scan by a
      * name the model does not store, and never look for the other nodes the address can mean.</p>
      *
-     * <p>Call inside a BM read transaction bound to this configuration's model.</p>
+     * <p>Call inside a BM read transaction bound to this project's model.</p>
      *
-     * @param config the configuration to resolve against
+     * @param metadataScope the metadata root to resolve against
      * @param normFqn the type-normalized address
      * @return the resolved (stored) spelling, or {@code null} when the address resolves to nothing
      */
-    static Set<String> resolvedSpellings(Configuration config, String normFqn)
+    static Set<String> resolvedSpellings(MetadataScope metadataScope, String normFqn)
     {
         // A Subsystem chain nests the same kind token repeatedly, which the generic child-feature
         // navigation does not model - SubsystemUtils owns that grammar. It is also the only family
@@ -1865,6 +1913,11 @@ public class GetProjectErrorsTool implements IMcpTool
         // never builds a combination) rather than by probing whole-address spellings.
         if (SubsystemUtils.parseSubsystemPath(normFqn) != null)
         {
+            Configuration config = metadataScope.configuration();
+            if (config == null)
+            {
+                return Collections.emptySet();
+            }
             Set<String> chains = new LinkedHashSet<>();
             for (String[] stored : SubsystemUtils.resolveStoredChain(config, normFqn))
             {
@@ -1877,6 +1930,11 @@ public class GetProjectErrorsTool implements IMcpTool
         PredefinedWriter.PredefinedRef predefined = PredefinedWriter.parseRef(normFqn);
         if (predefined != null)
         {
+            Configuration config = metadataScope.configuration();
+            if (config == null)
+            {
+                return Collections.emptySet();
+            }
             MetadataNodeResolver.MetadataNode owner =
                 MetadataNodeResolver.resolveExisting(config, predefined.ownerFqn());
             if (owner == null)
@@ -1895,10 +1953,10 @@ public class GetProjectErrorsTool implements IMcpTool
         String formPath = FormElementWriter.parseFormPath(normFqn);
         if (formPath != null)
         {
-            return FormStructureReader.resolveMdForm(config, formPath) != null
+            return FormStructureReader.resolveMdForm(metadataScope, formPath) != null
                 ? Collections.singleton(normFqn) : Collections.<String> emptySet();
         }
-        return MetadataNodeResolver.resolveExisting(config, normFqn) != null
+        return MetadataNodeResolver.resolveExisting(metadataScope, normFqn) != null
             ? Collections.singleton(normFqn) : Collections.<String> emptySet();
     }
 
@@ -1940,24 +1998,24 @@ public class GetProjectErrorsTool implements IMcpTool
      * <p>Call OUTSIDE a BM transaction: {@link FormElementWriter#readEditableForm} opens its own.</p>
      *
      * @param project the project owning the form
-     * @param config the project configuration
+     * @param metadataScope the project's metadata resolution root
      * @param member the deferred member probe (its ref and the spelling being probed)
      * @return the scan-scoping spellings (never empty) when the form AND the addressed leaf exist;
      *     an EMPTY list when the address is PROVEN absent; and {@code null} when the form content
      *     model could not be read at all - an infrastructure failure decides nothing and must never
      *     be reported as "this address does not exist"
      */
-    private static List<String> formMemberScopeSpellings(IProject project, Configuration config,
+    private static List<String> formMemberScopeSpellings(IProject project, MetadataScope metadataScope,
         DeferredMember member)
     {
         FormElementWriter.FormMemberRef ref = member.ref;
         FormElementWriter.FormEditContext ctx;
         try
         {
-            MdObject mdForm = FormStructureReader.resolveMdForm(config, ref.formPath);
+            MdObject mdForm = FormStructureReader.resolveMdForm(metadataScope, ref.formPath);
             if (mdForm == null)
             {
-                // The form itself is absent from this configuration: a decided "not here".
+                // The form itself is absent from this project's root: a decided "not here".
                 return Collections.emptyList();
             }
             ctx = FormElementWriter.editContextFor(project, mdForm);

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -894,7 +894,9 @@ public class GetProjectErrorsTool implements IMcpTool
      * </ul>
      *
      * <p>Natures that cannot be determined at all fall into the LAST bucket: unknowable is never
-     * evidence that a project holds nothing.</p>
+     * evidence that a project holds nothing. Nor does the nature list overrule the scope: a
+     * project whose Configuration was read IS a 1C:EDT project, and only a project with no such
+     * evidence is judged by its descriptor.</p>
      *
      * @param project the in-scope project whose configuration could not be read
      * @param metadataScope the project's metadata scope, when its kind could be resolved
@@ -915,7 +917,11 @@ public class GetProjectErrorsTool implements IMcpTool
         {
             return unreadableKnownProjectKindDecision(project, candidates, true);
         }
-        if (natures != null && containsAny(natures, V8_CONFIGURATION_NATURES))
+        // A project that HANDED OVER a Configuration is a 1C:EDT project by evidence, whatever
+        // its .project descriptor lists: the nature allowlist is the fallback for a root that
+        // could not be read, never a veto over a root that was.
+        boolean holdsConfiguration = metadataScope != null && metadataScope.configuration() != null;
+        if (holdsConfiguration || (natures != null && containsAny(natures, V8_CONFIGURATION_NATURES)))
         {
             return unreadableKnownProjectKindDecision(project, candidates, false);
         }

--- a/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
+++ b/mcp/bundles/com.ditrix.edt.mcp.server/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsTool.java
@@ -622,12 +622,7 @@ public class GetProjectErrorsTool implements IMcpTool
             && (!resolution.notFound.isEmpty() || !resolution.unsupported.isEmpty()))
         {
             // No resolved scope means no marker was scanned, so an all-clear would be invented.
-            resolution.error = ToolResult.error("Cannot scan " + PARAM_OBJECT_FQNS //$NON-NLS-1$
-                + " because none of the requested addresses resolved: " //$NON-NLS-1$
-                + String.join(", ", objectFqns) //$NON-NLS-1$
-                + ". Use the loose '" + PARAM_OBJECTS //$NON-NLS-1$
-                + "' filter to match reported locations, or call get_metadata_objects to find valid FQNs.") //$NON-NLS-1$
-                .toJson();
+            resolution.error = ToolResult.error(unscannableRefusal(resolution)).toJson();
             return resolution.error;
         }
         StringBuilder md = new StringBuilder();
@@ -646,6 +641,36 @@ public class GetProjectErrorsTool implements IMcpTool
         appendIncompleteScopeWarning(md, resolution.incompleteFor);
         appendUnresolvedWarnings(md, unresolvedShown, unresolvedFilteredOut);
         return md.toString();
+    }
+
+    /**
+     * The refusal for a request in which NOTHING could be scanned, worded per address.
+     *
+     * <p>The two verdicts have different remedies and must not share one sentence: a MISS is
+     * fixed by another spelling or the loose filter, while an UNSUPPORTED family is not a
+     * misspelling at all - its reason already names the tool that owns it. Collapsing both into
+     * "nothing resolved" sent half the callers to look up an FQN that was never wrong.</p>
+     *
+     * @param resolution the per-address verdicts, none of which resolved
+     * @return the refusal message
+     */
+    private static String unscannableRefusal(AddressResolution resolution)
+    {
+        StringBuilder message = new StringBuilder("Cannot scan ").append(PARAM_OBJECT_FQNS) //$NON-NLS-1$
+            .append(" because no requested address could be scanned."); //$NON-NLS-1$
+        if (!resolution.notFound.isEmpty())
+        {
+            message.append(" Not found: ").append(String.join(", ", resolution.notFound)) //$NON-NLS-1$ //$NON-NLS-2$
+                .append(". Use the loose '").append(PARAM_OBJECTS) //$NON-NLS-1$
+                .append("' filter to match reported locations, or call get_metadata_objects to ") //$NON-NLS-1$
+                .append("find valid FQNs."); //$NON-NLS-1$
+        }
+        for (Map<String, String> entry : resolution.unsupported)
+        {
+            message.append(' ').append(entry.get("fqn")).append(": ") //$NON-NLS-1$ //$NON-NLS-2$
+                .append(entry.get("reason")); //$NON-NLS-1$
+        }
+        return message.toString();
     }
 
     /**

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
@@ -2616,6 +2616,33 @@ public class GetProjectErrorsToolTest
     }
 
     @Test
+    public void testAnAllUnsupportedRequestKeepsItsOwnReason()
+    {
+        // Nothing was scanned, so it stays a refusal - but an UNSUPPORTED family is not a typo:
+        // its reason already names the tool that owns it, and the FQN-lookup advice would send
+        // the caller to fix an address that was never wrong.
+        String unsupported = "XDTOPackage.P.Property.N"; //$NON-NLS-1$
+        GetProjectErrorsTool.AddressResolution resolution =
+            new GetProjectErrorsTool.AddressResolution();
+        resolution.unsupported.add(
+            unsupportedEntry(unsupported, "call validate_xdto_package instead")); //$NON-NLS-1$
+
+        String report = GetProjectErrorsTool.assembleAddressReport(
+            Collections.<ErrorInfo> emptyList(), "P", null, //$NON-NLS-1$
+            Collections.singletonList(unsupported), 100, false, resolution,
+            new int[] {0}, new int[] {0});
+
+        assertTrue("the response must be a ToolResult refusal", //$NON-NLS-1$
+            report.contains("\"success\":false")); //$NON-NLS-1$
+        assertTrue("the address's OWN reason must survive the refusal: " + report, //$NON-NLS-1$
+            report.contains(unsupported) && report.contains("validate_xdto_package")); //$NON-NLS-1$
+        assertFalse("an unsupported family is not a misspelling to look up: " + report, //$NON-NLS-1$
+            report.contains("get_metadata_objects")); //$NON-NLS-1$
+        assertFalse("an unrun scan must never carry the clean heading", //$NON-NLS-1$
+            report.contains("# No Errors Found")); //$NON-NLS-1$
+    }
+
+    @Test
     public void testEveryResolvingYoReadingOfADeferredMemberAccumulates()
     {
         // The guard that lets the deferred path ACCUMULATE was not covered: with only one yo reading

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
@@ -1978,6 +1978,67 @@ public class GetProjectErrorsToolTest
                 "Catalog.Products.Predefined.Sample").isEmpty()); //$NON-NLS-1$
     }
 
+    @Test
+    public void testConfigurationOnlyFamiliesCannotResolveThroughAnExternalProjectsBase()
+    {
+        Configuration base = MdClassFactory.eINSTANCE.createConfiguration();
+        Subsystem subsystem = MdClassFactory.eINSTANCE.createSubsystem();
+        subsystem.setName("X"); //$NON-NLS-1$
+        base.getSubsystems().add(subsystem);
+        Catalog catalog = MdClassFactory.eINSTANCE.createCatalog();
+        catalog.setName("Products"); //$NON-NLS-1$
+        assertFalse(PredefinedWriter.create(catalog, "Sample", //$NON-NLS-1$
+            new PredefinedWriter.ItemProps(), false).isError());
+        base.getCatalogs().add(catalog);
+
+        List<String> candidates = Arrays.asList("Subsystem.X", //$NON-NLS-1$
+            "Catalog.Products.Predefined.Sample"); //$NON-NLS-1$
+        GetProjectErrorsTool.ProjectResolution decided = GetProjectErrorsTool.resolveInProject(
+            project("external"), readModel(), //$NON-NLS-1$
+            MetadataScopeTestFixtures.externalObjectsWithBase(base), candidates);
+
+        assertTrue("the structural absence is a completed decision", decided.passCompleted); //$NON-NLS-1$
+        assertTrue("a linked base must never resolve objects for the external project", //$NON-NLS-1$
+            decided.resolved.isEmpty());
+        assertTrue("configuration families are absent here, not unknown", //$NON-NLS-1$
+            decided.undecided.isEmpty());
+    }
+
+    @Test
+    public void testUnreadableConfigurationProjectDecidesStandaloneFamiliesAbsent()
+    {
+        String standalone = "ExternalDataProcessor.X"; //$NON-NLS-1$
+
+        GetProjectErrorsTool.ProjectResolution decided = GetProjectErrorsTool.projectDecision(
+            natureProject("loading", "com._1c.g5.v8.dt.core.V8ConfigurationNature"), //$NON-NLS-1$ //$NON-NLS-2$
+            null, null, Collections.singletonList(standalone));
+
+        assertTrue("the incompatible family is decided without reading the model", //$NON-NLS-1$
+            decided.passCompleted);
+        assertTrue("a configuration project can never own a standalone root", //$NON-NLS-1$
+            decided.resolved.isEmpty());
+        assertTrue("structural absence must not become undecided", decided.undecided.isEmpty()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testFailingExternalRootPreservesConfigurationFamilyAbsence()
+    {
+        String catalog = "Catalog.Nope"; //$NON-NLS-1$
+        String standalone = "ExternalDataProcessor.X"; //$NON-NLS-1$
+
+        GetProjectErrorsTool.ProjectResolution decided = GetProjectErrorsTool.resolveInProject(
+            project("external"), readModel(), MetadataScopeTestFixtures.failingExternalObjects(), //$NON-NLS-1$
+            Arrays.asList(catalog, standalone));
+
+        assertTrue("the configuration-family absence survives the failed root read", //$NON-NLS-1$
+            decided.passCompleted);
+        assertTrue(decided.resolved.isEmpty());
+        assertEquals("only the family owned by this project becomes undecided", //$NON-NLS-1$
+            singleton(standalone), decided.undecided);
+        assertFalse("the external failure cannot erase a structural absence", //$NON-NLS-1$
+            decided.undecided.contains(catalog));
+    }
+
 
     @Test
     public void testADeepSubsystemChainResolvesWithYoMixedPerLevel()

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
@@ -1928,6 +1928,31 @@ public class GetProjectErrorsToolTest
     }
 
     @Test
+    public void testAReadConfigurationOutranksAnUnrecognisedNature()
+    {
+        // Its BM model is not up, but the project already handed over its Configuration - so it IS
+        // a 1C:EDT project. Judged by the nature allowlist alone it would leave the universe, and a
+        // workspace scan next to one readable project would then call the address a proven MISS
+        // although the configuration that may own it was never looked at.
+        List<String> candidates = Collections.singletonList("Catalog.Nope"); //$NON-NLS-1$
+
+        GetProjectErrorsTool.ProjectResolution decided = GetProjectErrorsTool.projectDecision(
+            natureProject("cfg-odd-nature", "org.example.SomeOtherNature"), null, //$NON-NLS-1$ //$NON-NLS-2$
+            scope(MdClassFactory.eINSTANCE.createConfiguration()), candidates);
+        assertNotNull("a project that handed over a configuration is not a non-EDT project", //$NON-NLS-1$
+            decided);
+        assertEquals(singleton("Catalog.Nope"), decided.undecided); //$NON-NLS-1$
+        assertFalse("its pass did NOT complete - nothing was looked at", decided.passCompleted); //$NON-NLS-1$
+
+        // The other edge: WITHOUT that evidence the same descriptor still leaves the universe, or
+        // one ordinary Eclipse project would mute the missing-address report for the workspace.
+        assertNull("an unrecognised nature and no readable root is still not an EDT project", //$NON-NLS-1$
+            GetProjectErrorsTool.projectDecision(
+                natureProject("plain-odd-nature", "org.example.SomeOtherNature"), null, null, //$NON-NLS-1$ //$NON-NLS-2$
+                candidates));
+    }
+
+    @Test
     public void testExternalDataProcessorResolvesAgainstAnExternalObjectsScope()
     {
         ExternalDataProcessor processor = MdClassFactory.eINSTANCE.createExternalDataProcessor();

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/tools/impl/GetProjectErrorsToolTest.java
@@ -54,6 +54,7 @@ import com._1c.g5.v8.dt.metadata.mdclass.Catalog;
 import com._1c.g5.v8.dt.metadata.mdclass.CatalogAttribute;
 import com._1c.g5.v8.dt.metadata.mdclass.CatalogForm;
 import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
+import com._1c.g5.v8.dt.metadata.mdclass.ExternalDataProcessor;
 import com._1c.g5.v8.dt.metadata.mdclass.MdClassFactory;
 import com._1c.g5.v8.dt.metadata.mdclass.MdClassPackage;
 import com._1c.g5.v8.dt.metadata.mdclass.Subsystem;
@@ -67,6 +68,8 @@ import com.ditrix.edt.mcp.server.tools.IMcpTool;
 import com.ditrix.edt.mcp.server.tools.impl.GetProjectErrorsTool.ErrorInfo;
 import com.ditrix.edt.mcp.server.utils.FormElementWriter;
 import com.ditrix.edt.mcp.server.utils.MetadataNodeResolver;
+import com.ditrix.edt.mcp.server.utils.MetadataScope;
+import com.ditrix.edt.mcp.server.utils.MetadataScopeTestFixtures;
 import com.ditrix.edt.mcp.server.utils.MetadataTypeUtils;
 import com.ditrix.edt.mcp.server.utils.PredefinedWriter;
 
@@ -955,7 +958,7 @@ public class GetProjectErrorsToolTest
         when(model.executeReadonlyTask(any())).thenThrow(new IllegalStateException("model busy")); //$NON-NLS-1$
 
         GetProjectErrorsTool.ProjectResolution decided = GetProjectErrorsTool.resolveInProject(
-            project("P"), model, MdClassFactory.eINSTANCE.createConfiguration(), //$NON-NLS-1$
+            project("P"), model, scope(MdClassFactory.eINSTANCE.createConfiguration()), //$NON-NLS-1$
             Collections.singletonList("Catalog.Products")); //$NON-NLS-1$
 
         assertFalse("a pass that threw decided nothing and is not an inspection", //$NON-NLS-1$
@@ -973,7 +976,7 @@ public class GetProjectErrorsToolTest
         Configuration config = MdClassFactory.eINSTANCE.createConfiguration();
 
         GetProjectErrorsTool.ProjectResolution decided = GetProjectErrorsTool.resolveInProject(
-            project("P"), readModel(), config, Collections.singletonList("Catalog.Nope")); //$NON-NLS-1$ //$NON-NLS-2$
+            project("P"), readModel(), scope(config), Collections.singletonList("Catalog.Nope")); //$NON-NLS-1$ //$NON-NLS-2$
 
         assertTrue("a completed pass is an inspection", decided.passCompleted); //$NON-NLS-1$
         assertTrue("nothing resolved in an empty configuration", decided.resolved.isEmpty()); //$NON-NLS-1$
@@ -1221,7 +1224,7 @@ public class GetProjectErrorsToolTest
         config.getCatalogs().add(catalog);
 
         GetProjectErrorsTool.ProjectResolution decided = GetProjectErrorsTool.resolveInProject(
-            project("P"), readModel(), config, //$NON-NLS-1$
+            project("P"), readModel(), scope(config), //$NON-NLS-1$
             Collections.singletonList("Catalog.C.Form.ItemForm.Field.Code")); //$NON-NLS-1$
 
         assertTrue("and it must not decide the address", decided.resolved.isEmpty()); //$NON-NLS-1$
@@ -1231,7 +1234,7 @@ public class GetProjectErrorsToolTest
         // The counterpart: a form that is simply ABSENT is a decided miss - the undecided verdict
         // must not swallow the ordinary not-found one.
         GetProjectErrorsTool.ProjectResolution absent = GetProjectErrorsTool.resolveInProject(
-            project("P"), readModel(), config, //$NON-NLS-1$
+            project("P"), readModel(), scope(config), //$NON-NLS-1$
             Collections.singletonList("Catalog.C.Form.NoSuchForm.Field.Code")); //$NON-NLS-1$
         assertTrue(absent.resolved.isEmpty());
         assertTrue("an absent form is a decided miss, never undecided", //$NON-NLS-1$
@@ -1256,9 +1259,9 @@ public class GetProjectErrorsToolTest
 
         String member = "Catalog.C.Form.ItemForm.Field.Code"; //$NON-NLS-1$
         GetProjectErrorsTool.ProjectResolution undecided = GetProjectErrorsTool.resolveInProject(
-            project("A"), readModel(), withForm, Collections.singletonList(member)); //$NON-NLS-1$
+            project("A"), readModel(), scope(withForm), Collections.singletonList(member)); //$NON-NLS-1$
         GetProjectErrorsTool.ProjectResolution complete = GetProjectErrorsTool.resolveInProject(
-            project("B"), readModel(), MdClassFactory.eINSTANCE.createConfiguration(), //$NON-NLS-1$
+            project("B"), readModel(), scope(MdClassFactory.eINSTANCE.createConfiguration()), //$NON-NLS-1$
             Collections.singletonList(member));
 
         // The premise: A left it undecided while B ran to the end and resolved nothing.
@@ -1319,7 +1322,7 @@ public class GetProjectErrorsToolTest
         // End to end, both halves of the author's requirement in one fold:
         // a readable EDT project + a non-EDT one must still report the address missing...
         GetProjectErrorsTool.ProjectResolution readable = GetProjectErrorsTool.resolveInProject(
-            project("edt-ok"), readModel(), MdClassFactory.eINSTANCE.createConfiguration(), //$NON-NLS-1$
+            project("edt-ok"), readModel(), scope(MdClassFactory.eINSTANCE.createConfiguration()), //$NON-NLS-1$
             candidates);
         GetProjectErrorsTool.AddressResolution withNonEdt =
             new GetProjectErrorsTool.AddressResolution();
@@ -1366,7 +1369,7 @@ public class GetProjectErrorsToolTest
 
         // With a readable project alongside, the address must NOT be called missing.
         GetProjectErrorsTool.ProjectResolution readable = GetProjectErrorsTool.resolveInProject(
-            project("open"), readModel(), MdClassFactory.eINSTANCE.createConfiguration(), //$NON-NLS-1$
+            project("open"), readModel(), scope(MdClassFactory.eINSTANCE.createConfiguration()), //$NON-NLS-1$
             candidates);
         GetProjectErrorsTool.AddressResolution r = new GetProjectErrorsTool.AddressResolution();
         GetProjectErrorsTool.foldProjectDecisions(r, candidates, candidates, Arrays.asList(readable, closed));
@@ -1387,7 +1390,7 @@ public class GetProjectErrorsToolTest
         List<String> candidates = Collections.singletonList(fqn);
 
         GetProjectErrorsTool.ProjectResolution owner = GetProjectErrorsTool.resolveInProject(
-            project("A"), readModel(), configWithCatalog("C"), candidates); //$NON-NLS-1$ //$NON-NLS-2$
+            project("A"), readModel(), scope(configWithCatalog("C")), candidates); //$NON-NLS-1$ //$NON-NLS-2$
         GetProjectErrorsTool.ProjectResolution unreadable = GetProjectErrorsTool.projectDecision(
             project("B", true), null, null, candidates); //$NON-NLS-1$
 
@@ -1412,7 +1415,7 @@ public class GetProjectErrorsToolTest
 
         // The counterpart: with every project consulted there is nothing to warn about.
         GetProjectErrorsTool.ProjectResolution absentHere = GetProjectErrorsTool.resolveInProject(
-            project("B"), readModel(), MdClassFactory.eINSTANCE.createConfiguration(), candidates); //$NON-NLS-1$
+            project("B"), readModel(), scope(MdClassFactory.eINSTANCE.createConfiguration()), candidates); //$NON-NLS-1$
         GetProjectErrorsTool.AddressResolution complete =
             new GetProjectErrorsTool.AddressResolution();
         GetProjectErrorsTool.foldProjectDecisions(complete, candidates, candidates,
@@ -1433,13 +1436,13 @@ public class GetProjectErrorsToolTest
         String requested = "Catalog." + yo; //$NON-NLS-1$
 
         GetProjectErrorsTool.ProjectResolution a = GetProjectErrorsTool.resolveInProject(
-            project("A"), readModel(), configWithCatalog(ye), //$NON-NLS-1$
+            project("A"), readModel(), scope(configWithCatalog(ye)), //$NON-NLS-1$
             Collections.singletonList(requested));
         GetProjectErrorsTool.ProjectResolution b = GetProjectErrorsTool.resolveInProject(
-            project("B"), readModel(), configWithCatalog(yo), //$NON-NLS-1$
+            project("B"), readModel(), scope(configWithCatalog(yo)), //$NON-NLS-1$
             Collections.singletonList(requested));
         GetProjectErrorsTool.ProjectResolution c = GetProjectErrorsTool.resolveInProject(
-            project("C"), readModel(), MdClassFactory.eINSTANCE.createConfiguration(), //$NON-NLS-1$
+            project("C"), readModel(), scope(MdClassFactory.eINSTANCE.createConfiguration()), //$NON-NLS-1$
             Collections.singletonList(requested));
 
         GetProjectErrorsTool.AddressResolution resolution =
@@ -1504,10 +1507,10 @@ public class GetProjectErrorsToolTest
         String requested = "Catalog." + yo; //$NON-NLS-1$
 
         GetProjectErrorsTool.ProjectResolution a = GetProjectErrorsTool.resolveInProject(
-            project("A"), readModel(), configWithCatalog(ye), //$NON-NLS-1$
+            project("A"), readModel(), scope(configWithCatalog(ye)), //$NON-NLS-1$
             Collections.singletonList(requested));
         GetProjectErrorsTool.ProjectResolution b = GetProjectErrorsTool.resolveInProject(
-            project("B"), readModel(), configWithCatalog(yo), //$NON-NLS-1$
+            project("B"), readModel(), scope(configWithCatalog(yo)), //$NON-NLS-1$
             Collections.singletonList(requested));
 
         assertEquals("project A must report the spelling IT stores", //$NON-NLS-1$
@@ -1872,11 +1875,8 @@ public class GetProjectErrorsToolTest
     @Test
     public void testAnExternalObjectsProjectIsAbsentNotUndecided()
     {
-        // A project of external objects (reports / data processors) carries a V8 nature but has NO
-        // Configuration BY DESIGN - not "not yet". Classifying it as an unreadable EDT project (its
-        // nature IS a V8 one) turned every ordinary miss into a refusal on a workspace-wide scan,
-        // and made a projectName pointing at one unable to resolve anything ever. Its lack of a
-        // configuration is KNOWLEDGE: it cannot own an mdclass address, so it answers ABSENT.
+        // An external-objects project cannot hold a Catalog, so this family is absent even when its
+        // own external roots are unavailable; calling it undecided would mute a proven miss.
         List<String> candidates = Collections.singletonList("Catalog.Nope"); //$NON-NLS-1$
 
         GetProjectErrorsTool.ProjectResolution external = GetProjectErrorsTool.projectDecision(
@@ -1890,7 +1890,7 @@ public class GetProjectErrorsToolTest
 
         // So a workspace-wide scan next to a readable project reports an ordinary MISS...
         GetProjectErrorsTool.ProjectResolution readable = GetProjectErrorsTool.resolveInProject(
-            project("cfg"), readModel(), MdClassFactory.eINSTANCE.createConfiguration(), //$NON-NLS-1$
+            project("cfg"), readModel(), scope(MdClassFactory.eINSTANCE.createConfiguration()), //$NON-NLS-1$
             candidates);
         GetProjectErrorsTool.AddressResolution r = new GetProjectErrorsTool.AddressResolution();
         GetProjectErrorsTool.foldProjectDecisions(r, candidates, candidates, Arrays.asList(readable, external));
@@ -1925,6 +1925,57 @@ public class GetProjectErrorsToolTest
             closedProject("gone"), null, null, candidates); //$NON-NLS-1$
         assertEquals("unknowable natures are never proof that a project holds nothing", //$NON-NLS-1$
             singleton("Catalog.Nope"), unknowable.undecided); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testExternalDataProcessorResolvesAgainstAnExternalObjectsScope()
+    {
+        ExternalDataProcessor processor = MdClassFactory.eINSTANCE.createExternalDataProcessor();
+        processor.setName("X"); //$NON-NLS-1$
+        MetadataScope external = MetadataScopeTestFixtures.externalObjects(processor);
+        String english = "ExternalDataProcessor.X"; //$NON-NLS-1$
+        String russian = fromCp(0x0412, 0x043d, 0x0435, 0x0448, 0x043d, 0x044f, 0x044f,
+            0x041e, 0x0431, 0x0440, 0x0430, 0x0431, 0x043e, 0x0442, 0x043a, 0x0430) + ".X"; //$NON-NLS-1$
+
+        GetProjectErrorsTool.ProjectResolution decided = GetProjectErrorsTool.resolveInProject(
+            project("ext"), readModel(), external, Arrays.asList(english, russian)); //$NON-NLS-1$
+
+        assertTrue("the external-root resolve pass must complete", decided.passCompleted); //$NON-NLS-1$
+        assertEquals(singleton(english), decided.resolved.get(english));
+        assertEquals("the Russian type token must scope the same stored object", //$NON-NLS-1$
+            singleton(english), decided.resolved.get(russian));
+        assertTrue(decided.undecided.isEmpty());
+    }
+
+    @Test
+    public void testUnavailableExternalRootOnlyLeavesExternalFamiliesUndecided()
+    {
+        String catalog = "Catalog.Nope"; //$NON-NLS-1$
+        String externalFqn = "ExternalDataProcessor.X"; //$NON-NLS-1$
+        List<String> candidates = Arrays.asList(catalog, externalFqn);
+
+        GetProjectErrorsTool.ProjectResolution decided = GetProjectErrorsTool.projectDecision(
+            natureProject("ext", "com._1c.g5.v8.dt.core.V8ExternalObjectsNature"), //$NON-NLS-1$ //$NON-NLS-2$
+            null, MetadataScopeTestFixtures.unavailableExternalObjects(), candidates);
+
+        assertTrue("the project still decides configuration-only families", decided.passCompleted); //$NON-NLS-1$
+        assertFalse("a Catalog is structurally absent here, not unknown", //$NON-NLS-1$
+            decided.undecided.contains(catalog));
+        assertEquals("an unreadable external root cannot prove its own object absent", //$NON-NLS-1$
+            singleton(externalFqn), decided.undecided);
+    }
+
+    @Test
+    public void testConfigurationOnlyFamiliesAreAbsentWithoutABaseConfiguration()
+    {
+        MetadataScope external = MetadataScopeTestFixtures.externalObjects();
+
+        assertTrue("a subsystem cannot exist in an external-object root", //$NON-NLS-1$
+            GetProjectErrorsTool.resolvedSpellings(external,
+                "Subsystem.Sales.Subsystem.Orders").isEmpty()); //$NON-NLS-1$
+        assertTrue("a predefined item cannot exist there and must not dereference a null base", //$NON-NLS-1$
+            GetProjectErrorsTool.resolvedSpellings(external,
+                "Catalog.Products.Predefined.Sample").isEmpty()); //$NON-NLS-1$
     }
 
 
@@ -2453,6 +2504,32 @@ public class GetProjectErrorsToolTest
     }
 
     @Test
+    public void testAllMissAddressReportIsARefusalInsteadOfACleanHeading()
+    {
+        String missing = "Catalog.Nope"; //$NON-NLS-1$
+        String unsupported = "XDTOPackage.P.Property.N"; //$NON-NLS-1$
+        GetProjectErrorsTool.AddressResolution resolution =
+            new GetProjectErrorsTool.AddressResolution();
+        resolution.notFound.add(missing);
+        resolution.unsupported.add(unsupportedEntry(unsupported, "why")); //$NON-NLS-1$
+
+        String report = GetProjectErrorsTool.assembleAddressReport(
+            Collections.<ErrorInfo> emptyList(), "P", null, Arrays.asList(missing, unsupported), //$NON-NLS-1$
+            100, false, resolution, new int[] {0}, new int[] {0});
+
+        assertEquals("the refusal must be propagated as the resolution error", //$NON-NLS-1$
+            resolution.error, report);
+        assertTrue("the response must be a ToolResult refusal", //$NON-NLS-1$
+            report.contains("\"success\":false")); //$NON-NLS-1$
+        assertTrue("every unresolved address must be named", //$NON-NLS-1$
+            report.contains(missing) && report.contains(unsupported));
+        assertTrue("the refusal must give both supported recovery paths", //$NON-NLS-1$
+            report.contains("'objects'") && report.contains("get_metadata_objects")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertFalse("an unrun scan must never carry the clean heading", //$NON-NLS-1$
+            report.contains("# No Errors Found")); //$NON-NLS-1$
+    }
+
+    @Test
     public void testEveryResolvingYoReadingOfADeferredMemberAccumulates()
     {
         // The guard that lets the deferred path ACCUMULATE was not covered: with only one yo reading
@@ -2626,7 +2703,7 @@ public class GetProjectErrorsToolTest
 
         // A readable project that holds neither, plus one that cannot be consulted at all.
         GetProjectErrorsTool.ProjectResolution readable = GetProjectErrorsTool.resolveInProject(
-            project("open"), readModel(), MdClassFactory.eINSTANCE.createConfiguration(), //$NON-NLS-1$
+            project("open"), readModel(), scope(MdClassFactory.eINSTANCE.createConfiguration()), //$NON-NLS-1$
             Collections.singletonList(possible));
         GetProjectErrorsTool.ProjectResolution unreadable = GetProjectErrorsTool.projectDecision(
             closedProject("archived"), null, null, Collections.singletonList(possible)); //$NON-NLS-1$
@@ -2758,7 +2835,7 @@ public class GetProjectErrorsToolTest
     private static Map<String, Set<String>> resolvedIn(Configuration config, String... fqns)
     {
         GetProjectErrorsTool.ProjectResolution decided = GetProjectErrorsTool.resolveInProject(
-            project("P"), readModel(), config, Arrays.asList(fqns)); //$NON-NLS-1$
+            project("P"), readModel(), scope(config), Arrays.asList(fqns)); //$NON-NLS-1$
         assertTrue("the resolve pass must complete", decided.passCompleted); //$NON-NLS-1$
         return decided.resolved;
     }
@@ -2793,6 +2870,12 @@ public class GetProjectErrorsToolTest
         catalog.setName(storedName);
         config.getCatalogs().add(catalog);
         return config;
+    }
+
+    /** Wraps in-memory configurations in the same scope used by production resolution. */
+    private static MetadataScope scope(Configuration config)
+    {
+        return MetadataScope.ofConfiguration(config);
     }
 
     /** The owning form of the synthetic form model, as an FQN prefix. */

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataScopeTestFixtures.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataScopeTestFixtures.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 
 import com._1c.g5.v8.dt.core.platform.IExternalObjectProject;
+import com._1c.g5.v8.dt.metadata.mdclass.Configuration;
 import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
 
 /** Test-only access to external-object scopes that normally require a live EDT project. */
@@ -25,8 +26,22 @@ public final class MetadataScopeTestFixtures
     /** Builds a started external-object scope containing the supplied roots. */
     public static MetadataScope externalObjects(MdObject... objects)
     {
+        return externalObjectsWithBase(null, objects);
+    }
+
+    /** Builds a started external-object scope linked to the supplied base configuration. */
+    public static MetadataScope externalObjectsWithBase(Configuration base, MdObject... objects)
+    {
         IExternalObjectProject project = mock(IExternalObjectProject.class);
         when(project.getExternalObjects()).thenReturn(Arrays.asList(objects));
+        return MetadataScope.ofExternalObjectProject(null, base, project);
+    }
+
+    /** Builds an external-object scope whose root read fails after startup. */
+    public static MetadataScope failingExternalObjects()
+    {
+        IExternalObjectProject project = mock(IExternalObjectProject.class);
+        when(project.getExternalObjects()).thenThrow(new IllegalStateException("root read failed")); //$NON-NLS-1$
         return MetadataScope.ofExternalObjectProject(null, null, project);
     }
 

--- a/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataScopeTestFixtures.java
+++ b/mcp/tests/com.ditrix.edt.mcp.server.tests/src/com/ditrix/edt/mcp/server/utils/MetadataScopeTestFixtures.java
@@ -1,0 +1,38 @@
+/**
+ * MCP Server for EDT
+ * Copyright (C) 2026 Diversus (https://github.com/Diversus23)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package com.ditrix.edt.mcp.server.utils;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import com._1c.g5.v8.dt.core.platform.IExternalObjectProject;
+import com._1c.g5.v8.dt.metadata.mdclass.MdObject;
+
+/** Test-only access to external-object scopes that normally require a live EDT project. */
+public final class MetadataScopeTestFixtures
+{
+    private MetadataScopeTestFixtures()
+    {
+        // Prevent instantiation because the fixture has no state.
+    }
+
+    /** Builds a started external-object scope containing the supplied roots. */
+    public static MetadataScope externalObjects(MdObject... objects)
+    {
+        IExternalObjectProject project = mock(IExternalObjectProject.class);
+        when(project.getExternalObjects()).thenReturn(Arrays.asList(objects));
+        return MetadataScope.ofExternalObjectProject(null, null, project);
+    }
+
+    /** Builds an external-object scope whose EDT lifecycle never exposed its roots. */
+    public static MetadataScope unavailableExternalObjects()
+    {
+        return MetadataScope.ofExternalObjectProject(null, null, null);
+    }
+}

--- a/tests/e2e/tools/test_external_objects_project.py
+++ b/tests/e2e/tools/test_external_objects_project.py
@@ -28,7 +28,7 @@ from harness import (
     call, assert_ok, assert_error, assert_error_quality, assert_contains,
     assert_not_contains, assert_no_diff, assert_no_diff_rel, poll_diff_contains_rel,
     read_fixture_file, reset_fixture_rel, wait_for_project_ready, e2e_test, PROJECT,
-    EXT_OBJECTS_PROJECT, EXT_OBJECTS_REL,
+    EXT_OBJECTS_PROJECT, EXT_OBJECTS_REL, _fail,
 )
 
 # The Russian TYPE tokens for the two external-objects types. The bilingual token catalogue
@@ -125,6 +125,32 @@ def test_extobj_details_resolve_the_russian_type_token():
                     "the Russian token must resolve to the same object")
     assert_contains(r.text, "ExternalReport: ExtReport", "and so must the report token")
     assert_no_diff_rel(EXT_OBJECTS_REL, "a read tool must not touch the fixture")
+
+
+@e2e_test(tool="get_project_errors", kind="read")
+def test_extobj_project_errors_resolve_its_own_object():
+    """Exact error scopes resolve against this project's roots in both token languages."""
+    english = "ExternalDataProcessor.ExtProc"
+    r = call("get_project_errors",
+             {"projectName": EXT_OBJECTS_PROJECT, "objectFqns": [english]})
+    assert_ok(r, "get_project_errors on an external-objects project")
+    if (r.structured or {}).get("objectsResolved") != [english]:
+        _fail("the external data processor must resolve: %r" % (r.structured,))
+    if (r.structured or {}).get("objectsNotFound") != []:
+        _fail("the resolved external data processor must not be reported missing: %r"
+              % (r.structured,))
+
+    russian = RU_EXTERNAL_DATA_PROCESSOR + ".ExtProc"
+    ru = call("get_project_errors",
+              {"projectName": EXT_OBJECTS_PROJECT, "objectFqns": [russian]})
+    assert_ok(ru, "get_project_errors with the Russian external-object type token")
+    if (ru.structured or {}).get("objectsResolved") != [russian]:
+        _fail("the Russian type token must resolve the same external data processor: %r"
+              % (ru.structured,))
+    if (ru.structured or {}).get("objectsNotFound") != []:
+        _fail("the Russian spelling must not be reported missing: %r" % (ru.structured,))
+    assert_no_diff("a read tool must not touch the base project on disk")
+    assert_no_diff_rel(EXT_OBJECTS_REL, "a read tool must not touch the external fixture")
 
 
 @e2e_test(tool="get_metadata_details", kind="error")

--- a/tests/e2e/tools/test_get_project_errors.py
+++ b/tests/e2e/tools/test_get_project_errors.py
@@ -33,6 +33,8 @@ There are TWO object filters and they behave differently on purpose:
                    owning node. Scoping it to the member alone would match nothing and answer
                    `objectsResolved` next to "# No Errors Found" - the false all-clear this
                    input exists to prevent.
+                   If none of the requested addresses resolves, the call is refused because no
+                   marker scan ran; use `objects` or `get_metadata_objects` to recover.
 
 Anything that must observe a REAL marker seeds it first (a syntax error written into a
 fixture module with write_module_source, then a forced revalidation): the live marker set
@@ -429,12 +431,8 @@ def test_exact_address_that_exists_is_not_reported_missing_and_a_typo_is():
 
     typo = "Catalog.%s" % NO_SUCH_OBJECT
     bad = call("get_project_errors", {"projectName": PROJECT, "objectFqns": [typo]})
-    assert_ok(bad, "exact address that does not exist")
-    _assert_verdicts(bad, resolved=[], not_found=[typo], unsupported=[])
-    assert_contains(_report(bad), "objectsNotFound",
-                    "the human report must mirror the machine verdict")
-    assert_contains(_report(bad), "get_metadata_objects",
-                    "the report must point at the discovery tool")
+    error = assert_error(bad, "an all-miss exact-address call")
+    assert_error_quality(error, names=[typo], suggests=["objects", "get_metadata_objects"])
     assert_no_diff("reading project errors must not touch the project on disk")
 
 
@@ -462,16 +460,18 @@ def test_exact_form_member_leaf_is_really_checked():
     _assert_verdicts(r, resolved=[form], not_found=[], unsupported=[])
 
     ghost = "%s.Attribute.%s" % (form, NO_SUCH_ATTRIBUTE)
-    m = call("get_project_errors", {"projectName": PROJECT, "objectFqns": [ghost]})
-    assert_ok(m, "a form member that does not exist")
-    _assert_verdicts(m, resolved=[], not_found=[ghost], unsupported=[])
+    m = call("get_project_errors", {"projectName": PROJECT, "objectFqns": [form, ghost]})
+    assert_ok(m, "a form plus a member that does not exist")
+    _assert_verdicts(m, resolved=[form], not_found=[ghost], unsupported=[])
 
     # A CommonForm member leaf is checked the same way (its members live in the content
     # model too, while the CommonForm top object resolves on its own).
+    common_form = "CommonForm.%s" % FIXTURE_COMMON_FORM
     common_ghost = "CommonForm.%s.Attribute.%s" % (FIXTURE_COMMON_FORM, NO_SUCH_ATTRIBUTE)
-    c = call("get_project_errors", {"projectName": PROJECT, "objectFqns": [common_ghost]})
-    assert_ok(c, "a common-form member that does not exist")
-    _assert_verdicts(c, resolved=[], not_found=[common_ghost], unsupported=[])
+    c = call("get_project_errors",
+             {"projectName": PROJECT, "objectFqns": [common_form, common_ghost]})
+    assert_ok(c, "a common form plus a member that does not exist")
+    _assert_verdicts(c, resolved=[common_form], not_found=[common_ghost], unsupported=[])
     assert_no_diff("reading project errors must not touch the project on disk")
 
 
@@ -494,13 +494,14 @@ def test_exact_form_member_kind_must_match_the_element():
     assert_ok(r, "form members addressed with their own kind")
     _assert_verdicts(r, resolved=right, not_found=[], unsupported=[])
 
-    # The SAME names with the other item's kind, plus a misspelt kind token: all misses.
+    # Keep one real member in the request so the wrong-kind verdicts remain observable as a partial.
     wrong = ["%s.Button.%s" % (form, FIXTURE_FORM_FIELD),
              "%s.Field.%s" % (form, FIXTURE_FORM_DECORATION),
              "%s.Fielld.%s" % (form, FIXTURE_FORM_FIELD)]
-    w = call("get_project_errors", {"projectName": PROJECT, "objectFqns": wrong})
+    w = call("get_project_errors", {"projectName": PROJECT,
+                                    "objectFqns": [right[0]] + wrong})
     assert_ok(w, "form members addressed with a foreign / misspelt kind")
-    _assert_verdicts(w, resolved=[], not_found=wrong, unsupported=[])
+    _assert_verdicts(w, resolved=[right[0]], not_found=wrong, unsupported=[])
     assert_contains(_report(w), "objectsNotFound",
                     "the human report must name the wrong-kind addresses")
     assert_no_diff("reading project errors must not touch the project on disk")
@@ -535,17 +536,18 @@ def test_exact_handler_address_must_name_the_owning_items_kind():
     # A FOREIGN owner kind (Code is a FormField, not a Button) and a misspelt one: both misses.
     wrong = ["%s.Button.%s.Handler.OnChange" % (form, FIXTURE_FORM_FIELD),
              "%s.Fielld.%s.Handler.OnChange" % (form, FIXTURE_FORM_FIELD)]
-    w = call("get_project_errors", {"projectName": PROJECT, "objectFqns": wrong})
+    w = call("get_project_errors", {"projectName": PROJECT, "objectFqns": [right] + wrong})
     assert_ok(w, "handler addressed through a foreign / misspelt owner kind")
-    _assert_verdicts(w, resolved=[], not_found=wrong, unsupported=[])
+    _assert_verdicts(w, resolved=[right], not_found=wrong, unsupported=[])
     assert_contains(_report(w), "objectsNotFound",
                     "the human report must name the wrong-owner-kind addresses")
 
     # The EVENT leaf keeps its own say: a real owner with a bogus event is still a miss.
     ghost_event = "%s.Field.%s.Handler.NoSuchEvent_e2e_xyz" % (form, FIXTURE_FORM_FIELD)
-    g = call("get_project_errors", {"projectName": PROJECT, "objectFqns": [ghost_event]})
-    assert_ok(g, "a handler address whose event is bound to nothing")
-    _assert_verdicts(g, resolved=[], not_found=[ghost_event], unsupported=[])
+    g = call("get_project_errors",
+             {"projectName": PROJECT, "objectFqns": [right, ghost_event]})
+    assert_ok(g, "a real handler plus an event that is bound to nothing")
+    _assert_verdicts(g, resolved=[right], not_found=[ghost_event], unsupported=[])
 
 
 @e2e_test(tool="get_project_errors", kind="write-metadata")
@@ -625,15 +627,13 @@ def test_exact_form_and_form_member_addresses_really_select_the_forms_problems()
         assert_contains(_report(m), location,
                         "the member's rows must be the form's own rows, location included")
 
-    # 3) The widening must not blur the MISS verdicts: a ghost member and a wrong-kind member are
-    #    still reported missing and select nothing, even though their form has a problem.
+    # 3) The widening must not blur the misses: none resolved, so the dangerous unrun scan is refused
+    #    even though their containing form has a problem.
     misses = ["%s.Field.%s" % (form, NO_SUCH_ATTRIBUTE),
               "%s.Button.%s" % (form, FIXTURE_FORM_FIELD)]
     w = call("get_project_errors", {"projectName": PROJECT, "objectFqns": misses})
-    assert_ok(w, "ghost / wrong-kind members of a form that HAS a problem")
-    _assert_verdicts(w, resolved=[], not_found=misses, unsupported=[])
-    if (w.structured or {}).get("problemsFound", 0) != 0:
-        _fail("an address that resolved to nothing must select nothing: %r" % (w.structured,))
+    error = assert_error(w, "ghost / wrong-kind members of a form that HAS a problem")
+    assert_error_quality(error, names=misses, suggests=["objects", "get_metadata_objects"])
 
 
 @e2e_test(tool="get_project_errors", kind="write-metadata")
@@ -661,12 +661,12 @@ def test_exact_address_written_with_yo_resolves_against_the_stored_ye_name():
         # The verdict keeps the caller's own spelling, whichever one resolved.
         _assert_verdicts(r, resolved=[requested], not_found=[], unsupported=[])
 
-    # A ё name that exists in NEITHER spelling is still an ordinary miss: the fallback must not
+    # A ё name that exists in NEITHER spelling still refuses an all-miss scan: the fallback must not
     # blur the verdict into "everything resolves".
     ghost = "Catalog.Полёт" + NO_SUCH_OBJECT
     g = call("get_project_errors", {"projectName": PROJECT, "objectFqns": [ghost]})
-    assert_ok(g, "a ё address that exists in neither spelling")
-    _assert_verdicts(g, resolved=[], not_found=[ghost], unsupported=[])
+    error = assert_error(g, "a ё address that exists in neither spelling")
+    assert_error_quality(error, names=[ghost], suggests=["objects", "get_metadata_objects"])
 
 
 @e2e_test(tool="get_project_errors", kind="read")
@@ -692,15 +692,16 @@ def test_exact_form_member_kind_token_accepts_both_numbers_and_both_languages():
     # The guarantee is about SPELLING, not about accepting anything: a wrong kind is still a miss,
     # in the plural too.
     wrong = "%s.Buttons.%s" % (form, FIXTURE_FORM_FIELD)
-    w = call("get_project_errors", {"projectName": PROJECT, "objectFqns": [wrong]})
+    right = "%s.Field.%s" % (form, FIXTURE_FORM_FIELD)
+    w = call("get_project_errors", {"projectName": PROJECT, "objectFqns": [right, wrong]})
     assert_ok(w, "a plural token of the WRONG kind")
-    _assert_verdicts(w, resolved=[], not_found=[wrong], unsupported=[])
+    _assert_verdicts(w, resolved=[right], not_found=[wrong], unsupported=[])
     assert_no_diff("reading project errors must not touch the project on disk")
 
 
 @e2e_test(tool="get_project_errors", kind="read")
 def test_exact_address_with_unknown_head_or_kind_is_reported_missing():
-    """An unknown TYPE token and a misspelt KIND token are both plain misses.
+    """An unknown TYPE token and a misspelt KIND token are both named in the refusal.
 
     `Catalog.<real>.Fom.ItemForm` has a real head, so a build that judged the address by its
     head would call it found while the filter matched nothing - the exact failure mode the
@@ -710,8 +711,9 @@ def test_exact_address_with_unknown_head_or_kind_is_reported_missing():
     bad_head = "NoSuchType_e2e_xyz.Whatever"
     r = call("get_project_errors",
              {"projectName": PROJECT, "objectFqns": [bad_kind, bad_head]})
-    assert_ok(r, "exact addresses with an unknown kind / head")
-    _assert_verdicts(r, resolved=[], not_found=[bad_kind, bad_head], unsupported=[])
+    error = assert_error(r, "exact addresses with an unknown kind / head")
+    assert_error_quality(error, names=[bad_kind, bad_head],
+                         suggests=["objects", "get_metadata_objects"])
     assert_no_diff("reading project errors must not touch the project on disk")
 
 
@@ -724,12 +726,14 @@ def test_xdto_member_address_is_unsupported_not_missing():
     model that this tool never verified. The package level stays supported: it is an ordinary
     resolution, so a non-existent package is an ordinary miss.
     """
+    good = "Catalog.%s" % FIXTURE_CATALOG
     for member in ("XDTOPackage.P.ObjectType.T",
                    "XDTOPackage.P.Property.N",
                    "XDTOPackage.P.ObjectType.T.Property.N"):
-        r = call("get_project_errors", {"projectName": PROJECT, "objectFqns": [member]})
+        r = call("get_project_errors", {"projectName": PROJECT,
+                                        "objectFqns": [good, member]})
         assert_ok(r, "XDTO member address %s" % member)
-        _assert_verdicts(r, resolved=[], not_found=[], unsupported=[member])
+        _assert_verdicts(r, resolved=[good], not_found=[], unsupported=[member])
         assert_contains(_report(r), "objectsUnsupported",
                         "the human report must mirror the unsupported verdict")
         assert_not_contains(_report(r), "objectsNotFound",
@@ -738,9 +742,9 @@ def test_xdto_member_address_is_unsupported_not_missing():
     # The PACKAGE level is supported: this fixture has no XDTO package, so the honest verdict
     # for a package address is an ordinary miss - NOT "unsupported".
     pkg = "XDTOPackage.NoSuchPackage_e2e_xyz"
-    r = call("get_project_errors", {"projectName": PROJECT, "objectFqns": [pkg]})
+    r = call("get_project_errors", {"projectName": PROJECT, "objectFqns": [good, pkg]})
     assert_ok(r, "XDTO package-level address")
-    _assert_verdicts(r, resolved=[], not_found=[pkg], unsupported=[])
+    _assert_verdicts(r, resolved=[good], not_found=[pkg], unsupported=[])
     assert_no_diff("reading project errors must not touch the project on disk")
 
 

--- a/tests/e2e/tools/test_get_project_errors.py
+++ b/tests/e2e/tools/test_get_project_errors.py
@@ -739,6 +739,19 @@ def test_xdto_member_address_is_unsupported_not_missing():
         assert_not_contains(_report(r), "objectsNotFound",
                             "an unsupported address must never be called missing")
 
+    # A request made ONLY of unsupported addresses is still refused - nothing was scanned, so a
+    # clean heading would be invented - but the refusal must carry the address's OWN reason.
+    # The spelling advice belongs to a MISS: an unsupported family is not a wrong FQN.
+    only = call("get_project_errors", {"projectName": PROJECT,
+                                       "objectFqns": ["XDTOPackage.P.Property.N"]})
+    err = assert_error(only, "a request made only of unsupported addresses")
+    assert_contains(err, "XDTOPackage.P.Property.N",
+                    "the refusal must name the address it could not scan")
+    assert_contains(err, "validate_xdto_package",
+                    "the address's own remedy must survive the refusal")
+    assert_not_contains(err, "get_metadata_objects",
+                        "an unsupported family is not a misspelling to look up")
+
     # The PACKAGE level is supported: this fixture has no XDTO package, so the honest verdict
     # for a package address is an ordinary miss - NOT "unsupported".
     pkg = "XDTOPackage.NoSuchPackage_e2e_xyz"


### PR DESCRIPTION
Closes #604

Две независимые поломки в одном вызове, и вторая опаснее первой.

## 1. Адрес внешнего объекта не резолвился

`GetProjectErrorsTool` — неперенесённый хвост #309: все остальные FQN-адресуемые инструменты переведены на `MetadataScope`, а этот по-прежнему считал корнем FQN `Configuration`. В проекте внешних объектов конфигурации либо нет вовсе, либо это БАЗОВАЯ конфигурация, в коллекциях которой `ExternalDataProcessor.*` не лежит — поэтому адрес не разрешался никогда, хотя тот же FQN давно резолвит `get_metadata_details`.

Теперь по пути точной адресации идёт `MetadataScope`, а ветка «проект внешних объектов» разбирает СЕМЕЙСТВО адреса: конфигурационное семейство там по-прежнему решённо отсутствует (`Catalog.*` во внешнем проекте — это именно отсутствие), внешние семейства решает scope, а недоступный внешний корень даёт UNDECIDED, а не «не найдено». Невозможность посмотреть не выдаётся за отсутствие.

## 2. Неразрешённый адрес читался как «чисто»

Заголовок выбирался по `errors.isEmpty()`, а `errors` пуст ПО ПОСТРОЕНИЮ, когда не разрешился ни один адрес: скан просто не запускался. В ответе стояли `success: true`, `problemsFound: 0` и `# No Errors Found`, а `objectsNotFound` терялся рядом с ними — ровно та ложная приёмка, из-за которой issue и заведена.

Теперь вызов, у которого не разрешился НИ ОДИН адрес, отказывает и называет адреса и оба пути восстановления. Частичное разрешение сохраняет прежнюю форму: отчёт плюс предупреждение. `appendNoErrorsSection` и сама строка `# No Errors Found` не тронуты — их разбирает по префиксу `validate_xdto_package` и нестрогий путь.

## Проверено на живом стенде

| вызов | было | стало |
| --- | --- | --- |
| `ExternalDataProcessor.ExtProc` | `objectsNotFound`, `resolved: []`, «No Errors Found» | `objectsResolved: [ExtProc]`, `notFound: []` |
| `ВнешняяОбработка.ExtProc` | — | резолвится так же |
| промах по всем адресам | `success: true` + «No Errors Found» | отказ с названными адресами |
| обычная конфигурация | — | не затронута, находит реальную проблему объекта |
| частичный запрос | — | остаётся успехом с предупреждением |

Проверка обычной конфигурации специально сделана на объекте, у которого ЕСТЬ замечание (`md-list-object-presentation`): чистый ответ не доказал бы, что скан после перевода резолва вообще работает. В журнале EDT после прогона ноль записей severity-4 от плагина.

## Контракт e2e сдвинут осознанно

Тесты, которые проверяли классификацию промахов ОДНИМ только промахом, теперь просят вместе с ним заведомо валидный адрес — иначе их структурные проверки стали бы недостижимы за отказом. Сам отказ закреплён отдельно, в том числе тем, что неотработавший скан не имеет права нести чистый заголовок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
